### PR TITLE
Scaffold npm release pipeline (OIDC trusted publishing, monorepo-wide)

### DIFF
--- a/.agents/decisions/0005-npm-release-oidc.md
+++ b/.agents/decisions/0005-npm-release-oidc.md
@@ -1,0 +1,108 @@
+# 0005 — npm release via OIDC trusted publishing
+
+- **Status:** Accepted (scaffolding; unexecutable until a publishable package builds)
+- **Date:** 2026-05-30
+- **Affects:** npm publishing of every `shouldPublish` package, `/.github/workflows/`, the rush version mechanism
+- **PR / Issue:** infra/feishu-transport-release
+
+## Context
+
+The monorepo publishes more than one package to the public npm registry (the
+`@excitedjs/dreamux` CLI today; `@excitedjs/feishu-transport` and others as they
+are re-homed). We want **zero long-lived npm tokens**: npm's OIDC trusted
+publishing (GA 2025-07-31) lets a GitHub Actions job exchange its short-lived
+OIDC id-token for a publish token, and stamps build **provenance**. The
+reference flow exists in the sibling **claudemux** repo, but it is pnpm +
+changesets; dreamux is a Rush + pnpm monorepo, so the version+publish half has
+to be rush-native — and the publish must span every publishable package.
+
+Three hard constraints shaped the design:
+
+- **`rush publish` cannot do OIDC.** Confirmed against Rush 5.140.0:
+  `rush publish` has no `--provenance` flag and authenticates only via
+  `--npm-auth-token` / `common/config/rush/.npmrc-publish` (a token). It cannot
+  do tokenless OIDC or emit provenance.
+- **npm trusted publishing is per-package; `npm publish` is per-package.** Each
+  package is configured on npmjs.com individually. But one workflow *run* can
+  publish many packages: each `npm publish` does its own OIDC exchange, so every
+  package just lists the same workflow file as its trusted publisher.
+- **Main is protected.** The anti-leak guardrail (decision 0004) makes the
+  `gitleaks` check required on `main`, so CI cannot push a version-bump commit
+  straight to `main` with the default `GITHUB_TOKEN`.
+
+## Decision
+
+Two workflows, both `push: [main]`:
+
+- **`/.github/workflows/release.yml`** — the OIDC publish, and the single
+  workflow every publishable package registers as its trusted publisher. A plan
+  step enumerates `rush list --json` projects with `shouldPublish: true` and
+  **classifies each against npm into three states**: *published* (skip),
+  *new version of an existing package* (publish), or *never published* (skip +
+  warn — its first publish needs a one-time token bootstrap, see below). It then
+  loops `npm publish --provenance --access public` over the publish set (one
+  OIDC exchange per package). A non-404 lookup error (network / 5xx / auth)
+  fails the job loudly rather than being read as "not published". `id-token:
+  write`, `setup-node` `registry-url`, `npm install -g npm@11.5.1`, no
+  `NODE_AUTH_TOKEN`. No-ops (green) when nothing is ready to publish.
+- **`/.github/workflows/version.yml`** — the rush-native replacement for
+  `changeset version`. On merge to `main` it runs `rush publish --apply`
+  (consumes `common/changes/*` into package.json + CHANGELOG bumps across all
+  changed packages; no registry contact, no token) and opens a "version
+  packages" PR rather than pushing to protected `main`.
+
+So **Rush owns versioning, npm owns the OIDC upload**, and both halves are
+monorepo-wide.
+
+## Consequences
+
+- **Required setup the npm account owner must do** (per package, cannot be done
+  from the repo): for *each* package this pipeline should publish, register a
+  trusted publisher on npmjs.com — owner `excitedjs`, repository
+  `excitedjs/dreamux`, workflow **`release.yml`** (the same file for every
+  package), environment blank. Adding a package later = a rush.json entry + one
+  npm entry; no workflow change.
+- **Any push/merge is always safe — a never-published package is skipped, not
+  failed.** The plan step's three-state classification means a `shouldPublish`
+  package that does not exist on npm yet (e.g. `@excitedjs/dreamux`,
+  `shouldPublish: true`, v0.1.0, currently 404) is **skipped with a warning**,
+  not pushed through a doomed `npm publish`. So merging this PR — and every
+  later push — is green by default. The package is picked up automatically once
+  it has been bootstrapped (see next bullet); no `shouldPublish: false` toggle
+  is needed (and that toggle would be wrong anyway — it also drops the package
+  from `version.yml`'s `rush publish --apply` bumping). Classification reads
+  the registry only, so a misconfigured trusted publisher is **not** mistaken
+  for "absent": such a package exists on npm, so it is queued and its
+  `npm publish` fails loudly — which is the correct signal.
+- **First publish of any package is a one-time token bootstrap, not OIDC.** npm's
+  trusted-publisher config lives on a package's settings page, which exists only
+  after the package has been published once — so the *first* publish of each
+  package (dreamux, feishu-transport, …) must be a manual `npm publish` with a
+  token to create it; only then can the trusted publisher be configured and
+  `release.yml` (pure OIDC) take over from the next version. Confirmed from the
+  sibling **claudemux** repo: `@excitedjs/tm`'s only version (1.1.0) carries no
+  provenance despite `claudemux-release.yml` using `--provenance`, and the OIDC
+  workflow (PR #150) landed *after* the package was first published (PR #148).
+- **Per-package requirements** for a green publish: `shouldPublish: true` in
+  rush.json; a build (`npm run build` → `dist`) + a `files` allowlist (`prepack`
+  recommended so `npm pack` == CI output); a `repository` field pointing at
+  github.com/excitedjs/dreamux (npm provenance requires it); and no `workspace:`
+  protocol deps (`npm publish` does not rewrite them, unlike `pnpm publish`).
+- **Optional hardening:** run the publish in a protected GitHub Environment with
+  required reviewers (commented in the workflow); if enabled it must match the
+  npm trusted-publisher Environment field of every package.
+- The version workflow self-breaks its trigger loop: the version PR's merge
+  carries no new change files, so the next `rush publish --apply` is a no-op
+  (verified locally with an empty `common/changes/`).
+
+## Alternatives considered
+
+- **`rush publish --publish` for the upload** — rejected: no provenance,
+  token-only auth, incompatible with OIDC tokenless.
+- **Per-package release workflows** — rejected: N near-identical files that
+  drift, fighting Rush's coordinated monorepo model. One looping workflow scales
+  by adding a rush.json entry + one npm config. Revisit only if a package needs
+  different release governance (its own environment / reviewers).
+- **Single-run version+publish that pushes the bump to `main`** (the claudemux
+  shape) — rejected: needs a GitHub App token to push to protected `main`; the
+  version-PR model needs no extra secret.

--- a/.agents/root.md
+++ b/.agents/root.md
@@ -56,5 +56,6 @@ issues:
 | rename or restructure the public CLI / package | [`decisions/0002-cli-and-package-naming.md`](decisions/0002-cli-and-package-naming.md) |
 | add / change a global config key (`~/.dreamux/config.toml`) | [`decisions/0003-global-config-dir.md`](decisions/0003-global-config-dir.md) |
 | touch the anti-leak guardrail (`.gitleaks.toml`, `.npmrc`, CI / hook) | [`decisions/0004-anti-leak-guardrail.md`](decisions/0004-anti-leak-guardrail.md) |
+| touch npm publishing / the release workflows | [`decisions/0005-npm-release-oidc.md`](decisions/0005-npm-release-oidc.md) |
 | write a new decision record / new component doc | [`CONTRIBUTING.md`](CONTRIBUTING.md) |
 | modify the server runtime / Codex protocol handling | the issue links above + read the source — runtime details aren't yet promoted to the KB |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,168 @@
+# Release the monorepo's publishable packages to npm via OIDC trusted publishing.
+#
+# Monorepo-wide: on every push to main this job classifies each Rush project
+# with shouldPublish=true against npm and acts per state, so any push/merge is
+# always safe (it never fails just because a package isn't ready):
+#   - already published (name@version exists)      -> skip
+#   - new version of an existing package           -> publish via OIDC
+#   - never published at all (the package 404s)    -> SKIP + warn: its first
+#       publish must be a one-time manual token bootstrap (see below), after
+#       which this workflow takes over from the next version
+# A non-404 npm lookup error (network / 5xx / auth) fails the job loudly rather
+# than being mistaken for "not published". One workflow run can publish several
+# packages — npm does a fresh OIDC token exchange per `npm publish`, validated
+# against THAT package's trusted-publisher config.
+#
+# This is the workflow every publishable package must register as its trusted
+# publisher (npmjs.com -> package Settings -> Trusted Publisher):
+#   Provider:   GitHub Actions
+#   Owner:      excitedjs
+#   Repository: excitedjs/dreamux
+#   Workflow:   release.yml          <-- this file's name (same for EVERY package)
+#   Environment: (leave blank — none configured; see the commented block below)
+# Each package is configured separately on npm, but they all point at this one
+# file. Add a package -> register it in rush.json (shouldPublish: true) + add one
+# npm trusted-publisher entry pointing here. No workflow change needed.
+#
+# No long-lived npm token. npm 11.5.1+ detects the GitHub Actions OIDC
+# environment and exchanges the short-lived id-token for a publish token
+# automatically — so there is NO NODE_AUTH_TOKEN / NPM_TOKEN anywhere.
+#
+# Per-package requirements for a successful publish (enforce as packages land):
+#   - registered in rush.json with shouldPublish: true;
+#   - a build (npm run build -> dist) + a `files` allowlist (a `prepack` that
+#     builds is recommended so `npm pack` == CI output);
+#   - a package.json `repository` field pointing at github.com/excitedjs/dreamux
+#     (npm provenance requires it);
+#   - no `workspace:` protocol deps — `npm publish` does NOT rewrite them
+#     (unlike `pnpm publish`); depend only on published versions;
+#   - its own npm trusted-publisher entry (above), or the publish fails loudly.
+#   - FIRST publish is a one-time manual/token bootstrap. npm's trusted-publisher
+#     config lives on a package's settings page, which exists only AFTER the
+#     package is published once. So publish v1 manually with a token to create
+#     the package, then configure the trusted publisher; this workflow (pure
+#     OIDC) takes over from the next version. (Confirmed via the sibling
+#     claudemux repo: @excitedjs/tm's first version was a token bootstrap — it
+#     carries no provenance, and the OIDC workflow landed after it.)
+
+name: release
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+concurrency:
+  group: release
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    name: publish changed packages to npm (OIDC trusted publishing)
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: read   # checkout only
+      id-token: write  # OIDC token for npm trusted publishing
+    # Hardening (optional, recommended): run the publish in a protected GitHub
+    # Environment with required reviewers, so a real npm publish needs human
+    # approval even on a push to main. If you enable this, create the
+    # environment in repo Settings and also set the same name in the npm
+    # trusted-publisher "Environment" field of every package.
+    # environment: npm-publish
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          # OIDC tokenless trusted publishing needs Node >= 22.14.0; '22'
+          # resolves to the latest 22.x on GitHub-hosted runners (always above
+          # that). registry-url writes the npmjs registry into .npmrc.
+          node-version: '22'
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Plan — classify each publishable package against npm
+        id: plan
+        run: |
+          # Enumerate every Rush project with shouldPublish=true (rush list emits
+          # clean JSON on stdout; its banner goes to stderr). The plan is written
+          # to a TSV file so the loop below runs in this shell (a pipe would put
+          # the counter in a subshell and lose it).
+          node common/scripts/install-run-rush.js list --json 2>/dev/null \
+            | node -e 'let s="";process.stdin.on("data",d=>s+=d).on("end",()=>{for(const p of JSON.parse(s).projects){if(p.shouldPublish)process.stdout.write([p.name,p.version,p.path].join("\t")+"\n")}})' \
+            > "$RUNNER_TEMP/publishable.tsv"
+
+          # Classify a package without conflating a real 404 with a transient
+          # failure. Echoes one of: absent | published | new-version. Returns 1
+          # (fails the job) on any npm error that is NOT an E404 — network, 5xx,
+          # auth — so a flaky lookup can never be mistaken for "not published".
+          # `npm view` reads the registry independently of publish auth, so a
+          # missing/misconfigured trusted publisher never shows up here as a 404;
+          # it would surface later as a loud `npm publish` failure, as it should.
+          classify() {
+            local name="$1" version="$2" out
+            if ! out="$(npm view "$name" version 2>&1)"; then
+              if printf '%s\n' "$out" | grep -q 'E404'; then echo absent; return 0; fi
+              printf '::error::npm view %s failed (not an E404): %s\n' "$name" "$out" >&2
+              return 1
+            fi
+            if out="$(npm view "$name@$version" version 2>&1)"; then echo published; return 0; fi
+            if printf '%s\n' "$out" | grep -q 'E404'; then echo new-version; return 0; fi
+            printf '::error::npm view %s@%s failed (not an E404): %s\n' "$name" "$version" "$out" >&2
+            return 1
+          }
+
+          : > "$RUNNER_TEMP/to-publish.tsv"
+          count=0
+          while IFS="$(printf '\t')" read -r name version path; do
+            [ -z "$name" ] && continue
+            # A non-E404 npm error returns 1 here and fails the whole job, by
+            # design — never silently skip a package on a flaky lookup.
+            state="$(classify "$name" "$version")" || exit 1
+            case "$state" in
+              published)
+                echo "::notice::$name@$version is already on npm — skip." ;;
+              absent)
+                # Never published: skip (so a merge / push stays green) and warn.
+                # Its first publish must be a one-time manual token bootstrap;
+                # this OIDC workflow takes over from the next version. See header.
+                echo "::warning::$name has never been published — skipping (merge/push stays green). First publish must be a one-time manual token bootstrap (npm publish v1 with a token to create the package), then configure its npm trusted publisher; this workflow takes over from the next version." ;;
+              new-version)
+                echo "::notice::$name@$version is a new version of an existing package — queueing."
+                printf '%s\t%s\t%s\n' "$name" "$version" "$path" >> "$RUNNER_TEMP/to-publish.tsv"
+                count=$((count + 1)) ;;
+            esac
+          done < "$RUNNER_TEMP/publishable.tsv"
+          echo "count=$count" >> "$GITHUB_OUTPUT"
+          if [ "$count" -eq 0 ]; then
+            echo "::notice::No existing package has an unpublished version — nothing to publish."
+          fi
+
+      - name: Upgrade npm for OIDC trusted publishing
+        if: steps.plan.outputs.count != '0'
+        # Two npm thresholds matter:
+        #   >= 9.6.0  — `--provenance` (attestation; still needs a token)
+        #   >= 11.5.1 — OIDC tokenless trusted publishing (GA 2025-07-31): npm
+        #               exchanges the GitHub OIDC token for a short-lived publish
+        #               token, no NODE_AUTH_TOKEN. Node 22 LTS ships npm 10.x,
+        #               below this — so pin the exact version that introduced it.
+        run: npm install -g npm@11.5.1
+
+      - name: Build (rush, monorepo-aware — one pass for all packages)
+        if: steps.plan.outputs.count != '0'
+        run: |
+          node common/scripts/install-run-rush.js install
+          node common/scripts/install-run-rush.js build
+
+      - name: Publish each queued package (OIDC trusted publishing)
+        if: steps.plan.outputs.count != '0'
+        run: |
+          # One `npm publish` per package — each does its own OIDC exchange,
+          # validated against that package's npm trusted-publisher config. No
+          # NODE_AUTH_TOKEN: npm 11.5.1+ uses the GitHub Actions OIDC token.
+          while IFS="$(printf '\t')" read -r name version path; do
+            [ -z "$name" ] && continue
+            echo "::group::Publishing $name@$version ($path)"
+            ( cd "$path" && npm publish --provenance --access public )
+            echo "::endgroup::"
+          done < "$RUNNER_TEMP/to-publish.tsv"

