### PR TITLE
feat: add codexmux dispatcher plugin

### DIFF
--- a/.agents/components/codex-marketplace.md
+++ b/.agents/components/codex-marketplace.md
@@ -1,0 +1,47 @@
+# Component: codex marketplace
+
+`/codex-marketplace/` is a local Codex marketplace root for the codex-native
+codexmux product layer. It is not a Rush package and does not add runtime code
+to `@excitedjs/dreamux`.
+
+## Files
+
+| Path | Role |
+|---|---|
+| `/codex-marketplace/.agents/plugins/marketplace.json` | Marketplace metadata named `dreamux`; entries point at `./plugins/<name>` relative to `/codex-marketplace/` |
+| `/codex-marketplace/plugins/codexmux/.codex-plugin/plugin.json` | Codex plugin manifest |
+| `/codex-marketplace/plugins/codexmux/skills/codexmux-dispatcher/SKILL.md` | Dispatcher skill for pinned `tm` delegation |
+| `/codex-marketplace/README.md` | Local install, prewarm, and demonstration flow |
+
+## Runtime Boundary
+
+The plugin keeps the boundary from
+[the dispatcher tm decision](../decisions/dispatcher-tm-boundary.md):
+
+- dreamux server hosts dispatcher Codex app-server processes only
+- the dispatcher invokes `tm` through the command boundary
+- dreamux does not own teammate daemons, teammate DB state, or `teammate.*`
+  admin methods
+
+## tm Strategy
+
+The first product slice pins `@excitedjs/tm@2.1.2` in the dispatcher skill,
+requires `tm spawn --engine codex`, and prewarms it with:
+
+```bash
+npm exec --yes --package @excitedjs/tm@2.1.2 -- tm --help
+```
+
+Do not replace this with bare `@excitedjs/tm@latest`. Do not use
+`tm wait --fresh` for Codex teammates; `--fresh` is Claude-only in tm 2.1.2. A
+self-contained tm artifact can be added later after the thin dispatcher ->
+skill -> tm path is validated end to end.
+
+## Validation
+
+Validate the plugin and skill structure before pushing:
+
+```bash
+python3 /data00/home/dyzhu/.codex/skills/.system/plugin-creator/scripts/validate_plugin.py ./codex-marketplace/plugins/codexmux
+python3 /data00/home/dyzhu/.codex/skills/.system/skill-creator/scripts/quick_validate.py ./codex-marketplace/plugins/codexmux/skills/codexmux-dispatcher
+```

--- a/.agents/components/codex-marketplace.md
+++ b/.agents/components/codex-marketplace.md
@@ -37,11 +37,3 @@ Do not replace this with bare `@excitedjs/tm@latest`. Do not use
 self-contained tm artifact can be added later after the thin dispatcher ->
 skill -> tm path is validated end to end.
 
-## Validation
-
-Validate the plugin and skill structure before pushing:
-
-```bash
-python3 /data00/home/dyzhu/.codex/skills/.system/plugin-creator/scripts/validate_plugin.py ./codex-marketplace/plugins/codexmux
-python3 /data00/home/dyzhu/.codex/skills/.system/skill-creator/scripts/quick_validate.py ./codex-marketplace/plugins/codexmux/skills/codexmux-dispatcher
-```

--- a/.agents/components/repo-structure.md
+++ b/.agents/components/repo-structure.md
@@ -18,6 +18,7 @@ sibling claudemux repo import one implementation instead of drifting copies.
 
 | Path | Purpose |
 |---|---|
+| `/codex-marketplace/` | Local Codex marketplace root for the `codexmux` plugin and dispatcher skill; not a Rush package |
 | `/rush.json` | Rush project list + pnpm/Node version pins |
 | `/common/config/rush/` | Rush command definitions (`command-line.json`), pnpm `.npmrc`, version policies, generated `pnpm-lock.yaml` |
 | `/common/scripts/install-run-rush.js` | Bootstrap that shells out to `npx @microsoft/rush@<version>` (see [the Rush + pnpm decision](../decisions/rush-pnpm-monorepo.md)) |

