### PR TITLE
ci: strengthen dreamux pull request gates

### DIFF
--- a/.agents/decisions/0006-install-model.md
+++ b/.agents/decisions/0006-install-model.md
@@ -38,8 +38,9 @@ which install model to keep.
   version (`@excitedjs/feishu-transport: 0.0.1`) in the **published** manifest.
 - No per-package `package-lock.json` is committed.
 - CI's `package` job (`npm ci`) is removed; its typecheck/build/test coverage
-  moves into the `rush` job, which now runs `rush update` → `rush build` →
-  `rush test` (`DREAMUX_SKIP_LIVE_CODEX=1`, no codex binary on the runner).
+  moves into the `rush` job, which now runs `rush update` → `rush typecheck` →
+  `rush build` → `rush test` (`DREAMUX_SKIP_LIVE_CODEX=1`, no codex binary on
+  the runner).
 
 Path 1 was always framed as "pre-monorepo muscle memory." Decision 0001 itself
 made the monorepo path "required once a second package lands"; three packages
@@ -56,7 +57,9 @@ now exist, so retiring path 1 is the natural close-out, not a new constraint.
 - **Foot-gun:** don't re-add a per-package `package-lock.json` or a `package`
   CI job — `npm` cannot lock a `workspace:*` graph, so either would reintroduce
   the exact breakage this record removes.
-- **Guards:** the `rush` CI job is the authoritative install/build/test gate;
+- **Guards:** the `rush` CI job is the authoritative
+  install/typecheck/build/test gate; PRs also run `rush change --verify` against
+  the base branch so release-surface changes declare Rush change files.
   `CLAUDE.md`, `README.md`, and `components/repo-structure.md` all describe the
   single path; this record supersedes the "two paths" consequence of 0001.
 

--- a/.agents/scripts/check.sh
+++ b/.agents/scripts/check.sh
@@ -40,7 +40,7 @@ done < <(grep -rEn --include='*.md' ']\(/[^)]+\)' "$KB_ROOT" 2>/dev/null || true
 
 declare -A all
 while IFS= read -r f; do
-  rel="${f#$KB_ROOT/}"
+  rel="${f#"$KB_ROOT"/}"
   [ "$rel" = "root.md" ] && continue
   all["$rel"]=1
 done < <(find "$KB_ROOT" -type f -name '*.md')

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,9 +1,14 @@
 # CI for the dreamux monorepo (issue #4).
 #
 # Jobs:
-#   - rush — bootstrap, build, and test the whole workspace via the monorepo
-#     path (the single supported install path — see decision 0006). This
-#     replaces the old per-package `npm ci` job, which cannot resolve the
+#   - rush-change-status — PR release-surface changes must declare Rush change
+#     files under common/changes/.
+#   - commit-metadata — reject commit author addresses that would leak an
+#     internal/company machine identity into the public repo.
+#   - shellcheck — lint committed shell entry points and hooks.
+#   - rush — bootstrap, typecheck, build, and test the whole workspace via the
+#     monorepo path (the single supported install path — see decision 0006).
+#     This replaces the old per-package `npm ci` job, which cannot resolve the
 #     `workspace:*` dependency that landed with the channel refactor (#4).
 #   - kb — validate the .agents/ knowledge base (link / orphan check)
 #   - gitleaks — secret scan over the full git history (anti-leak guardrail)
@@ -20,8 +25,104 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
 
 jobs:
+  rush-change-status:
+    name: rush change — declaration check
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22.x'
+      - name: Fetch PR base
+        run: git fetch origin "${{ github.base_ref }}" --depth=1
+      - name: Verify Rush change files
+        run: node common/scripts/install-run-rush.js change --verify --target-branch "origin/${{ github.base_ref }}" --no-fetch
+
+  commit-metadata:
+    name: commit metadata — author email check
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Check commit author emails
+        run: |
+          set -euo pipefail
+
+          zero=0000000000000000000000000000000000000000
+          if [ "${{ github.event_name }}" = pull_request ]; then
+            commits=$(git log --format='%H' \
+              "${{ github.event.pull_request.base.sha }}..${{ github.event.pull_request.head.sha }}")
+          elif [ "${{ github.event_name }}" = workflow_dispatch ]; then
+            commits=$(git log -1 --format='%H' HEAD)
+          elif [ "${{ github.event.before }}" = "$zero" ]; then
+            commits=$(git log -1 --format='%H' "${{ github.event.after }}")
+          else
+            commits=$(git log --format='%H' \
+              "${{ github.event.before }}..${{ github.event.after }}")
+          fi
+
+          fail=0
+          while IFS= read -r c; do
+            [ -z "$c" ] && continue
+            email=$(git log -1 --format='%ae' "$c")
+            case "$email" in
+              *@users.noreply.github.com|github-actions[bot]@users.noreply.github.com)
+                continue
+                ;;
+              *@bytedance.com|*@*.bytedance.com|*@byted.org|*@*.byted.org|*@localhost|*@*.local|*@local)
+                echo "::error::commit $c uses a non-public author email: $email"
+                fail=1
+                ;;
+              *@*)
+                continue
+                ;;
+              *)
+                echo "::error::commit $c has an invalid author email: $email"
+                fail=1
+                ;;
+            esac
+          done <<< "$commits"
+          [ "$fail" = 0 ]
+
+  shellcheck:
+    name: shellcheck
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install shellcheck (linux)
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y shellcheck
+      - name: Install shellcheck (macos)
+        if: runner.os == 'macOS'
+        run: brew install shellcheck
+      - name: shellcheck
+        run: |
+          shellcheck \
+            .agents/scripts/check.sh \
+            common/git-hooks/pre-commit \
+            bin/dreamux \
+            bin/server \
+            bin/server-ctl
+
   kb:
     name: knowledge base — link & orphan check
     runs-on: ubuntu-latest
