### PR TITLE
Add anti-leak guardrail (gitleaks) for the public repo

### DIFF
--- a/.agents/decisions/0004-anti-leak-guardrail.md
+++ b/.agents/decisions/0004-anti-leak-guardrail.md
@@ -1,0 +1,57 @@
+# 0004 — Anti-leak guardrail (gitleaks)
+
+- **Status:** Accepted
+- **Date:** 2026-05-30
+- **Affects:** repo root (`/.gitleaks.toml`, `/.npmrc`), CI (`/.github/workflows/ci.yml`), git hooks (`/common/git-hooks/`)
+- **PR / Issue:** chore/anti-leak-guardrail
+
+## Context
+
+`excitedjs/dreamux` is a **public** open-source repo, but it is developed
+alongside company-internal tooling. Company-internal content — Feishu
+identifiers (`ou_`/`oc_`/`cli_`), internal tokens/secrets, private-mirror
+registry URLs, internal hostnames — must never reach a commit, because a
+leaked commit is public and permanent (forks, mirrors, caches survive a
+later deletion). A naïve `npm install` can also bake a non-public mirror
+URL into the lockfile. The repo shares this concern, and a single canonical
+config, with the sibling **claudemux** repo.
+
+## Decision
+
+Land a layered guardrail:
+
+- **`/.gitleaks.toml`** — gitleaks `useDefault` ruleset (private keys,
+  generic high-entropy secrets, cloud tokens) plus generic Feishu id /
+  credential formats. No real values, so the config is itself safe to
+  commit.
+- **`/.npmrc`** — pins the public npm registry so `install` never resolves
+  through (or records) a private mirror.
+- **Pre-commit hook** (`/common/git-hooks/pre-commit`) — `gitleaks protect
+  --staged` against the staged diff. If gitleaks isn't installed it
+  warn-and-passes; CI is the real gate. Rush installs hooks from
+  `common/git-hooks/` on `rush install`/`update` (the idiomatic monorepo
+  home — no husky / root `package.json` needed).
+- **CI gate** (`/.github/workflows/ci.yml`, job `gitleaks`) — `gitleaks
+  detect` over the **full** git history (`fetch-depth: 0`, includes the
+  committed lockfile) with `--exit-code 1`. The pinned gitleaks binary is
+  downloaded directly rather than via `gitleaks-action` (which needs an org
+  license key and hides the command); the invocation is kept identical to
+  the hook's.
+
+## Consequences
+
+- **`.gitleaks.toml` and `.npmrc` are a shared canonical, kept
+  byte-identical with the claudemux repo.** Do not edit them in only one
+  repo. If gitleaks false-positives (e.g. on `package-lock.json` integrity
+  hashes), **stop and ask** rather than adding a local allowlist or an
+  `--no-git` / path-exclusion workaround — any change must be synced across
+  both repos or the two configs drift. (Verified clean on gitleaks 8.30.1:
+  the lockfile's sha512 integrity hashes do not trip the generic rule.)
+- "Non-bypassable" depends on the repo owner enabling the `gitleaks` job as
+  a **required status check** in branch protection; the workflow file alone
+  does not enforce it.
+- The hook auto-installs only on the rush path. The per-package npm path
+  (`cd packages/dreamux && npm install`) skips it — a contributor opts in
+  with `git config core.hooksPath common/git-hooks`. CI covers either way.
+- The red line is also written into [`/CLAUDE.md`](/CLAUDE.md)
+  ("Always-binding engineering rules") so every session loads it.

--- a/.agents/root.md
+++ b/.agents/root.md
@@ -55,5 +55,6 @@ issues:
 | understand why rush + pnpm | [`decisions/0001-rush-pnpm-monorepo.md`](decisions/0001-rush-pnpm-monorepo.md) |
 | rename or restructure the public CLI / package | [`decisions/0002-cli-and-package-naming.md`](decisions/0002-cli-and-package-naming.md) |
 | add / change a global config key (`~/.dreamux/config.toml`) | [`decisions/0003-global-config-dir.md`](decisions/0003-global-config-dir.md) |
+| touch the anti-leak guardrail (`.gitleaks.toml`, `.npmrc`, CI / hook) | [`decisions/0004-anti-leak-guardrail.md`](decisions/0004-anti-leak-guardrail.md) |
 | write a new decision record / new component doc | [`CONTRIBUTING.md`](CONTRIBUTING.md) |
 | modify the server runtime / Codex protocol handling | the issue links above + read the source — runtime details aren't yet promoted to the KB |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,9 +1,11 @@
 # CI for the dreamux monorepo (issue #4).
 #
-# Two jobs:
+# Jobs:
 #   - package — typecheck, build, vitest against the per-package npm path
 #     (matches `cd packages/dreamux && npm install && npm test`)
 #   - kb — validate the .agents/ knowledge base (link / orphan check)
+#   - rush — bootstrap & build smoke test of the monorepo path
+#   - gitleaks — secret scan over the full git history (anti-leak guardrail)
 #
 # The rush bootstrap (`node common/scripts/install-run-rush.js update`) is
 # intentionally exercised in CI too, in a separate job, so a broken
@@ -64,3 +66,36 @@ jobs:
         run: node common/scripts/install-run-rush.js update
       - name: rush build
         run: node common/scripts/install-run-rush.js build
+
+  gitleaks:
+    name: gitleaks — secret scan (full history)
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    # Anti-leak guardrail. dreamux is a PUBLIC repo: company-internal content
+    # (Feishu ids, tokens, private-mirror URLs, secrets) must never land in a
+    # commit. This job is the authoritative, non-bypassable gate — the
+    # committed pre-commit hook (common/git-hooks/pre-commit) is only a local
+    # pre-flight that warn-and-passes when gitleaks isn't installed.
+    #
+    # `gitleaks detect` scans the whole git history, so it catches a secret
+    # even if it was added and then "fixed" in a later commit; fetch-depth: 0
+    # gives the job that full history (incl. the committed package-lock.json).
+    # The gitleaks binary is pinned and downloaded directly rather than via
+    # gitleaks-action, which needs a license key for org repos and would hide
+    # the exact command — kept identical to the local hook's invocation.
+    env:
+      GITLEAKS_VERSION: '8.30.1'
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Install gitleaks ${{ env.GITLEAKS_VERSION }}
+        run: |
+          mkdir -p "$RUNNER_TEMP/gitleaks"
+          curl -sSfL "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz" \
+            | tar -xz -C "$RUNNER_TEMP/gitleaks" gitleaks
+          echo "$RUNNER_TEMP/gitleaks" >> "$GITHUB_PATH"
+      - name: gitleaks version
+        run: gitleaks version
+      - name: gitleaks detect (full history, lockfile included, --exit-code 1)
+        run: gitleaks detect --source . --config .gitleaks.toml --redact --exit-code 1 -v

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,37 @@
+# Anti-leak guardrail config for gitleaks (https://github.com/gitleaks/gitleaks).
+#
+# Keeps gitleaks' built-in rules (private keys, generic high-entropy secrets,
+# cloud / API tokens) via `useDefault`, and adds Feishu identifier / credential
+# formats. Only generic, public formats live here -- no real values and no
+# organization-specific strings -- so this file is safe to commit and never
+# leaks anything itself.
+title = "anti-leak guardrail"
+
+[extend]
+# Inherit gitleaks' built-in ruleset (private keys, generic secrets, tokens).
+useDefault = true
+
+[[rules]]
+id = "feishu-open-id"
+description = "Feishu open_id"
+regex = '''ou_[0-9a-f]{32}'''
+tags = ["feishu", "identifier"]
+
+[[rules]]
+id = "feishu-chat-id"
+description = "Feishu chat_id"
+regex = '''oc_[0-9a-f]{32}'''
+tags = ["feishu", "identifier"]
+
+[[rules]]
+id = "feishu-app-id"
+description = "Feishu app id"
+regex = '''cli_[a-z0-9]{14,}'''
+tags = ["feishu", "credential"]
+
+[allowlist]
+# Documentation placeholder app ids written as a run of x's (e.g.
+# cli_xxxxxxxxxxxxxxxx) are not real values. The anchor keeps anything that is
+# not entirely x's -- i.e. a real-format id -- still flagged.
+description = "Documentation placeholder app ids (a run of x's)."
+regexes = ['''^cli_x+$''']

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,3 @@
+# Pin the public npm registry. Keeps `install` from resolving through a private
+# mirror and from recording a non-public registry URL in the lockfile.
+registry=https://registry.npmjs.org/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,6 +67,17 @@ dir)? When in doubt, runtime dir — that's the safer default.
 
 ## Always-binding engineering rules
 
+- **Public repo — never commit company-internal content. (Red line.)**
+  `excitedjs/dreamux` is a public open-source repo. Feishu identifiers
+  (`ou_`/`oc_`/`cli_`), internal tokens/secrets, private-mirror registry URLs,
+  internal hostnames — none of it ever goes in a commit; a leaked commit is
+  public and permanent. The anti-leak guardrail enforces this: the committed
+  `.gitleaks.toml`, the `gitleaks protect --staged` pre-commit hook
+  (`common/git-hooks/pre-commit`), and a full-history `gitleaks detect`
+  CI gate. `.gitleaks.toml` and `.npmrc` are a **shared canonical kept
+  byte-identical with the claudemux repo** — do not edit them in only one repo;
+  if gitleaks false-positives, stop and ask rather than adding a local
+  allowlist, and sync any config change across both repos.
 - **No new runtime dependencies on dev tools.** PR #6 removed `tsx`; do
   not reintroduce it for bin launchers. The launchers exec `node` on
   compiled `dist/` output.

--- a/common/git-hooks/pre-commit
+++ b/common/git-hooks/pre-commit
@@ -1,0 +1,31 @@
+#!/bin/sh
+# Anti-leak guardrail — local pre-commit secret scan.
+#
+# dreamux is a PUBLIC repo: company-internal content (Feishu ids, tokens,
+# private-mirror registry URLs, secrets) must never be committed. This hook is
+# a fast local pre-flight that scans the *staged* changes with gitleaks before
+# they become a commit, using the committed .gitleaks.toml config.
+#
+# If gitleaks isn't installed it warn-and-passes: the GitHub Actions job runs
+# the authoritative `gitleaks detect` over the full history and is the real,
+# non-bypassable gate. This hook only shortens the feedback loop.
+#
+# Rush installs this script into .git/hooks on `rush install` / `rush update`.
+# For the per-package npm path (cd packages/dreamux && npm install), install it
+# manually:  git config core.hooksPath common/git-hooks
+
+if ! command -v gitleaks >/dev/null 2>&1; then
+  echo "[anti-leak] gitleaks not installed — skipping local scan; CI will enforce." >&2
+  echo "[anti-leak] install: https://github.com/gitleaks/gitleaks#installing" >&2
+  exit 0
+fi
+
+repo_root=$(git rev-parse --show-toplevel)
+
+if ! gitleaks protect --staged \
+  --config "$repo_root/.gitleaks.toml" \
+  --redact --exit-code 1 -v; then
+  echo "[anti-leak] gitleaks flagged a potential secret in your staged changes." >&2
+  echo "[anti-leak] Remove it before committing — this is a public repo." >&2
+  exit 1
+fi


### PR DESCRIPTION
## Why

`excitedjs/dreamux` is a **public** open-source repo developed alongside
company-internal tooling. Company-internal content — Feishu identifiers
(`ou_`/`oc_`/`cli_`), internal tokens/secrets, private-mirror registry URLs,
internal hostnames — must never reach a commit. A leaked commit is public and
permanent (forks, mirrors, caches survive a later deletion).

## What this adds

A layered guardrail:

- **`.gitleaks.toml`** — gitleaks `useDefault` ruleset (private keys, generic
  high-entropy secrets, cloud tokens) + generic Feishu id/credential formats.
  No real values, so the config is itself safe to commit.
- **`.npmrc`** — pins the public npm registry so `install` never resolves
  through (or records) a private mirror in the lockfile.
- **`common/git-hooks/pre-commit`** — `gitleaks protect --staged` against the
  staged diff. Warn-and-passes when gitleaks isn't installed (CI is the real
  gate). Rush installs hooks from `common/git-hooks/` on `rush install`/`update`
  — the idiomatic monorepo home, no husky / root `package.json` needed.