--- a/.agents/root.md
+++ b/.agents/root.md
@@ -20,6 +20,7 @@ issues:
 
 ```
 /                                  rush monorepo root
+├── codex-marketplace/             local Codex marketplace for codexmux
 ├── rush.json                      rush + pnpm config
 ├── common/                        rush scaffolding (config + bootstrap)
 ├── packages/
@@ -41,7 +42,8 @@ issues:
 ## Navigation
 
 - [`components/`](components/) — one doc per piece (repo-structure today;
-  server / codex-client / feishu-bot / cli to be added as they stabilize).
+  codex-marketplace today; server / codex-client / feishu-bot / cli to be
+  added as they stabilize).
 - [`decisions/README.md`](decisions/README.md) — accepted decision records,
   indexed by topic slug. Do not prefix new records with sequence numbers.
 - `domains/`, `proposals/`, `research/`, `rules/` — empty for now; add
@@ -55,6 +57,7 @@ issues:
 
 | You're about to ... | Read first |
 |---|---|
+| add/change the Codex plugin marketplace or dispatcher skill | [`components/codex-marketplace.md`](components/codex-marketplace.md) |
 | add/change a package, move source between packages | [`components/repo-structure.md`](components/repo-structure.md) |
 | browse decisions by topic | [`decisions/README.md`](decisions/README.md) |
 | understand why rush + pnpm | [`decisions/rush-pnpm-monorepo.md`](decisions/rush-pnpm-monorepo.md) |

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Design background:
 | Looking for | Read |
 |---|---|
 | The package itself (install, run, configure, MVP verification, config reference, testing) | [`packages/dreamux/README.md`](packages/dreamux/README.md) |
+| Codex-native codexmux plugin install and dispatcher skill flow | [`codex-marketplace/README.md`](codex-marketplace/README.md) |
 | Architecture, decisions, knowledge-delta protocol | [`.agents/root.md`](.agents/root.md) |
 | Always-loaded agent operating rules | [`CLAUDE.md`](CLAUDE.md) (`AGENTS.md` is a symlink) |
 | Monorepo layout reference | [`.agents/components/repo-structure.md`](.agents/components/repo-structure.md) |
@@ -28,6 +29,7 @@ Design background:
 
 ```
 /
+├── codex-marketplace/     local Codex marketplace for the codexmux plugin
 ├── packages/
 │   ├── dreamux/           @excitedjs/dreamux — the host server
 │   └── channel/
@@ -63,6 +65,21 @@ package README:
 
 Repo-root `bin/{dreamux,server,server-ctl}` are thin shims that forward
 to `packages/dreamux/bin/` so pre-monorepo PATH entries keep working.
+
+## Codexmux plugin
+
+The codex-native product layer lives in
+[`codex-marketplace/`](codex-marketplace/). It installs as a local Codex
+marketplace named `dreamux` and provides the `codexmux-dispatcher` skill.
+
+```bash
+codex plugin marketplace add ./codex-marketplace
+codex plugin add codexmux@dreamux
+npm exec --yes --package @excitedjs/tm@2.1.2 -- tm --help
+```
+
+The skill keeps the runtime boundary thin: dreamux server hosts dispatchers;
+the dispatcher invokes the pinned `tm` CLI for teammate work.
 
 ## License
 