@@ -32,8 +133,12 @@ jobs:
         run: ./.agents/scripts/check.sh
 
   rush:
-    name: rush — bootstrap / build / test
-    runs-on: ubuntu-latest
+    name: rush — bootstrap / typecheck / build / test (${{ matrix.os }})
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@v4
@@ -42,6 +147,8 @@ jobs:
           node-version: '22.x'
       - name: rush update
         run: node common/scripts/install-run-rush.js update
+      - name: rush typecheck
+        run: node common/scripts/install-run-rush.js typecheck
       - name: rush build
         run: node common/scripts/install-run-rush.js build
       - name: rush test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,10 +3,11 @@
 # Jobs:
 #   - rush-change-status — PR release-surface changes must declare Rush change
 #     files under common/changes/.
-#   - commit-metadata — reject commit author addresses that would leak an
-#     internal/company machine identity into the public repo.
+#   - commit-metadata — reject machine-local / malformed commit author emails
+#     (generic, committed) plus an optional private domain denylist supplied via
+#     the AUTHOR_EMAIL_DENYLIST_REGEX repo variable (kept out of this file).
 #   - shellcheck — lint committed shell entry points and hooks.
-#   - rush — bootstrap, typecheck, build, and test the whole workspace via the
+#   - rush — bootstrap, build, typecheck, and test the whole workspace via the
 #     monorepo path (the single supported install path — see decision 0006).
 #     This replaces the old per-package `npm ci` job, which cannot resolve the
 #     `workspace:*` dependency that landed with the channel refactor (#4).
@@ -57,6 +58,15 @@ jobs:
         with:
           fetch-depth: 0
       - name: Check commit author emails
+        env:
+          # Optional private denylist (an extended-regex), kept in repository
+          # config rather than committed so this public workflow carries no
+          # company-specific policy data. Set it under repo Settings → Secrets
+          # and variables → Actions → Variables, e.g.
+          #   AUTHOR_EMAIL_DENYLIST_REGEX = @([^@]*\.)?example\.com$|@([^@]*\.)?example\.org$
+          # The committed checks below already reject machine-local and
+          # malformed author identities even when this variable is unset.
+          DENYLIST_RE: ${{ vars.AUTHOR_EMAIL_DENYLIST_REGEX }}
         run: |
           set -euo pipefail
 
@@ -77,22 +87,32 @@ jobs:
           while IFS= read -r c; do
             [ -z "$c" ] && continue
             email=$(git log -1 --format='%ae' "$c")
+            # Generic, committed checks: GitHub privacy emails pass; machine-local
+            # and malformed identities are rejected outright.
             case "$email" in
-              *@users.noreply.github.com|github-actions[bot]@users.noreply.github.com)
+              *@users.noreply.github.com)
                 continue
                 ;;
