### PR TITLE
fix(release): extract JSON from rush list stdout (banner crashed the Plan step)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -84,12 +84,16 @@ jobs:
       - name: Plan — classify each publishable package against npm
         id: plan
         run: |
-          # Enumerate every Rush project with shouldPublish=true (rush list emits
-          # clean JSON on stdout; its banner goes to stderr). The plan is written
-          # to a TSV file so the loop below runs in this shell (a pipe would put
-          # the counter in a subshell and lose it).
+          # Enumerate every Rush project with shouldPublish=true. The
+          # install-run-rush.js bootstrap prints a banner ("The rush.json
+          # configuration requests Rush version ...") plus rush's own
+          # 'Invoking "rush list --json"' preamble to STDOUT before the JSON, so
+          # we extract the JSON object (first '{' .. last '}') instead of parsing
+          # the whole stream. The plan is written to a TSV file so the loop below
+          # runs in this shell (a pipe would put the counter in a subshell and
+          # lose it).
           node common/scripts/install-run-rush.js list --json 2>/dev/null \
-            | node -e 'let s="";process.stdin.on("data",d=>s+=d).on("end",()=>{for(const p of JSON.parse(s).projects){if(p.shouldPublish)process.stdout.write([p.name,p.version,p.path].join("\t")+"\n")}})' \
+            | node -e 'let s="";process.stdin.on("data",d=>s+=d).on("end",()=>{const a=s.indexOf("{"),b=s.lastIndexOf("}");if(a<0||b<a){console.error("release plan: no JSON object found in `rush list --json` output");process.exit(1)}for(const p of JSON.parse(s.slice(a,b+1)).projects){if(p.shouldPublish)process.stdout.write([p.name,p.version,p.path].join("\t")+"\n")}})' \
             > "$RUNNER_TEMP/publishable.tsv"
 
           # Classify a package without conflating a real 404 with a transient


### PR DESCRIPTION
## Symptom

Since #5 merged, the **`release` workflow fails on every push to main** at the *Plan — classify each publishable package against npm* step:

```
SyntaxError: Unexpected token 'T', "The rush.j"... is not valid JSON
    at JSON.parse (<anonymous>)
```

(`ci` and `version packages` are green; only `release` is red.)

## Root cause

The Plan step pipes the project list into a JSON parser:

```sh
node common/scripts/install-run-rush.js list --json 2>/dev/null \
  | node -e '... JSON.parse(stdin) ...'
```

Its comment assumes the rush bootstrap banner goes to **stderr**. It doesn't — `install-run-rush.js` logs `"The rush.json configuration requests Rush version 5.140.0"` (and rush's own `Invoking "rush list --json"` preamble) to **stdout**, ahead of the JSON. So `2>/dev/null` doesn't strip it, and `JSON.parse` dies on the first word.

This is **latent breakage from #4**, not a regression from #5: #4 swapped the minimal `install-run-rush.js` for the full rushstack bootstrap (which prints that banner). It never fired before because #4's merge tip commit carried `[skip ci]`, so the release workflow's first real run was the #5 merge.

## Fix

Extract the JSON object from the stream (`indexOf('{')` … `lastIndexOf('}')`) instead of parsing the whole thing, and fail loudly with a clear message if no object is found. Comment corrected to describe the actual stdout shape. One-step change, no other logic touched.

## Verification

Replayed the exact pipeline locally against the real polluted stdout:

```
@excitedjs/dreamux        0.1.1  packages/dreamux
@excitedjs/feishu-transport 0.0.1 packages/channel/feishu-transport
```

- `@excitedjs/feishu-channel` (`shouldPublish: false`) correctly excluded; exit 0.
- Both emitted packages are already at their published versions, so classify → `published → skip` → `count=0` → "nothing to publish" → the job goes green.
- `release.yml` still parses as valid YAML; diff clean of internal markers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)