### PR TITLE
feat(feishu-transport): bot-member-added normalizer + mentionName helper

### DIFF
--- a/common/changes/@excitedjs/feishu-transport/feishu-bot-member-core_2026-05-31-06-49.json
+++ b/common/changes/@excitedjs/feishu-transport/feishu-bot-member-core_2026-05-31-06-49.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Add core parsing helpers for Feishu bot-member-added events and mention names.",
+      "type": "patch",
+      "packageName": "@excitedjs/feishu-transport"
+    }
+  ],
+  "packageName": "@excitedjs/feishu-transport",
+  "email": "11888364+LanTingShuXu@users.noreply.github.com"
+}

--- a/packages/channel/feishu-transport/src/index.ts
+++ b/packages/channel/feishu-transport/src/index.ts
@@ -30,11 +30,17 @@ export {
   narrowMetaFromEvent,
   toChannelInbound,
   applyMentions,
+  mentionName,
   extractPostText,
   type InboundMessage,
   type ParsedInbound,
   type ChannelInbound,
 } from './parse/content.js'
+export {
+  normalizeBotMemberAddedEvent,
+  BOT_MEMBER_ADDED_EVENT_TYPE,
+  type FeishuBotMemberAddedEvent,
+} from './parse/bot-member.js'
 export {
   normalizeCommentEvent,
   DOC_COMMENT_EVENT_TYPE,

--- a/packages/channel/feishu-transport/src/parse/bot-member.ts
+++ b/packages/channel/feishu-transport/src/parse/bot-member.ts
@@ -1,0 +1,41 @@
+/**
+ * Decoding the `im.chat.member.bot.added_v1` event envelope.
+ *
+ * Hosts use this event to notice when the Feishu bot is added to a chat. The
+ * decode is deliberately narrow and pure: it only extracts stable envelope
+ * identifiers, performs no I/O, and returns `null` for unroutable payloads.
+ */
+
+import { asString, isRecord } from '../json.js'
+
+/** The Feishu event_type this decoder is for. */
+export const BOT_MEMBER_ADDED_EVENT_TYPE = 'im.chat.member.bot.added_v1'
+
+/** A normalized bot-added event — the identifying fields the payload carries. */
+export interface FeishuBotMemberAddedEvent {
+  /** Chat id the bot was added to. */
+  chatId: string
+  /** Feishu event id from the header, empty when the host passes a bare event. */
+  eventId: string
+}
+
+/**
+ * Reshape a raw `im.chat.member.bot.added_v1` payload into a
+ * `FeishuBotMemberAddedEvent`. Tolerates either a full `{ header, event }`
+ * envelope or the bare event body delivered by some host adapters. Pure: no
+ * I/O, never throws.
+ */
+export function normalizeBotMemberAddedEvent(
+  raw: unknown,
+): FeishuBotMemberAddedEvent | null {
+  if (!isRecord(raw)) return null
+  const event = isRecord(raw.event) ? raw.event : raw
+  const chatId = asString(event.chat_id)
+  if (chatId === '') return null
+
+  const header = isRecord(raw.header) ? raw.header : {}
+  return {
+    chatId,
+    eventId: asString(header.event_id),
+  }
+}

--- a/packages/channel/feishu-transport/src/parse/content.ts
+++ b/packages/channel/feishu-transport/src/parse/content.ts
@@ -255,6 +255,14 @@ export function applyMentions(text: string, mentions: Mention[] | undefined): st
   return out
 }
 
