### PR TITLE
Settle the install model (monorepo-only) — finish the #4 channel refactor

### DIFF
--- a/.agents/components/repo-structure.md
+++ b/.agents/components/repo-structure.md
@@ -1,8 +1,18 @@
 # Component: repo structure
 
-Rush + pnpm monorepo since issue #4. The `@excitedjs/dreamux` package
-under `/packages/dreamux/` is the only project today, but the layout is
-ready for additional packages without a second restructure.
+Rush + pnpm monorepo since issue #4. Three packages today, all wired
+through pnpm `workspace:*` and installed via the rush path only (see
+[decision 0006](../decisions/0006-install-model.md)):
+
+| Package | Folder | Role |
+|---|---|---|
+| `@excitedjs/dreamux` | `/packages/dreamux/` | the host server |
+| `@excitedjs/feishu-transport` | `/packages/channel/feishu-transport/` | platform-I/O core; **sole** importer of `@larksuiteoapi/node-sdk` |
+| `@excitedjs/feishu-channel` | `/packages/channel/feishu-channel/` | per-host channel layer (placeholder today) |
+
+The channel refactor (#4) extracted the Feishu platform I/O out of the
+dreamux host into `@excitedjs/feishu-transport`, so the host and the
+sibling claudemux repo import one implementation instead of drifting copies.
 
 ## Top-level
 
@@ -30,7 +40,7 @@ verbatim through the move):
 | `src/codex/` | Codex WS+Unix JSON-RPC client, supervisor, turn collector, init handshake |
 | `src/db/` | SQLite schema + repository |
 | `src/dispatcher/` | DispatcherRuntime, TurnManager, fail-fast approval handler |
-| `src/feishu/` | Bot adapter, content / render (copied verbatim from claudemux) |
+| `src/feishu/` | Thin bot adapter over `@excitedjs/feishu-transport` (`createFeishuTransport` + `parseInbound`); the drifted in-tree `content`/`render`/`types` copies were deleted by #4 |
 | `src/runtime/` | Path builders, env-only secrets, codex-args parser |
 | `src/server.ts` | Top-level `Server` class wiring everything together |
 | `db/migrations/0001_init.sql` | Initial SQLite schema |
@@ -38,17 +48,21 @@ verbatim through the move):
 | `bin/server`, `bin/server-ctl` | Backward-compat aliases shipped before the monorepo split |
 | `tests/` | vitest: smoke (16), bin-launcher (8), codex-0134-live (4) |
 
-## Two installation paths
+## Installation — the rush path only
 
-| Method | When |
-|---|---|
-| `cd packages/dreamux && npm install && npm test` | Single-package workflow; matches pre-monorepo muscle memory |
-| `node common/scripts/install-run-rush.js update` then `rush build && rush test` | Monorepo workflow; required once a second package lands |
+```bash
+node common/scripts/install-run-rush.js update   # then build / test
+node common/scripts/install-run-rush.js build
+node common/scripts/install-run-rush.js test
+```
 
-Both paths must keep working. CI runs the rush path; per-package
-package-lock.json is kept committed so the npm path stays reproducible.
-See [decision 0001](../decisions/0001-rush-pnpm-monorepo.md) for the
-rationale.
+The per-package `cd packages/dreamux && npm install` path is **retired**:
+`@excitedjs/dreamux` now depends on `@excitedjs/feishu-transport` via the
+pnpm `workspace:*` protocol, which `npm` cannot resolve. There is no
+committed per-package `package-lock.json`. External consumers are
+unaffected — pnpm rewrites `workspace:*` to a real version at publish time.
+See [decision 0006](../decisions/0006-install-model.md) (which retires the
+two-paths consequence of [decision 0001](../decisions/0001-rush-pnpm-monorepo.md)).
 
 ## Public surface
 

--- a/.agents/decisions/0001-rush-pnpm-monorepo.md
+++ b/.agents/decisions/0001-rush-pnpm-monorepo.md
@@ -48,6 +48,10 @@ Concrete shape:
   a future decision retires one. Per-package `package-lock.json` files
   stay committed so the npm path is reproducible; `pnpm-lock.yaml` lives
   in `common/config/rush/` once `rush update` runs.
