### PR TITLE
Task 1: define dreamux state and log paths

### DIFF
--- a/packages/dreamux/src/admin/socket.ts
+++ b/packages/dreamux/src/admin/socket.ts
@@ -176,7 +176,7 @@ function acquirePidLock(
       throw new Error(
         `admin socket lockfile ${lockPath} is held by another live dreamux serve process (pid ${holder}). ` +
           'Refusing to bind to avoid split-brain admin control. ' +
-          'Stop the other instance, or set CODEX_HOST_ADMIN_SOCKET to a different path.',
+          'Stop the other instance before starting a new one.',
       );
     }
     // Stale lock (unreadable PID, or PID belongs to a dead process).
@@ -191,7 +191,7 @@ function acquirePidLock(
   }
   throw new Error(
     `admin socket lockfile ${lockPath} could not be acquired after ${RECLAIM_ATTEMPTS} reclaim attempts; ` +
-      'a competitor is racing us. Retry, or set CODEX_HOST_ADMIN_SOCKET to a different path.',
+      'a competitor is racing us. Retry after the other startup finishes.',
   );
 }
 

--- a/packages/dreamux/src/cli/server-ctl.ts
+++ b/packages/dreamux/src/cli/server-ctl.ts
@@ -1,7 +1,7 @@
 /**
  * `server-ctl` — admin CLI that talks to the server via Unix socket.
  *
- * Connects to the admin socket (CODEX_HOST_ADMIN_SOCKET or default), sends a
+ * Connects to the admin socket under ~/.dreamux/state/admin.sock, sends a
  * single NDJSON request, prints the response, exits.
  *
  * Usage:
@@ -183,8 +183,8 @@ Usage:
   ${programName} dispatcher stop --id <ID>
   ${programName} dispatcher remove --id <ID>
 
-Environment:
-  CODEX_HOST_ADMIN_SOCKET   override the admin socket path (default: ~/.dreamux/runtime/admin.sock)
+Admin socket:
+  ~/.dreamux/state/admin.sock
 `);
 }
 

--- a/packages/dreamux/src/cli/server.ts
+++ b/packages/dreamux/src/cli/server.ts
@@ -6,8 +6,7 @@
  *   dreamux serve --help
  *
  * Configuration sources (highest precedence first):
- *   1. environment variables (CODEX_HOST_RUNTIME_DIR, CODEX_HOST_ADMIN_SOCKET,
- *      CODEX_HOST_CODEX_BIN) — escape hatch for CI / one-off debug runs
+ *   1. CODEX_HOST_CODEX_BIN — escape hatch for CI / one-off debug runs
  *   2. per-dispatcher fields in SQLite (codex_args_json: approvalPolicy, extraArgs)
  *   3. ~/.dreamux/config.json — user-editable global defaults and channel secrets; auto-created
  *      with sensible defaults on first boot (see src/runtime/config.ts)
@@ -17,11 +16,16 @@
  */
 
 import { mkdirSync } from 'node:fs';
-import { dirname } from 'node:path';
 
 import { Server } from '../server.js';
 import { loadOrInitConfig } from '../runtime/config.js';