--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -1,0 +1,92 @@
+# Version packages with Rush, the protected-main-safe way.
+#
+# This is the rush-native replacement for `changeset version`, and it is
+# monorepo-wide: `rush publish --apply` bumps every package that has pending
+# change files, not any single package. Instead of pushing a bump commit
+# straight to main (which a protected main with the required gitleaks check
+# would reject), it opens a "version packages" PR:
+#   contributors run `rush change` on their feature PRs (creates change files
+#   under common/changes/);  on merge to main this job runs `rush publish
+#   --apply` to consume those change files into package.json + CHANGELOG bumps,
+#   and raises a PR with the result. A maintainer merges that PR, and the push
+#   to main triggers release.yml, which publishes the new versions via OIDC.
+#
+# The loop is self-breaking: the version PR's own merge carries no new change
+# files, so the next run's `rush publish --apply` produces no diff and no-ops.
+#
+# SCAFFOLDING: with no change files this job no-ops on every push to main —
+# verified locally: `rush publish --apply` exits clean and leaves the tree
+# unchanged when common/changes/ is empty.
+
+name: version packages
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+concurrency:
+  group: version-packages
+  cancel-in-progress: false
+
+jobs:
+  version:
+    name: apply rush change files -> version PR
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: write       # push the release branch (a feature branch, not main)
+      pull-requests: write  # open / update the version PR
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22.x'
+
+      - name: Apply pending change files (rush)
+        id: apply
+        run: |
+          node common/scripts/install-run-rush.js install
+          # --apply consumes common/changes/*.json into package.json + CHANGELOG
+          # bumps and deletes the change files. No --publish, so nothing is sent
+          # to the registry and no npm token is involved.
+          node common/scripts/install-run-rush.js publish --apply
+          # Scope the change check to the version artifacts only: package.json /
+          # CHANGELOG bumps under packages/ and consumed change files under
+          # common/changes/. This deliberately ignores `rush install` byproducts
+          # (e.g. a freshly generated common/config/rush/pnpm-lock.yaml) so they
+          # never sneak into the version PR or produce a false "changed".
+          if [ -n "$(git status --porcelain -- packages common/changes)" ]; then
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "::notice::No pending change files — nothing to version."
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Open / update the version PR
+        if: steps.apply.outputs.changed == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          branch="release/version-packages"
+          # Public-repo identity: GitHub noreply, never an internal address.
+          git config user.name 'github-actions[bot]'
+          git config user.email 'github-actions[bot]@users.noreply.github.com'
+          git checkout -B "$branch"
+          # Stage only version artifacts (bumps + consumed change files), never
+          # install byproducts like a generated pnpm-lock.yaml.
+          git add packages common/changes
+          git commit -m "chore(release): version packages"
+          git push --force-with-lease origin "$branch"
+          if gh pr view "$branch" --json number >/dev/null 2>&1; then
+            echo "Version PR already open for $branch — updated by the force-push."
+          else
+            gh pr create \
+              --base main --head "$branch" \
+              --title "chore(release): version packages" \
+              --body "Automated by \`version.yml\`. Applies pending \`rush change\` files (package.json + CHANGELOG bumps across all changed packages). Merging this PR publishes the new versions via \`release.yml\` (OIDC)."
+          fi