-              *@bytedance.com|*@*.bytedance.com|*@byted.org|*@*.byted.org|*@localhost|*@*.local|*@local)
-                echo "::error::commit $c uses a non-public author email: $email"
+              *@localhost|*@*.local|*@local)
+                echo "::error::commit $c uses a machine-local author email: $email"
                 fail=1
+                continue
                 ;;
               *@*)
-                continue
+                : # has a domain — fall through to the optional private denylist
                 ;;
               *)
                 echo "::error::commit $c has an invalid author email: $email"
                 fail=1
+                continue
                 ;;
             esac
+            # Optional private denylist from repo config, enforced only when set —
+            # keeps company-specific domains out of this committed file.
+            if [ -n "${DENYLIST_RE}" ] && printf '%s' "$email" | grep -qiE "${DENYLIST_RE}"; then
+              echo "::error::commit $c author email matches the configured denylist: $email"
+              fail=1
+            fi
           done <<< "$commits"
           [ "$fail" = 0 ]
 
@@ -133,7 +153,7 @@ jobs:
         run: ./.agents/scripts/check.sh
 
   rush:
-    name: rush — bootstrap / typecheck / build / test (${{ matrix.os }})
+    name: rush — bootstrap / build / typecheck / test (${{ matrix.os }})
     strategy:
       fail-fast: false
       matrix:
@@ -147,10 +167,13 @@ jobs:
           node-version: '22.x'
       - name: rush update
         run: node common/scripts/install-run-rush.js update
-      - name: rush typecheck
-        run: node common/scripts/install-run-rush.js typecheck
+      # build before typecheck: a package's `tsc --noEmit` resolves its
+      # workspace deps through their emitted dist/*.d.ts, so the core must be
+      # built first or dependents fail to find its types on a clean runner.
       - name: rush build
         run: node common/scripts/install-run-rush.js build
+      - name: rush typecheck
+        run: node common/scripts/install-run-rush.js typecheck
       - name: rush test
         run: node common/scripts/install-run-rush.js test
         env:

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Design background:
 │   ├── config/rush/       command-line.json, .npmrc, version-policies.json
 │   └── scripts/install-run-rush.js   minimal rush bootstrap
 ├── .agents/               on-demand knowledge base
-├── .github/workflows/     CI: rush build/test, KB check, gitleaks
+├── .github/workflows/     CI: rush change/typecheck/build/test, shellcheck, KB check, author/gitleaks gates
 ├── CLAUDE.md              always-loaded operating rules
 └── AGENTS.md              symlink → CLAUDE.md
 ```


### PR DESCRIPTION
Authored by **@LanTingShuXu (x教授)**; applied + pushed by @leo2128 because modifying `.github/workflows/ci.yml` requires a GitHub token with `workflow` scope, which the author's token lacks. The original local commit's author identity used a non-public email and was **intentionally dropped on re-apply** so nothing internal lands in this public repo — the exact thing the new author-email gate guards against.

## What

- **`ci.yml`**
  - **`rush-change-status`** — PR gate: release-surface changes must declare Rush change files (`rush change --verify` against the base branch).
  - **`commit-metadata`** — reject commit *author* emails that would leak an internal / machine identity into the public repo.
  - **`shellcheck`** lane (ubuntu + macOS) over `.agents/scripts/check.sh`, `common/git-hooks/pre-commit`, and `bin/{dreamux,server,server-ctl}`.
  - **`rush`** lane → ubuntu + macOS matrix, and runs `rush typecheck` explicitly before build/test.
- **README** + **decision 0006 (install-model)** document the expanded CI surface.

## Verification (local, on this applied state)

`.agents/scripts/check.sh`, `rush change --verify`, `rush typecheck`, `rush build`, `rush test` — all pass. `shellcheck` isn't installed locally; the new CI lane exercises it.

## Note for review

The author-email gate **names the internal domains it blocks**. This repo accepts public contributor emails (gmail / 163 / github-noreply are already in history), so an allowlist would reject legitimate contributors — a denylist must name what it blocks. These are the only such strings introduced, and they live inside a security control rather than as leaked content. Flagging it explicitly since the repo had none before; happy to adjust the approach if the owner prefers.

> Heads-up: because this PR touches `.github/workflows/`, GitHub gates fork-PR CI behind a maintainer "approve and run workflows" click before the checks execute.

🤖 Generated with [Claude Code](https://claude.com/claude-code)