### PR TITLE
Task 2: validate config schema and secrets

### DIFF
--- a/.agents/decisions/global-config-dir.md
+++ b/.agents/decisions/global-config-dir.md
@@ -32,11 +32,12 @@ We needed a user-editable global config that is:
 
 ## Decision
 
-Create `~/.dreamux/config.json` at server startup if absent. Subsequent boots
-merge missing keys with built-in defaults in memory. `dreamux onboard` writes
-the file with mode `0600` and upserts only the current
-`feishu.bots.<dispatcher-id>` entry when the JSON file already exists; existing
-global settings and other bot secrets are preserved.
+Historically this decision created `~/.dreamux/config.json` at server startup
+if absent. The current MVP, superseded by top-level-design, fails loudly when
+the file is missing from `dreamux serve`; `dreamux onboard` creates the file
+with mode `0600` and upserts only the current `feishu.bots.<dispatcher-id>`
+entry when the JSON file already exists. Existing global settings and other bot
+secrets are preserved.
 
 Older installs that have only `~/.dreamux/config.toml` fail fast with an
 explicit migration message. dreamux does not silently create default JSON over
@@ -82,8 +83,8 @@ a same-key global default. See `src/runtime/codex-args.ts`.
 
 Dispatcher rows store `bot_secret_ref=config:<dispatcher-id>` for onboarded
 bots; the actual Feishu app secret lives in `feishu.bots.<dispatcher-id>`.
-`dreamux config show` redacts `app_secret` by default. Operators must pass
-`--raw` explicitly to print the unredacted local file.
+`dreamux config show` redacts `app_secret`; there is no CLI raw mode for
+printing the unredacted local file.
 
 ## Consequences
 
@@ -102,7 +103,7 @@ bots; the actual Feishu app secret lives in `feishu.bots.<dispatcher-id>`.
 - A typo in the JSON file fails server startup
   but does **not** auto-revert to defaults. That's deliberate — silent
   fallback would mask the very mistakes the file is supposed to surface.
-  Use `dreamux config show --raw` when redaction cannot parse a broken file.
+  Fix the JSON file directly when redaction cannot parse it.
 - A legacy `config.toml` without `config.json` fails startup/onboard instead of
   being ignored. Manual migration is required so the old runtime directory and
   dispatcher database remain visible.

--- a/.agents/decisions/top-level-design.md
+++ b/.agents/decisions/top-level-design.md
@@ -172,8 +172,8 @@ is stdio.
 
 Socket path builders must live in `src/runtime/paths.ts`. They must enforce a
 short Unix socket path budget before spawning child processes. Dispatcher ids are
-sanitized and length-checked so derived `admin.sock` and `codex.sock` paths stay
-within Linux and macOS `sun_path` limits.
+validated as stable path segments and length-checked so derived `admin.sock` and
+`codex.sock` paths stay within Linux and macOS `sun_path` limits.
 
 There is no `runtime_dir`, no SQLite database, no persisted inbound message
 queue, and no persisted reaction ledger.

