### PR TITLE
feat: thread Feishu replies through shared outbound targets

### DIFF
--- a/.agents/CONTRIBUTING.md
+++ b/.agents/CONTRIBUTING.md
@@ -22,7 +22,7 @@ being terse.
 
 - new package added / removed under `packages/`
 - a CLI subcommand added / removed / renamed (issue #4 made `dreamux` the
-  unified surface — see decision 0002)
+  unified surface — see [the CLI naming decision](decisions/cli-and-package-naming.md))
 - a settled design decision after debate (write a decision record)
 - a new external dependency that materially shapes the runtime (a
   database engine swap, a new IPC mechanism)
@@ -52,7 +52,7 @@ being terse.
 | Kind | When to use | Naming |
 |---|---|---|
 | `components/<thing>.md` | A piece big enough to have its own contract / mental model (server, CLI, codex-client, feishu-bot, repo-structure) | kebab-case, no number |
-| `decisions/NNNN-<slug>.md` | A choice that was debated and settled; future maintainers need the *why* | 4-digit zero-padded number, kebab-case slug |
+| `decisions/<slug>.md` | A choice that was debated and settled; future maintainers need the *why* | topic slug, kebab-case, no sequence number |
 | `domains/<area>.md` | A cross-cutting contract that spans multiple components | kebab-case |
 | `proposals/<slug>.md` | An active design under discussion | kebab-case |
 | `research/<slug>.md` | A frozen investigation snapshot; must end with an explicit "disposition" section (Promoted / Deferred / Out of scope) | kebab-case |
@@ -61,7 +61,7 @@ being terse.
 ## Decision record template
 
 ```markdown
-# NNNN — <decision title>
+# <decision title>
 
 - **Status:** Accepted | In progress | Superseded by [link]
 - **Date:** YYYY-MM-DD

--- a/.agents/components/repo-structure.md
+++ b/.agents/components/repo-structure.md
@@ -2,7 +2,7 @@
 
 Rush + pnpm monorepo since issue #4. Three packages today, all wired
 through pnpm `workspace:*` and installed via the rush path only (see
-[decision 0006](../decisions/0006-install-model.md)):
+[the install-model decision](../decisions/install-model.md)):
 
 | Package | Folder | Role |
 |---|---|---|
@@ -20,7 +20,7 @@ sibling claudemux repo import one implementation instead of drifting copies.
 |---|---|
 | `/rush.json` | Rush project list + pnpm/Node version pins |
 | `/common/config/rush/` | Rush command definitions (`command-line.json`), pnpm `.npmrc`, version policies, generated `pnpm-lock.yaml` |
-| `/common/scripts/install-run-rush.js` | Bootstrap that shells out to `npx @microsoft/rush@<version>` (see [decision 0001](../decisions/0001-rush-pnpm-monorepo.md)) |
+| `/common/scripts/install-run-rush.js` | Bootstrap that shells out to `npx @microsoft/rush@<version>` (see [the Rush + pnpm decision](../decisions/rush-pnpm-monorepo.md)) |
 | `/common/temp/` | Rush working dir (gitignored) |
 | `/packages/dreamux/` | The `@excitedjs/dreamux` package |
 | `/bin/` | Thin shims that forward to `/packages/dreamux/bin/` so pre-monorepo PATH entries keep working |
@@ -61,8 +61,8 @@ The per-package `cd packages/dreamux && npm install` path is **retired**:
 pnpm `workspace:*` protocol, which `npm` cannot resolve. There is no
 committed per-package `package-lock.json`. External consumers are
 unaffected — pnpm rewrites `workspace:*` to a real version at publish time.
-See [decision 0006](../decisions/0006-install-model.md) (which retires the
-two-paths consequence of [decision 0001](../decisions/0001-rush-pnpm-monorepo.md)).
+See [the install-model decision](../decisions/install-model.md) (which retires
+the two-paths consequence of [the Rush + pnpm decision](../decisions/rush-pnpm-monorepo.md)).
 
 ## Rush change files
 
@@ -114,7 +114,7 @@ multi-package release notes precise while still using Rush as the validator.
 
 - npm package: `@excitedjs/dreamux`
 - CLI binaries installed by the package:
-  - `dreamux` (preferred, see [decision 0002](../decisions/0002-cli-and-package-naming.md))
+  - `dreamux` (preferred, see [the CLI naming decision](../decisions/cli-and-package-naming.md))
   - `dreamux-server` (legacy alias)
   - `server-ctl` (legacy alias)
 
@@ -126,4 +126,4 @@ multi-package release notes precise while still using Rush as the validator.
 | `~/.codex-host/` | Server-owned runtime state: SQLite (`state.db`), admin socket, per-dispatcher codex sockets and logs. | The server |
 
 The split is load-bearing: a `rm -rf ~/.codex-host` recovery never loses
-user-edited settings. See [decision 0003](../decisions/0003-global-config-dir.md).
+user-edited settings. See [the global-config decision](../decisions/global-config-dir.md).

--- a/.agents/components/repo-structure.md
+++ b/.agents/components/repo-structure.md
@@ -64,6 +64,52 @@ unaffected — pnpm rewrites `workspace:*` to a real version at publish time.
 See [decision 0006](../decisions/0006-install-model.md) (which retires the
 two-paths consequence of [decision 0001](../decisions/0001-rush-pnpm-monorepo.md)).
 
+## Rush change files
+
+Release-facing changes need Rush change files under
+`/common/changes/<package>/`. Always validate them before pushing:
+
+```bash
+node common/scripts/install-run-rush.js change --verify --no-fetch
+```
+
+Rush can generate change files non-interactively when every changed package
+uses the same release type and message:
+
+```bash
+node common/scripts/install-run-rush.js change \
+  --bulk \
+  --message "Short release note" \
+  --bump-type patch \
+  --target-branch main \
+  --no-fetch \
+  --overwrite
+```
+
+Use `--email "<git author>"` only when Rush cannot infer the author from git.
+Do not paste real email addresses into chat or issue comments; some channels
+treat them as sensitive data.
+
+When changed packages need different release notes, write one JSON file per
+package instead of forcing `--bulk`. The accepted schema is:
+
+```json
+{
+  "changes": [
+    {
+      "comment": "Short release note",
+      "type": "patch",
+      "packageName": "@excitedjs/dreamux"
+    }
+  ],
+  "packageName": "@excitedjs/dreamux",
+  "email": "<git author>"
+}
+```
+
+Then run the same `rush change --verify --no-fetch` command. This keeps
+multi-package release notes precise while still using Rush as the validator.
+
 ## Public surface
 
 - npm package: `@excitedjs/dreamux`

--- a/.agents/decisions/README.md
+++ b/.agents/decisions/README.md
@@ -1,0 +1,28 @@
+# Decision Records
+
+Decision records use stable topic slugs, not sequence numbers. Do not create
+`0001-...` style names; concurrent agents regularly collide on numbers, while
+topic slugs remain reviewable and merge-friendly.
+
+## Browse by Theme
+
+| Theme | Records |
+|---|---|
+| Repository shape | [rush-pnpm-monorepo](rush-pnpm-monorepo.md), [install-model](install-model.md) |
+| Public surface | [cli-and-package-naming](cli-and-package-naming.md), [global-config-dir](global-config-dir.md) |
+| Release and safeguards | [npm-release-oidc](npm-release-oidc.md), [anti-leak-guardrail](anti-leak-guardrail.md) |
+
+## Alphabetical Index
+
+- [anti-leak-guardrail](anti-leak-guardrail.md)
+- [cli-and-package-naming](cli-and-package-naming.md)
+- [global-config-dir](global-config-dir.md)
+- [install-model](install-model.md)
+- [npm-release-oidc](npm-release-oidc.md)
+- [rush-pnpm-monorepo](rush-pnpm-monorepo.md)
+
+## Adding a Record
+
+Use `decisions/<topic-slug>.md`, with a kebab-case slug that names the
+decision's subject. If two agents write records in parallel, the filenames
+should remain distinct without negotiating a sequence number.

--- a/.agents/decisions/anti-leak-guardrail.md
+++ b/.agents/decisions/anti-leak-guardrail.md
@@ -1,4 +1,4 @@
-# 0004 — Anti-leak guardrail (gitleaks)
+# Anti-leak guardrail (gitleaks)
 
 - **Status:** Accepted
 - **Date:** 2026-05-30

--- a/.agents/decisions/cli-and-package-naming.md
+++ b/.agents/decisions/cli-and-package-naming.md
@@ -1,4 +1,4 @@
-# 0002 — Package name `@excitedjs/dreamux`, unified `dreamux` CLI
+# Package name `@excitedjs/dreamux`, unified `dreamux` CLI
 
 - **Status:** Accepted
 - **Date:** 2026-05-28

--- a/.agents/decisions/global-config-dir.md
+++ b/.agents/decisions/global-config-dir.md
@@ -1,4 +1,4 @@
-# 0003 — Global config in `~/.dreamux/config.toml`
+# Global config in `~/.dreamux/config.toml`
 
 - **Status:** Accepted
 - **Date:** 2026-05-28
@@ -79,7 +79,7 @@ Secrets (per-dispatcher `bot_secret_ref`) deliberately stay in env vars
 - The file is created with mode `0600`. Operators expecting world-readable
   configs need to chmod after the fact (and document why).
 - Two directories now matter: `~/.dreamux/` (user-editable) and
-  `~/.codex-host/` (server state). README + decision-0001 link the two so
+  `~/.codex-host/` (server state). README + the Rush + pnpm decision link the two so
   newcomers see the split.
 
 **Foot-guns:**

--- a/.agents/decisions/install-model.md
+++ b/.agents/decisions/install-model.md
@@ -38,8 +38,9 @@ which install model to keep.
   version (`@excitedjs/feishu-transport: 0.0.1`) in the **published** manifest.
 - No per-package `package-lock.json` is committed.
 - CI's `package` job (`npm ci`) is removed; its typecheck/build/test coverage
-  moves into the `rush` job, which now runs `rush update` → `rush build` →
-  `rush test` (`DREAMUX_SKIP_LIVE_CODEX=1`, no codex binary on the runner).
+  moves into the `rush` job, which now runs `rush update` → `rush typecheck` →
+  `rush build` → `rush test` (`DREAMUX_SKIP_LIVE_CODEX=1`, no codex binary on
+  the runner).
 
 Path 1 was always framed as "pre-monorepo muscle memory." The Rush + pnpm decision itself
 made the monorepo path "required once a second package lands"; three packages
@@ -56,7 +57,9 @@ now exist, so retiring path 1 is the natural close-out, not a new constraint.
 - **Foot-gun:** don't re-add a per-package `package-lock.json` or a `package`
   CI job — `npm` cannot lock a `workspace:*` graph, so either would reintroduce
   the exact breakage this record removes.
-- **Guards:** the `rush` CI job is the authoritative install/build/test gate;
+- **Guards:** the `rush` CI job is the authoritative
+  install/typecheck/build/test gate; PRs also run `rush change --verify` against
+  the base branch so release-surface changes declare Rush change files.
   `CLAUDE.md`, `README.md`, and `components/repo-structure.md` all describe the
   single path; this record supersedes the "two paths" consequence of
   [the Rush + pnpm decision](rush-pnpm-monorepo.md).

--- a/.agents/decisions/install-model.md
+++ b/.agents/decisions/install-model.md
@@ -1,4 +1,4 @@
-# 0006 — One install path: the monorepo (rush) path only
+# One install path: the monorepo (rush) path only
 
 - **Status:** Accepted
 - **Date:** 2026-05-31
@@ -7,7 +7,7 @@
 
 ## Context
 
-[Decision 0001](0001-rush-pnpm-monorepo.md) committed the repo to keeping
+[The Rush + pnpm decision](rush-pnpm-monorepo.md) committed the repo to keeping
 **two** install paths working "until a future decision retires one":
 
 1. **Per-package** — `cd packages/dreamux && npm install && npm test`, backed
@@ -41,7 +41,7 @@ which install model to keep.
   moves into the `rush` job, which now runs `rush update` → `rush build` →
   `rush test` (`DREAMUX_SKIP_LIVE_CODEX=1`, no codex binary on the runner).
 
-Path 1 was always framed as "pre-monorepo muscle memory." Decision 0001 itself
+Path 1 was always framed as "pre-monorepo muscle memory." The Rush + pnpm decision itself
 made the monorepo path "required once a second package lands"; three packages
 now exist, so retiring path 1 is the natural close-out, not a new constraint.
 
@@ -58,7 +58,8 @@ now exist, so retiring path 1 is the natural close-out, not a new constraint.
   the exact breakage this record removes.
 - **Guards:** the `rush` CI job is the authoritative install/build/test gate;
   `CLAUDE.md`, `README.md`, and `components/repo-structure.md` all describe the
-  single path; this record supersedes the "two paths" consequence of 0001.
+  single path; this record supersedes the "two paths" consequence of
+  [the Rush + pnpm decision](rush-pnpm-monorepo.md).
 
 ## Alternatives considered
 

--- a/.agents/decisions/npm-release-oidc.md
+++ b/.agents/decisions/npm-release-oidc.md
@@ -1,4 +1,4 @@
-# 0005 — npm release via OIDC trusted publishing
+# npm release via OIDC trusted publishing
 
 - **Status:** Accepted (scaffolding; unexecutable until a publishable package builds)
 - **Date:** 2026-05-30
@@ -26,7 +26,7 @@ Three hard constraints shaped the design:
   package is configured on npmjs.com individually. But one workflow *run* can
   publish many packages: each `npm publish` does its own OIDC exchange, so every
   package just lists the same workflow file as its trusted publisher.
-- **Main is protected.** The anti-leak guardrail (decision 0004) makes the
+- **Main is protected.** The [anti-leak guardrail](anti-leak-guardrail.md) makes the
   `gitleaks` check required on `main`, so CI cannot push a version-bump commit
   straight to `main` with the default `GITHUB_TOKEN`.
 

--- a/.agents/decisions/rush-pnpm-monorepo.md
+++ b/.agents/decisions/rush-pnpm-monorepo.md
@@ -1,4 +1,4 @@
-# 0001 — Adopt Rush + pnpm for the dreamux monorepo
+# Adopt Rush + pnpm for the dreamux monorepo
 
 - **Status:** Accepted
 - **Date:** 2026-05-28
@@ -48,7 +48,7 @@ Concrete shape:
   a future decision retires one. Per-package `package-lock.json` files
   stay committed so the npm path is reproducible; `pnpm-lock.yaml` lives
   in `common/config/rush/` once `rush update` runs.
-  > **Superseded (2026-05-31) by [decision 0006](0006-install-model.md).**
+  > **Superseded (2026-05-31) by [the install-model decision](install-model.md).**
   > The channel refactor (#4) introduced a `workspace:*` dependency that
   > `npm` cannot resolve, so the per-package npm path is retired and the
   > monorepo rush path is now the only supported one.

--- a/.agents/root.md
+++ b/.agents/root.md
@@ -62,5 +62,6 @@ issues:
 | add / change a global config key (`~/.dreamux/config.toml`) | [`decisions/0003-global-config-dir.md`](decisions/0003-global-config-dir.md) |
 | touch the anti-leak guardrail (`.gitleaks.toml`, `.npmrc`, CI / hook) | [`decisions/0004-anti-leak-guardrail.md`](decisions/0004-anti-leak-guardrail.md) |
 | touch npm publishing / the release workflows | [`decisions/0005-npm-release-oidc.md`](decisions/0005-npm-release-oidc.md) |
+| add or verify Rush change files | [`components/repo-structure.md#rush-change-files`](components/repo-structure.md#rush-change-files) |
 | write a new decision record / new component doc | [`CONTRIBUTING.md`](CONTRIBUTING.md) |
 | modify the server runtime / Codex protocol handling | the issue links above + read the source — runtime details aren't yet promoted to the KB |