### PR DESCRIPTION
Lays the npm publishing pipeline for the monorepo's packages **before** they are
re-homed. Workflow scaffolding only — no package builds yet. (Generalized from
the original feishu-transport-only version: publishes every `shouldPublish`
package, not just one.)

## Design — two workflows, both monorepo-wide

Zero long-lived npm token: npm 11.5.1+ exchanges the GitHub Actions OIDC
id-token for a short-lived publish token and stamps build provenance.

**Verified against Rush 5.140.0:** `rush publish` has **no `--provenance`** and
authenticates **only** via a token, so it cannot do tokenless OIDC. The
responsibilities are split:

| Workflow | Role |
|---|---|
| **`release.yml`** | The OIDC publish — and the single file **every** package registers as its trusted publisher. A plan step classifies each `rush list --json` `shouldPublish` project against npm (see below), then **loops** `npm publish --provenance --access public` over the publish set (one OIDC exchange per package). `id-token: write`, `setup-node` `registry-url`, `npm@11.5.1`, **no `NODE_AUTH_TOKEN`**. |
| **`version.yml`** | Rush-native replacement for `changeset version`. `rush publish --apply` bumps every changed package and opens a **version PR** (not a push to protected `main`). |

**Rush owns versioning; npm owns the OIDC upload.** One run can publish N
packages — npm validates each publish's OIDC token against that package's own
trusted-publisher config. Rationale + alternatives in
`.agents/decisions/0005-npm-release-oidc.md`.