- **CI job `gitleaks`** (`.github/workflows/ci.yml`) — `gitleaks detect` over
  the **full** git history (`fetch-depth: 0`, includes the committed lockfile)
  with `--exit-code 1`. The pinned gitleaks binary (`8.30.1`) is downloaded
  directly rather than via `gitleaks-action` (which needs an org license key
  and hides the command); the invocation is kept identical to the hook's.
- **Docs** — the red line is added to `CLAUDE.md` ("Always-binding engineering
  rules") and rationale is recorded in `.agents/decisions/0004-anti-leak-guardrail.md`.

## Verification (done locally before opening this PR)

- `gitleaks 8.30.1 detect` over the full history with this config → **`no leaks
  found`** (3 commits, incl. the committed `package-lock.json`).
- **No false positive** on the lockfile's 183 `sha512` integrity hashes — the
  generic high-entropy rule does not trip on them.
- All 183 `resolved` URLs in the committed lockfile point at
  `registry.npmjs.org` — no private mirror already baked into public history.
- Hook tested both ways: clean staged tree passes; a planted synthetic
  `ou_…` id is blocked (`feishu-open-id` rule, redacted output, exit 1).
- `.agents/scripts/check.sh` passes; `ci.yml` is valid YAML.

## Notes for the reviewer

- **`.gitleaks.toml` and `.npmrc` are a shared canonical kept byte-identical
  with the claudemux repo.** Don't edit them in only one repo. If gitleaks ever
  false-positives, stop and sync the fix across both repos rather than adding a
  one-sided allowlist.
- **"Non-bypassable" still needs branch protection.** The workflow runs the
  scan, but making it a hard gate requires enabling the `gitleaks` job as a
  **required status check** in the repo's branch-protection settings — the
  workflow file alone can be merged around.
- The hook auto-installs only on the rush path; the per-package npm path opts
  in with `git config core.hooksPath common/git-hooks`. CI covers either way.