--- a/.agents/root.md
+++ b/.agents/root.md
@@ -42,8 +42,8 @@ issues:
 
 - [`components/`](components/) — one doc per piece (repo-structure today;
   server / codex-client / feishu-bot / cli to be added as they stabilize).
-- [`decisions/`](decisions/) — accepted decision records. Newest at the
-  top of the index in each file's frontmatter; ordered numerically.
+- [`decisions/README.md`](decisions/README.md) — accepted decision records,
+  indexed by topic slug. Do not prefix new records with sequence numbers.
 - `domains/`, `proposals/`, `research/`, `rules/` — empty for now; add
   here when material grows past a single file's worth.
 - [`CONTRIBUTING.md`](CONTRIBUTING.md) — when to update this KB, how to
@@ -56,12 +56,13 @@ issues:
 | You're about to ... | Read first |
 |---|---|
 | add/change a package, move source between packages | [`components/repo-structure.md`](components/repo-structure.md) |
-| understand why rush + pnpm | [`decisions/0001-rush-pnpm-monorepo.md`](decisions/0001-rush-pnpm-monorepo.md) |
-| install / build / test the repo, or wonder why `npm ci` is gone | [`decisions/0006-install-model.md`](decisions/0006-install-model.md) |
-| rename or restructure the public CLI / package | [`decisions/0002-cli-and-package-naming.md`](decisions/0002-cli-and-package-naming.md) |
-| add / change a global config key (`~/.dreamux/config.toml`) | [`decisions/0003-global-config-dir.md`](decisions/0003-global-config-dir.md) |
-| touch the anti-leak guardrail (`.gitleaks.toml`, `.npmrc`, CI / hook) | [`decisions/0004-anti-leak-guardrail.md`](decisions/0004-anti-leak-guardrail.md) |
-| touch npm publishing / the release workflows | [`decisions/0005-npm-release-oidc.md`](decisions/0005-npm-release-oidc.md) |
+| browse decisions by topic | [`decisions/README.md`](decisions/README.md) |
+| understand why rush + pnpm | [`decisions/rush-pnpm-monorepo.md`](decisions/rush-pnpm-monorepo.md) |
+| install / build / test the repo, or wonder why `npm ci` is gone | [`decisions/install-model.md`](decisions/install-model.md) |
+| rename or restructure the public CLI / package | [`decisions/cli-and-package-naming.md`](decisions/cli-and-package-naming.md) |
+| add / change a global config key (`~/.dreamux/config.toml`) | [`decisions/global-config-dir.md`](decisions/global-config-dir.md) |
+| touch the anti-leak guardrail (`.gitleaks.toml`, `.npmrc`, CI / hook) | [`decisions/anti-leak-guardrail.md`](decisions/anti-leak-guardrail.md) |
+| touch npm publishing / the release workflows | [`decisions/npm-release-oidc.md`](decisions/npm-release-oidc.md) |
 | add or verify Rush change files | [`components/repo-structure.md#rush-change-files`](components/repo-structure.md#rush-change-files) |
 | write a new decision record / new component doc | [`CONTRIBUTING.md`](CONTRIBUTING.md) |
 | modify the server runtime / Codex protocol handling | the issue links above + read the source — runtime details aren't yet promoted to the KB |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,7 +24,7 @@ fix it in the same PR.
 - `/rush.json`, `/common/config/rush/`, `/common/scripts/install-run-rush.js`
   are the rush + pnpm scaffolding.
 - `/bin/` shims forward to `/packages/dreamux/bin/` for backward-compat with
-  pre-monorepo PATH entries — see `.agents/decisions/0002-cli-and-package-naming.md`.
+  pre-monorepo PATH entries — see `.agents/decisions/cli-and-package-naming.md`.
 - `/.agents/` is the on-demand knowledge base. Start at `.agents/root.md`.
 
 **One install path — the monorepo path.** Build and test through rush:
@@ -42,15 +42,15 @@ to the real version at publish time, so external `npm install @excitedjs/dreamux
 is unaffected — only the in-repo per-package path is gone. There is no committed
 per-package `package-lock.json`.
 
-Reasoning: `.agents/decisions/0006-install-model.md` (which retires the
-two-paths consequence of `.agents/decisions/0001-rush-pnpm-monorepo.md`).
+Reasoning: `.agents/decisions/install-model.md` (which retires the
+two-paths consequence of `.agents/decisions/rush-pnpm-monorepo.md`).
 
 ## CLI surface
 
 The user-facing CLI is `dreamux` (subcommands `server start`, `server status`,
 `dispatcher add|remove|list|status|start|stop`). The legacy `dreamux-server`
 and `server-ctl` binaries are kept as aliases — see
-`.agents/decisions/0002-cli-and-package-naming.md`. New documentation and
+`.agents/decisions/cli-and-package-naming.md`. New documentation and
 examples should introduce `dreamux <verb>`.
 
 ## Knowledge-delta protocol
@@ -66,7 +66,7 @@ kinds are in [`.agents/CONTRIBUTING.md`](.agents/CONTRIBUTING.md).
 Run `.agents/scripts/check.sh` before committing KB changes; CI rejects
 what the script rejects.
 
-## Two home directories (decision 0003)
+## Two home directories (global-config decision)
 
 - `~/.dreamux/config.toml` — user-editable global config; auto-created on
   first boot. Source of truth: the operator.

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Design background:
 │   ├── config/rush/       command-line.json, .npmrc, version-policies.json
 │   └── scripts/install-run-rush.js   minimal rush bootstrap
 ├── .agents/               on-demand knowledge base
-├── .github/workflows/     CI: rush build/test, KB check, gitleaks
+├── .github/workflows/     CI: rush change/typecheck/build/test, shellcheck, KB check, author/gitleaks gates
 ├── CLAUDE.md              always-loaded operating rules
 └── AGENTS.md              symlink → CLAUDE.md
 ```

--- a/README.md
+++ b/README.md
@@ -20,9 +20,9 @@ Design background:
 | Architecture, decisions, knowledge-delta protocol | [`.agents/root.md`](.agents/root.md) |
 | Always-loaded agent operating rules | [`CLAUDE.md`](CLAUDE.md) (`AGENTS.md` is a symlink) |
 | Monorepo layout reference | [`.agents/components/repo-structure.md`](.agents/components/repo-structure.md) |
-| Why Rush + pnpm | [`.agents/decisions/0001-rush-pnpm-monorepo.md`](.agents/decisions/0001-rush-pnpm-monorepo.md) |
-| Why the monorepo path is the only install path | [`.agents/decisions/0006-install-model.md`](.agents/decisions/0006-install-model.md) |
-| Why `@excitedjs/dreamux` + `dreamux` CLI + the two legacy aliases | [`.agents/decisions/0002-cli-and-package-naming.md`](.agents/decisions/0002-cli-and-package-naming.md) |
+| Why Rush + pnpm | [`.agents/decisions/rush-pnpm-monorepo.md`](.agents/decisions/rush-pnpm-monorepo.md) |
+| Why the monorepo path is the only install path | [`.agents/decisions/install-model.md`](.agents/decisions/install-model.md) |
+| Why `@excitedjs/dreamux` + `dreamux` CLI + the two legacy aliases | [`.agents/decisions/cli-and-package-naming.md`](.agents/decisions/cli-and-package-naming.md) |
 
 ## Repo layout
 
@@ -48,7 +48,7 @@ Design background:
 
 The monorepo path is the single supported install path (the workspace now
 spans three packages wired with `workspace:*`, which `npm` cannot resolve —
-see [decision 0006](.agents/decisions/0006-install-model.md)):
+see [the install-model decision](.agents/decisions/install-model.md)):
 
 ```bash
 node common/scripts/install-run-rush.js update

--- a/common/changes/@excitedjs/dreamux/feishu-channel-contract_2026-05-30-19-13.json
+++ b/common/changes/@excitedjs/dreamux/feishu-channel-contract_2026-05-30-19-13.json
@@ -1,7 +1,7 @@
 {
   "changes": [
     {
-      "comment": "Thread Feishu replies with outbound targets",
+      "comment": "Thread Feishu replies and drop bot-loop inbound messages",
       "type": "patch",
       "packageName": "@excitedjs/dreamux"
     }

--- a/common/changes/@excitedjs/dreamux/feishu-channel-contract_2026-05-30-19-13.json
+++ b/common/changes/@excitedjs/dreamux/feishu-channel-contract_2026-05-30-19-13.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Thread Feishu replies with outbound targets",
+      "type": "patch",
+      "packageName": "@excitedjs/dreamux"
+    }
+  ],
+  "packageName": "@excitedjs/dreamux",
+  "email": "LanTingShuXu <lantingshuxu@users.noreply.github.com>"
+}

--- a/common/changes/@excitedjs/feishu-transport/feishu-channel-contract_2026-05-30-19-13.json
+++ b/common/changes/@excitedjs/feishu-transport/feishu-channel-contract_2026-05-30-19-13.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Thread Feishu replies with outbound targets",
+      "type": "patch",
+      "packageName": "@excitedjs/feishu-transport"
+    }
+  ],
+  "packageName": "@excitedjs/feishu-transport",
+  "email": "LanTingShuXu <lantingshuxu@users.noreply.github.com>"
+}

--- a/packages/channel/feishu-transport/README.md
+++ b/packages/channel/feishu-transport/README.md
@@ -30,7 +30,7 @@ The single place that imports the Feishu SDK.
 ## Build / test
 
 Built and tested through the monorepo (rush) path — the only supported install
-path (see [decision 0006](../../../.agents/decisions/0006-install-model.md)).
+path (see [the install-model decision](../../../.agents/decisions/install-model.md)).
 From the repo root:
 
 ```sh