## Merge is always safe — the pipeline self-adapts (this round's fix)

The plan step classifies each publishable package into **three states** so a
push/merge never fails just because a package isn't ready:

| State (`npm view`) | Meaning | Action |
|---|---|---|
| `name@version` exists | already published | skip |
| `name` exists, `@version` 404s | new version of an existing package | **publish via OIDC** |
| `name` itself 404s | never published | **skip + `::warning::` (needs bootstrap)** |
| any **non-E404** error (network / 5xx / auth) | flaky lookup | **fail the job loudly** — never mistaken for "not published" |

So merging this PR is green by default. `@excitedjs/dreamux` (`shouldPublish`,
not on npm yet) is **skipped with a warning**, not a doomed publish — and it's
picked up automatically once bootstrapped. (No `shouldPublish: false` toggle
needed; that would be wrong anyway — it also drops the package from `version.yml`
bumping.) Classification reads the registry only, so a *misconfigured* trusted
publisher isn't confused with *absent*: the package exists, so it's queued and
its `npm publish` fails loudly — the correct signal.

> Verified against the real registry: `@excitedjs/dreamux@0.1.0` → absent,
> `@excitedjs/tm@1.1.0` → published, `@excitedjs/tm@9.9.9` → new-version, and an
> unreachable registry → `ECONNREFUSED` correctly **not** treated as a 404.

