### PR TITLE
feat(feishu-transport): add Feishu bot-member parse helpers

### DIFF
--- a/common/changes/@excitedjs/feishu-transport/feishu-bot-member-core_2026-05-31-06-49.json
+++ b/common/changes/@excitedjs/feishu-transport/feishu-bot-member-core_2026-05-31-06-49.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Add core parsing helpers for Feishu bot-member-added events and mention names.",
+      "type": "patch",
+      "packageName": "@excitedjs/feishu-transport"
+    }
+  ],
+  "packageName": "@excitedjs/feishu-transport",
+  "email": "11888364+LanTingShuXu@users.noreply.github.com"
+}

--- a/packages/channel/feishu-transport/src/index.ts
+++ b/packages/channel/feishu-transport/src/index.ts
@@ -30,11 +30,17 @@ export {
   narrowMetaFromEvent,
   toChannelInbound,
   applyMentions,
+  mentionName,
   extractPostText,
   type InboundMessage,
   type ParsedInbound,
   type ChannelInbound,
 } from './parse/content.js'
+export {
+  normalizeBotMemberAddedEvent,
+  BOT_MEMBER_ADDED_EVENT_TYPE,
+  type FeishuBotMemberAddedEvent,
+} from './parse/bot-member.js'
 export {
   normalizeCommentEvent,
   DOC_COMMENT_EVENT_TYPE,

--- a/packages/channel/feishu-transport/src/parse/bot-member.ts
+++ b/packages/channel/feishu-transport/src/parse/bot-member.ts
@@ -1,0 +1,41 @@
+/**
+ * Decoding the `im.chat.member.bot.added_v1` event envelope.
+ *
+ * Hosts use this event to notice when the Feishu bot is added to a chat. The
+ * decode is deliberately narrow and pure: it only extracts stable envelope
+ * identifiers, performs no I/O, and returns `null` for unroutable payloads.
+ */
+
+import { asString, isRecord } from '../json.js'
+
+/** The Feishu event_type this decoder is for. */
+export const BOT_MEMBER_ADDED_EVENT_TYPE = 'im.chat.member.bot.added_v1'
+
+/** A normalized bot-added event — the identifying fields the payload carries. */
+export interface FeishuBotMemberAddedEvent {
+  /** Chat id the bot was added to. */
+  chatId: string
+  /** Feishu event id from the header, empty when the host passes a bare event. */
+  eventId: string
+}
+
+/**
+ * Reshape a raw `im.chat.member.bot.added_v1` payload into a
+ * `FeishuBotMemberAddedEvent`. Tolerates either a full `{ header, event }`
+ * envelope or the bare event body delivered by some host adapters. Pure: no
+ * I/O, never throws.
+ */
+export function normalizeBotMemberAddedEvent(
+  raw: unknown,
+): FeishuBotMemberAddedEvent | null {
+  if (!isRecord(raw)) return null
+  const event = isRecord(raw.event) ? raw.event : raw
+  const chatId = asString(event.chat_id)
+  if (chatId === '') return null
+
+  const header = isRecord(raw.header) ? raw.header : {}
+  return {
+    chatId,
+    eventId: asString(header.event_id),
+  }
+}

--- a/packages/channel/feishu-transport/src/parse/content.ts
+++ b/packages/channel/feishu-transport/src/parse/content.ts
@@ -255,6 +255,14 @@ export function applyMentions(text: string, mentions: Mention[] | undefined): st
   return out
 }
 
