### PR TITLE
fix(release): add repository field so OIDC provenance publish passes

### DIFF
--- a/common/changes/@excitedjs/dreamux/fix-publish-provenance-repository_2026-05-31-15-34.json
+++ b/common/changes/@excitedjs/dreamux/fix-publish-provenance-repository_2026-05-31-15-34.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Add repository field so npm provenance validation passes on OIDC publish",
+      "type": "none",
+      "packageName": "@excitedjs/dreamux"
+    }
+  ],
+  "packageName": "@excitedjs/dreamux",
+  "email": "YourWildDad <15624809+YourWildDad@users.noreply.github.com>"
+}

--- a/common/changes/@excitedjs/feishu-transport/fix-publish-provenance-repository_2026-05-31-15-34.json
+++ b/common/changes/@excitedjs/feishu-transport/fix-publish-provenance-repository_2026-05-31-15-34.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Add repository field so npm provenance validation passes on OIDC publish",
+      "type": "none",
+      "packageName": "@excitedjs/feishu-transport"
+    }
+  ],
+  "packageName": "@excitedjs/feishu-transport",
+  "email": "YourWildDad <15624809+YourWildDad@users.noreply.github.com>"
+}

--- a/packages/channel/feishu-transport/package.json
+++ b/packages/channel/feishu-transport/package.json
@@ -3,6 +3,11 @@
   "version": "0.0.2",
   "description": "Shared Feishu platform-I/O core for dreamux and claudemux: connect / receive / send / auth / render / parse + stateless policy (issue excitedjs/dreamux#25).",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/excitedjs/dreamux.git",
+    "directory": "packages/channel/feishu-transport"
+  },
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/dreamux/package.json
+++ b/packages/dreamux/package.json
@@ -3,6 +3,11 @@
   "version": "0.1.2",
   "description": "Codex-host server — single-session MVP. One node process hosts N dispatchers, each binding 1 Feishu bot + 1 Codex thread.",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/excitedjs/dreamux.git",
+    "directory": "packages/dreamux"
+  },
   "type": "module",
   "main": "./dist/server.js",
   "engines": {


### PR DESCRIPTION
## Root cause

The release run for #11 (commit 8352a04) failed at the publish step with two **distinct** problems, only the first of which was visible:

1. **Missing npm trusted-publisher for `@excitedjs/dreamux`** — `npm publish` 404'd on `PUT .../@excitedjs%2fdreamux`. Fixed outside the repo (trusted publisher now configured on npmjs.com: GitHub Actions / excitedjs / dreamux / `release.yml`).
2. **Missing `repository` field → provenance validation fails (this PR).** Once auth cleared, the publish reached provenance verification and npm rejected it:

   ```
   npm error code E422
   npm error 422 ... Error verifying sigstore provenance bundle:
   package.json: "repository.url" is "", expected to match
   "https://github.com/excitedjs/dreamux" from provenance
   ```

`npm publish --provenance` builds the provenance statement from the GitHub Actions OIDC context (`https://github.com/excitedjs/dreamux`) and then requires the package's `repository.url` to match it. Neither `@excitedjs/dreamux` nor `@excitedjs/feishu-transport` declared a `repository` field — their `0.1.1` / `0.0.1` were token-bootstrap first publishes that carried no provenance, so the gap was invisible until the first OIDC `--provenance` publish.

`@excitedjs/dreamux` is first in `rush.json`, so it hit E422 first and `set -e` aborted the loop before `@excitedjs/feishu-transport` was ever attempted — but it has the identical gap and would have failed the same way.

## Fix

Add a `repository` block (with monorepo `directory`) to both publishable packages, matching the proven shape of the already-published `@excitedjs/tm`. `none`-type rush change files so versions stay at **0.1.2 / 0.0.2** (no bump — the downstream stacked PR needs exactly `@excitedjs/feishu-transport@0.0.2`).

## Publish path

Merging this PR pushes to `main`, which fires `release.yml`. That fresh run checks out the fixed commit, re-classifies both versions as unpublished, and publishes both via OIDC. (Re-running the original failed run would re-checkout 8352a04 and E422 forever — the fix only reaches the workflow as a new commit on main.)

## Validation

- `rush change --verify --target-branch origin/main` → pass
- both `package.json` + both change files are valid JSON
- anti-leak grep over the diff: clean

## Note (not fixed here, by design)

The publish loop runs under `bash -eo pipefail`, so one package's failure aborts the rest. The workflow header documents the multi-package loop as intentional; left as optional future hardening rather than widening this PR.

Refs #11.