+/** Return the display name for an open_id in a Feishu mention list, if present. */
+export function mentionName(
+  mentions: Mention[] | undefined,
+  openId: string,
+): string | undefined {
+  return mentions?.find((m) => m.id?.open_id === openId)?.name
+}
+
 /**
  * Flatten a Feishu rich-text "post" payload into plain text. A post is
  * locale-wrapped (`{ zh_cn: { title, content } }`) and its body is an array of

--- a/packages/channel/feishu-transport/tests/bot-member.test.ts
+++ b/packages/channel/feishu-transport/tests/bot-member.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, test } from 'vitest'
+import {
+  BOT_MEMBER_ADDED_EVENT_TYPE,
+  normalizeBotMemberAddedEvent,
+} from '../src/parse/bot-member'
+
+describe('normalizeBotMemberAddedEvent', () => {
+  test('exports the Feishu bot-member-added event type', () => {
+    expect(BOT_MEMBER_ADDED_EVENT_TYPE).toBe('im.chat.member.bot.added_v1')
+  })
+
+  test('extracts chat id and event id from a full event envelope', () => {
+    expect(
+      normalizeBotMemberAddedEvent({
+        header: {
+          event_id: 'evt_1',
+          event_type: BOT_MEMBER_ADDED_EVENT_TYPE,
+        },
+        event: {
+          chat_id: 'oc_1',
+        },
+      }),
+    ).toEqual({
+      chatId: 'oc_1',
+      eventId: 'evt_1',
+    })
+  })
+
+  test('accepts a bare event body and leaves event id empty', () => {
+    expect(normalizeBotMemberAddedEvent({ chat_id: 'oc_2' })).toEqual({
+      chatId: 'oc_2',
+      eventId: '',
+    })
+  })
+
+  test('returns null for non-object or unroutable payloads', () => {
+    expect(normalizeBotMemberAddedEvent(null)).toBeNull()
+    expect(normalizeBotMemberAddedEvent('not an event')).toBeNull()
+    expect(normalizeBotMemberAddedEvent({})).toBeNull()
+    expect(normalizeBotMemberAddedEvent({ event: {} })).toBeNull()
+    expect(normalizeBotMemberAddedEvent({ event: { chat_id: '' } })).toBeNull()
+    expect(normalizeBotMemberAddedEvent({ event: { chat_id: 42 } })).toBeNull()
+  })
+})

--- a/packages/channel/feishu-transport/tests/content.test.ts
+++ b/packages/channel/feishu-transport/tests/content.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'vitest'
-import { applyMentions, extractPostText, narrowMetaFromEvent, parseInbound, toChannelInbound } from '../src/parse/content'
+import { applyMentions, extractPostText, mentionName, narrowMetaFromEvent, parseInbound, toChannelInbound } from '../src/parse/content'
 import type { InboundMessage } from '../src/parse/content'
 import type { Mention } from '../src/contract/types'
 
@@ -15,6 +15,16 @@ describe('parseInbound — text', () => {
   test('resolves @-mention placeholders to display names', () => {
     const msg = message('text', { text: '@_user_1 ping' }, [{ key: '@_user_1', name: 'Alice' }])
     expect(parseInbound(msg).text).toBe('@Alice ping')
+  })
+
+  test('finds a mention display name by open_id', () => {
+    const mentions: Mention[] = [
+      { key: '@_user_1', name: 'Alice', id: { open_id: 'ou_a' } },
+      { key: '@_user_2', name: 'Bob', id: { open_id: 'ou_b' } },
+    ]
+    expect(mentionName(mentions, 'ou_b')).toBe('Bob')
+    expect(mentionName(mentions, 'ou_missing')).toBeUndefined()
+    expect(mentionName(undefined, 'ou_b')).toBeUndefined()
   })
 
   test('text with no JSON content falls back gracefully', () => {


### PR DESCRIPTION
## What

Adds two missing core parsing capabilities to `@excitedjs/feishu-transport`, so downstream channel adapters can route bot lifecycle events and resolve mention names without re-implementing the parsing.

### `normalizeBotMemberAddedEvent(raw)` + `BOT_MEMBER_ADDED_EVENT_TYPE`
New file `src/parse/bot-member.ts`. Decodes the `im.chat.member.bot.added_v1` envelope (the event a host sees when the Feishu bot is added to a chat).

- Pure function: no I/O, never throws.
- Tolerates either a full `{ header, event }` envelope or a bare event body delivered by some host adapters.
- Returns `{ chatId, eventId }` or `null`; `null` when `chat_id` is missing or non-string.
- `eventId` comes from `header.event_id`, defaulting to `''` for a bare event.
- `BOT_MEMBER_ADDED_EVENT_TYPE === 'im.chat.member.bot.added_v1'`.

### `mentionName(mentions, openId)`
Added to `src/parse/content.ts`. Returns the display name for an `open_id` in a Feishu mention list, or `undefined` when absent.

## Exports & tests
- Re-exported from `src/index.ts` (`normalizeBotMemberAddedEvent`, `BOT_MEMBER_ADDED_EVENT_TYPE`, `FeishuBotMemberAddedEvent`, `mentionName`).
- New `tests/bot-member.test.ts`; `mentionName` coverage added to `tests/content.test.ts`.
- Rush changefile: `patch` bump for `@excitedjs/feishu-transport`.

## Validation
Author validated locally before pushing — `rush build` / typecheck / `rush test` / `rush change --verify` all passed. This branch is the rebased-onto-current-`main` form of that locally-validated commit (one trivial conflict in `tests/content.test.ts` resolved by taking the union of the import line). CI will confirm the rebase resolution.

## Release
A separate release/version PR will patch-bump `@excitedjs/feishu-transport` after this merges; the actual published npm version is determined by that release PR, not this one.