--- a/codex-marketplace/.agents/plugins/marketplace.json
+++ b/codex-marketplace/.agents/plugins/marketplace.json
@@ -1,0 +1,20 @@
+{
+  "name": "dreamux",
+  "interface": {
+    "displayName": "Dreamux"
+  },
+  "plugins": [
+    {
+      "name": "codexmux",
+      "source": {
+        "source": "local",
+        "path": "./plugins/codexmux"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Developer Tools"
+    }
+  ]
+}

--- a/codex-marketplace/README.md
+++ b/codex-marketplace/README.md
@@ -1,0 +1,63 @@
+# Codexmux Marketplace
+
+This directory is a local Codex plugin marketplace for the dreamux dispatcher
+product layer.
+
+It contains:
+
+- `.agents/plugins/marketplace.json` — marketplace metadata named `dreamux`
+- `plugins/codexmux/` — the Codex plugin source
+- `plugins/codexmux/skills/codexmux-dispatcher/` — dispatcher instructions for
+  pinned `tm` delegation
+
+## Install Locally
+
+From the repository root:
+
+```bash
+codex plugin marketplace add ./codex-marketplace
+codex plugin add codexmux@dreamux
+```
+
+Prewarm the pinned tm package before using the dispatcher flow:
+
+```bash
+npm exec --yes --package @excitedjs/tm@2.1.2 -- tm --help
+```
+
+## Runtime Boundary
+
+The dreamux server hosts dispatcher Codex app-server processes only. Codexmux
+does not add server-owned teammate state, admin methods, or database tables.
+The dispatcher agent invokes `tm` commands, and tm owns the work behind that
+command boundary.
+
+## First Demonstration
+
+Ask the dispatcher to delegate a bounded task and include the target repo path,
+for example:
+
+```text
+Use codexmux to spawn a tm teammate in /path/to/repo, run the focused tests, and summarize the result.
+```
+
+The skill should run:
+
+```bash
+npm exec --yes --package @excitedjs/tm@2.1.2 -- tm spawn /path/to/repo --engine codex ...
+npm exec --yes --package @excitedjs/tm@2.1.2 -- tm wait <name> --timeout 180
+```
+
+If `tm` fails, the dispatcher reports the failed verb, teammate name, repo path,
+and useful stderr/stdout instead of attributing the failure to dreamux server
+state.
+
+If `tm spawn --engine codex` reports that the Codex daemon exited before
+binding its socket, verify the dispatcher environment can run:
+
+```bash
+codex app-server --listen unix:///tmp/codexmux-check.sock
+```
+
+Read-only filesystem or operation-permitted errors here are environment
+failures below codexmux.

--- a/codex-marketplace/plugins/codexmux/.codex-plugin/plugin.json
+++ b/codex-marketplace/plugins/codexmux/.codex-plugin/plugin.json
@@ -1,0 +1,29 @@
+{
+  "name": "codexmux",
+  "version": "0.1.0",
+  "description": "Delegate bounded dispatcher work to tm-managed Codex teammates.",
+  "author": {
+    "name": "excitedjs"
+  },
+  "repository": "https://github.com/excitedjs/dreamux",
+  "license": "MIT",
+  "keywords": [
+    "codexmux",
+    "dreamux",
+    "tm",
+    "dispatcher",
+    "teammates"
+  ],
+  "skills": "./skills/",
+  "interface": {
+    "displayName": "Codexmux",
+    "shortDescription": "Delegate dispatcher work to tm teammates",
+    "longDescription": "Codexmux teaches a dreamux dispatcher how to call the pinned tm CLI, spawn a teammate in an explicit repo, wait for the result, and report failures without adding server-owned teammate state.",
+    "developerName": "excitedjs",
+    "category": "Developer Tools",
+    "capabilities": [
+      "Interactive"
+    ],
+    "defaultPrompt": "Use codexmux when dispatcher work should be delegated to a tm teammate."
+  }
+}

--- a/codex-marketplace/plugins/codexmux/skills/codexmux-dispatcher/SKILL.md
+++ b/codex-marketplace/plugins/codexmux/skills/codexmux-dispatcher/SKILL.md
@@ -1,0 +1,111 @@
+---
+name: codexmux-dispatcher
+description: Use from a dreamux dispatcher thread when work should be delegated to a tm-managed Codex teammate in a specific repository. Applies to bounded engineering tasks, test runs, codebase inspections, or follow-up work where the dispatcher should spawn/send/wait through the pinned @excitedjs/tm CLI and report the result back to the source chat.
+---
+
+# Codexmux Dispatcher
+
+Use this skill only from the dispatcher agent. The dreamux server hosts the
+dispatcher lifecycle; it does not own tm teammate daemons, teammate DB rows, or
+`teammate.*` admin methods.
+
+## Boundaries
+
+- Use `tm` through the pinned package: `@excitedjs/tm@2.1.2`.
+- Pass `--engine codex` on every `tm spawn`; `tm spawn` defaults to Claude.
+- Do not use bare `npx -y @excitedjs/tm` or `@excitedjs/tm@latest`.
+- Do not call dreamux admin APIs to create teammate state.
+- Do not infer a repo from the dispatcher cwd. A dispatcher cwd is server-owned
+  runtime space, not a worktree.
+- Do not ask a tm-managed teammate to spawn another tm teammate.
+
+## Before Delegating
+
+Delegate when the request is bounded and can be completed by one teammate:
+running tests, inspecting a code path, drafting a narrow patch, or collecting a
+specific result. Handle the work directly when the request is tiny, ambiguous,
+security-sensitive, or missing a repository path.
+
+Resolve the repo path in this order:
+
+1. An absolute path in the user request.
+2. `TM_DISPATCHER_DIR`, if set by the operator.
+3. Ask the user for the repo path. Do not guess.
+
+Use an absolute repo path for `tm spawn`. If the user gives a relative path,
+make it absolute only when its base is explicit.
+
+## Command Shape
+
+Use this prefix for every tm command:
+
+```bash
+npm exec --yes --package @excitedjs/tm@2.1.2 -- tm
+```
+
+Preflight once per dispatcher session or after npm cache cleanup:
+
+```bash
+npm exec --yes --package @excitedjs/tm@2.1.2 -- tm --help
+```
+
+## First-Turn Delegation
+
+1. Pick a flat teammate name: lowercase letters, digits, and hyphens; keep it
+   short and tied to the task, such as `tests-api` or `scan-auth`.
+2. Spawn with the repo path, intent, and the full task prompt:
+
+```bash
+npm exec --yes --package @excitedjs/tm@2.1.2 -- tm spawn /absolute/repo \
+  --name tests-api \
+  --engine codex \
+  --timeout 180 \
+  --intent "Run focused API tests and summarize failures" \
+  --prompt "Run the focused API tests. Report commands, failures, and the smallest next fix."
+```
+
+3. If `tm spawn` exits `0`, use its printed reply as the teammate result. If it
+   exits `124`, the Codex turn did not finish within the sync window; wait
+   without `--fresh`:
+
+```bash
+npm exec --yes --package @excitedjs/tm@2.1.2 -- tm wait tests-api --timeout 180
+```
+
+4. Reply to the source chat with the teammate result, including the command
+   summary and any explicit failure.
+
+## Follow-Up Delegation
+
+If a teammate name already exists for the same task, send a follow-up instead
+of spawning a duplicate:
+
+```bash
+npm exec --yes --package @excitedjs/tm@2.1.2 -- tm send tests-api \
+  --prompt "Use the previous context. Re-run the focused test after the latest fix and summarize only changed results."
+npm exec --yes --package @excitedjs/tm@2.1.2 -- tm wait tests-api --timeout 180
+```
+
+## Failure Reporting
+
+When a tm command fails, stop the delegation sequence and report:
+
+- which `tm` verb failed
+- the teammate name and repo path
+- the exit status if available
+- the first useful stderr/stdout lines
+- whether retrying the same teammate is safe
+
+Known early startup failure to report verbatim:
+
+```text
+codex daemon (pid N) exited before binding /tmp/teammate-codex/<name>/socket
+```
+
+That means the Codex app-server daemon did not become reachable. Do not retry
+silently; report the environment failure and ask the operator to verify
+`codex app-server --listen unix:///tmp/codexmux-check.sock` in the dispatcher
+environment.
+
+Do not say the dreamux server lost or recovered teammate state. The server does
+not own that state.

--- a/codex-marketplace/plugins/codexmux/skills/codexmux-dispatcher/agents/openai.yaml
+++ b/codex-marketplace/plugins/codexmux/skills/codexmux-dispatcher/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Codexmux Dispatcher"
+  short_description: "Delegate bounded work to tm teammates from a dreamux dispatcher."
+  default_prompt: "Use codexmux dispatcher delegation when a request should be handled by a tm teammate."


### PR DESCRIPTION
## Summary

- add a local Codex marketplace under `codex-marketplace/`
- add the `codexmux` plugin manifest and `codexmux-dispatcher` skill
- document the pinned `@excitedjs/tm@2.1.2` command boundary and install flow
- record the marketplace component in the `.agents` knowledge base

## Boundary

- dreamux server still hosts dispatchers only
- no server-owned teammate runtime, DB table, or admin API is added
- dispatcher delegation goes through `tm spawn --engine codex` and related `tm` commands

## Validation

- Codex plugin manifest validated with the local Codex plugin validator
- `codexmux-dispatcher` skill structure validated with the local skill validator
- `.agents/scripts/check.sh`
- `CODEX_HOME=<temp> codex plugin marketplace add ./codex-marketplace`
- `CODEX_HOME=<temp> codex plugin add codexmux@dreamux`
- `npm --cache <temp> exec --yes --package @excitedjs/tm@2.1.2 -- tm --help`
- `npm_config_cache=<temp> node common/scripts/install-run-rush.js change --verify --no-fetch`

## Known gap from the first end-to-end smoke

- `tm spawn ...` without `--engine codex` defaults to Claude and hit workspace trust in the sandbox clone; the skill now requires `--engine codex`.
- `tm wait --fresh` is not supported for Codex teammates in tm 2.1.2; the skill now uses plain `tm wait --timeout` only after a sync timeout.
- A real `tm spawn --engine codex ... --prompt ...` smoke reached the Codex daemon path but failed with `codex daemon (pid N) exited before binding .../socket` in this sandbox. Direct `codex app-server --listen ...` also failed here with filesystem/permission errors. Production e2e is deferred to the non-sandbox daemon shape.