## Required setup — only you (npm account owner) can do this

**1. First publish of each package is a one-time token bootstrap, not OIDC.**
npm's trusted-publisher config lives on a package's settings page, which exists
only **after** the package is published once. So each package's *first* publish
is a manual `npm publish` with a token to create it; then configure the trusted
publisher and `release.yml` (pure OIDC) takes over from the next version.
(Confirmed via claudemux: `@excitedjs/tm`'s only version carries **no
provenance** despite its `--provenance` workflow, and that OIDC workflow landed
*after* the package's first publish.)

**2. Trusted publisher per package** — for **each** package, on **npmjs.com** →
package → Settings → Trusted Publisher:

| Field | Value |
|---|---|
| Provider | **GitHub Actions** |
| Organization / owner | `excitedjs` |
| Repository | `excitedjs/dreamux` |
| Workflow filename | **`release.yml`** (same for every package) |
| Environment | *(leave blank)* |

## Notes for the reviewer

- **Unexecutable end-to-end until a package builds** — validated offline: both
  workflows pass YAML + **`actionlint`** (shellcheck on the `run:` scripts); the
  plan's `rush list --json` → TSV one-liner and the three-state npm
  classification were both run against the real repo/registry; `rush publish
  --apply` confirmed to no-op on an empty `common/changes/`.
- **Per-package readiness** (in `release.yml` + ADR): `shouldPublish: true`;
  a build + `files` allowlist (`prepack` recommended); a `repository` field
  (provenance requires it); no `workspace:` protocol deps (`npm publish` doesn't
  rewrite them).
- **Optional hardening (your call):** commented `environment: npm-publish` block
  — gate real publishes behind required reviewers; if enabled it must match the
  npm trusted-publisher Environment field of every package.

Renamed from `feishu-transport-release.yml` / `feishu-transport-version.yml` to
the monorepo-level `release.yml` / `version.yml`. Rebased on `main` (guardrail
PR #1 is merged). Public-repo rules kept: GitHub noreply identity, no internal
content, no co-author trailer.

Opened for your review — **not merged.**