+  > **Superseded (2026-05-31) by [decision 0006](0006-install-model.md).**
+  > The channel refactor (#4) introduced a `workspace:*` dependency that
+  > `npm` cannot resolve, so the per-package npm path is retired and the
+  > monorepo rush path is now the only supported one.
 - Adding a package = drop it in `packages/<name>/`, register in
   `rush.json`, run `rush update`. No other config edits.
 - First-time `rush update` will download Rush via npx (~3–5s with a warm

--- a/.agents/decisions/0004-anti-leak-guardrail.md
+++ b/.agents/decisions/0004-anti-leak-guardrail.md
@@ -50,8 +50,8 @@ Land a layered guardrail:
 - "Non-bypassable" depends on the repo owner enabling the `gitleaks` job as
   a **required status check** in branch protection; the workflow file alone
   does not enforce it.
-- The hook auto-installs only on the rush path. The per-package npm path
-  (`cd packages/dreamux && npm install`) skips it — a contributor opts in
-  with `git config core.hooksPath common/git-hooks`. CI covers either way.
+- The hook auto-installs on the rush path (`rush install` / `rush update`).
+  A contributor who hasn't run rush yet can opt in with
+  `git config core.hooksPath common/git-hooks`. CI covers either way.
 - The red line is also written into [`/CLAUDE.md`](/CLAUDE.md)
   ("Always-binding engineering rules") so every session loads it.

--- a/.agents/decisions/0006-install-model.md
+++ b/.agents/decisions/0006-install-model.md
@@ -1,0 +1,75 @@
+# 0006 — One install path: the monorepo (rush) path only
+
+- **Status:** Accepted
+- **Date:** 2026-05-31
+- **Affects:** install workflow, CI, `CLAUDE.md`, `README.md`, every package's `package.json`
+- **PR / Issue:** channel refactor [#4](https://github.com/excitedjs/dreamux/issues/4); this record completes its install-model decision.
+
+## Context
+
+[Decision 0001](0001-rush-pnpm-monorepo.md) committed the repo to keeping
+**two** install paths working "until a future decision retires one":
+
+1. **Per-package** — `cd packages/dreamux && npm install && npm test`, backed
+   by a committed `packages/dreamux/package-lock.json`.
+2. **Monorepo** — `rush update` / `rush build` / `rush test`.
+
+The channel refactor (#4) made path 1 unworkable. `@excitedjs/dreamux` now
+depends on the freshly-extracted `@excitedjs/feishu-transport` via the pnpm
+`workspace:*` protocol. `npm` does not understand `workspace:*`, so
+`npm install` / `npm ci` inside `packages/dreamux/` can no longer resolve the
+dependency graph. The WIP that merged #4 therefore **deleted**
+`packages/dreamux/package-lock.json` (it cannot be regenerated while a
+`workspace:*` dep is present) and left the contradiction unresolved — the CI
+`package` job (`npm ci`) was left broken and `CLAUDE.md`'s "two install paths"
+rule was left violated. This record settles it.
+
+By the time this was decided, `@excitedjs/feishu-transport@0.0.1` and
+`@excitedjs/dreamux@0.1.1` were already published to npm, so the
+publish-blocker that #4 was waiting on is gone; the only open question was
+which install model to keep.
+
+## Decision
+
+**Keep only the monorepo (rush) path. Retire the per-package npm path.**
+
+- `package.json` dependencies stay on `workspace:*` — the correct idiom for a
+  rush `useWorkspaces: true` repo, and what pnpm already rewrites to a real
+  version (`@excitedjs/feishu-transport: 0.0.1`) in the **published** manifest.
+- No per-package `package-lock.json` is committed.
+- CI's `package` job (`npm ci`) is removed; its typecheck/build/test coverage
+  moves into the `rush` job, which now runs `rush update` → `rush build` →
+  `rush test` (`DREAMUX_SKIP_LIVE_CODEX=1`, no codex binary on the runner).
+
+Path 1 was always framed as "pre-monorepo muscle memory." Decision 0001 itself
+made the monorepo path "required once a second package lands"; three packages
+now exist, so retiring path 1 is the natural close-out, not a new constraint.
+
+## Consequences
+
+- **External consumers are unaffected.** `workspace:*` is a source-only
+  protocol; pnpm rewrites it to the real published version at publish time, so
+  `npm install @excitedjs/dreamux` resolves `@excitedjs/feishu-transport`
+  normally. Verified against the published `@excitedjs/dreamux@0.1.1` manifest.
+- **In-repo build/test is rush-only.** `cd packages/dreamux && npm install` now
+  fails by design. Use `node common/scripts/install-run-rush.js update` first.
+- **Foot-gun:** don't re-add a per-package `package-lock.json` or a `package`
+  CI job — `npm` cannot lock a `workspace:*` graph, so either would reintroduce
+  the exact breakage this record removes.
+- **Guards:** the `rush` CI job is the authoritative install/build/test gate;
+  `CLAUDE.md`, `README.md`, and `components/repo-structure.md` all describe the
+  single path; this record supersedes the "two paths" consequence of 0001.
+
+## Alternatives considered
+
+- **(b) Pin to the published version + regenerate a per-package lockfile.**
+  Replace `workspace:*` with `@excitedjs/feishu-transport: ^0.0.1` and commit a
+  fresh `packages/dreamux/package-lock.json` so `npm ci` works again. Rejected:
+  it abandons the `workspace:*` idiom, couples every core version bump to a
+  dreamux relock, and risks the in-repo build silently resolving the *published*
+  core from npm instead of the local workspace source — defeating the point of
+  the monorepo. `workspace:*` already links the local package (verified: the
+  symlink `packages/dreamux/node_modules/@excitedjs/feishu-transport →
+  ../../../channel/feishu-transport`).
+- **Keep both paths.** Not possible: one `package.json` dependency string cannot
+  be both `workspace:*` (for pnpm) and a registry range (for npm) at once.

--- a/.agents/root.md
+++ b/.agents/root.md
@@ -23,11 +23,15 @@ issues:
 ├── rush.json                      rush + pnpm config
 ├── common/                        rush scaffolding (config + bootstrap)
 ├── packages/
-│   └── dreamux/                   @excitedjs/dreamux — the only package today
-│       ├── bin/                   dreamux / server / server-ctl launchers
-│       ├── src/                   admin, cli, codex, db, dispatcher, feishu, runtime
-│       ├── tests/                 vitest (smoke + live-codex + bin-launcher)
-│       └── db/migrations/         SQLite schema migrations
+│   ├── dreamux/                   @excitedjs/dreamux — the host server
+│   │   ├── bin/                   dreamux / server / server-ctl launchers
+│   │   ├── src/                   admin, cli, codex, db, dispatcher, feishu, runtime
+│   │   ├── tests/                 vitest (smoke + live-codex + bin-launcher)
+│   │   └── db/migrations/         SQLite schema migrations
+│   └── channel/
+│       ├── feishu-transport/      @excitedjs/feishu-transport — platform-I/O core
+│       │                          (sole @larksuiteoapi/node-sdk importer)
+│       └── feishu-channel/        @excitedjs/feishu-channel — channel layer (placeholder)
 ├── bin/                           thin redirectors → packages/dreamux/bin/
 ├── .agents/                       this knowledge base
 ├── .github/workflows/             CI
@@ -53,6 +57,7 @@ issues:
 |---|---|
 | add/change a package, move source between packages | [`components/repo-structure.md`](components/repo-structure.md) |
 | understand why rush + pnpm | [`decisions/0001-rush-pnpm-monorepo.md`](decisions/0001-rush-pnpm-monorepo.md) |
+| install / build / test the repo, or wonder why `npm ci` is gone | [`decisions/0006-install-model.md`](decisions/0006-install-model.md) |
 | rename or restructure the public CLI / package | [`decisions/0002-cli-and-package-naming.md`](decisions/0002-cli-and-package-naming.md) |
 | add / change a global config key (`~/.dreamux/config.toml`) | [`decisions/0003-global-config-dir.md`](decisions/0003-global-config-dir.md) |
 | touch the anti-leak guardrail (`.gitleaks.toml`, `.npmrc`, CI / hook) | [`decisions/0004-anti-leak-guardrail.md`](decisions/0004-anti-leak-guardrail.md) |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,7 +63,7 @@ jobs:
     #
     # `gitleaks detect` scans the whole git history, so it catches a secret
     # even if it was added and then "fixed" in a later commit; fetch-depth: 0
-    # gives the job that full history (incl. the committed package-lock.json).
+    # gives the job that full history (incl. the committed pnpm-lock.yaml).
     # The gitleaks binary is pinned and downloaded directly rather than via
     # gitleaks-action, which needs a license key for org repos and would hide
     # the exact command — kept identical to the local hook's invocation.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,15 +1,16 @@
 # CI for the dreamux monorepo (issue #4).
 #
 # Jobs:
-#   - package — typecheck, build, vitest against the per-package npm path
-#     (matches `cd packages/dreamux && npm install && npm test`)
+#   - rush — bootstrap, build, and test the whole workspace via the monorepo
+#     path (the single supported install path — see decision 0006). This
+#     replaces the old per-package `npm ci` job, which cannot resolve the
+#     `workspace:*` dependency that landed with the channel refactor (#4).
 #   - kb — validate the .agents/ knowledge base (link / orphan check)
-#   - rush — bootstrap & build smoke test of the monorepo path
 #   - gitleaks — secret scan over the full git history (anti-leak guardrail)
 #
 # The rush bootstrap (`node common/scripts/install-run-rush.js update`) is
-# intentionally exercised in CI too, in a separate job, so a broken
-# rush.json fails CI rather than waiting for the next contributor's
+# the only way to install a `workspace:*` graph, so a broken rush.json or
+# lockfile fails CI here rather than waiting for the next contributor's
 # `rush update` to discover it.
 
 name: ci
@@ -21,29 +22,6 @@ on:
     branches: [main]
 
 jobs:
-  package:
-    name: package — typecheck / build / test
-    runs-on: ubuntu-latest
-    timeout-minutes: 15
-    defaults:
-      run:
-        working-directory: packages/dreamux
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
-        with:
-          node-version: '22.x'
-          cache: npm
-          cache-dependency-path: packages/dreamux/package-lock.json
-      - run: npm ci
-      - run: npm run typecheck
-      - run: npm run build
-      - run: npm test
-        env:
-          # No codex binary on the CI runner; opt-in skip with the loud
-          # warning (rather than silent skip — see tests/codex-0134-live.test.ts).
-          DREAMUX_SKIP_LIVE_CODEX: '1'
-
   kb:
     name: knowledge base — link & orphan check
     runs-on: ubuntu-latest
@@ -54,7 +32,7 @@ jobs:
         run: ./.agents/scripts/check.sh
 
   rush:
-    name: rush — bootstrap & build (smoke)
+    name: rush — bootstrap / build / test
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
@@ -66,6 +44,12 @@ jobs:
         run: node common/scripts/install-run-rush.js update
       - name: rush build
         run: node common/scripts/install-run-rush.js build
+      - name: rush test
+        run: node common/scripts/install-run-rush.js test
+        env:
+          # No codex binary on the CI runner; opt-in skip with the loud
+          # warning (rather than silent skip — see tests/codex-0134-live.test.ts).
+          DREAMUX_SKIP_LIVE_CODEX: '1'
 
   gitleaks:
     name: gitleaks — secret scan (full history)

--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@ common/autoinstallers/*/node_modules/
 # rush per-project build/test caches and logs (transient; contain local paths)
 **/.rush/temp/
 
-# Per-package lockfiles are still committed so a developer can `cd
-# packages/<x> && npm install && npm test` without running rush at all.
-# common/config/rush/pnpm-lock.yaml is the source of truth for rush itself.
+# The only committed lockfile is common/config/rush/pnpm-lock.yaml (the source
+# of truth for the whole workspace). The per-package npm path is retired — no
+# per-package package-lock.json is committed. See
+# .agents/decisions/0006-install-model.md.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,21 +17,33 @@ fix it in the same PR.
 
 `excitedjs/dreamux` is a **Rush + pnpm monorepo** since issue #4.
 
-- `/packages/<name>/` holds publishable packages. Today: `@excitedjs/dreamux`.
+- `/packages/<name>/` holds publishable packages. Today: `@excitedjs/dreamux`
+  (the host), `@excitedjs/feishu-transport` (the platform-I/O core, sole owner
+  of the `@larksuiteoapi/node-sdk` import), and `@excitedjs/feishu-channel`
+  (per-host channel layer, a placeholder today) — see the channel refactor (#4).
 - `/rush.json`, `/common/config/rush/`, `/common/scripts/install-run-rush.js`
   are the rush + pnpm scaffolding.
 - `/bin/` shims forward to `/packages/dreamux/bin/` for backward-compat with
   pre-monorepo PATH entries — see `.agents/decisions/0002-cli-and-package-naming.md`.
 - `/.agents/` is the on-demand knowledge base. Start at `.agents/root.md`.
 
-Two install paths are supported and both must keep working:
+**One install path — the monorepo path.** Build and test through rush:
 
-1. **Per-package** (`cd packages/dreamux && npm install && npm test`) — matches
-   pre-monorepo muscle memory; per-package `package-lock.json` stays committed.
-2. **Monorepo** (`node common/scripts/install-run-rush.js update && rush build && rush test`)
-   — required once a second package exists.
+```
+node common/scripts/install-run-rush.js update   # then build / test
+node common/scripts/install-run-rush.js build
+node common/scripts/install-run-rush.js test
+```
 
-Reasoning: `.agents/decisions/0001-rush-pnpm-monorepo.md`.
+The per-package npm path (`cd packages/dreamux && npm install`) is **retired**:
+`@excitedjs/dreamux` depends on `@excitedjs/feishu-transport` via the pnpm
+`workspace:*` protocol, which `npm` cannot resolve. pnpm rewrites `workspace:*`
+to the real version at publish time, so external `npm install @excitedjs/dreamux`
+is unaffected — only the in-repo per-package path is gone. There is no committed
+per-package `package-lock.json`.
+
+Reasoning: `.agents/decisions/0006-install-model.md` (which retires the
+two-paths consequence of `.agents/decisions/0001-rush-pnpm-monorepo.md`).
 
 ## CLI surface
 

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Design background:
 | Always-loaded agent operating rules | [`CLAUDE.md`](CLAUDE.md) (`AGENTS.md` is a symlink) |
 | Monorepo layout reference | [`.agents/components/repo-structure.md`](.agents/components/repo-structure.md) |
 | Why Rush + pnpm | [`.agents/decisions/0001-rush-pnpm-monorepo.md`](.agents/decisions/0001-rush-pnpm-monorepo.md) |
+| Why the monorepo path is the only install path | [`.agents/decisions/0006-install-model.md`](.agents/decisions/0006-install-model.md) |
 | Why `@excitedjs/dreamux` + `dreamux` CLI + the two legacy aliases | [`.agents/decisions/0002-cli-and-package-naming.md`](.agents/decisions/0002-cli-and-package-naming.md) |
 
 ## Repo layout
@@ -28,37 +29,32 @@ Design background:
 ```
 /
 ├── packages/
-│   └── dreamux/           @excitedjs/dreamux — the only package today
+│   ├── dreamux/           @excitedjs/dreamux — the host server
+│   └── channel/
+│       ├── feishu-transport/   @excitedjs/feishu-transport — platform-I/O core
+│       └── feishu-channel/     @excitedjs/feishu-channel — channel layer (placeholder)
 ├── bin/                   thin forwarders → packages/dreamux/bin/
 ├── rush.json              rush + pnpm + Node version pins
 ├── common/
 │   ├── config/rush/       command-line.json, .npmrc, version-policies.json
 │   └── scripts/install-run-rush.js   minimal rush bootstrap
 ├── .agents/               on-demand knowledge base
-├── .github/workflows/     CI: package typecheck/build/test, KB check, rush smoke
+├── .github/workflows/     CI: rush build/test, KB check, gitleaks
 ├── CLAUDE.md              always-loaded operating rules
 └── AGENTS.md              symlink → CLAUDE.md
 ```
 
 ## Quick start
 
-Two install paths are supported and both work; CI exercises both.
-
-**Per-package** (matches pre-monorepo muscle memory):
-
-```bash
-cd packages/dreamux
-npm install
-npm test
-./bin/dreamux server start
-```
-
-**Monorepo** (required once a second package exists):
+The monorepo path is the single supported install path (the workspace now
+spans three packages wired with `workspace:*`, which `npm` cannot resolve —
+see [decision 0006](.agents/decisions/0006-install-model.md)):
 
 ```bash
 node common/scripts/install-run-rush.js update
 node common/scripts/install-run-rush.js build
 node common/scripts/install-run-rush.js test
+./packages/dreamux/bin/dreamux server start
 ```
 
 Full quick start, config reference, and MVP verification path are in the

--- a/common/config/rush/command-line.json
+++ b/common/config/rush/command-line.json
@@ -16,7 +16,12 @@
       "description": "Bulk-runs vitest across every package that declares a `test` script.",
       "enableParallelism": true,
       "ignoreMissingScript": true,
-      "incremental": false
+      "incremental": false,
+      // The test run legitimately writes to stderr (server logs, and the loud
+      // DREAMUX_SKIP_LIVE_CODEX skip notice). Rush otherwise treats any stderr
+      // as a warning and exits non-zero even though every test passed, which
+      // would fail CI on a green run. vitest's own exit code is what gates pass.
+      "allowWarningsInSuccessfulBuild": true
     },
     {
       "name": "typecheck",

--- a/common/git-hooks/pre-commit
+++ b/common/git-hooks/pre-commit
@@ -11,8 +11,8 @@
 # non-bypassable gate. This hook only shortens the feedback loop.
 #
 # Rush installs this script into .git/hooks on `rush install` / `rush update`.
-# For the per-package npm path (cd packages/dreamux && npm install), install it
-# manually:  git config core.hooksPath common/git-hooks
+# If your hooks aren't wired up yet, point git at this directory manually:
+#   git config core.hooksPath common/git-hooks
 
 if ! command -v gitleaks >/dev/null 2>&1; then
   echo "[anti-leak] gitleaks not installed — skipping local scan; CI will enforce." >&2

--- a/packages/channel/feishu-transport/README.md
+++ b/packages/channel/feishu-transport/README.md
@@ -25,15 +25,16 @@ The single place that imports the Feishu SDK.
 - Consumed as a **published, version-pinned package** by both repos; the two
   hosts never depend on each other.
 - Built via rush in topological order (`rush build` builds this before any
-  dependent). Standalone `npm run build` works once its own deps are installed.
+  dependent).
 
 ## Build / test
 
+Built and tested through the monorepo (rush) path — the only supported install
+path (see [decision 0006](../../../.agents/decisions/0006-install-model.md)).
+From the repo root:
+
 ```sh
-# monorepo (preferred)
 node common/scripts/install-run-rush.js update
 node common/scripts/install-run-rush.js build
-
-# per-package
-npm install && npm run build && npm test
+node common/scripts/install-run-rush.js test
 ```

--- a/packages/dreamux/README.md
+++ b/packages/dreamux/README.md
@@ -47,27 +47,19 @@ threads, tm registry isolation, cross-machine coordination, web UI.
 
 ## Install / build / test
 
-Two paths; both work, pick whichever fits the workflow.
-
-**Per-package (this directory).** Matches pre-monorepo muscle memory and
-runs the `prepare` hook (`tsc → dist/`):
-
-```bash
-cd packages/dreamux
-npm install
-npm run build       # also runs automatically via `prepare`
-npm run typecheck   # tsc --noEmit (no emit)
-npm test            # smoke + bin-launcher + (live) codex-0134 tests
-```
-
-**Monorepo (from repo root).** Required once a second package exists; CI
-exercises this path so a broken `rush.json` fails CI:
+Use the monorepo (rush) path from the repo root — it is the only supported
+install path. This package depends on `@excitedjs/feishu-transport` via the
+pnpm `workspace:*` protocol, which `npm` cannot resolve, so
+`cd packages/dreamux && npm install` no longer works (see
+[decision 0006](../../.agents/decisions/0006-install-model.md)):
 
 ```bash
 node common/scripts/install-run-rush.js update
 node common/scripts/install-run-rush.js build
 node common/scripts/install-run-rush.js test
 ```
+
+CI exercises this path, so a broken `rush.json` or lockfile fails CI.
 
 The bin launchers shell out to plain `node` against the compiled `dist/`
 output; **no `tsx` is needed at runtime** (PR #6).
@@ -204,7 +196,8 @@ JSON object stored in `dispatchers.codex_args_json`:
 ## Testing
 
 ```bash
-npm test           # smoke + bin-launcher + codex-0134-live
+# from the repo root (the only supported path — see decision 0006)
+node common/scripts/install-run-rush.js test   # smoke + bin-launcher + codex-0134-live
 ```
 
 - `tests/smoke.test.ts` — fake-codex-driven dispatcher behavior:

--- a/packages/dreamux/bin/dreamux
+++ b/packages/dreamux/bin/dreamux
@@ -2,7 +2,8 @@
 # Launcher for the unified `dreamux` CLI (issue #4).
 # Resolves its own location through symlinks so it works from any cwd and
 # via any chain of symlinks (npm-link, ~/bin shortcuts, etc.). Runs the
-# compiled dist output produced by `npm install` / `rush build`.
+# compiled dist output (built by `rush build` in a source checkout; already
+# present in the published npm package).
 set -eu
 
 SOURCE="${BASH_SOURCE[0]}"
@@ -25,7 +26,7 @@ DIR="$(cd -- "$(dirname -- "$SOURCE")/.." &> /dev/null && pwd)"
 TARGET="$DIR/dist/cli/dreamux.js"
 if [ ! -f "$TARGET" ]; then
   echo "dreamux: $TARGET is missing." >&2
-  echo "Run 'npm install' (it runs 'npm run build' via the prepare hook), 'npm run build', or 'rush build' from the monorepo root first." >&2
+  echo "Build it first from the repo root: node common/scripts/install-run-rush.js build (rush build)." >&2
   exit 1
 fi
 exec node "$TARGET" "$@"

--- a/packages/dreamux/bin/server
+++ b/packages/dreamux/bin/server
@@ -3,8 +3,8 @@
 #
 # Resolves its own location (following symlinks) so it works from any cwd
 # AND when invoked via a symlink (e.g. `npm install -g` puts a symlink under
-# the node bin dir). Runs the compiled dist output produced by
-# `npm install` / `npm run build`.
+# the node bin dir). Runs the compiled dist output (built by `rush build` in a
+# source checkout; already present in the published npm package).
 set -eu
 
 SOURCE="${BASH_SOURCE[0]}"
@@ -29,7 +29,7 @@ DIR="$(cd -- "$(dirname -- "$SOURCE")/.." &> /dev/null && pwd)"
 TARGET="$DIR/dist/cli/server.js"
 if [ ! -f "$TARGET" ]; then
   echo "dreamux-server: $TARGET is missing." >&2
-  echo "Run 'npm install' (it runs 'npm run build' via the prepare hook) or 'npm run build' from $DIR first." >&2
+  echo "Build it first from the repo root: node common/scripts/install-run-rush.js build (rush build)." >&2
   exit 1
 fi
 exec node "$TARGET" "$@"

--- a/packages/dreamux/bin/server-ctl
+++ b/packages/dreamux/bin/server-ctl
@@ -22,7 +22,7 @@ DIR="$(cd -- "$(dirname -- "$SOURCE")/.." &> /dev/null && pwd)"
 TARGET="$DIR/dist/cli/server-ctl.js"
 if [ ! -f "$TARGET" ]; then
   echo "server-ctl: $TARGET is missing." >&2
-  echo "Run 'npm install' (it runs 'npm run build' via the prepare hook) or 'npm run build' from $DIR first." >&2
+  echo "Build it first from the repo root: node common/scripts/install-run-rush.js build (rush build)." >&2
   exit 1
 fi
 exec node "$TARGET" "$@"

--- a/packages/dreamux/tests/bin-launcher.test.ts
+++ b/packages/dreamux/tests/bin-launcher.test.ts
@@ -49,9 +49,10 @@ const ROOT_BIN_SERVER = join(MONOREPO_ROOT, 'bin', 'server');
 const ROOT_BIN_CTL = join(MONOREPO_ROOT, 'bin', 'server-ctl');
 
 beforeAll(() => {
-  // Acceptance criterion: a built dist/ exists for the package; `npm
-  // install`'s prepare hook produces it. Repo-root shims forward into
-  // this same dist/, so checking the package paths is sufficient.
+  // Acceptance criterion: a built dist/ exists for the package; `rush build`
+  // produces it (the published npm package ships it prebuilt). Repo-root
+  // shims forward into this same dist/, so checking the package paths is
+  // sufficient.
   for (const f of [
     join(PACKAGE_ROOT, 'dist', 'cli', 'dreamux.js'),
     join(PACKAGE_ROOT, 'dist', 'cli', 'server.js'),
@@ -59,7 +60,7 @@ beforeAll(() => {
   ]) {
     if (!existsSync(f)) {
       throw new Error(
-        `dist artefact ${f} is missing — run 'npm run build' before these tests.`,
+        `dist artefact ${f} is missing — run 'rush build' before these tests.`,
       );
     }
   }

--- a/rush.json
+++ b/rush.json
@@ -7,9 +7,10 @@
  *   - Node >= 22.7.0: matches the runtime requirement of the dreamux server
  *     (per @excitedjs/dreamux package.json's engines.node field).
  *
- * Single-project for now (@excitedjs/dreamux), but the layout is ready to
- * grow into multiple packages — additions go under packages/<name>/ and
- * get registered in the `projects` array below.
+ * Three projects today (@excitedjs/dreamux host, @excitedjs/feishu-transport
+ * core, @excitedjs/feishu-channel placeholder), wired with pnpm workspace:*.
+ * More packages go under packages/<name>/ and get registered in the
+ * `projects` array below.
  *
  * Install / build / test:
  *   node common/scripts/install-run-rush.js update


### PR DESCRIPTION
## Why

The WIP that merged the channel refactor (#4) left `main` half-finished. `@excitedjs/dreamux` now depends on the newly-extracted `@excitedjs/feishu-transport` via the pnpm `workspace:*` protocol, the per-package `packages/dreamux/package-lock.json` was deleted (it can't be regenerated while a `workspace:*` dep is present), and the contradiction was left unresolved:

- the CI `package` job (`npm ci`) is **broken** — `npm` can't resolve `workspace:*`;
- `CLAUDE.md`'s "two install paths, both must keep working" rule is **violated**.

Both core packages are now published to npm (`@excitedjs/feishu-transport@0.0.1`, `@excitedjs/dreamux@0.1.1`), so the publish blocker #4 was waiting on is gone. The only open question was the install model.

## Decision — keep one install path (the monorepo/rush path)

Recorded in [`.agents/decisions/0006-install-model.md`](../blob/feat/complete-channel-install-model/.agents/decisions/0006-install-model.md). Decision 0001 already made the monorepo path "required once a second package lands" and explicitly left the per-package path to be retired "by a future decision"; three packages now exist, so this is the natural close-out.

`workspace:*` stays — it's the correct rush `useWorkspaces: true` idiom, and pnpm rewrites it to a real version in the **published** manifest, so external `npm install @excitedjs/dreamux` is unaffected (verified against `@excitedjs/dreamux@0.1.1`, which pins `@excitedjs/feishu-transport: 0.0.1`).

## What changed

- **CI** (`.github/workflows/ci.yml`): drop the broken `package` (`npm ci`) job; the `rush` job now runs `update → build → test` (`DREAMUX_SKIP_LIVE_CODEX=1`), so typecheck/build/test coverage is preserved on the supported path.
- **Docs**: `CLAUDE.md`, `README.md`, `packages/dreamux/README.md`, `.agents/root.md`, `.agents/components/repo-structure.md` now describe one install path and the three packages (dreamux host + `feishu-transport` core + `feishu-channel` placeholder). The stale `src/feishu/` "content/render copied verbatim" note is corrected to the thin transport adapter.
- **KB**: new `decisions/0006-install-model.md`; decision 0001's "two paths" consequence marked superseded. `.gitignore` lockfile comment updated.

No source code changed — this is the config/docs decision that makes the merged #4 coherent and CI-green.

## Verification

- `rush build` — 3/3 green; `rush test` — green (`DREAMUX_SKIP_LIVE_CODEX=1`).
- `workspace:*` links the local core (symlink `packages/dreamux/node_modules/@excitedjs/feishu-transport → ../../../channel/feishu-transport`).
- `.agents/scripts/check.sh` — KB OK (8 files reachable).
- Red-line: full diff clean of internal markers (`bnpm`/`byted`/full-format Feishu ids).

## Remaining follow-ups (deferred, per #4's checklist — a later PR)

- Wire the access gate (`gate()`) into the dreamux host so the five group-chat hazards are enforced (today only solved in the core lib).
- Outbound contract upgrade: reply threading + `@`-back + the stored-reply-id DB column.

🤖 Generated with [Claude Code](https://claude.com/claude-code)