-import { adminSocketPath, databasePath, runtimeRoot } from '../runtime/paths.js';
+import {
+  adminSocketPath,
+  codexAppServerLogDir,
+  feishuChannelLogDir,
+  logsRoot,
+  stateRoot,
+} from '../runtime/paths.js';
 
 async function main(): Promise<void> {
   if (process.argv.includes('--help') || process.argv.includes('-h')) {
@@ -42,8 +46,10 @@ async function main(): Promise<void> {
     console.error(`[server] loaded global config from ${configFile}`);
   }
 
-  mkdirSync(runtimeRoot(), { recursive: true });
-  mkdirSync(dirname(databasePath()), { recursive: true });
+  mkdirSync(stateRoot(), { recursive: true });
+  mkdirSync(logsRoot(), { recursive: true });
+  mkdirSync(codexAppServerLogDir(), { recursive: true });
+  mkdirSync(feishuChannelLogDir(), { recursive: true });
 
   const server = new Server({ config });
   await server.start();
@@ -68,18 +74,15 @@ Global config:
   ~/.dreamux/config.json    Auto-created on first boot. Override with the
                             DREAMUX_CONFIG_DIR env var. Edit and restart to
                             apply. Holds defaults for codex.bin,
-                            approval_policy, runtime_dir, outbound retries,
+                            approval_policy, outbound retries,
                             and Feishu channel secrets.
 
 Runtime data:
-  ~/.dreamux/runtime/       SQLite, admin socket, per-dispatcher logs and
-                            app-server control sockets. Override via
-                            'runtime_dir' in config, or
-                            CODEX_HOST_RUNTIME_DIR env (env wins).
+  ~/.dreamux/state/         server state, admin socket, legacy SQLite state,
+                            and per-dispatcher Codex sockets.
+  ~/.dreamux/logs/          server, Feishu channel, and Codex app-server logs.
 
 Environment overrides (highest precedence):
-  CODEX_HOST_RUNTIME_DIR    Overrides config.runtime_dir
-  CODEX_HOST_ADMIN_SOCKET   Overrides config.admin_socket
   CODEX_HOST_CODEX_BIN      Overrides config.codex.bin
   DREAMUX_CONFIG_DIR        Overrides ~/.dreamux (where config.json lives)
 

--- a/packages/dreamux/src/onboard/run.ts
+++ b/packages/dreamux/src/onboard/run.ts
@@ -15,7 +15,9 @@ import {
   dispatcherCodexHome,
   dispatcherCodexSkillsDir,
   databasePath,
+  logsRoot,
   setRuntimeConfig,
+  stateRoot,
 } from '../runtime/paths.js';
 import {
   dispatcherCodexHomeDoctorContext,
@@ -66,7 +68,7 @@ export async function runOnboard(
   const dreamuxConfig = dreamuxConfigFromAnswers(answers, existingConfig);
   const effectiveAnswers = {
     ...answers,
-    runtimeDir: dreamuxConfig.runtime_dir,
+    runtimeDir: stateRoot(),
     codexBin: dreamuxConfig.codex.bin,
   };
   setRuntimeConfig(dreamuxConfig);
@@ -74,7 +76,10 @@ export async function runOnboard(
   ensureDirectory(answers.configDir, ledger, 'dreamux config directory', {
     dryRun: answers.dryRun,
   });
-  ensureDirectory(effectiveAnswers.runtimeDir, ledger, 'dreamux runtime directory', {
+  ensureDirectory(stateRoot(), ledger, 'dreamux state directory', {
+    dryRun: answers.dryRun,
+  });
+  ensureDirectory(logsRoot(), ledger, 'dreamux logs directory', {
     dryRun: answers.dryRun,
   });
   writeTextFile(

--- a/packages/dreamux/src/onboard/service.ts
+++ b/packages/dreamux/src/onboard/service.ts
@@ -2,6 +2,7 @@ import { homedir } from 'node:os';
 import { join } from 'node:path';
 
 import { build as buildPlist } from 'plist';
+import { logsRoot, stateRoot } from '../runtime/paths.js';
 
 import {
   ensureDirectory,
@@ -68,7 +69,7 @@ export async function installUserService(
 ): Promise<ServiceInstallResult> {
   const homeDir = options.homeDir ?? homedir();
   const unit = serviceUnitPath(options.platform, homeDir);
-  const logDir = join(options.answers.runtimeDir, 'logs');
+  const logDir = logsRoot();
   const stdoutLog = join(logDir, 'daemon.stdout.log');
   const stderrLog = join(logDir, 'daemon.stderr.log');
   ensureDirectory(logDir, options.ledger, 'daemon log directory', {
@@ -122,7 +123,7 @@ export function renderLaunchdPlist(
     ProgramArguments: [answers.dreamuxBin, 'serve'],
     RunAtLoad: true,
     KeepAlive: true,
-    WorkingDirectory: answers.runtimeDir,
+    WorkingDirectory: stateRoot(),
     EnvironmentVariables: managedServiceEnvironment(answers),
     StandardOutPath: stdoutLog,
     StandardErrorPath: stderrLog,
@@ -140,7 +141,7 @@ Description=dreamux dispatcher daemon
 [Service]
 Type=simple
 ExecStart=${systemdEscapeArg(answers.dreamuxBin)} serve
-WorkingDirectory=${systemdEscapeArg(answers.runtimeDir)}
+WorkingDirectory=${systemdEscapeArg(stateRoot())}
 ${Object.entries(managedServiceEnvironment(answers))
   .map(([key, value]) => `Environment=${key}=${systemdEscapeEnv(value)}`)
   .join('\n')}
@@ -159,7 +160,6 @@ export function managedServiceEnvironment(
 ): Record<string, string> {
   const env: Record<string, string> = {
     DREAMUX_CONFIG_DIR: answers.configDir,
-    CODEX_HOST_RUNTIME_DIR: answers.runtimeDir,
     CODEX_HOST_CODEX_BIN: answers.codexBin,
   };
   return env;

--- a/packages/dreamux/src/runtime/dispatcher-codex-home.ts
+++ b/packages/dreamux/src/runtime/dispatcher-codex-home.ts
@@ -7,14 +7,17 @@ import { join, normalize, sep } from 'node:path';
 import { parse as parseToml, TomlError } from 'smol-toml';
 
 import {
+  DREAMUX_UNIX_SOCKET_PATH_MAX_BYTES,
   dispatcherAppServerControlDir,
   dispatcherCodexConfigPath,
   dispatcherCodexHome,
   dispatcherCodexSkillsDir,
   dispatcherSocketPath,
+  unixSocketPathFitsBudget,
 } from './paths.js';
 
-export const DISPATCHER_APP_SERVER_SOCKET_PATH_MAX_BYTES = 103;
+export const DISPATCHER_APP_SERVER_SOCKET_PATH_MAX_BYTES =
+  DREAMUX_UNIX_SOCKET_PATH_MAX_BYTES;
 
 export interface DispatcherCodexHomeDoctorContext {
   dispatcherId: string;
@@ -95,7 +98,7 @@ export function validateDispatcherCodexHome(
       `dispatcher app-server socket must not be under /tmp: ${context.socketPath}`,
     );
   }
-  if (!socketPathFitsUnixLimit(context.socketPath)) {
+  if (!unixSocketPathFitsBudget(context.socketPath)) {
     const bytes = Buffer.byteLength(context.socketPath, 'utf8');
     errors.push(
       `dispatcher app-server socket path is too long for Unix sockets (${bytes} bytes > ${DISPATCHER_APP_SERVER_SOCKET_PATH_MAX_BYTES} safe bytes): ${context.socketPath}`,
@@ -156,13 +159,6 @@ function hasAuth(codexHome: string, env: NodeJS.ProcessEnv): boolean {
       const value = env[name];
       return value !== undefined && value.trim() !== '';
     },
-  );
-}
-
-function socketPathFitsUnixLimit(path: string): boolean {
-  return (
-    Buffer.byteLength(path, 'utf8') <=
-    DISPATCHER_APP_SERVER_SOCKET_PATH_MAX_BYTES
   );
 }
 

--- a/packages/dreamux/src/runtime/paths.ts
+++ b/packages/dreamux/src/runtime/paths.ts
@@ -1,26 +1,24 @@
 /**
- * Filesystem layout for the dreamux server runtime.
+ * Filesystem layout for dreamux-owned runtime state and logs.
  *
- * Default root: ~/.dreamux/runtime/  (override via env CODEX_HOST_RUNTIME_DIR
- * or `runtime_dir` in ~/.dreamux/config.json — env wins, see config.ts).
- * Layout:
- *   <root>/
- *     state.db                  SQLite database (dispatchers + inbound_buffer)
- *     admin.sock                server-ctl admin Unix socket
- *     dispatchers/<id>/
- *       app-server-control/     Codex app-server control sockets
- *       stdout.log              Codex stdout
- *       stderr.log              Codex stderr (load-bearing for debug)
+ * Effective MVP layout:
+ *   ~/.dreamux/
+ *     state/
+ *       server.json
+ *       admin.sock
+ *       state.db              legacy SQLite location until Task 11 removes it
+ *       <dispatcher-id>/
+ *         status.json
+ *         access.json
+ *         codex.sock          Codex app-server Unix socket
+ *     logs/
+ *       dreamux-server.log
+ *       codex-app-server/
+ *         <dispatcher-id>.log
  *
- * Dispatchers intentionally do not set CODEX_HOME. Codex app-server processes
- * use Codex's global default home (`~/.codex`) for auth, config, and skills.
- * Dispatcher cwd is configured during onboard and stored on the dispatcher row;
- * dispatcherCodexCwd() exists only as a legacy fallback.
- *
- * Issue ~/.dreamux/ config (feat/global-config-dir): paths.* functions
- * read an optionally-injected `DreamuxConfig` snapshot for non-env
- * defaults. Server.start() calls setRuntimeConfig() once at boot; bare
- * tests / standalone callers fall back to the built-in defaults.
+ * `runtime_dir` is no longer an effective runtime contract. The legacy
+ * runtimeRoot() function remains as a compatibility alias for stateRoot()
+ * while older call sites are retired.
  */
 
 import { homedir } from 'node:os';
@@ -28,9 +26,10 @@ import { join } from 'node:path';
 
 import {
   BUILT_IN_DEFAULTS,
-  expandHome,
   type DreamuxConfig,
 } from './config.js';
+
+export const DREAMUX_UNIX_SOCKET_PATH_MAX_BYTES = 103;
 
 let currentConfig: DreamuxConfig = BUILT_IN_DEFAULTS;
 
@@ -52,27 +51,38 @@ export function getRuntimeConfig(): DreamuxConfig {
   return currentConfig;
 }
 
+export function dreamuxRoot(): string {
+  return join(homedir(), '.dreamux');
+}
+
+export function stateRoot(): string {
+  return join(dreamuxRoot(), 'state');
+}
+
+export function logsRoot(): string {
+  return join(dreamuxRoot(), 'logs');
+}
+
+/**
+ * Legacy compatibility alias. New code should call stateRoot().
+ */
 export function runtimeRoot(): string {
-  const fromEnv = process.env['CODEX_HOST_RUNTIME_DIR'];
-  if (fromEnv !== undefined && fromEnv !== '') return fromEnv;
-  return expandHome(currentConfig.runtime_dir) || join(homedir(), '.dreamux', 'runtime');
+  return stateRoot();
 }
 
 export function databasePath(): string {
-  return join(runtimeRoot(), 'state.db');
+  return join(stateRoot(), 'state.db');
 }
 
 export function adminSocketPath(): string {
-  const fromEnv = process.env['CODEX_HOST_ADMIN_SOCKET'];
-  if (fromEnv !== undefined && fromEnv !== '') return fromEnv;
-  if (currentConfig.admin_socket !== null) {
-    return expandHome(currentConfig.admin_socket);
-  }
-  return join(runtimeRoot(), 'admin.sock');
+  return assertUnixSocketPathBudget(
+    join(stateRoot(), 'admin.sock'),
+    'admin socket path',
+  );
 }
 
 export function dispatcherDir(id: string): string {
-  return join(runtimeRoot(), 'dispatchers', id);
+  return join(stateRoot(), dispatcherPathSegment(id));
 }
 
 export function dispatcherCodexCwd(id: string): string {
@@ -97,17 +107,67 @@ export function dispatcherCodexSkillsDir(id: string): string {
 }
 
 export function dispatcherAppServerControlDir(id: string): string {
-  return join(dispatcherDir(id), 'app-server-control');
+  return dispatcherDir(id);
 }
 
 export function dispatcherSocketPath(id: string): string {
-  return join(dispatcherAppServerControlDir(id), 'as.sock');
+  return assertUnixSocketPathBudget(
+    join(dispatcherDir(id), 'codex.sock'),
+    `dispatcher '${id}' Codex socket path`,
+  );
 }
 
 export function dispatcherStdoutLog(id: string): string {
-  return join(dispatcherDir(id), 'stdout.log');
+  return dispatcherCodexAppServerLogPath(id);
 }
 
 export function dispatcherStderrLog(id: string): string {
-  return join(dispatcherDir(id), 'stderr.log');
+  return dispatcherCodexAppServerErrorLogPath(id);
+}
+
+export function serverLogPath(): string {
+  return join(logsRoot(), 'dreamux-server.log');
+}
+
+export function codexAppServerLogDir(): string {
+  return join(logsRoot(), 'codex-app-server');
+}
+
+export function feishuChannelLogDir(): string {
+  return join(logsRoot(), 'feishu-channel');
+}
+
+export function dispatcherCodexAppServerLogPath(id: string): string {
+  return join(codexAppServerLogDir(), `${dispatcherPathSegment(id)}.log`);
+}
+
+export function dispatcherCodexAppServerErrorLogPath(id: string): string {
+  return join(codexAppServerLogDir(), `${dispatcherPathSegment(id)}.stderr.log`);
+}
+
+export function dispatcherStatusPath(id: string): string {
+  return join(dispatcherDir(id), 'status.json');
+}
+
+export function dispatcherAccessPath(id: string): string {
+  return join(dispatcherDir(id), 'access.json');
+}
+
+export function unixSocketPathFitsBudget(path: string): boolean {
+  return Buffer.byteLength(path, 'utf8') <= DREAMUX_UNIX_SOCKET_PATH_MAX_BYTES;
+}
+
+export function assertUnixSocketPathBudget(path: string, label: string): string {
+  if (unixSocketPathFitsBudget(path)) return path;
+  const bytes = Buffer.byteLength(path, 'utf8');
+  throw new Error(
+    `${label} is too long for Unix sockets (${bytes} bytes > ${DREAMUX_UNIX_SOCKET_PATH_MAX_BYTES} safe bytes): ${path}`,
+  );
+}
+
+export function dispatcherPathSegment(id: string): string {
+  if (id.trim() === '') {
+    throw new Error('dispatcher id must not be empty when building paths');
+  }
+  return id.replaceAll(/[^A-Za-z0-9._-]/g, '_');
 }

--- a/packages/dreamux/tests/dispatcher-codex-home.test.ts
+++ b/packages/dreamux/tests/dispatcher-codex-home.test.ts
@@ -39,10 +39,10 @@ describe('global Codex home doctor', () => {
 
   it('places app-server sockets under the dreamux dispatcher runtime directory', () => {
     expect(dispatcherSocketPath('flow')).toBe(
-      join(dispatcherAppServerControlDir('flow'), 'as.sock'),
+      join(dispatcherAppServerControlDir('flow'), 'codex.sock'),
     );
     expect(dispatcherSocketPath('flow')).toContain(
-      join('dispatchers', 'flow', 'app-server-control'),
+      join('.dreamux', 'state', 'flow'),
     );
     expect(dispatcherSocketPath('flow')).not.toMatch(/^\/tmp(?:\/|$)/);
     expect(Buffer.byteLength(dispatcherSocketPath('frontend-service'), 'utf8'))
@@ -97,19 +97,12 @@ describe('global Codex home doctor', () => {
   });
 
   it('rejects too-long app-server socket paths before bind', () => {
-    setRuntimeConfig({
-      ...BUILT_IN_DEFAULTS,
-      runtime_dir: join(runtimeDir, 'runtime-root-with-a-long-custom-name'),
-    });
-    writeDispatcherHome('dispatcher-with-long-id');
+    process.env['HOME'] = join(runtimeDir, 'h'.repeat(90));
 
-    const result = validateDispatcherCodexHome('dispatcher-with-long-id', {
-      env: {},
-    });
-
-    expect(result.ok).toBe(false);
-    expect(formatDispatcherCodexHomeErrors(result)).toContain(
-      'socket path is too long',
+    expect(() =>
+      validateDispatcherCodexHome('dispatcher-with-long-id', { env: {} }),
+    ).toThrow(
+      /Codex socket path is too long/,
     );
   });
 

--- a/packages/dreamux/tests/doctor.test.ts
+++ b/packages/dreamux/tests/doctor.test.ts
@@ -13,10 +13,12 @@ import { openDatabase } from '../src/db/schema.js';
 import { runDreamuxDoctor } from '../src/cli/doctor.js';
 import type { CommandRunner } from '../src/onboard/types.js';
 import {
+  databasePath,
   dispatcherCodexHome,
   dispatcherCodexSkillsDir,
   resetRuntimeConfig,
   setRuntimeConfig,
+  stateRoot,
 } from '../src/runtime/paths.js';
 
 class FakeRunner implements CommandRunner {
@@ -212,8 +214,8 @@ describe('dreamux doctor command', () => {
     if (options.auth) {
       writeFileSync(join(dispatcherCodexHome('flow'), 'auth.json'), '{}');
     }
-    mkdirSync(runtimeDir, { recursive: true });
-    const db = openDatabase({ path: join(runtimeDir, 'state.db') });
+    mkdirSync(stateRoot(), { recursive: true });
+    const db = openDatabase({ path: databasePath() });
     try {
       new DispatcherRepo(db).create({
         dispatcher_id: 'flow',

--- a/packages/dreamux/tests/global-config.test.ts
+++ b/packages/dreamux/tests/global-config.test.ts
@@ -27,6 +27,7 @@ import {
   resetRuntimeConfig,
   runtimeRoot,
   setRuntimeConfig,
+  stateRoot,
 } from '../src/runtime/paths.js';
 import { codexArgsToCli, parseCodexArgs } from '../src/runtime/codex-args.js';
 
@@ -243,45 +244,46 @@ describe('precedence: env > per-dispatcher > config > built-in', () => {
     resetRuntimeConfig();
   });
 
-  it('paths.runtimeRoot reflects config when no env override', () => {
+  it('runtimeRoot aliases stateRoot and ignores config.runtime_dir', () => {
     writeFileSync(globalConfigFile({ configDir }), JSON.stringify({
       runtime_dir: '/tmp/from-config',
     }));
     const { config } = loadOrInitConfig({ configDir });
     setRuntimeConfig(config);
-    expect(runtimeRoot()).toBe('/tmp/from-config');
+    expect(runtimeRoot()).toBe(stateRoot());
+    expect(runtimeRoot()).not.toBe('/tmp/from-config');
   });
 
-  it('CODEX_HOST_RUNTIME_DIR env beats config.runtime_dir', () => {
+  it('CODEX_HOST_RUNTIME_DIR no longer overrides runtime paths', () => {
     writeFileSync(globalConfigFile({ configDir }), JSON.stringify({
       runtime_dir: '/tmp/from-config',
     }));
     const { config } = loadOrInitConfig({ configDir });
     setRuntimeConfig(config);
     process.env['CODEX_HOST_RUNTIME_DIR'] = '/tmp/from-env';
-    expect(runtimeRoot()).toBe('/tmp/from-env');
+    expect(runtimeRoot()).toBe(stateRoot());
   });
 
-  it('adminSocketPath: env > config.admin_socket > <runtime_dir>/admin.sock', () => {
+  it('adminSocketPath is fixed under stateRoot', () => {
     writeFileSync(globalConfigFile({ configDir }), JSON.stringify({
       runtime_dir: '/tmp/rt',
       admin_socket: '/tmp/cfg-admin.sock',
     }));
     const { config } = loadOrInitConfig({ configDir });
     setRuntimeConfig(config);
-    expect(adminSocketPath()).toBe('/tmp/cfg-admin.sock');
+    expect(adminSocketPath()).toBe(join(stateRoot(), 'admin.sock'));
 
     process.env['CODEX_HOST_ADMIN_SOCKET'] = '/tmp/env-admin.sock';
-    expect(adminSocketPath()).toBe('/tmp/env-admin.sock');
+    expect(adminSocketPath()).toBe(join(stateRoot(), 'admin.sock'));
   });
 
-  it('admin_socket derives from runtime_dir when not set in config', () => {
+  it('admin_socket no longer derives from runtime_dir', () => {
     writeFileSync(globalConfigFile({ configDir }), JSON.stringify({
       runtime_dir: '/tmp/rt',
     }));
     const { config } = loadOrInitConfig({ configDir });
     setRuntimeConfig(config);
-    expect(adminSocketPath()).toBe('/tmp/rt/admin.sock');
+    expect(adminSocketPath()).toBe(join(stateRoot(), 'admin.sock'));
   });
 
   it('parseCodexArgs: per-dispatcher overrides config defaults', () => {

--- a/packages/dreamux/tests/onboard.test.ts
+++ b/packages/dreamux/tests/onboard.test.ts
@@ -19,8 +19,10 @@ import {
 } from '../src/onboard/wizard.js';
 import type { CommandRunner, OnboardAnswers } from '../src/onboard/types.js';
 import {
+  databasePath,
   dispatcherCodexHome,
   dispatcherCodexSkillsDir,
+  logsRoot,
   resetRuntimeConfig,
 } from '../src/runtime/paths.js';
 
@@ -166,7 +168,7 @@ describe('dreamux onboard', () => {
       ),
     ).toBe(true);
 
-    const db = openDatabase({ path: join(root, 'runtime', 'state.db') });
+    const db = openDatabase({ path: databasePath() });
     try {
       const row = new DispatcherRepo(db).get('flow');
       expect(row).toMatchObject({
@@ -201,9 +203,9 @@ describe('dreamux onboard', () => {
       )?.status,
     ).toBe('created');
     expect(
-      ledger.get(join(root, 'runtime', 'logs', 'daemon.stdout.log'))?.status,
+      ledger.get(join(logsRoot(), 'daemon.stdout.log'))?.status,
     ).toBe('created');
-    expect(ledger.get(join(root, 'runtime', 'state.db'))?.status).toBe(
+    expect(ledger.get(databasePath())?.status).toBe(
       'created',
     );
   });
@@ -339,7 +341,9 @@ describe('dreamux onboard', () => {
     });
     expect(existsSync(ignoredRuntimeDir)).toBe(false);
 
-    const db = openDatabase({ path: join(existingRuntimeDir, 'state.db') });
+    expect(existsSync(existingRuntimeDir)).toBe(false);
+
+    const db = openDatabase({ path: databasePath() });
     try {
       expect(new DispatcherRepo(db).get('docs')).toMatchObject({
         dispatcher_id: 'docs',

--- a/packages/dreamux/tests/runtime-paths.test.ts
+++ b/packages/dreamux/tests/runtime-paths.test.ts
@@ -1,0 +1,100 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { homedir, tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import {
+  DREAMUX_UNIX_SOCKET_PATH_MAX_BYTES,
+  adminSocketPath,
+  codexAppServerLogDir,
+  databasePath,
+  dispatcherAccessPath,
+  dispatcherCodexAppServerErrorLogPath,
+  dispatcherCodexAppServerLogPath,
+  dispatcherDir,
+  dispatcherSocketPath,
+  dispatcherStatusPath,
+  dreamuxRoot,
+  logsRoot,
+  resetRuntimeConfig,
+  runtimeRoot,
+  serverLogPath,
+  stateRoot,
+  unixSocketPathFitsBudget,
+} from '../src/runtime/paths.js';
+
+describe('runtime paths', () => {
+  let root: string;
+  let previousHome: string | undefined;
+
+  beforeEach(() => {
+    root = mkdtempSync(join(tmpdir(), 'dreamux-paths-'));
+    previousHome = process.env['HOME'];
+    process.env['HOME'] = join(root, 'home');
+    delete process.env['CODEX_HOST_RUNTIME_DIR'];
+    delete process.env['CODEX_HOST_ADMIN_SOCKET'];
+    resetRuntimeConfig();
+  });
+
+  afterEach(() => {
+    if (previousHome === undefined) delete process.env['HOME'];
+    else process.env['HOME'] = previousHome;
+    resetRuntimeConfig();
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  it('uses ~/.dreamux/state and ~/.dreamux/logs as the effective layout', () => {
+    expect(dreamuxRoot()).toBe(join(homedir(), '.dreamux'));
+    expect(stateRoot()).toBe(join(dreamuxRoot(), 'state'));
+    expect(logsRoot()).toBe(join(dreamuxRoot(), 'logs'));
+    expect(runtimeRoot()).toBe(stateRoot());
+    expect(databasePath()).toBe(join(stateRoot(), 'state.db'));
+    expect(adminSocketPath()).toBe(join(stateRoot(), 'admin.sock'));
+
+    expect(dispatcherDir('dispatcher-a')).toBe(
+      join(stateRoot(), 'dispatcher-a'),
+    );
+    expect(dispatcherStatusPath('dispatcher-a')).toBe(
+      join(stateRoot(), 'dispatcher-a', 'status.json'),
+    );
+    expect(dispatcherAccessPath('dispatcher-a')).toBe(
+      join(stateRoot(), 'dispatcher-a', 'access.json'),
+    );
+    expect(dispatcherSocketPath('dispatcher-a')).toBe(
+      join(stateRoot(), 'dispatcher-a', 'codex.sock'),
+    );
+  });
+
+  it('places logs under component log directories', () => {
+    expect(serverLogPath()).toBe(join(logsRoot(), 'dreamux-server.log'));
+    expect(codexAppServerLogDir()).toBe(
+      join(logsRoot(), 'codex-app-server'),
+    );
+    expect(dispatcherCodexAppServerLogPath('dispatcher-a')).toBe(
+      join(logsRoot(), 'codex-app-server', 'dispatcher-a.log'),
+    );
+    expect(dispatcherCodexAppServerErrorLogPath('dispatcher-a')).toBe(
+      join(logsRoot(), 'codex-app-server', 'dispatcher-a.stderr.log'),
+    );
+  });
+
+  it('sanitizes dispatcher ids before using them as path segments', () => {
+    expect(dispatcherDir('team/alpha beta')).toBe(
+      join(stateRoot(), 'team_alpha_beta'),
+    );
+  });
+
+  it('rejects Unix socket paths that exceed the safe sun_path budget', () => {
+    expect(unixSocketPathFitsBudget('x'.repeat(DREAMUX_UNIX_SOCKET_PATH_MAX_BYTES)))
+      .toBe(true);
+    expect(
+      unixSocketPathFitsBudget('x'.repeat(DREAMUX_UNIX_SOCKET_PATH_MAX_BYTES + 1)),
+    ).toBe(false);
+
+    process.env['HOME'] = join(root, 'h'.repeat(90));
+    expect(() => adminSocketPath()).toThrow(/too long for Unix sockets/);
+    expect(() => dispatcherSocketPath('dispatcher-a')).toThrow(
+      /too long for Unix sockets/,
+    );
+  });
+});

--- a/packages/dreamux/tests/smoke.test.ts
+++ b/packages/dreamux/tests/smoke.test.ts
@@ -209,7 +209,8 @@ describe('dreamux MVP smoke', () => {
 
   it('creates the app-server socket directory outside the global Codex home', async () => {
     rmSync(runtimeDir, { recursive: true, force: true });
-    runtimeDir = mkdtempSync(join(homedir(), '.dreamux-smoke-'));
+    runtimeDir = mkdtempSync(join(previousHome ?? homedir(), '.dreamux-smoke-'));
+    process.env['HOME'] = join(runtimeDir, 'home');
     const capturedCodexOptions: CodexProcessOptions[] = [];
     server = buildServer({
       runtimeDir,


### PR DESCRIPTION
## Summary

Implements Task 1 from #36: the runtime paths/state/log contract.

- Centralizes the effective runtime layout in `src/runtime/paths.ts` under `~/.dreamux/state` and `~/.dreamux/logs`.
- Moves dispatcher Codex sockets to `~/.dreamux/state/<dispatcher>/codex.sock` and Codex app-server logs to the component log directory.
- Adds Unix socket path budget helpers/tests for the safe `sun_path` limit.
- Stops `runtime_dir`, `CODEX_HOST_RUNTIME_DIR`, `admin_socket`, and `CODEX_HOST_ADMIN_SOCKET` from affecting effective runtime/admin socket paths.
- Updates serve/onboard/service/admin CLI wiring to use the new path contract while leaving legacy config fields for the later config cleanup tasks.

## Task tracking

Closes the Task 1 checklist item in #36 when merged into the integration branch.

## Validation

- `node common/scripts/install-run-rush.js build --to @excitedjs/dreamux`
- `node common/scripts/install-run-rush.js test --to @excitedjs/dreamux`
- `.agents/scripts/check.sh`
- `git diff --check`