--- a/packages/dreamux/README.md
+++ b/packages/dreamux/README.md
@@ -76,23 +76,23 @@ output; **no `tsx` is needed at runtime** (PR #6).
 
 The launcher works from any cwd and via symlinks (PR #6 + bin-launcher tests).
 
-The server keeps operator-edited config separate from runtime state — by design (see
-[the global-config decision](../../.agents/decisions/global-config-dir.md)):
+The server keeps operator-edited config separate from state and logs — by
+design (see [the top-level design](../../.agents/decisions/top-level-design.md)):
 
 | Path | Purpose | Source of truth |
 |---|---|---|
-| `~/.dreamux/config.json`                 | User-editable global config and Feishu bot secrets — auto-created on first boot; edit and restart to apply | the operator |
-| `~/.dreamux/runtime/state.db`            | SQLite (dispatchers + inbound buffer)      | the server |
-| `~/.dreamux/runtime/admin.sock`          | Admin Unix socket (`0600`)                 | the server |
+| `~/.dreamux/config.json`                 | User-editable config and Feishu bot secrets — created by `dreamux onboard`; edit and restart to apply | the operator |
+| `~/.dreamux/state/state.db`              | Legacy SQLite state until the MVP state cleanup lands | the server |
+| `~/.dreamux/state/admin.sock`            | Admin Unix socket (`0600`)                 | the server |
 | dispatcher `codex_cwd`                   | Codex app-server cwd, configured during onboard or dispatcher registration | the operator |
 | `~/.codex/`                              | Codex global default home: auth, memory, config, and skills | the operator / Codex |
 | `~/.codex/skills/codexmux-dispatcher/SKILL.md` | Dispatcher skill copied by `dreamux onboard` | dreamux installer |
-| `~/.dreamux/runtime/dispatchers/<id>/app-server-control/as.sock` | Codex app-server Unix socket | the server |
-| `~/.dreamux/runtime/dispatchers/<id>/*.log` | Codex stdout / stderr                    | the server |
+| `~/.dreamux/state/<id>/codex.sock`       | Codex app-server Unix socket              | the server |
+| `~/.dreamux/logs/codex-app-server/<id>.log` | Codex app-server stdout                 | the server |
 
-`rm -rf ~/.dreamux/runtime` is a safe runtime recovery — your dreamux config
-and global Codex auth survive. `runtime_dir` and `admin_socket` paths in the
-config can move the runtime subtree anywhere you like.
+`rm -rf ~/.dreamux/state ~/.dreamux/logs` is a state/log recovery path — your
+dreamux config and global Codex auth survive. `runtime_dir` and `admin_socket`
+keys in older config files no longer move the effective state or socket paths.
 
 ## Configure a dispatcher
 
@@ -112,9 +112,8 @@ config can move the runtime subtree anywhere you like.
 For normal installs, prefer `dreamux onboard`; it writes
 `feishu.bots.<dispatcher-id>.app_secret` into `~/.dreamux/config.json` and
 registers the dispatcher with `bot_secret_ref=config:<dispatcher-id>`.
-`dreamux config show` redacts these secrets by default; use
-`dreamux config show --raw` only when you intentionally need the unredacted
-local file.
+`dreamux config show` redacts these secrets. There is no CLI raw mode for
+printing the unredacted local file.
 
 ## MVP verification path (issue #2 §"MVP 验收脚本")
 
@@ -132,13 +131,13 @@ local file.
 
 ## Configuration reference
 
-Precedence for every config-able value (highest wins): env var →
+Precedence for Codex-related config values (highest wins): env var →
 per-dispatcher field → `~/.dreamux/config.json` → built-in default.
 See [the global-config decision](../../.agents/decisions/global-config-dir.md).
 
 ### Global: `~/.dreamux/config.json`
 
-Auto-created on first boot with this default shape:
+Created by `dreamux onboard` with this shape:
 
 ```json
 {
@@ -172,6 +171,10 @@ default JSON over it; manually create `config.json` preserving the old
 `runtime_dir` and other settings, add the needed `feishu.bots` entries, then
 move the legacy TOML file aside.
 
+The `runtime_dir` and `admin_socket` keys are legacy compatibility fields.
+Current runtime paths are fixed under `~/.dreamux/state` and
+`~/.dreamux/logs`.
+
 ### `codex_args_json` (per-dispatcher, overrides global)
 
 JSON object stored in `dispatchers.codex_args_json`:
@@ -190,8 +193,8 @@ JSON object stored in `dispatchers.codex_args_json`:
 
 | Var                          | Purpose                                            |
 | ---------------------------- | -------------------------------------------------- |
-| `CODEX_HOST_RUNTIME_DIR`     | Override `runtime_dir`                             |
-| `CODEX_HOST_ADMIN_SOCKET`    | Override admin Unix socket path                    |
+| `CODEX_HOST_RUNTIME_DIR`     | Legacy; no longer changes effective runtime paths  |
+| `CODEX_HOST_ADMIN_SOCKET`    | Legacy; no longer changes the admin socket path    |
 | `CODEX_HOST_CODEX_BIN`       | Override `codex.bin`                               |
 | `DREAMUX_CONFIG_DIR`         | Override `~/.dreamux` (where `config.json` lives)  |
 | `BOT_SECRET_<NAME>`          | Legacy/manual bot secrets referenced by `env:BOT_SECRET_<NAME>` |

--- a/packages/dreamux/src/admin/methods.ts
+++ b/packages/dreamux/src/admin/methods.ts
@@ -9,6 +9,7 @@
 import type { Server } from '../server.js';
 import { AdminError } from './protocol.js';
 import type { DispatcherStatus, InboundState } from '../db/types.js';
+import { validateDispatcherId } from '../runtime/dispatcher-id.js';
 
 export type AdminHandler = (
   server: Server,
@@ -23,11 +24,20 @@ export const adminMethods: Record<string, AdminHandler> = {
   }),
 
   'dispatcher.add': (server, params) => {
-    const id = mustString(params, 'dispatcher_id');
+    const id = mustDispatcherId(params);
     const botAppId = mustString(params, 'bot_app_id');
     const botSecretRef = mustString(params, 'bot_secret_ref');
     const codexArgsJson = optionalString(params, 'codex_args_json') ?? '{}';
     const codexCwd = optionalString(params, 'codex_cwd');
+    const duplicateApp = server.repos.dispatchers
+      .list()
+      .find((row) => row.bot_app_id === botAppId && row.dispatcher_id !== id);
+    if (duplicateApp !== undefined) {
+      throw new AdminError(
+        'BAD_REQUEST',
+        `bot_app_id '${botAppId}' is already used by dispatcher '${duplicateApp.dispatcher_id}'`,
+      );
+    }
     try {
       const row = server.repos.dispatchers.create({
         dispatcher_id: id,
@@ -55,7 +65,7 @@ export const adminMethods: Record<string, AdminHandler> = {
   },
 
   'dispatcher.remove': async (server, params) => {
-    const id = mustString(params, 'dispatcher_id');
+    const id = mustDispatcherId(params);
     const row = server.repos.dispatchers.get(id);
     if (row === null) {
       throw new AdminError('DISPATCHER_NOT_FOUND', `no dispatcher with id '${id}'`);
@@ -68,7 +78,7 @@ export const adminMethods: Record<string, AdminHandler> = {
   'dispatcher.list': (server) => ({ dispatchers: server.summarize() }),
 
   'dispatcher.status': (server, params) => {
-    const id = mustString(params, 'dispatcher_id');
+    const id = mustDispatcherId(params);
     const row = server.repos.dispatchers.get(id);
     if (row === null) {
       throw new AdminError('DISPATCHER_NOT_FOUND', `no dispatcher with id '${id}'`);
@@ -87,7 +97,7 @@ export const adminMethods: Record<string, AdminHandler> = {
   },
 
   'dispatcher.start': async (server, params) => {
-    const id = mustString(params, 'dispatcher_id');
+    const id = mustDispatcherId(params);
     const row = server.repos.dispatchers.get(id);
     if (row === null) {
       throw new AdminError('DISPATCHER_NOT_FOUND', `no dispatcher with id '${id}'`);
@@ -97,7 +107,7 @@ export const adminMethods: Record<string, AdminHandler> = {
   },
 
   'dispatcher.stop': async (server, params) => {
-    const id = mustString(params, 'dispatcher_id');
+    const id = mustDispatcherId(params);
     await server.stopDispatcher(id);
     return { dispatcher_id: id, status: 'stopped' };
   },
@@ -111,6 +121,18 @@ function mustString(
     throw new AdminError('BAD_REQUEST', `missing or non-string param '${key}'`);
   }
   return params[key] as string;
+}
+
+function mustDispatcherId(
+  params: Record<string, unknown> | undefined,
+): string {
+  const id = mustString(params, 'dispatcher_id');
+  try {
+    return validateDispatcherId(id);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    throw new AdminError('BAD_REQUEST', message);
+  }
 }
 
 function optionalString(

--- a/packages/dreamux/src/cli/dreamux.ts
+++ b/packages/dreamux/src/cli/dreamux.ts
@@ -15,9 +15,11 @@ import yargs, { type Argv } from 'yargs';
 import { hideBin } from 'yargs/helpers';
 
 import {
+  assertConfigFileMode,
   globalConfigFile,
   redactConfigForDisplay,
 } from '../runtime/config.js';
+import { validateDispatcherId } from '../runtime/dispatcher-id.js';
 import { runOnboard } from '../onboard/run.js';
 import {
   runUninstall,
@@ -65,6 +67,10 @@ function adminEnv(): NodeJS.ProcessEnv {
 function requiredString(value: unknown, name: string): string {
   if (typeof value === 'string' && value.trim() !== '') return value;
   throw new Error(`missing required option --${name}`);
+}
+
+function requiredDispatcherId(value: unknown): string {
+  return validateDispatcherId(requiredString(value, 'id'));
 }
 
 function optionalString(value: unknown): string | null {
@@ -121,7 +127,7 @@ function buildDispatcherCommands(y: Argv): Argv {
           'dispatcher',
           'add',
           '--id',
-          requiredString(argv.id, 'id'),
+          requiredDispatcherId(argv.id),
           '--bot-app-id',
           requiredString(argv.botAppId, 'bot-app-id'),
           '--bot-secret-ref',
@@ -144,7 +150,7 @@ function buildDispatcherCommands(y: Argv): Argv {
         const verb = requiredString(argv._[1], 'dispatcher verb') as DispatcherVerb;
         await execEntry(
           SERVER_CTL_ENTRY,
-          ['dispatcher', verb, '--id', requiredString(argv.id, 'id')],
+          ['dispatcher', verb, '--id', requiredDispatcherId(argv.id)],
           adminEnv(),
         );
       },
@@ -281,20 +287,15 @@ function buildConfigCommands(y: Argv): Argv {
     .command(
       'show',
       'Print the dreamux global config file',
-      (yy) =>
-        yy.option('raw', {
-          type: 'boolean',
-          describe: 'Print unredacted config, including channel secrets',
-        }),
-      (argv) => {
+      (yy) => yy,
+      () => {
         const file = globalConfigFile();
         if (!existsSync(file)) {
           throw new Error(`config file does not exist: ${file}`);
         }
+        assertConfigFileMode(file);
         const raw = readFileSync(file, 'utf8');
-        process.stdout.write(
-          argv.raw === true ? raw : redactConfigForDisplay(raw, file),
-        );
+        process.stdout.write(redactConfigForDisplay(raw, file));
       },
     )
     .demandCommand(1, 'Choose a config command')

--- a/packages/dreamux/src/cli/server.ts
+++ b/packages/dreamux/src/cli/server.ts
@@ -8,8 +8,8 @@
  * Configuration sources (highest precedence first):
  *   1. CODEX_HOST_CODEX_BIN — escape hatch for CI / one-off debug runs
  *   2. per-dispatcher fields in SQLite (codex_args_json: approvalPolicy, extraArgs)
- *   3. ~/.dreamux/config.json — user-editable global defaults and channel secrets; auto-created
- *      with sensible defaults on first boot (see src/runtime/config.ts)
+ *   3. ~/.dreamux/config.json — user-editable global defaults and channel secrets;
+ *      created by `dreamux onboard`
  *   4. built-in defaults compiled into the binary
  *
  * Per-dispatcher Feishu secrets live in the dreamux JSON config.
@@ -18,7 +18,7 @@
 import { mkdirSync } from 'node:fs';
 
 import { Server } from '../server.js';
-import { loadOrInitConfig } from '../runtime/config.js';
+import { loadConfig } from '../runtime/config.js';
 import {
   adminSocketPath,
   codexAppServerLogDir,
@@ -33,18 +33,10 @@ async function main(): Promise<void> {
     return;
   }
 
-  // Load (or create on first boot) ~/.dreamux/config.json *before* anything
-  // else looks at runtime paths — paths.* consults the active config for
-  // its non-env defaults. A parse error here fails-fast with a file:line
-  // pointer; the operator fixes the file and restarts.
-  const { config, configFile, createdOnThisBoot } = loadOrInitConfig();
-  if (createdOnThisBoot) {
-    console.error(
-      `[server] created ${configFile} with default settings — edit and restart to change`,
-    );
-  } else {
-    console.error(`[server] loaded global config from ${configFile}`);
-  }
+  // Load ~/.dreamux/config.json before anything else starts. Missing or invalid
+  // config is a setup error; `dreamux serve` must not silently create defaults.
+  const { config, configFile } = loadConfig();
+  console.error(`[server] loaded global config from ${configFile}`);
 
   mkdirSync(stateRoot(), { recursive: true });
   mkdirSync(logsRoot(), { recursive: true });
@@ -71,7 +63,7 @@ Usage:
   dreamux serve [--help]
 
 Global config:
-  ~/.dreamux/config.json    Auto-created on first boot. Override with the
+  ~/.dreamux/config.json    Created by 'dreamux onboard'. Override with the
                             DREAMUX_CONFIG_DIR env var. Edit and restart to
                             apply. Holds defaults for codex.bin,
                             approval_policy, outbound retries,

--- a/packages/dreamux/src/onboard/config-files.ts
+++ b/packages/dreamux/src/onboard/config-files.ts
@@ -3,6 +3,7 @@ import {
   BUILT_IN_DEFAULTS,
   stringifyConfig,
 } from '../runtime/config.js';
+import { validateDispatcherId } from '../runtime/dispatcher-id.js';
 import type { OnboardAnswers } from './types.js';
 
 export function buildDreamuxConfigJson(answers: OnboardAnswers): string {
@@ -13,8 +14,9 @@ export function dreamuxConfigFromAnswers(
   answers: OnboardAnswers,
   existing?: DreamuxConfig,
 ): DreamuxConfig {
+  validateDispatcherId(answers.dispatcherId);
   const base = existing ?? dreamuxConfigDefaultsFromAnswers(answers);
-  return {
+  const next: DreamuxConfig = {
     runtime_dir: base.runtime_dir,
     admin_socket: base.admin_socket,
     codex: {
@@ -32,6 +34,8 @@ export function dreamuxConfigFromAnswers(
       },
     },
   };
+  assertUniqueFeishuAppIds(next);
+  return next;
 }
 
 function dreamuxConfigDefaultsFromAnswers(
@@ -67,4 +71,17 @@ export function dispatcherCodexArgsJson(): string {
     sandboxMode: 'workspace-write',
     extraArgs: [],
   });
+}
+
+function assertUniqueFeishuAppIds(config: DreamuxConfig): void {
+  const seen = new Map<string, string>();
+  for (const [dispatcherId, bot] of Object.entries(config.feishu.bots)) {
+    const existing = seen.get(bot.app_id);
+    if (existing !== undefined && existing !== dispatcherId) {
+      throw new Error(
+        `Feishu app_id for dispatcher '${dispatcherId}' duplicates dispatcher '${existing}'`,
+      );
+    }
+    seen.set(bot.app_id, dispatcherId);
+  }
 }

--- a/packages/dreamux/src/onboard/wizard.ts
+++ b/packages/dreamux/src/onboard/wizard.ts
@@ -11,6 +11,7 @@ import {
 } from '@clack/prompts';
 
 import { expandHome } from '../runtime/config.js';
+import { validateDispatcherId } from '../runtime/dispatcher-id.js';
 import type { OnboardAnswers } from './types.js';
 
 export interface OnboardCliOptions {
@@ -102,7 +103,9 @@ export function answersFromOptions(
   return {
     configDir: normalizePath(options.configDir ?? defaultConfigDir(options)),
     runtimeDir: normalizePath(options.runtimeDir ?? defaultRuntimeDir(options)),
-    dispatcherId: options.dispatcherId ?? DEFAULT_DISPATCHER_ID,
+    dispatcherId: validateDispatcherId(
+      options.dispatcherId ?? DEFAULT_DISPATCHER_ID,
+    ),
     dispatcherCwd: normalizePath(dispatcherCwd),
     codexBin: options.codexBin ?? 'codex',
     botAppId,

--- a/packages/dreamux/src/runtime/config.ts
+++ b/packages/dreamux/src/runtime/config.ts
@@ -2,8 +2,7 @@
  * Global dreamux configuration loaded from `~/.dreamux/config.json`.
  *
  * Layout:
- *   ~/.dreamux/          dreamux configuration, channel secrets, and runtime
- *   ~/.dreamux/runtime/  SQLite, sockets, dispatcher logs, and dispatcher state
+ *   ~/.dreamux/config.json  dreamux configuration and local channel secrets
  *
  * Format: JSON. dreamux does not write TOML files.
  */
@@ -16,8 +15,10 @@ import {
   mkdirSync,
   openSync,
   readFileSync,
+  statSync,
   writeSync,
 } from 'node:fs';
+import { validateDispatcherId } from './dispatcher-id.js';
 
 export interface DreamuxConfig {
   /** Where dreamux stores runtime state. */
@@ -131,7 +132,7 @@ export function redactConfigForDisplay(raw: string, file: string): string {
     const msg = err instanceof Error ? err.message : String(err);
     throw new Error(
       `dreamux config parse error in ${file}: ${msg}\n` +
-        `Use 'dreamux config show --raw' to print the file without redaction.`,
+        'Fix the JSON syntax before running `dreamux config show`.',
     );
   }
   redactFeishuSecrets(parsed);
@@ -139,6 +140,13 @@ export function redactConfigForDisplay(raw: string, file: string): string {
 }
 
 function readConfigFile(file: string): DreamuxConfig {
+  if (!existsSync(file)) {
+    throw new Error(
+      `dreamux config is missing at ${file}.\n` +
+        'Run `dreamux onboard` to create it before starting the server.',
+    );
+  }
+  assertConfigFileMode(file);
   const raw = readFileSync(file, 'utf8');
   let parsed: unknown;
   try {
@@ -147,7 +155,7 @@ function readConfigFile(file: string): DreamuxConfig {
     const msg = err instanceof Error ? err.message : String(err);
     throw new Error(
       `dreamux config parse error in ${file}: ${msg}\n` +
-        `Fix the JSON syntax in ${file} and restart, or delete the file to regenerate defaults.`,
+        `Fix the JSON syntax in ${file}, then restart. Run \`dreamux onboard\` if you need to recreate the config.`,
     );
   }
   return mergeWithDefaults(parsed, file);