--- a/packages/channel/feishu-transport/src/index.ts
+++ b/packages/channel/feishu-transport/src/index.ts
@@ -27,10 +27,13 @@ export type { AccessStore } from './contract/access-store.js'
 // ── parse/ — Feishu content → forwardable text + comment-event decode ──
 export {
   parseInbound,
+  narrowMetaFromEvent,
+  toChannelInbound,
   applyMentions,
   extractPostText,
   type InboundMessage,
   type ParsedInbound,
+  type ChannelInbound,
 } from './parse/content.js'
 export {
   normalizeCommentEvent,

--- a/packages/channel/feishu-transport/src/parse/content.ts
+++ b/packages/channel/feishu-transport/src/parse/content.ts
@@ -24,6 +24,15 @@ export interface InboundMessage {
 export interface ParsedInbound {
   /** Human-readable text to forward to the engine. */
   text: string
+  /** Optional flat/narrow metadata supplied by the host's event normalizer. */
+  meta?: Record<string, unknown>
+}
+
+export interface ChannelInbound {
+  /** Flattened markdown-ish text suitable for a narrow channel payload. */
+  text: string
+  /** Flat string-only metadata with protocol-safe underscore keys. */
+  meta: Record<string, string>
 }
 
 /**
@@ -60,6 +69,80 @@ export function parseInbound(message: InboundMessage): ParsedInbound {
     default:
       return { text: `(${type} message)` }
   }
+}
+
+/**
+ * Extract canonical, narrow metadata from a Feishu inbound event envelope.
+ *
+ * Content parsing only sees `message.content`; identifiers such as
+ * `message_id`, `chat_id`, and `sender_id` live in the event envelope. Keeping
+ * this Feishu-specific field mapping in core prevents dreamux and claudemux
+ * from copy-drifting it in their host adapters.
+ */
+export function narrowMetaFromEvent(rawEvent: unknown): Record<string, unknown> {
+  if (!rawEvent || typeof rawEvent !== 'object' || Array.isArray(rawEvent)) return {}
+  const root = rawEvent as Record<string, unknown>
+  const event = asRecord(root.event) ?? root
+  const message = asRecord(event.message) ?? {}
+  const sender = asRecord(event.sender) ?? {}
+  const senderId = asRecord(sender.sender_id)
+
+  return omitEmptyStrings({
+    message_id: asString(message.message_id),
+    chat_id: asString(message.chat_id),
+    chat_type: asString(message.chat_type),
+    sender_id: asString(senderId?.open_id),
+    sender_type: asString(sender.sender_type),
+    root_id: asString(message.root_id),
+    parent_id: asString(message.parent_id),
+    create_time: asString(message.create_time),
+  })
+}
+
+/**
+ * Convert parsed inbound content into the channel protocol's narrow payload.
+ *
+ * `parseInbound` owns Feishu content flattening; the host may add raw event
+ * metadata under `parsed.meta` before calling this. This function is deliberately
+ * engine-agnostic: it preserves only text plus a flat string metadata bag. Keys
+ * with hyphens or other protocol-unsafe characters are dropped, and nested /
+ * non-string values are not stringified blindly.
+ */
+export function toChannelInbound(parsed: ParsedInbound): ChannelInbound {
+  const text = parsed.text === '' ? '(empty message)' : parsed.text
+  return { text, meta: sanitizeChannelMeta(parsed.meta) }
+}
+
+const CHANNEL_META_KEY_RE = /^[A-Za-z0-9_]+$/
+
+function sanitizeChannelMeta(meta: Record<string, unknown> | undefined): Record<string, string> {
+  const out: Record<string, string> = {}
+  if (!meta) return out
+  for (const [key, value] of Object.entries(meta)) {
+    if (!CHANNEL_META_KEY_RE.test(key)) continue
+    if (typeof value === 'string') {
+      out[key] = value
+    }
+  }
+  return out
+}
+
+function asRecord(value: unknown): Record<string, unknown> | undefined {
+  return value && typeof value === 'object' && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : undefined
+}
+
+function asString(value: unknown): string | undefined {
+  return typeof value === 'string' ? value : undefined
+}
+
+function omitEmptyStrings(input: Record<string, string | undefined>): Record<string, unknown> {
+  const out: Record<string, unknown> = {}
+  for (const [key, value] of Object.entries(input)) {
+    if (value !== undefined && value !== '') out[key] = value
+  }
+  return out
 }
 
 /**

--- a/packages/channel/feishu-transport/src/transport/feishu.ts
+++ b/packages/channel/feishu-transport/src/transport/feishu.ts
@@ -284,11 +284,12 @@ export interface FeishuTransport {
    */
   start(routes: InboundRoutes): Promise<void>
   /**
-   * Send a text message to the target chat. When `replyToMessageId` is set, the
-   * message is posted through Feishu's reply endpoint so it threads beneath the
-   * triggering message; `mentionUserIds` are rendered as leading card mentions.
-   * `target.conversationKey` is a channel-layer routing hint the transport
-   * never reads.
+   * Send a text message to the target chat. Without `replyToMessageId`, routing
+   * is by `target.chatId`. With `replyToMessageId`, Feishu's reply endpoint
+   * routes by the source message id; callers must only pass a message id that
+   * was observed in `target.chatId`, never an arbitrary external message id.
+   * `mentionUserIds` are rendered as leading card mentions. `conversationKey`
+   * is a channel-layer routing hint the transport never reads.
    */
   send(target: OutboundTarget, text: string): Promise<FeishuSendResult>
   /**

--- a/packages/channel/feishu-transport/src/transport/feishu.ts
+++ b/packages/channel/feishu-transport/src/transport/feishu.ts
@@ -284,15 +284,11 @@ export interface FeishuTransport {
    */
   start(routes: InboundRoutes): Promise<void>
   /**
-   * Send a text message to the target chat. Routed by `chat_id`, never by a
-   * message_id, so a forged reply target cannot redirect the message into an
-   * unrelated conversation.
-   *
-   * PR1 reads only `target.chatId` (behavior-identical to the old
-   * `sendText(chatId, text)`). Honoring `target.replyToMessageId` (reply-threading
-   * via `im.message.reply`) and `target.mentionUserIds` (auto @-back) lands in
-   * dreamux#25 PR2 (gap ④), with its own tests; `target.conversationKey` is a
-   * channel-layer routing hint the transport never reads.
+   * Send a text message to the target chat. When `replyToMessageId` is set, the
+   * message is posted through Feishu's reply endpoint so it threads beneath the
+   * triggering message; `mentionUserIds` are rendered as leading card mentions.
+   * `target.conversationKey` is a channel-layer routing hint the transport
+   * never reads.
    */
   send(target: OutboundTarget, text: string): Promise<FeishuSendResult>
   /**
@@ -457,23 +453,14 @@ export function createFeishuTransport(
       // too large for one card produces several cards, each sent as its own
       // message_id so the recipient sees a threaded continuation.
       //
-      // PR1: addressed by `chatId` only — behavior-identical to the old
-      // `sendText`. `replyToMessageId` / `mentionUserIds` are wired in PR2.
-      const cards = renderMarkdownToCards(text)
+      const cards = renderMarkdownToCards(textWithLeadingMentions(target, text))
       const messageIds: string[] = []
       for (const card of cards) {
         const content = cardToContent(card)
         // Fail fast on a card that could not be split under Feishu's hard cap,
         // preserving dreamux's prior per-card send guard (see assertCardContentFits).
         assertCardContentFits(content)
-        const res = await client.im.message.create({
-          params: { receive_id_type: 'chat_id' },
-          data: {
-            receive_id: target.chatId,
-            msg_type: 'interactive',
-            content,
-          },
-        })
+        const res = await sendInteractiveCard(client, target, content)
         const id = res.data?.message_id
         if (id) messageIds.push(id)
       }
@@ -591,6 +578,43 @@ export function createFeishuTransport(
       wsClient = undefined
     },
   }
+}
+
+type MessageSendResponse = { data?: { message_id?: string } }
+
+type MessageApiWithReply = {
+  reply(args: {
+    path: { message_id: string }
+    data: { msg_type: string; content: string }
+  }): Promise<MessageSendResponse>
+}
+
+async function sendInteractiveCard(
+  client: lark.Client,
+  target: OutboundTarget,
+  content: string,
+): Promise<MessageSendResponse> {
+  const data = { msg_type: 'interactive', content }
+  if (target.replyToMessageId !== undefined) {
+    const messageApi = client.im.message as unknown as MessageApiWithReply
+    return messageApi.reply({
+      path: { message_id: target.replyToMessageId },
+      data,
+    })
+  }
+  return client.im.message.create({
+    params: { receive_id_type: 'chat_id' },
+    data: {
+      receive_id: target.chatId,
+      ...data,
+    },
+  })
+}
+
+function textWithLeadingMentions(target: OutboundTarget, text: string): string {
+  const mentions = target.mentionUserIds ?? []
+  if (mentions.length === 0) return text
+  return `${mentions.map((id) => `<@${id}>`).join(' ')}\n${text}`
 }
 
 /** How many times to try resolving the bot's open_id before giving up. */

--- a/packages/channel/feishu-transport/tests/content.test.ts
+++ b/packages/channel/feishu-transport/tests/content.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'vitest'
-import { applyMentions, extractPostText, parseInbound } from '../src/parse/content'
+import { applyMentions, extractPostText, narrowMetaFromEvent, parseInbound, toChannelInbound } from '../src/parse/content'
 import type { InboundMessage } from '../src/parse/content'
 import type { Mention } from '../src/contract/types'
 
@@ -45,6 +45,113 @@ describe('parseInbound — attachments', () => {
 
   test('an unknown message type is summarized', () => {
     expect(parseInbound(message('audio', { duration: 3 })).text).toBe('(audio message)')
+  })
+})
+
+describe('toChannelInbound', () => {
+  test('preserves flattened text and string-only underscore metadata', () => {
+    expect(
+      toChannelInbound({
+        text: 'hello',
+        meta: {
+          message_id: 'om_1',
+          chat_id: 'oc_1',
+          sender_type: 'user',
+          'root-id': 'dropped',
+          nested: { value: 'dropped' },
+          count: 1,
+          empty_ok: '',
+        },
+      }),
+    ).toEqual({
+      text: 'hello',
+      meta: {
+        message_id: 'om_1',
+        chat_id: 'oc_1',
+        sender_type: 'user',
+        empty_ok: '',
+      },
+    })
+  })
+
+  test('keeps media degradation explicit in the flattened text', () => {
+    const parsed = parseInbound(message('image', { image_key: 'img_v2_abc' }))
+    expect(toChannelInbound(parsed)).toEqual({ text: '(image)', meta: {} })
+  })
+
+  test('empty text degrades to an explicit placeholder', () => {
+    expect(toChannelInbound({ text: '' })).toEqual({
+      text: '(empty message)',
+      meta: {},
+    })
+  })
+})
+
+describe('narrowMetaFromEvent', () => {
+  test('extracts canonical envelope metadata from an event payload', () => {
+    expect(
+      narrowMetaFromEvent({
+        event: {
+          sender: {
+            sender_type: 'user',
+            sender_id: { open_id: 'ou_sender' },
+          },
+          message: {
+            message_id: 'om_1',
+            chat_id: 'oc_1',
+            chat_type: 'group',
+            root_id: 'om_root',
+            parent_id: 'om_parent',
+            create_time: '1780000000000',
+            content: JSON.stringify({ text: 'ignored here' }),
+          },
+        },
+      }),
+    ).toEqual({
+      message_id: 'om_1',
+      chat_id: 'oc_1',
+      chat_type: 'group',
+      sender_id: 'ou_sender',
+      sender_type: 'user',
+      root_id: 'om_root',
+      parent_id: 'om_parent',
+      create_time: '1780000000000',
+    })
+  })
+
+  test('extracts metadata from already-unwrapped event payloads', () => {
+    expect(
+      narrowMetaFromEvent({
+        sender: { sender_type: 'app', sender_id: { open_id: 'ou_app' } },
+        message: {
+          message_id: 'om_2',
+          chat_id: 'oc_2',
+          chat_type: 'p2p',
+        },
+      }),
+    ).toEqual({
+      message_id: 'om_2',
+      chat_id: 'oc_2',
+      chat_type: 'p2p',
+      sender_id: 'ou_app',
+      sender_type: 'app',
+    })
+  })
+
+  test('drops missing, empty, nested, and non-string envelope values', () => {
+    expect(
+      narrowMetaFromEvent({
+        event: {
+          sender: { sender_type: '', sender_id: { open_id: 42 } },
+          message: {
+            message_id: '',
+            chat_id: 'oc_1',
+            chat_type: { nested: true },
+            create_time: 1780000000000,
+          },
+        },
+      }),
+    ).toEqual({ chat_id: 'oc_1' })
   })
 })
 

--- a/packages/channel/feishu-transport/tests/transport.test.ts
+++ b/packages/channel/feishu-transport/tests/transport.test.ts
@@ -8,8 +8,7 @@
  * Ported from claudemux's `feishu.test.ts` (the source of truth). The only
  * adaptations: the transport no longer takes a lock path (election moved out of
  * core), and the outbound entry point is `send(target, text)` rather than
- * `sendText(chatId, text)` — the PR1 impl reads only `target.chatId`, so these
- * assertions are unchanged in behavior.
+ * `sendText(chatId, text)`.
  */
 
 import * as lark from '@larksuiteoapi/node-sdk'
@@ -117,13 +116,14 @@ describe('commentFromBatchQuery', () => {
  */
 function stubClient() {
   const create = vi.fn(async () => ({ data: { message_id: 'om_stub' } }))
+  const reply = vi.fn(async () => ({ data: { message_id: 'om_reply_stub' } }))
   const patch = vi.fn(async () => ({}))
   const update = vi.fn(async () => ({}))
   const reactionCreate = vi.fn(async () => ({ data: { reaction_id: 'rk_stub' } }))
   const reactionDelete = vi.fn(async () => ({}))
   const stub = {
     im: {
-      message: { create, patch, update },
+      message: { create, reply, patch, update },
       messageReaction: { create: reactionCreate, delete: reactionDelete },
     },
     drive: {
@@ -135,6 +135,7 @@ function stubClient() {
   return {
     client: stub as unknown as lark.Client,
     create,
+    reply,
     patch,
     update,
     reactionCreate,
@@ -185,6 +186,35 @@ describe('createFeishuTransport — send', () => {
     const result = await transport.send({ chatId: 'oc_chat' }, 'hi')
 
     expect(result.messageIds).toEqual([])
+  })
+
+  test('threads replies under the source message and prefixes @-back mentions', async () => {
+    const stub = stubClient()
+    const transport = buildTransport(stub)
+
+    const result = await transport.send(
+      {
+        chatId: 'oc_chat',
+        replyToMessageId: 'om_source',
+        mentionUserIds: ['ou_sender'],
+      },
+      'done',
+    )
+
+    expect(result.messageIds).toEqual(['om_reply_stub'])
+    expect(stub.create).not.toHaveBeenCalled()
+    expect(stub.reply).toHaveBeenCalledTimes(1)
+    const calls = stub.reply.mock.calls as unknown as Array<
+      [{ path: { message_id: string }; data: { msg_type: string; content: string } }]
+    >
+    const call = calls[0]?.[0]
+    expect(call?.path.message_id).toBe('om_source')
+    expect(call?.data.msg_type).toBe('interactive')
+    const card = JSON.parse(call?.data.content ?? '{}') as {
+      body: { elements: { tag: string; content: string }[] }
+    }
+    expect(card.body.elements[0]?.content).toContain('<at id="ou_sender"></at>')
+    expect(card.body.elements[0]?.content).toContain('done')
   })
 
   test('renders a multi-card body into one im.message.create per card', async () => {

--- a/packages/dreamux/README.md
+++ b/packages/dreamux/README.md
@@ -20,7 +20,7 @@ Design background:
 - Legacy aliases: `dreamux-server` (= `dreamux server start`) and
   `server-ctl` (= `dreamux <verb>`). Kept so pre-monorepo operators
   don't have to rewrite PATH entries; see
-  [`.agents/decisions/0002-cli-and-package-naming.md`](../../.agents/decisions/0002-cli-and-package-naming.md).
+  [the CLI naming decision](../../.agents/decisions/cli-and-package-naming.md).
 - A SQLite-backed runtime (`dispatchers` + `inbound_buffer`) plus the
   Feishu / Codex adapters that drive each dispatcher.
 
@@ -51,7 +51,7 @@ Use the monorepo (rush) path from the repo root — it is the only supported
 install path. This package depends on `@excitedjs/feishu-transport` via the
 pnpm `workspace:*` protocol, which `npm` cannot resolve, so
 `cd packages/dreamux && npm install` no longer works (see
-[decision 0006](../../.agents/decisions/0006-install-model.md)):
+[the install-model decision](../../.agents/decisions/install-model.md)):
 
 ```bash
 node common/scripts/install-run-rush.js update
@@ -76,7 +76,8 @@ output; **no `tsx` is needed at runtime** (PR #6).
 
 Both work from any cwd and via symlinks (PR #6 + bin-launcher tests).
 
-The server uses two separate home directories — by design (decision 0003):
+The server uses two separate home directories — by design (see
+[the global-config decision](../../.agents/decisions/global-config-dir.md)):
 
 | Path | Purpose | Source of truth |
 |---|---|---|
@@ -128,7 +129,7 @@ export BOT_SECRET_FLOW='cli_secret_XXX'
 
 Precedence for every config-able value (highest wins): env var →
 per-dispatcher field → `~/.dreamux/config.toml` → built-in default.
-See [decision 0003](../../.agents/decisions/0003-global-config-dir.md).
+See [the global-config decision](../../.agents/decisions/global-config-dir.md).
 
 ### Global: `~/.dreamux/config.toml`
 
@@ -196,7 +197,7 @@ JSON object stored in `dispatchers.codex_args_json`:
 ## Testing
 
 ```bash
-# from the repo root (the only supported path — see decision 0006)
+# from the repo root (the only supported path — see the install-model decision)
 node common/scripts/install-run-rush.js test   # smoke + bin-launcher + codex-0134-live
 ```
 

--- a/packages/dreamux/src/channel/feishu-gate.ts
+++ b/packages/dreamux/src/channel/feishu-gate.ts
@@ -1,0 +1,41 @@
+import { isBotSenderType, type Mention } from '@excitedjs/feishu-transport';
+
+export interface CompatibleFeishuGateInput {
+  senderId: string;
+  senderType?: string;
+  chatType: string;
+  botOpenId?: string;
+  mentions?: Mention[];
+}
+
+export type CompatibleFeishuGateResult =
+  | { action: 'deliver' }
+  | { action: 'drop'; reason: string };
+
+/**
+ * Compatibility-first inbound gate for dreamux's Feishu channel.
+ *
+ * This deliberately does not enable pairing or allowlists yet. The current
+ * product behavior stays open, while the loop/ambiguity hazards that can make
+ * a channel self-amplify are blocked before messages enter the durable FIFO.
+ */
+export function compatibleFeishuGate(
+  input: CompatibleFeishuGateInput,
+): CompatibleFeishuGateResult {
+  if (input.senderId === '') {
+    return { action: 'drop', reason: 'missing sender id' };
+  }
+  if (input.botOpenId !== undefined && input.senderId === input.botOpenId) {
+    return { action: 'drop', reason: 'message sent by this bot' };
+  }
+  if (isBotSenderType(input.senderType)) {
+    return { action: 'drop', reason: `bot sender type: ${input.senderType}` };
+  }
+  if (input.chatType === 'group' && input.botOpenId === undefined) {
+    return {
+      action: 'drop',
+      reason: 'group message received before bot open_id was resolved',
+    };
+  }
+  return { action: 'deliver' };
+}

--- a/packages/dreamux/src/channel/feishu-gate.ts
+++ b/packages/dreamux/src/channel/feishu-gate.ts
@@ -1,11 +1,10 @@
-import { isBotSenderType, type Mention } from '@excitedjs/feishu-transport';
+import { isBotSenderType } from '@excitedjs/feishu-transport';
 
 export interface CompatibleFeishuGateInput {
   senderId: string;
   senderType?: string;
   chatType: string;
   botOpenId?: string;
-  mentions?: Mention[];
 }
 
 export type CompatibleFeishuGateResult =

--- a/packages/dreamux/src/channel/outbound.ts
+++ b/packages/dreamux/src/channel/outbound.ts
@@ -1,12 +1,12 @@
 import type { InboundRow } from '../db/types.js';
 
 export interface ChannelOutboundTarget {
-  /** Stable channel-local conversation id. Feishu maps this to chat_id. */
+  /** Stable channel-local conversation id. */
   conversationId: string;
-  /** Optional source message id for channel-native reply threading. */
-  replyToMessageId?: string;
-  /** Optional channel-local user ids to mention in the reply. */
-  mentionUserIds?: string[];
+  /** Optional channel-local source message to thread under. */
+  replyTo?: string;
+  /** Optional channel-local participants to bring into the reply. */
+  mentionUsers?: string[];
   /** Optional host/runtime routing hint, opaque to the channel adapter. */
   conversationKey?: string;
 }
@@ -20,10 +20,10 @@ export function outboundTargetForInbound(row: InboundRow): ChannelOutboundTarget
   return {
     conversationId: row.source_chat_id,
     ...(row.source_message_id !== null
-      ? { replyToMessageId: row.source_message_id }
+      ? { replyTo: row.source_message_id }
       : {}),
     ...(row.sender_id !== null && row.sender_id !== ''
-      ? { mentionUserIds: [row.sender_id] }
+      ? { mentionUsers: [row.sender_id] }
       : {}),
   };
 }

--- a/packages/dreamux/src/channel/outbound.ts
+++ b/packages/dreamux/src/channel/outbound.ts
@@ -1,0 +1,29 @@
+import type { InboundRow } from '../db/types.js';
+
+export interface ChannelOutboundTarget {
+  /** Stable channel-local conversation id. Feishu maps this to chat_id. */
+  conversationId: string;
+  /** Optional source message id for channel-native reply threading. */
+  replyToMessageId?: string;
+  /** Optional channel-local user ids to mention in the reply. */
+  mentionUserIds?: string[];
+  /** Optional host/runtime routing hint, opaque to the channel adapter. */
+  conversationKey?: string;
+}
+
+export interface OutboundSink {
+  /** Send `text` to a channel target; return the channel message ids sent. */
+  send(target: ChannelOutboundTarget, text: string): Promise<string[]>;
+}
+
+export function outboundTargetForInbound(row: InboundRow): ChannelOutboundTarget {
+  return {
+    conversationId: row.source_chat_id,
+    ...(row.source_message_id !== null
+      ? { replyToMessageId: row.source_message_id }
+      : {}),
+    ...(row.sender_id !== null && row.sender_id !== ''
+      ? { mentionUserIds: [row.sender_id] }
+      : {}),
+  };
+}

--- a/packages/dreamux/src/dispatcher/runtime.ts
+++ b/packages/dreamux/src/dispatcher/runtime.ts
@@ -33,9 +33,10 @@ import type {
   ThreadResumeResponse,
   ThreadStartResponse,
 } from '../codex/types.js';
-import { TurnManager, type OutboundSink } from './turn-manager.js';
+import { TurnManager } from './turn-manager.js';
 import { createFailFastApprovalHandler } from './approval.js';
 import { dispatcherCodexCwd, dispatcherStdoutLog, dispatcherStderrLog, dispatcherSocketPath } from '../runtime/paths.js';
+import { outboundTargetForInbound, type OutboundSink } from '../channel/outbound.js';
 
 export interface DispatcherRuntimeDeps {
   dispatchers: DispatcherRepo;
@@ -142,8 +143,8 @@ export class DispatcherRuntime {
           const chatId = this.currentInboundChatId;
           if (chatId === null) return;
           try {
-            await this.deps.outbound.sendText(
-              chatId,
+            await this.deps.outbound.send(
+              { conversationId: chatId },
               `Codex 请求了一次审批（${req.method}），但当前 dispatcher 不支持审批 —— 本轮将失败。`,
             );
           } catch {
@@ -285,8 +286,8 @@ export class DispatcherRuntime {
         `inbound ${row.id} was 'running' at restart — marked unknown (at-most-once); chat=${row.source_chat_id}`,
       );
       try {
-        await this.deps.outbound.sendText(
-          row.source_chat_id,
+        await this.deps.outbound.send(
+          outboundTargetForInbound(row),
           `上一次的执行结果未知（server 重启时正在进行）。请确认是否需要重新发送：\n> ${row.parsed_text.slice(0, 200)}`,
         );
       } catch (err) {

--- a/packages/dreamux/src/dispatcher/turn-manager.ts
+++ b/packages/dreamux/src/dispatcher/turn-manager.ts
@@ -23,11 +23,7 @@ import type { InboundRepo } from '../db/repository.js';
 import type { InboundRow } from '../db/types.js';
 import type { CodexWsClient } from '../codex/rpc.js';
 import { extractAssistantText, runTurn } from '../codex/events.js';
-
-export interface OutboundSink {
-  /** Send `text` to `chatId`; return the array of feishu message_ids sent. */
-  sendText(chatId: string, text: string): Promise<string[]>;
-}
+import { outboundTargetForInbound, type OutboundSink } from '../channel/outbound.js';
 
 export interface TurnManagerOptions {
   dispatcherId: string;
@@ -148,8 +144,8 @@ export class TurnManager {
       this.opts.inbound.markFailed(row.id, msg);
       // Best-effort tell the user something went wrong.
       try {
-        await this.opts.outbound.sendText(
-          row.source_chat_id,
+        await this.opts.outbound.send(
+          outboundTargetForInbound(row),
           `本次请求执行失败：${msg}`,
         );
       } catch (sendErr) {
@@ -159,20 +155,17 @@ export class TurnManager {
     }
 
     this.opts.inbound.markAwaitingOutbound(row.id, assistantText);
-    await this.sendOutbound(row.id, row.source_chat_id, assistantText);
+    await this.sendOutbound(row, assistantText);
   }
 
   /** Send assistant text to feishu with bounded retry. */
-  private async sendOutbound(
-    inboundId: number,
-    chatId: string,
-    text: string,
-  ): Promise<void> {
+  private async sendOutbound(row: InboundRow, text: string): Promise<void> {
     let lastError: unknown;
+    const target = outboundTargetForInbound(row);
     for (let attempt = 0; attempt <= this.outboundRetries; attempt++) {
       try {
-        const ids = await this.opts.outbound.sendText(chatId, text);
-        this.opts.inbound.markCompleted(inboundId, ids);
+        const ids = await this.opts.outbound.send(target, text);
+        this.opts.inbound.markCompleted(row.id, ids);
         return;
       } catch (err) {
         lastError = err;
@@ -184,8 +177,8 @@ export class TurnManager {
       }
     }
     const msg = lastError instanceof Error ? lastError.message : String(lastError);
-    this.log('error', `outbound send failed for inbound ${inboundId}: ${msg}`);
-    this.opts.inbound.markOutboundFailed(inboundId, msg);
+    this.log('error', `outbound send failed for inbound ${row.id}: ${msg}`);
+    this.opts.inbound.markOutboundFailed(row.id, msg);
   }
 
   /**
@@ -210,7 +203,7 @@ export class TurnManager {
         );
         continue;
       }
-      await this.sendOutbound(row.id, row.source_chat_id, row.assistant_text);
+      await this.sendOutbound(row, row.assistant_text);
     }
   }
 

--- a/packages/dreamux/src/feishu/bot.ts
+++ b/packages/dreamux/src/feishu/bot.ts
@@ -33,6 +33,7 @@ export interface FeishuInboundEvent {
   chatId: string;
   chatType: string; // 'p2p' | 'group' | ...
   senderId: string;
+  senderType: string;
   messageType: string;
   /** Raw JSON-encoded content as Feishu delivered it. */
   rawContent: string;
@@ -117,6 +118,7 @@ function normalizeInboundEvent(raw: unknown): FeishuInboundEvent | null {
   const sender = (event['sender'] ?? {}) as Record<string, unknown>;
   const senderId =
     ((sender['sender_id'] as Record<string, unknown>)?.['open_id'] as string) ?? '';
+  const senderType = (sender['sender_type'] as string) ?? '';
   const messageId = (message['message_id'] as string) ?? '';
   const chatId = (message['chat_id'] as string) ?? '';
   const chatType = (message['chat_type'] as string) ?? '';
@@ -138,6 +140,7 @@ function normalizeInboundEvent(raw: unknown): FeishuInboundEvent | null {
     chatId,
     chatType,
     senderId,
+    senderType,
     messageType,
     rawContent,
     parsedText: parsed.text,

--- a/packages/dreamux/src/feishu/bot.ts
+++ b/packages/dreamux/src/feishu/bot.ts
@@ -10,8 +10,8 @@
  *     each raw event with the core's `parseInbound`, and forwards a
  *     `FeishuInboundEvent`. The route handler awaits `handler`, so the message is
  *     durably enqueued before the SDK acks (the deferred-ACK invariant).
- *   - `sendText(chatId, text)` delegates to the core's `send({ chatId }, text)`.
- *     The per-card size guard and the multi-card split both live in the core now.
+ *   - `send(target, text)` delegates to the core transport, preserving reply
+ *     threading / @-back metadata from the durable inbound row.
  *   - `botOpenId` surfaces the core transport's `selfId`.
  *
  * Tests inject a `FakeFeishuBot` via `createFakeFeishuBot()` instead of opening
@@ -22,6 +22,7 @@ import {
   createFeishuTransport,
   parseInbound,
   type Mention,
+  type OutboundTarget,
 } from '@excitedjs/feishu-transport';
 
 /** The Feishu event_type carrying inbound chat messages. */
@@ -54,7 +55,7 @@ export interface FeishuBot {
   readonly appId: string;
   readonly botOpenId: string | undefined;
   start(handler: InboundHandler): Promise<void>;
-  sendText(chatId: string, text: string): Promise<FeishuSendResult>;
+  send(target: OutboundTarget, text: string): Promise<FeishuSendResult>;
   close(): Promise<void>;
 }
 
@@ -91,8 +92,8 @@ export function createFeishuBot(opts: CreateBotOptions): FeishuBot {
       });
     },
 
-    async sendText(chatId: string, text: string): Promise<FeishuSendResult> {
-      const { messageIds } = await transport.send({ chatId }, text);
+    async send(target: OutboundTarget, text: string): Promise<FeishuSendResult> {
+      const { messageIds } = await transport.send(target, text);
       return { messageIds };
     },
 
@@ -149,13 +150,23 @@ function normalizeInboundEvent(raw: unknown): FeishuInboundEvent | null {
 // -------------------------------------------------------------- fake (tests)
 
 export interface FakeFeishuBot extends FeishuBot {
-  readonly sentMessages: Array<{ chatId: string; text: string; messageIds: string[] }>;
+  readonly sentMessages: Array<{
+    chatId: string;
+    target: OutboundTarget;
+    text: string;
+    messageIds: string[];
+  }>;
   inject(event: FeishuInboundEvent): Promise<void>;
   setSendError(err: Error | null): void;
 }
 
 export function createFakeFeishuBot(appId: string = 'fake_bot'): FakeFeishuBot {
-  const sent: Array<{ chatId: string; text: string; messageIds: string[] }> = [];
+  const sent: Array<{
+    chatId: string;
+    target: OutboundTarget;
+    text: string;
+    messageIds: string[];
+  }> = [];
   let handler: InboundHandler | null = null;
   let nextMessageId = 1;
   let sendError: Error | null = null;
@@ -169,12 +180,12 @@ export function createFakeFeishuBot(appId: string = 'fake_bot'): FakeFeishuBot {
     async start(h: InboundHandler): Promise<void> {
       handler = h;
     },
-    async sendText(chatId: string, text: string): Promise<FeishuSendResult> {
+    async send(target: OutboundTarget, text: string): Promise<FeishuSendResult> {
       if (sendError !== null) {
         throw sendError;
       }
       const id = `om_fake_${nextMessageId++}`;
-      sent.push({ chatId, text, messageIds: [id] });
+      sent.push({ chatId: target.chatId, target, text, messageIds: [id] });
       return { messageIds: [id] };
     },
     async close(): Promise<void> {

--- a/packages/dreamux/src/feishu/bot.ts
+++ b/packages/dreamux/src/feishu/bot.ts
@@ -20,10 +20,14 @@
 
 import {
   createFeishuTransport,
+  narrowMetaFromEvent,
   parseInbound,
+  toChannelInbound,
   type Mention,
   type OutboundTarget,
 } from '@excitedjs/feishu-transport';
+
+import type { ChannelOutboundTarget } from '../channel/outbound.js';
 
 /** The Feishu event_type carrying inbound chat messages. */
 const IM_MESSAGE_EVENT_TYPE = 'im.message.receive_v1';
@@ -104,36 +108,54 @@ export function createFeishuBot(opts: CreateBotOptions): FeishuBot {
   };
 }
 
+export function channelOutboundToFeishuTarget(
+  target: ChannelOutboundTarget,
+): OutboundTarget {
+  return {
+    chatId: target.conversationId,
+    ...(target.replyTo !== undefined
+      ? { replyToMessageId: target.replyTo }
+      : {}),
+    ...(target.mentionUsers !== undefined
+      ? { mentionUserIds: target.mentionUsers }
+      : {}),
+    ...(target.conversationKey !== undefined
+      ? { conversationKey: target.conversationKey }
+      : {}),
+  };
+}
+
 /**
  * Reshape a raw `im.message.receive_v1` payload into a `FeishuInboundEvent`,
- * using the core's `parseInbound` for the content→text flattening (incl. the
- * `interactive`-card parse the old in-package copy had lost). Returns `null`
- * for a payload missing the message_id or chat_id that make it routable.
+ * using the core's `parseInbound` + `narrowMetaFromEvent` + `toChannelInbound`
+ * for content flattening and event-envelope metadata. Returns `null` for a
+ * payload missing the message_id or chat_id that make it routable.
  */
 function normalizeInboundEvent(raw: unknown): FeishuInboundEvent | null {
   if (!raw || typeof raw !== 'object') return null;
   const root = raw as Record<string, unknown>;
   const event = (root['event'] ?? root) as Record<string, unknown>;
   const message = (event['message'] ?? {}) as Record<string, unknown>;
-  const sender = (event['sender'] ?? {}) as Record<string, unknown>;
-  const senderId =
-    ((sender['sender_id'] as Record<string, unknown>)?.['open_id'] as string) ?? '';
-  const senderType = (sender['sender_type'] as string) ?? '';
-  const messageId = (message['message_id'] as string) ?? '';
-  const chatId = (message['chat_id'] as string) ?? '';
-  const chatType = (message['chat_type'] as string) ?? '';
   const messageType = (message['message_type'] as string) ?? '';
   const rawContent = (message['content'] as string) ?? '';
   const mentions = (message['mentions'] as Mention[] | undefined) ?? [];
-  const createTime = (message['create_time'] as string) ?? '';
-
-  if (messageId === '' || chatId === '') return null;
-
   const parsed = parseInbound({
     message_type: messageType,
     content: rawContent,
     mentions,
   });
+  const payload = toChannelInbound({
+    ...parsed,
+    meta: narrowMetaFromEvent(raw),
+  });
+  const messageId = payload.meta['message_id'] ?? '';
+  const chatId = payload.meta['chat_id'] ?? '';
+  const chatType = payload.meta['chat_type'] ?? '';
+  const senderId = payload.meta['sender_id'] ?? '';
+  const senderType = payload.meta['sender_type'] ?? '';
+  const createTime = payload.meta['create_time'] ?? '';
+
+  if (messageId === '' || chatId === '') return null;
 
   return {
     messageId,
@@ -143,7 +165,7 @@ function normalizeInboundEvent(raw: unknown): FeishuInboundEvent | null {
     senderType,
     messageType,
     rawContent,
-    parsedText: parsed.text,
+    parsedText: payload.text,
     mentions,
     createTime,
     raw,

--- a/packages/dreamux/src/runtime/codex-args.ts
+++ b/packages/dreamux/src/runtime/codex-args.ts
@@ -14,7 +14,7 @@
  *   1. dispatchers.codex_args_json (this JSON)
  *   2. global defaults from ~/.dreamux/config.toml (passed in as `defaults`)
  *   3. hardcoded fallbacks (`'never'`, `'workspace-write'`, `[]`)
- * Per the feat/global-config-dir work — see decision 0003.
+ * Per the feat/global-config-dir work — see the global-config decision.
  *
  * `approvalPolicy` not in the trusted-local allowlist fails-fast at startup
  * (issue #2 §"实现陷阱"): dispatcher refuses to come up if the policy may

--- a/packages/dreamux/src/runtime/config.ts
+++ b/packages/dreamux/src/runtime/config.ts
@@ -98,7 +98,7 @@ export const DEFAULT_CONFIG_TOML = `# dreamux global configuration (~/.dreamux/c
 # Edit this file and restart \`dreamux server start\` to apply changes.
 # Runtime data (SQLite, sockets, dispatcher logs) lives separately in
 # \`runtime_dir\` below — this file holds only user-editable settings.
-# See .agents/decisions/0003-global-config-dir.md for the design rationale.
+# See .agents/decisions/global-config-dir.md for the design rationale.
 #
 # Precedence (highest wins):
 #   1. environment variables (CODEX_HOST_RUNTIME_DIR, CODEX_HOST_ADMIN_SOCKET,
@@ -288,7 +288,7 @@ function mergeWithDefaults(raw: unknown, file: string): DreamuxConfig {
     'codex.',
   );
   // Validate approval_policy against the same allowlist as codex-args.ts.
-  // Keep the two in sync — see decision 0001 / issue #2 §"信任模型".
+  // Keep the two in sync — see the Rush + pnpm decision / issue #2 §"信任模型".
   const ALLOWED_POLICIES = new Set([
     'never',
     'auto',

--- a/packages/dreamux/src/server.ts
+++ b/packages/dreamux/src/server.ts
@@ -23,6 +23,7 @@ import { DispatcherRuntime } from './dispatcher/runtime.js';
 import type { CodexProcess, CodexProcessOptions } from './codex/supervisor.js';
 import type { CodexWsClient } from './codex/rpc.js';
 import { createFeishuBot, type FeishuBot, type FeishuInboundEvent } from './feishu/bot.js';
+import { compatibleFeishuGate } from './channel/feishu-gate.js';
 import { parseCodexArgs, codexArgsToCli } from './runtime/codex-args.js';
 import { resolveBotSecret } from './runtime/secrets.js';
 import { BUILT_IN_DEFAULTS, type DreamuxConfig } from './runtime/config.js';
@@ -185,11 +186,11 @@ export class Server {
           (await bot.send(
             {
               chatId: target.conversationId,
-              ...(target.replyToMessageId !== undefined
-                ? { replyToMessageId: target.replyToMessageId }
+              ...(target.replyTo !== undefined
+                ? { replyToMessageId: target.replyTo }
                 : {}),
-              ...(target.mentionUserIds !== undefined
-                ? { mentionUserIds: target.mentionUserIds }
+              ...(target.mentionUsers !== undefined
+                ? { mentionUserIds: target.mentionUsers }
                 : {}),
               ...(target.conversationKey !== undefined
                 ? { conversationKey: target.conversationKey }
@@ -210,6 +211,19 @@ export class Server {
     try {
       await runtime.start();
       await bot.start(async (event: FeishuInboundEvent) => {
+        const gate = compatibleFeishuGate({
+          senderId: event.senderId,
+          senderType: event.senderType,
+          chatType: event.chatType,
+          botOpenId: bot.botOpenId,
+          mentions: event.mentions,
+        });
+        if (gate.action === 'drop') {
+          console.error(
+            `[server] dropped feishu inbound for dispatcher '${id}': ${gate.reason}`,
+          );
+          return;
+        }
         runtime.enqueueInbound({
           source_chat_id: event.chatId,
           source_message_id: event.messageId,

--- a/packages/dreamux/src/server.ts
+++ b/packages/dreamux/src/server.ts
@@ -181,7 +181,22 @@ export class Server {
       dispatchers: this.repos.dispatchers,
       inbound: this.repos.inbound,
       outbound: {
-        sendText: async (chatId, text) => (await bot.sendText(chatId, text)).messageIds,
+        send: async (target, text) =>
+          (await bot.send(
+            {
+              chatId: target.conversationId,
+              ...(target.replyToMessageId !== undefined
+                ? { replyToMessageId: target.replyToMessageId }
+                : {}),
+              ...(target.mentionUserIds !== undefined
+                ? { mentionUserIds: target.mentionUserIds }
+                : {}),
+              ...(target.conversationKey !== undefined
+                ? { conversationKey: target.conversationKey }
+                : {}),
+            },
+            text,
+          )).messageIds,
       },
       codexBinPath: this.resolveCodexBinPath(),
       codexProcessFactory: this.opts.codexProcessFactory,

--- a/packages/dreamux/src/server.ts
+++ b/packages/dreamux/src/server.ts
@@ -22,7 +22,12 @@ import type { DispatcherRow, DispatcherStatus } from './db/types.js';
 import { DispatcherRuntime } from './dispatcher/runtime.js';
 import type { CodexProcess, CodexProcessOptions } from './codex/supervisor.js';
 import type { CodexWsClient } from './codex/rpc.js';
-import { createFeishuBot, type FeishuBot, type FeishuInboundEvent } from './feishu/bot.js';
+import {
+  channelOutboundToFeishuTarget,
+  createFeishuBot,
+  type FeishuBot,
+  type FeishuInboundEvent,
+} from './feishu/bot.js';
 import { compatibleFeishuGate } from './channel/feishu-gate.js';
 import { parseCodexArgs, codexArgsToCli } from './runtime/codex-args.js';
 import { resolveBotSecret } from './runtime/secrets.js';
@@ -183,21 +188,7 @@ export class Server {
       inbound: this.repos.inbound,
       outbound: {
         send: async (target, text) =>
-          (await bot.send(
-            {
-              chatId: target.conversationId,
-              ...(target.replyTo !== undefined
-                ? { replyToMessageId: target.replyTo }
-                : {}),
-              ...(target.mentionUsers !== undefined
-                ? { mentionUserIds: target.mentionUsers }
-                : {}),
-              ...(target.conversationKey !== undefined
-                ? { conversationKey: target.conversationKey }
-                : {}),
-            },
-            text,
-          )).messageIds,
+          (await bot.send(channelOutboundToFeishuTarget(target), text)).messageIds,
       },
       codexBinPath: this.resolveCodexBinPath(),
       codexProcessFactory: this.opts.codexProcessFactory,
@@ -216,7 +207,6 @@ export class Server {
           senderType: event.senderType,
           chatType: event.chatType,
           botOpenId: bot.botOpenId,
-          mentions: event.mentions,
         });
         if (gate.action === 'drop') {
           console.error(

--- a/packages/dreamux/tests/bin-launcher.test.ts
+++ b/packages/dreamux/tests/bin-launcher.test.ts
@@ -5,7 +5,7 @@
  *   1. The package-local launchers under packages/dreamux/bin/:
  *      `dreamux`, `server`, `server-ctl`.
  *   2. The repo-root forwarders under <repo>/bin/ that operators with
- *      pre-monorepo PATH entries still rely on (issue #4, decision 0002).
+ *      pre-monorepo PATH entries still rely on (issue #4, CLI naming decision).
  *
  * Each launcher must:
  *   - work from any cwd (resolve its own location via $BASH_SOURCE)

--- a/packages/dreamux/tests/feishu-gate.test.ts
+++ b/packages/dreamux/tests/feishu-gate.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from 'vitest';
+
+import { compatibleFeishuGate } from '../src/channel/feishu-gate.js';
+
+describe('compatibleFeishuGate', () => {
+  it('keeps normal user messages deliverable', () => {
+    expect(
+      compatibleFeishuGate({
+        senderId: 'ou_user',
+        senderType: 'user',
+        chatType: 'group',
+        botOpenId: 'ou_bot',
+      }),
+    ).toEqual({ action: 'deliver' });
+  });
+
+  it('drops missing sender id', () => {
+    expect(
+      compatibleFeishuGate({
+        senderId: '',
+        senderType: 'user',
+        chatType: 'p2p',
+        botOpenId: 'ou_bot',
+      }),
+    ).toEqual({ action: 'drop', reason: 'missing sender id' });
+  });
+
+  it('drops self-sent bot-loop messages', () => {
+    expect(
+      compatibleFeishuGate({
+        senderId: 'ou_bot',
+        senderType: 'user',
+        chatType: 'group',
+        botOpenId: 'ou_bot',
+      }),
+    ).toEqual({ action: 'drop', reason: 'message sent by this bot' });
+  });
+
+  it('drops Feishu bot/app sender types', () => {
+    expect(
+      compatibleFeishuGate({
+        senderId: 'ou_peer_bot',
+        senderType: 'app',
+        chatType: 'group',
+        botOpenId: 'ou_bot',
+      }),
+    ).toEqual({ action: 'drop', reason: 'bot sender type: app' });
+  });
+
+  it('drops group messages when bot open_id is unknown', () => {
+    expect(
+      compatibleFeishuGate({
+        senderId: 'ou_user',
+        senderType: 'user',
+        chatType: 'group',
+      }),
+    ).toEqual({
+      action: 'drop',
+      reason: 'group message received before bot open_id was resolved',
+    });
+  });
+});

--- a/packages/dreamux/tests/smoke.test.ts
+++ b/packages/dreamux/tests/smoke.test.ts
@@ -65,6 +65,7 @@ function fakeInbound(
     chatId,
     chatType: 'group',
     senderId: 'ou_sender_test',
+    senderType: 'user',
     messageType: 'text',
     rawContent: JSON.stringify({ text }),
     parsedText: text,
@@ -84,6 +85,10 @@ async function waitFor(
     await new Promise((r) => setTimeout(r, 20));
   }
   throw new Error('waitFor timed out');
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
 describe('dreamux MVP smoke', () => {
@@ -138,6 +143,47 @@ describe('dreamux MVP smoke', () => {
     const d = server.repos.dispatchers.get('flow');
     expect(d?.thread_id).toMatch(/^thread_fake_/);
     expect(d?.status).toBe('ready');
+  });
+
+  it('compatible Feishu gate drops bot-loop messages before durable enqueue', async () => {
+    server = buildServer({ runtimeDir, fake, bot });
+    server.repos.dispatchers.create({
+      dispatcher_id: 'flow',
+      bot_app_id: 'cli_smoke',
+      bot_secret_ref: 'env:UNUSED',
+    });
+    await server.start();
+
+    await bot.inject({
+      ...fakeInbound('oc_group_a', 'loop', 'om_loop'),
+      senderId: bot.botOpenId ?? '',
+    });
+
+    await sleep(80);
+    expect(server.repos.inbound.getById(1)).toBeNull();
+    expect(fake.turnsHandled).toBe(0);
+    expect(bot.sentMessages).toEqual([]);
+  });
+
+  it('compatible Feishu gate drops Feishu bot/app sender types', async () => {
+    server = buildServer({ runtimeDir, fake, bot });
+    server.repos.dispatchers.create({
+      dispatcher_id: 'flow',
+      bot_app_id: 'cli_smoke',
+      bot_secret_ref: 'env:UNUSED',
+    });
+    await server.start();
+
+    await bot.inject({
+      ...fakeInbound('oc_group_a', 'bot says hi', 'om_bot'),
+      senderId: 'ou_peer_bot',
+      senderType: 'bot',
+    });
+
+    await sleep(80);
+    expect(server.repos.inbound.getById(1)).toBeNull();
+    expect(fake.turnsHandled).toBe(0);
+    expect(bot.sentMessages).toEqual([]);
   });
 
   it('FIFO: same-dispatcher messages process serially', async () => {

--- a/packages/dreamux/tests/smoke.test.ts
+++ b/packages/dreamux/tests/smoke.test.ts
@@ -122,6 +122,11 @@ describe('dreamux MVP smoke', () => {
     await waitFor(() => bot.sentMessages.length >= 1);
     expect(bot.sentMessages[0]).toMatchObject({
       chatId: 'oc_group_a',
+      target: {
+        chatId: 'oc_group_a',
+        replyToMessageId: 'om_1',
+        mentionUserIds: ['ou_sender_test'],
+      },
       text: 'echo: hi',
     });
 
@@ -229,11 +234,11 @@ describe('dreamux MVP smoke', () => {
     await server.start();
 
     let attempts = 0;
-    const origSend = bot.sendText.bind(bot);
-    bot.sendText = async (chat: string, text: string) => {
+    const origSend = bot.send.bind(bot);
+    bot.send = async (target, text) => {
       attempts++;
       if (attempts === 1) throw new Error('transient feishu hiccup');
-      return origSend(chat, text);
+      return origSend(target, text);
     };
 
     await bot.inject(fakeInbound('oc_group_a', 'retry-me', 'om_r'));


### PR DESCRIPTION
## Summary

- upgrade the shared Feishu transport `send(OutboundTarget, text)` path to honor `replyToMessageId` via `im.message.reply`
- render `mentionUserIds` as leading card mentions, so dreamux can @-back the original sender
- add a dreamux-local channel outbound contract so dispatcher/turn-manager code does not depend directly on Feishu types
- map durable inbound metadata (`source_chat_id`, `source_message_id`, `sender_id`) into outbound targets for normal replies, retry, and crash-recovery notifications
- add a compatibility-default Feishu inbound gate: normal user messages still deliver, while missing sender id, self-sent bot-loop messages, Feishu `bot`/`app` sender types, and ambiguous group messages before `botOpenId` resolution are dropped before durable enqueue

## Scope

This is the first dreamux implementation slice for issue #6 / the Feishu-channel isomorphism work. It keeps the access model compatible with today's behavior: no pairing or allowlist requirement is enabled. The gate is intentionally thin and defensive; the stricter `gate()` / AccessStore policy remains a pluggable follow-up.

## Verification

- `node common/scripts/install-run-rush.js build`
- `DREAMUX_SKIP_LIVE_CODEX=1 node common/scripts/install-run-rush.js test`
  - local Codex is `0.135.0`; the live `0.134.x` compatibility test is intentionally skipped by that env var
- `node common/scripts/install-run-rush.js change --verify --no-fetch`
- red-line scan over changed files for internal domains/package registries/long Feishu ids/secrets: no new hit; only existing source comments mention generic token handling