+/** Return the display name for an open_id in a Feishu mention list, if present. */
+export function mentionName(
+  mentions: Mention[] | undefined,
+  openId: string,
+): string | undefined {
+  return mentions?.find((m) => m.id?.open_id === openId)?.name
+}
+
 /**
  * Flatten a Feishu rich-text "post" payload into plain text. A post is
  * locale-wrapped (`{ zh_cn: { title, content } }`) and its body is an array of

--- a/packages/channel/feishu-transport/tests/bot-member.test.ts
+++ b/packages/channel/feishu-transport/tests/bot-member.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, test } from 'vitest'
+import {
+  BOT_MEMBER_ADDED_EVENT_TYPE,
+  normalizeBotMemberAddedEvent,
+} from '../src/parse/bot-member'
+
+describe('normalizeBotMemberAddedEvent', () => {
+  test('exports the Feishu bot-member-added event type', () => {
+    expect(BOT_MEMBER_ADDED_EVENT_TYPE).toBe('im.chat.member.bot.added_v1')
+  })
+
+  test('extracts chat id and event id from a full event envelope', () => {
+    expect(
+      normalizeBotMemberAddedEvent({
+        header: {
+          event_id: 'evt_1',
+          event_type: BOT_MEMBER_ADDED_EVENT_TYPE,
+        },
+        event: {
+          chat_id: 'oc_1',
+        },
+      }),
+    ).toEqual({
+      chatId: 'oc_1',
+      eventId: 'evt_1',
+    })
+  })
+
+  test('accepts a bare event body and leaves event id empty', () => {
+    expect(normalizeBotMemberAddedEvent({ chat_id: 'oc_2' })).toEqual({
+      chatId: 'oc_2',
+      eventId: '',
+    })
+  })
+
+  test('returns null for non-object or unroutable payloads', () => {
+    expect(normalizeBotMemberAddedEvent(null)).toBeNull()
+    expect(normalizeBotMemberAddedEvent('not an event')).toBeNull()
+    expect(normalizeBotMemberAddedEvent({})).toBeNull()
+    expect(normalizeBotMemberAddedEvent({ event: {} })).toBeNull()
+    expect(normalizeBotMemberAddedEvent({ event: { chat_id: '' } })).toBeNull()
+    expect(normalizeBotMemberAddedEvent({ event: { chat_id: 42 } })).toBeNull()
+  })
+})

--- a/packages/channel/feishu-transport/tests/content.test.ts
+++ b/packages/channel/feishu-transport/tests/content.test.ts
@@ -1,5 +1,12 @@
 import { describe, expect, test } from 'vitest'
-import { applyMentions, extractPostText, narrowMetaFromEvent, parseInbound, toChannelInbound } from '../src/parse/content'
+import {
+  applyMentions,
+  extractPostText,
+  mentionName,
+  narrowMetaFromEvent,
+  parseInbound,
+  toChannelInbound,
+} from '../src/parse/content'
 import type { InboundMessage } from '../src/parse/content'
 import type { Mention } from '../src/contract/types'
 
@@ -15,6 +22,16 @@ describe('parseInbound — text', () => {
   test('resolves @-mention placeholders to display names', () => {
     const msg = message('text', { text: '@_user_1 ping' }, [{ key: '@_user_1', name: 'Alice' }])
     expect(parseInbound(msg).text).toBe('@Alice ping')
+  })
+
+  test('finds a mention display name by open_id', () => {
+    const mentions: Mention[] = [
+      { key: '@_user_1', name: 'Alice', id: { open_id: 'ou_a' } },
+      { key: '@_user_2', name: 'Bob', id: { open_id: 'ou_b' } },
+    ]
+    expect(mentionName(mentions, 'ou_b')).toBe('Bob')
+    expect(mentionName(mentions, 'ou_missing')).toBeUndefined()
+    expect(mentionName(undefined, 'ou_b')).toBeUndefined()
   })
 
   test('text with no JSON content falls back gracefully', () => {


### PR DESCRIPTION
Authored by **@LanTingShuXu (x教授)** (commit `63e4e59`, applied via `git am` so authorship is preserved); pushed by @leo2128 because his token can't push a main-based branch to his stale fork (it would re-introduce `.github/workflows/ci.yml`, which needs `workflow` scope).

Adds the engine-agnostic Feishu **parse** primitives that claudemux's bot-discovery (#17) currently does inline — lifting them into the shared core per the agreed boundary (core = 长链/分发/解析/编码; bot-discovery policy/stores stay host). Both hosts can now reuse these.

## New exports (`@excitedjs/feishu-transport`)

- `BOT_MEMBER_ADDED_EVENT_TYPE = 'im.chat.member.bot.added_v1'`
- `normalizeBotMemberAddedEvent(raw) → { chatId, eventId } | null` — tolerates the `{header, event}` envelope or a bare event; `chatId` empty/non-string → `null`; `eventId` from `header.event_id` (default `''`); pure, no I/O, never throws.
- `mentionName(mentions, openId) → string | undefined`

## Verification (local, on this applied state)

`rush update` → `rush build` → `rush typecheck` → `DREAMUX_SKIP_LIVE_CODEX=1 rush test` — all green (only the local Codex 0.134 live smoke is skipped). `rush change --verify` finds the change file. Diff is red-line clean (no internal domains/ids).

## Follow-on

After merge, the release/version PR patch-bumps `@excitedjs/feishu-transport`; claudemux then pins the new version and migrates #17's inline parse to consume `normalizeBotMemberAddedEvent` (resolving #13's conflict in the same rebase). — per the owner's sequencing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)