@@ -180,6 +188,15 @@ function atomicWriteIfAbsent(file: string, content: string): boolean {
     closeSync(fd);
   }
   return true;
+}
+
+export function assertConfigFileMode(file: string): void {
+  if (process.platform === 'win32') return;
+  const mode = statSync(file).mode & 0o777;
+  if (mode === 0o600) return;
+  throw new Error(
+    `dreamux config file must be mode 0600: ${file} has mode 0${mode.toString(8)}`,
+  );
 }
 
 function mergeWithDefaults(raw: unknown, file: string): DreamuxConfig {
@@ -290,24 +307,48 @@ function readFeishuBots(
     );
   }
   const bots: Record<string, FeishuBotConfig> = {};
+  const appIdToDispatcher = new Map<string, string>();
   for (const [id, rawBot] of Object.entries(rawBots)) {
+    validateDispatcherId(id, `feishu.bots key '${id}'`);
     if (!isPlainObject(rawBot)) {
       throw new Error(
         `dreamux config error in ${file}: feishu.bots.${id} must be an object (got ${describeType(rawBot)})`,
       );
     }
+    rejectUnknownFeishuBotKeys(rawBot, id, file);
+    const app_id = requireNonEmptyString(rawBot, 'app_id', file, `feishu.bots.${id}.`);
+    const existing = appIdToDispatcher.get(app_id);
+    if (existing !== undefined) {
+      throw new Error(
+        `dreamux config error in ${file}: feishu.bots.${id}.app_id duplicates feishu.bots.${existing}.app_id`,
+      );
+    }
+    appIdToDispatcher.set(app_id, id);
     bots[id] = {
-      app_id: requireString(rawBot, 'app_id', '', file, `feishu.bots.${id}.`),
-      app_secret: requireString(
+      app_id,
+      app_secret: requireNonEmptyString(
         rawBot,
         'app_secret',
-        '',
         file,
         `feishu.bots.${id}.`,
       ),
     };
   }
   return bots;
+}
+
+function rejectUnknownFeishuBotKeys(
+  rawBot: Record<string, unknown>,
+  id: string,
+  file: string,
+): void {
+  const allowed = new Set(['app_id', 'app_secret']);
+  for (const key of Object.keys(rawBot)) {
+    if (allowed.has(key)) continue;
+    throw new Error(
+      `dreamux config error in ${file}: feishu.bots.${id}.${key} is not supported; MVP Feishu config accepts only app_id and app_secret`,
+    );
+  }
 }
 
 function isPlainObject(v: unknown): v is Record<string, unknown> {
@@ -324,6 +365,19 @@ function requireString(
   const v = obj[key];
   if (v === undefined) return fallback;
   return ensureString(v, `${prefix}${key}`, file);
+}
+
+function requireNonEmptyString(
+  obj: Record<string, unknown>,
+  key: string,
+  file: string,
+  prefix = '',
+): string {
+  const value = requireString(obj, key, '', file, prefix);
+  if (value.trim() !== '') return value;
+  throw new Error(
+    `dreamux config error in ${file}: ${prefix}${key} must be a non-empty string`,
+  );
 }
 
 function ensureString(v: unknown, key: string, file: string): string {

--- a/packages/dreamux/src/runtime/dispatcher-id.ts
+++ b/packages/dreamux/src/runtime/dispatcher-id.ts
@@ -1,0 +1,11 @@
+export const DISPATCHER_ID_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._-]{0,63}$/;
+
+export const DISPATCHER_ID_RULE =
+  '1-64 characters, starting with an ASCII letter or digit, and containing only ASCII letters, digits, dot, underscore, or dash';
+
+export function validateDispatcherId(id: string, label = 'dispatcher id'): string {
+  if (!DISPATCHER_ID_PATTERN.test(id)) {
+    throw new Error(`${label} must be ${DISPATCHER_ID_RULE}: ${id}`);
+  }
+  return id;
+}

--- a/packages/dreamux/src/runtime/paths.ts
+++ b/packages/dreamux/src/runtime/paths.ts
@@ -28,6 +28,7 @@ import {
   BUILT_IN_DEFAULTS,
   type DreamuxConfig,
 } from './config.js';
+import { validateDispatcherId } from './dispatcher-id.js';
 
 export const DREAMUX_UNIX_SOCKET_PATH_MAX_BYTES = 103;
 
@@ -35,8 +36,8 @@ let currentConfig: DreamuxConfig = BUILT_IN_DEFAULTS;
 
 /**
  * Set the active configuration snapshot. Called once by Server.start() with
- * the result of loadOrInitConfig(); tests can call it to inject a custom
- * snapshot. Idempotent.
+ * the result of loadConfig(); tests can call it to inject a custom snapshot.
+ * Idempotent.
  */
 export function setRuntimeConfig(config: DreamuxConfig): void {
   currentConfig = config;
@@ -57,6 +58,10 @@ export function dreamuxRoot(): string {
 
 export function stateRoot(): string {
   return join(dreamuxRoot(), 'state');
+}
+
+export function serverJsonPath(): string {
+  return join(stateRoot(), 'server.json');
 }
 
 export function logsRoot(): string {
@@ -166,8 +171,5 @@ export function assertUnixSocketPathBudget(path: string, label: string): string 
 }
 
 export function dispatcherPathSegment(id: string): string {
-  if (id.trim() === '') {
-    throw new Error('dispatcher id must not be empty when building paths');
-  }
-  return id.replaceAll(/[^A-Za-z0-9._-]/g, '_');
+  return validateDispatcherId(id);
 }

--- a/packages/dreamux/tests/doctor.test.ts
+++ b/packages/dreamux/tests/doctor.test.ts
@@ -121,6 +121,21 @@ describe('dreamux doctor command', () => {
     expect(result.dispatchers[0]?.managedService).toBeNull();
   });
 
+  it('does not expose Feishu app secrets in doctor results', async () => {
+    const runner = new FakeRunner();
+    const config = writeConfig();
+    writeDispatcher(config.runtimeDir, { auth: true });
+
+    const result = await runDreamuxDoctor({
+      runner,
+      platform: 'linux',
+      homeDir: join(root, 'home'),
+      env: {},
+    });
+
+    expect(JSON.stringify(result)).not.toContain('secret-test');
+  });
+
   it('checks managed-service dispatcher auth when a service is installed', async () => {
     const runner = new FakeRunner();
     const config = writeConfig();
@@ -173,6 +188,7 @@ describe('dreamux doctor command', () => {
           },
         },
       }),
+      { mode: 0o600 },
     );
     return { runtimeDir };
   }

--- a/packages/dreamux/tests/global-config.test.ts
+++ b/packages/dreamux/tests/global-config.test.ts
@@ -26,10 +26,17 @@ import {
   adminSocketPath,
   resetRuntimeConfig,
   runtimeRoot,
+  serverJsonPath,
   setRuntimeConfig,
   stateRoot,
 } from '../src/runtime/paths.js';
 import { codexArgsToCli, parseCodexArgs } from '../src/runtime/codex-args.js';
+
+function writeConfigObjectAt(configDir: string, value: unknown): void {
+  writeFileSync(globalConfigFile({ configDir }), JSON.stringify(value), {
+    mode: 0o600,
+  });
+}
 
 describe('global config (~/.dreamux/config.json)', () => {
   let configDir: string;
@@ -56,6 +63,14 @@ describe('global config (~/.dreamux/config.json)', () => {
     rmSync(configDir, { recursive: true, force: true });
     resetRuntimeConfig();
   });
+
+  function writeConfigObject(value: unknown): void {
+    writeConfigObjectAt(configDir, value);
+  }
+
+  function writeConfigText(file: string, content: string, mode = 0o600): void {
+    writeFileSync(file, content, { mode });
+  }
 
   it('first boot creates the config dir and JSON file', () => {
     expect(existsSync(join(configDir, 'config.json'))).toBe(false);
@@ -98,7 +113,7 @@ describe('global config (~/.dreamux/config.json)', () => {
         },
       },
     });
-    writeFileSync(file, original);
+    writeConfigText(file, original);
 
     const { config, createdOnThisBoot } = loadOrInitConfig({ configDir });
     expect(createdOnThisBoot).toBe(false);
@@ -114,7 +129,7 @@ describe('global config (~/.dreamux/config.json)', () => {
 
   it('parse error fails fast with the config path', () => {
     const file = globalConfigFile({ configDir });
-    writeFileSync(file, `{"runtime_dir": "/ok"`);
+    writeConfigText(file, `{"runtime_dir": "/ok"`);
     expect(() => loadOrInitConfig({ configDir })).toThrow(/config\.json/);
     expect(() => loadOrInitConfig({ configDir })).toThrow(/dreamux config parse error/);
   });
@@ -127,6 +142,12 @@ describe('global config (~/.dreamux/config.json)', () => {
     expect(() => loadOrInitConfig({ configDir })).toThrow(/legacy dreamux config/);
     expect(() => loadConfig({ configDir })).toThrow(/Create .*config\.json/);
     expect(existsSync(jsonFile)).toBe(false);
+  });
+
+  it('loadConfig loudly fails when config.json is missing', () => {
+    expect(() => loadConfig({ configDir })).toThrow(/dreamux config is missing/);
+    expect(() => loadConfig({ configDir })).toThrow(/dreamux onboard/);
+    expect(existsSync(globalConfigFile({ configDir }))).toBe(false);
   });
 
   it('redacts Feishu app secrets for display', () => {
@@ -161,26 +182,130 @@ describe('global config (~/.dreamux/config.json)', () => {
   });
 
   it('rejects invalid config values', () => {
-    const file = globalConfigFile({ configDir });
-    writeFileSync(file, JSON.stringify({ codex: { approval_policy: 'ask-every-time' } }));
+    writeConfigObject({ codex: { approval_policy: 'ask-every-time' } });
     expect(() => loadOrInitConfig({ configDir })).toThrow(
       /approval_policy='ask-every-time'/,
     );
 
-    writeFileSync(file, JSON.stringify({ runtime_dir: 42 }));
+    writeConfigObject({ runtime_dir: 42 });
     expect(() => loadOrInitConfig({ configDir })).toThrow(
       /runtime_dir must be a string/,
     );
 
-    writeFileSync(file, JSON.stringify({ codex: { initialize_timeout_ms: 0 } }));
+    writeConfigObject({ codex: { initialize_timeout_ms: 0 } });
     expect(() => loadOrInitConfig({ configDir })).toThrow(
       /initialize_timeout_ms must be > 0/,
     );
 
-    writeFileSync(file, JSON.stringify({ outbound: { retries: -1 } }));
+    writeConfigObject({ outbound: { retries: -1 } });
     expect(() => loadOrInitConfig({ configDir })).toThrow(
       /retries must be >= 0/,
     );
+  });
+
+  it('accepts the MVP Feishu bot schema', () => {
+    writeConfigObject({
+      feishu: {
+        bots: {
+          'dispatcher-a': {
+            app_id: 'app-a',
+            app_secret: 'secret-a',
+          },
+          'dispatcher.b': {
+            app_id: 'app-b',
+            app_secret: 'secret-b',
+          },
+        },
+      },
+    });
+
+    const { config } = loadConfig({ configDir });
+    expect(config.feishu.bots['dispatcher-a']).toEqual({
+      app_id: 'app-a',
+      app_secret: 'secret-a',
+    });
+    expect(config.feishu.bots['dispatcher.b']).toEqual({
+      app_id: 'app-b',
+      app_secret: 'secret-b',
+    });
+  });
+
+  it('rejects unsupported Feishu bot secret fields', () => {
+    writeConfigObject({
+      feishu: {
+        bots: {
+          flow: {
+            app_id: 'app-flow',
+            app_secret: 'secret-flow',
+            encrypt_key: 'future-webhook-only',
+          },
+        },
+      },
+    });
+
+    expect(() => loadConfig({ configDir })).toThrow(/encrypt_key is not supported/);
+    expect(() => loadConfig({ configDir })).toThrow(/only app_id and app_secret/);
+  });
+
+  it('requires unique Feishu app_id values across all dispatchers', () => {
+    writeConfigObject({
+      feishu: {
+        bots: {
+          flow: {
+            app_id: 'app-shared',
+            app_secret: 'secret-flow',
+          },
+          docs: {
+            app_id: 'app-shared',
+            app_secret: 'secret-docs',
+          },
+        },
+      },
+    });
+
+    expect(() => loadConfig({ configDir })).toThrow(/duplicates feishu\.bots\.flow\.app_id/);
+  });
+
+  it('rejects dispatcher ids that would not be stable path segments', () => {
+    writeConfigObject({
+      feishu: {
+        bots: {
+          'team/alpha beta': {
+            app_id: 'app-flow',
+            app_secret: 'secret-flow',
+          },
+        },
+      },
+    });
+
+    expect(() => loadConfig({ configDir })).toThrow(/feishu\.bots key/);
+    expect(() => loadConfig({ configDir })).toThrow(/ASCII letters/);
+  });
+
+  it('requires non-empty Feishu app_id and app_secret values', () => {
+    writeConfigObject({
+      feishu: {
+        bots: {
+          flow: {
+            app_id: '',
+            app_secret: 'secret-flow',
+          },
+        },
+      },
+    });
+    expect(() => loadConfig({ configDir })).toThrow(/app_id must be a non-empty string/);
+
+    writeConfigObject({
+      feishu: {
+        bots: {
+          flow: {
+            app_id: 'app-flow',
+            app_secret: '   ',
+          },
+        },
+      },
+    });
+    expect(() => loadConfig({ configDir })).toThrow(/app_secret must be a non-empty string/);
   });
 
   it('expandHome expands ~/ and bare ~', () => {
@@ -201,6 +326,14 @@ describe('global config (~/.dreamux/config.json)', () => {
     expect(createdOnThisBoot).toBe(true);
     const mode = statSync(configFile).mode & 0o777;
     expect(mode).toBe(0o600);
+  });
+
+  it('rejects existing config files that are not mode 0600', () => {
+    if (process.platform === 'win32') return;
+    const file = globalConfigFile({ configDir });
+    writeConfigText(file, JSON.stringify(BUILT_IN_DEFAULTS), 0o644);
+
+    expect(() => loadConfig({ configDir })).toThrow(/must be mode 0600/);
   });
 
   it('throws when the config dir cannot be written', () => {
@@ -245,9 +378,9 @@ describe('precedence: env > per-dispatcher > config > built-in', () => {
   });
 
   it('runtimeRoot aliases stateRoot and ignores config.runtime_dir', () => {
-    writeFileSync(globalConfigFile({ configDir }), JSON.stringify({
+    writeConfigObjectAt(configDir, {
       runtime_dir: '/tmp/from-config',
-    }));
+    });
     const { config } = loadOrInitConfig({ configDir });
     setRuntimeConfig(config);
     expect(runtimeRoot()).toBe(stateRoot());
@@ -255,9 +388,9 @@ describe('precedence: env > per-dispatcher > config > built-in', () => {
   });
 
   it('CODEX_HOST_RUNTIME_DIR no longer overrides runtime paths', () => {
-    writeFileSync(globalConfigFile({ configDir }), JSON.stringify({
+    writeConfigObjectAt(configDir, {
       runtime_dir: '/tmp/from-config',
-    }));
+    });
     const { config } = loadOrInitConfig({ configDir });
     setRuntimeConfig(config);
     process.env['CODEX_HOST_RUNTIME_DIR'] = '/tmp/from-env';
@@ -265,10 +398,10 @@ describe('precedence: env > per-dispatcher > config > built-in', () => {
   });
 
   it('adminSocketPath is fixed under stateRoot', () => {
-    writeFileSync(globalConfigFile({ configDir }), JSON.stringify({
+    writeConfigObjectAt(configDir, {
       runtime_dir: '/tmp/rt',
       admin_socket: '/tmp/cfg-admin.sock',
-    }));
+    });
     const { config } = loadOrInitConfig({ configDir });
     setRuntimeConfig(config);
     expect(adminSocketPath()).toBe(join(stateRoot(), 'admin.sock'));
@@ -278,12 +411,13 @@ describe('precedence: env > per-dispatcher > config > built-in', () => {
   });
 
   it('admin_socket no longer derives from runtime_dir', () => {
-    writeFileSync(globalConfigFile({ configDir }), JSON.stringify({
+    writeConfigObjectAt(configDir, {
       runtime_dir: '/tmp/rt',
-    }));
+    });
     const { config } = loadOrInitConfig({ configDir });
     setRuntimeConfig(config);
     expect(adminSocketPath()).toBe(join(stateRoot(), 'admin.sock'));
+    expect(serverJsonPath()).toBe(join(stateRoot(), 'server.json'));
   });
 
   it('parseCodexArgs: per-dispatcher overrides config defaults', () => {
@@ -335,19 +469,17 @@ describe('sandbox_mode precedence', () => {
   });
 
   it('config file value is loaded and validated', () => {
-    writeFileSync(
-      globalConfigFile({ configDir }),
-      JSON.stringify({ codex: { sandbox_mode: 'danger-full-access' } }),
-    );
+    writeConfigObjectAt(configDir, {
+      codex: { sandbox_mode: 'danger-full-access' },
+    });
     const { config } = loadOrInitConfig({ configDir });
     expect(config.codex.sandbox_mode).toBe('danger-full-access');
   });
 
   it('config rejects an invalid sandbox_mode at load time', () => {
-    writeFileSync(
-      globalConfigFile({ configDir }),
-      JSON.stringify({ codex: { sandbox_mode: 'not-a-mode' } }),
-    );
+    writeConfigObjectAt(configDir, {
+      codex: { sandbox_mode: 'not-a-mode' },
+    });
     expect(() => loadOrInitConfig({ configDir })).toThrow(
       /sandbox_mode='not-a-mode'/,
     );

--- a/packages/dreamux/tests/onboard.test.ts
+++ b/packages/dreamux/tests/onboard.test.ts
@@ -295,6 +295,7 @@ describe('dreamux onboard', () => {
           },
         },
       }),
+      { mode: 0o600 },
     );
     const answers = testAnswers({
       configDir,
@@ -354,6 +355,58 @@ describe('dreamux onboard', () => {
     } finally {
       db.close();
     }
+  });
+
+  it('rejects a new dispatcher that reuses an existing Feishu app_id', async () => {
+    const runner = new FakeRunner();
+    const configDir = join(root, 'config');
+    const existingConfig = JSON.stringify({
+      runtime_dir: join(root, 'existing-runtime'),
+      admin_socket: null,
+      codex: {
+        bin: 'codex',
+        approval_policy: 'never',
+        sandbox_mode: 'workspace-write',
+        extra_args: [],
+        initialize_timeout_ms: 10000,
+      },
+      outbound: {
+        retries: 3,
+        retry_delay_ms: 1000,
+      },
+      feishu: {
+        bots: {
+          flow: {
+            app_id: 'app-shared',
+            app_secret: 'secret-flow',
+          },
+        },
+      },
+    });
+    mkdirSync(configDir, { recursive: true });
+    writeFileSync(join(configDir, 'config.json'), existingConfig, {
+      mode: 0o600,
+    });
+
+    await expect(
+      runOnboard({
+        answers: testAnswers({
+          configDir,
+          dispatcherId: 'docs',
+          botAppId: 'app-shared',
+          botAppSecret: 'secret-docs',
+          registerService: false,
+        }),
+        runner,
+        platform: 'linux',
+        homeDir: join(root, 'home'),
+        env: {},
+      }),
+    ).rejects.toThrow(/duplicates dispatcher 'flow'/);
+
+    expect(readFileSync(join(configDir, 'config.json'), 'utf8')).toBe(
+      existingConfig,
+    );
   });
 
   it('fails non-interactive setup when required channel inputs are missing', () => {

--- a/packages/dreamux/tests/runtime-paths.test.ts
+++ b/packages/dreamux/tests/runtime-paths.test.ts
@@ -18,6 +18,7 @@ import {
   logsRoot,
   resetRuntimeConfig,
   runtimeRoot,
+  serverJsonPath,
   serverLogPath,
   stateRoot,
   unixSocketPathFitsBudget,
@@ -48,6 +49,7 @@ describe('runtime paths', () => {
     expect(stateRoot()).toBe(join(dreamuxRoot(), 'state'));
     expect(logsRoot()).toBe(join(dreamuxRoot(), 'logs'));
     expect(runtimeRoot()).toBe(stateRoot());
+    expect(serverJsonPath()).toBe(join(stateRoot(), 'server.json'));
     expect(databasePath()).toBe(join(stateRoot(), 'state.db'));
     expect(adminSocketPath()).toBe(join(stateRoot(), 'admin.sock'));
 
@@ -78,10 +80,12 @@ describe('runtime paths', () => {
     );
   });
 
-  it('sanitizes dispatcher ids before using them as path segments', () => {
-    expect(dispatcherDir('team/alpha beta')).toBe(
-      join(stateRoot(), 'team_alpha_beta'),
+  it('rejects dispatcher ids that are not valid path segments', () => {
+    expect(dispatcherDir('dispatcher-a')).toBe(
+      join(stateRoot(), 'dispatcher-a'),
     );
+    expect(() => dispatcherDir('team/alpha beta')).toThrow(/dispatcher id/);
+    expect(() => dispatcherDir('team_alpha_beta')).not.toThrow();
   });
 
   it('rejects Unix socket paths that exceed the safe sun_path budget', () => {

--- a/packages/dreamux/tests/uninstall.test.ts
+++ b/packages/dreamux/tests/uninstall.test.ts
@@ -49,7 +49,7 @@ describe('dreamux uninstall', () => {
     mkdirSync(dirname(servicePath), { recursive: true });
     writeFileSync(join(configDir, 'config.json'), JSON.stringify({
       runtime_dir: runtimeDir,
-    }));
+    }), { mode: 0o600 });
     writeFileSync(join(runtimeDir, 'state.db'), '');
     writeFileSync(servicePath, '[Service]\nExecStart=dreamux serve\n');
 
@@ -149,7 +149,13 @@ describe('dreamux uninstall', () => {
       mkdirSync(configDir, { recursive: true });
       mkdirSync(runtimeDir, { recursive: true });
       mkdirSync(dirname(servicePath), { recursive: true });
-      writeFileSync(join(configDir, testCase.file), testCase.content);
+      if (testCase.file === 'config.json') {
+        writeFileSync(join(configDir, testCase.file), testCase.content, {
+          mode: 0o600,
+        });
+      } else {
+        writeFileSync(join(configDir, testCase.file), testCase.content);
+      }
       writeFileSync(join(runtimeDir, 'state.db'), '');
       writeFileSync(servicePath, '[Service]\nExecStart=dreamux serve\n');
 


### PR DESCRIPTION
## Summary

- Enforce the MVP Feishu config schema: dispatcher bot config accepts only `app_id` and `app_secret`, requires non-empty values, and rejects duplicate `app_id` declarations.
- Require private `0600` config files on config reads, make `dreamux serve` fail loudly when config is missing, and keep `config show` redacted with no raw mode.
- Validate dispatcher ids before they become path segments, add `serverJsonPath()`, and update docs that still described legacy runtime paths or raw config display.

## Tests

- `node common/scripts/install-run-rush.js build --to @excitedjs/dreamux`
- `node common/scripts/install-run-rush.js test --to @excitedjs/dreamux`
- `.agents/scripts/check.sh`
- `git diff --check`

Tracking: #36 Task 2.