### PR TITLE
Task 3: install workspace dispatcher skill

### DIFF
--- a/.agents/components/dispatcher-skill.md
+++ b/.agents/components/dispatcher-skill.md
@@ -1,6 +1,6 @@
 # Component: dispatcher skill
 
-`/packages/dreamux/skills/codexmux-dispatcher/SKILL.md` is the bundled Codex
+`/packages/dreamux/skills/dispatcher/SKILL.md` is the bundled Codex
 skill that teaches dispatcher app-server sessions how to delegate product work
 through `tm`.
 
@@ -20,7 +20,7 @@ See [the dispatcher tm packaging decision](../decisions/dispatcher-tm-packaging.
 
 | Path | Role |
 |---|---|
-| `/packages/dreamux/skills/codexmux-dispatcher/SKILL.md` | Bundled dispatcher skill shipped in the npm package |
+| `/packages/dreamux/skills/dispatcher/SKILL.md` | Bundled dispatcher skill shipped in the npm package |
 | `<dispatcher cwd>/.codex/skills/dispatcher/SKILL.md` | Installed copy written by `dreamux onboard` for one dispatcher |
 | `/packages/dreamux/bin/tm` | Public wrapper that forwards to the package-local `@excitedjs/tm` executable |
 

--- a/.agents/components/repo-structure.md
+++ b/.agents/components/repo-structure.md
@@ -46,7 +46,7 @@ verbatim through the move):
 | `db/migrations/0001_init.sql` | Legacy SQLite schema; targeted for removal by [top-level-design](../decisions/top-level-design.md) |
 | `bin/dreamux` | Public CLI launcher (`dreamux serve`, `dreamux dispatcher ...`) |
 | `bin/tm` | Public wrapper that forwards to the package-local `@excitedjs/tm` executable |
-| `skills/codexmux-dispatcher/SKILL.md` | Bundled dispatcher Codex skill copied into each dispatcher's `<cwd>/.codex/skills/dispatcher/` by onboarding |
+| `skills/dispatcher/SKILL.md` | Bundled dispatcher Codex skill copied into each dispatcher's `<cwd>/.codex/skills/dispatcher/` by onboarding |
 | `tests/` | vitest: smoke, bin-launcher, dispatcher Codex home doctor, codex live integration |
 
 ## Installation — the rush path only

--- a/.agents/decisions/dispatcher-tm-packaging.md
+++ b/.agents/decisions/dispatcher-tm-packaging.md
@@ -82,11 +82,9 @@ At the time of this decision, the branch already contains:
 - `@excitedjs/tm` as a `@excitedjs/dreamux` dependency.
 - `/packages/dreamux/bin/tm`.
 - dispatcher app-server `PATH` injection for the dreamux package bin directory.
-
-The remaining implementation gap is onboarding: it still needs to install the
-bundled dispatcher skill to `<dispatcher cwd>/.codex/skills/dispatcher/`
-instead of the old global Codex skill path, and the bundled skill source
-directory still needs to be aligned to the `dispatcher` name.
+- `dreamux onboard` installs the bundled dispatcher skill to
+  `<dispatcher cwd>/.codex/skills/dispatcher/`.
+- The bundled skill source directory and frontmatter name are `dispatcher`.
 
 ## Alternatives considered
 

--- a/packages/dreamux/README.md
+++ b/packages/dreamux/README.md
@@ -21,7 +21,7 @@ Design background:
   wrapper around the package-local `@excitedjs/tm` dependency for dispatcher
   skills.
 - A bundled dispatcher Codex skill, copied by `dreamux onboard` into
-  `~/.codex/skills/codexmux-dispatcher/SKILL.md`.
+  `<dispatcher cwd>/.codex/skills/dispatcher/SKILL.md`.
 - A SQLite-backed runtime (`dispatchers` + `inbound_buffer`) plus the
   Feishu / Codex adapters that drive each dispatcher.
 
@@ -36,9 +36,9 @@ Design background:
 - **Dispatcher cwd is explicit, Codex state stays global.** The Codex
   daemon's cwd is configured during `dreamux onboard` or
   `dreamux dispatcher add --codex-cwd`. Dispatcher app-server processes
-  use Codex's global default home (`~/.codex`) for auth, memory, config, and
-  skills. dreamux keeps only app-server sockets/logs/SQLite under its runtime
-  directory.
+  use Codex's global default home (`~/.codex`) for auth, memory, and config.
+  The dispatcher skill is workspace-local under the dispatcher cwd. dreamux
+  keeps only app-server sockets/logs/SQLite under its runtime directory.
 - **FIFO + at-most-once.** One running turn per dispatcher. After a server
   crash, `running` inbound rows are flipped to `unknown` (the user is told
   to confirm or resend); `awaiting_outbound` rows are safely retried.
@@ -85,8 +85,8 @@ design (see [the top-level design](../../.agents/decisions/top-level-design.md))
 | `~/.dreamux/state/state.db`              | Legacy SQLite state until the MVP state cleanup lands | the server |
 | `~/.dreamux/state/admin.sock`            | Admin Unix socket (`0600`)                 | the server |
 | dispatcher `codex_cwd`                   | Codex app-server cwd, configured during onboard or dispatcher registration | the operator |
-| `~/.codex/`                              | Codex global default home: auth, memory, config, and skills | the operator / Codex |
-| `~/.codex/skills/codexmux-dispatcher/SKILL.md` | Dispatcher skill copied by `dreamux onboard` | dreamux installer |
+| `~/.codex/`                              | Codex global default home: auth, memory, and config | the operator / Codex |
+| `<dispatcher cwd>/.codex/skills/dispatcher/SKILL.md` | Dispatcher skill copied by `dreamux onboard`; reported but not deleted by `dreamux uninstall` | dreamux installer |
 | `~/.dreamux/state/<id>/codex.sock`       | Codex app-server Unix socket              | the server |
 | `~/.dreamux/logs/codex-app-server/<id>.log` | Codex app-server stdout                 | the server |
 

--- a/packages/dreamux/skills/dispatcher/SKILL.md
+++ b/packages/dreamux/skills/dispatcher/SKILL.md
@@ -1,9 +1,9 @@
 ---
-name: codexmux-dispatcher
+name: dispatcher
 description: Use from a dreamux dispatcher thread when work should be delegated to a tm-managed Codex teammate in a specific repository. Applies to bounded engineering tasks, test runs, codebase inspections, or follow-up work where the dispatcher should spawn/send/wait through the tm CLI exposed by the dreamux package and report the result back to the source chat.
 ---
 
-# Codexmux Dispatcher
+# Dispatcher
 
 Use this skill only from the dispatcher agent. The dreamux server hosts the
 dispatcher lifecycle; it does not own tm teammate daemons, teammate DB rows, or
@@ -17,8 +17,8 @@ dispatcher lifecycle; it does not own tm teammate daemons, teammate DB rows, or
 - Do not use `npx`, `npm exec --package @excitedjs/tm`, or
   `@excitedjs/tm@latest`; the dreamux package owns the tm dependency version.
 - Do not call dreamux admin APIs to create teammate state.
-- Do not infer a repo from the dispatcher cwd. A dispatcher cwd is server-owned
-  runtime space, not a worktree.
+- Do not infer the tm repo path from the dispatcher cwd unless the user or
+  operator explicitly made that cwd the requested repo.
 - Do not ask a tm-managed teammate to spawn another tm teammate.
 
 ## Before Delegating

--- a/packages/dreamux/src/cli/doctor.ts
+++ b/packages/dreamux/src/cli/doctor.ts
@@ -18,6 +18,7 @@ import {
 } from '../runtime/dispatcher-codex-home.js';
 import {
   databasePath as runtimeDatabasePath,
+  dispatcherCodexCwd,
   runtimeRoot,
   setRuntimeConfig,
 } from '../runtime/paths.js';
@@ -197,6 +198,7 @@ function readDispatchers(
       const codexCliArgs = codexArgsToCli(codexArgs);
       const context = dispatcherCodexHomeDoctorContext(row.dispatcher_id, {
         codexCliArgs,
+        dispatcherCwd: row.codex_cwd ?? dispatcherCodexCwd(row.dispatcher_id),
       });
       const foreground = validateDispatcherCodexHome(context, {
         env,

--- a/packages/dreamux/src/cli/dreamux.ts
+++ b/packages/dreamux/src/cli/dreamux.ts
@@ -229,7 +229,7 @@ function buildUninstallCommand(y: Argv): Argv {
     })
     .option('runtime-dir', {
       type: 'string',
-      describe: 'dreamux runtime directory',
+      describe: 'Legacy option ignored; uninstall removes dreamux state/log paths',
     });
 }
 

--- a/packages/dreamux/src/dispatcher/runtime.ts
+++ b/packages/dreamux/src/dispatcher/runtime.ts
@@ -135,6 +135,7 @@ export class DispatcherRuntime {
         await this.deps.codexHomeDoctor(
           dispatcherCodexHomeDoctorContext(this.dispatcherId, {
             codexCliArgs: extraArgs,
+            dispatcherCwd: cwd,
           }),
         );
       }

--- a/packages/dreamux/src/onboard/dispatcher-skill.ts
+++ b/packages/dreamux/src/onboard/dispatcher-skill.ts
@@ -10,21 +10,21 @@ const PACKAGE_ROOT = dirname(dirname(HERE));
 const DISPATCHER_SKILL_SOURCE = join(
   PACKAGE_ROOT,
   'skills',
-  'codexmux-dispatcher',
+  'dispatcher',
   'SKILL.md',
 );
 
 export function installDispatcherSkill(options: {
-  skillsDir: string;
+  skillPath: string;
   ledger: OnboardFileLedger;
   dryRun: boolean;
 }): void {
   const content = readDispatcherSkill();
   writeTextFile(
-    join(options.skillsDir, 'codexmux-dispatcher', 'SKILL.md'),
+    options.skillPath,
     content,
     options.ledger,
-    'global Codex skill',
+    'workspace-local dispatcher skill',
     { mode: 0o600, dryRun: options.dryRun },
   );
 }

--- a/packages/dreamux/src/onboard/run.ts
+++ b/packages/dreamux/src/onboard/run.ts
@@ -13,7 +13,8 @@ import {
 import {
   dispatcherAppServerControlDir,
   dispatcherCodexHome,
-  dispatcherCodexSkillsDir,
+  dispatcherWorkspaceCodexSkillsDir,
+  dispatcherWorkspaceSkillPath,
   databasePath,
   logsRoot,
   setRuntimeConfig,
@@ -95,12 +96,6 @@ export async function runOnboard(
     dryRun: answers.dryRun,
   });
   ensureDirectory(
-    dispatcherCodexSkillsDir(answers.dispatcherId),
-    ledger,
-    'global Codex skills directory',
-    { dryRun: answers.dryRun },
-  );
-  ensureDirectory(
     dispatcherAppServerControlDir(answers.dispatcherId),
     ledger,
     'dispatcher app-server control directory',
@@ -112,9 +107,15 @@ export async function runOnboard(
     'dispatcher cwd',
     { dryRun: answers.dryRun },
   );
+  ensureDirectory(
+    dispatcherWorkspaceCodexSkillsDir(effectiveAnswers.dispatcherCwd),
+    ledger,
+    'workspace-local Codex skills directory',
+    { dryRun: answers.dryRun },
+  );
 
   installDispatcherSkill({
-    skillsDir: dispatcherCodexSkillsDir(answers.dispatcherId),
+    skillPath: dispatcherWorkspaceSkillPath(effectiveAnswers.dispatcherCwd),
     ledger,
     dryRun: answers.dryRun,
   });
@@ -193,6 +194,7 @@ function runDispatcherDoctor(
   const codexCliArgs = codexArgsToCli(codexArgs);
   const context = dispatcherCodexHomeDoctorContext(answers.dispatcherId, {
     codexCliArgs,
+    dispatcherCwd: answers.dispatcherCwd,
   });
   if (answers.dryRun) {
     return {

--- a/packages/dreamux/src/onboard/uninstall.ts
+++ b/packages/dreamux/src/onboard/uninstall.ts
@@ -2,6 +2,9 @@ import { existsSync, rmSync } from 'node:fs';
 import { homedir } from 'node:os';
 import { basename, join, resolve, sep } from 'node:path';
 
+import { DispatcherRepo } from '../db/repository.js';
+import { openDatabase } from '../db/schema.js';
+import type { DispatcherRow } from '../db/types.js';
 import { ExecaCommandRunner } from './commands.js';
 import {
   LAUNCHD_LABEL,
@@ -11,12 +14,17 @@ import {
 import type { CommandRunner, ServicePlatform } from './types.js';
 import {
   assertNoLegacyTomlOnly,
-  BUILT_IN_DEFAULTS,
   expandHome,
   globalConfigDir,
   globalConfigFile,
   loadConfig,
 } from '../runtime/config.js';
+import {
+  databasePath,
+  dispatcherWorkspaceSkillPath,
+  logsRoot,
+  stateRoot,
+} from '../runtime/paths.js';
 
 export type UninstallStatus = 'removed' | 'missing' | 'skipped';
 
@@ -50,12 +58,16 @@ export async function runUninstall(
   const runner = options.runner ?? new ExecaCommandRunner();
   const dryRun = options.dryRun ?? false;
   const configDir = normalizePath(options.configDir ?? globalConfigDir());
-  const runtimeDir = normalizePath(resolveRuntimeDir(configDir, options.runtimeDir));
   const entries: UninstallEntry[] = [];
   const unit = serviceUnitPath(options.platform, options.homeDir ?? homedir());
+  validateConfigIfPresent(configDir);
+  const stateDir = normalizePath(stateRoot());
+  const logDir = normalizePath(logsRoot());
 
-  assertSafeOwnedDirectory(runtimeDir, 'dreamux runtime directory');
+  assertSafeOwnedDirectory(stateDir, 'dreamux state directory');
+  assertSafeOwnedDirectory(logDir, 'dreamux logs directory');
   assertSafeOwnedDirectory(configDir, 'dreamux config directory');
+  const workspaceSkillPaths = collectWorkspaceSkillPaths();
 
   await unregisterService({
     unitPath: unit.path,
@@ -70,7 +82,9 @@ export async function runUninstall(
     await runBestEffort(runner, 'systemctl', ['--user', 'daemon-reload'], dryRun);
   }
 
-  removeOwnedDirectory(runtimeDir, entries, 'dreamux runtime directory', dryRun);
+  reportWorkspaceSkills(workspaceSkillPaths, entries);
+  removeOwnedDirectory(stateDir, entries, 'dreamux state directory', dryRun);
+  removeOwnedDirectory(logDir, entries, 'dreamux logs directory', dryRun);
   removeOwnedDirectory(configDir, entries, 'dreamux config directory', dryRun);
 
   return {
@@ -82,13 +96,42 @@ export async function runUninstall(
   };
 }
 
-function resolveRuntimeDir(configDir: string, explicit: string | undefined): string {
-  if (explicit !== undefined && explicit !== '') return explicit;
+function validateConfigIfPresent(configDir: string): void {
   assertNoLegacyTomlOnly({ configDir });
-  if (!existsSync(globalConfigFile({ configDir }))) {
-    return BUILT_IN_DEFAULTS.runtime_dir;
+  if (!existsSync(globalConfigFile({ configDir }))) return;
+  loadConfig({ configDir });
+}
+
+function collectWorkspaceSkillPaths(): string[] {
+  const dbPath = databasePath();
+  if (!existsSync(dbPath)) return [];
+  const db = openDatabase({ path: dbPath });
+  try {
+    return new DispatcherRepo(db)
+      .list()
+      .map(dispatcherWorkspaceSkillPathFromRow)
+      .filter((path): path is string => path !== null);
+  } finally {
+    db.close();
   }
-  return loadConfig({ configDir }).config.runtime_dir;
+}
+
+function dispatcherWorkspaceSkillPathFromRow(row: DispatcherRow): string | null {
+  if (row.codex_cwd === null || row.codex_cwd.trim() === '') return null;
+  return dispatcherWorkspaceSkillPath(row.codex_cwd);
+}
+
+function reportWorkspaceSkills(
+  paths: string[],
+  entries: UninstallEntry[],
+): void {
+  for (const path of uniquePaths(paths)) {
+    entries.push({
+      path,
+      status: existsSync(path) ? 'skipped' : 'missing',
+      reason: 'workspace-local dispatcher skill (not removed)',
+    });
+  }
 }
 
 async function unregisterService(options: {

--- a/packages/dreamux/src/runtime/dispatcher-codex-home.ts
+++ b/packages/dreamux/src/runtime/dispatcher-codex-home.ts
@@ -9,9 +9,11 @@ import { parse as parseToml, TomlError } from 'smol-toml';
 import {
   DREAMUX_UNIX_SOCKET_PATH_MAX_BYTES,
   dispatcherAppServerControlDir,
+  dispatcherCodexCwd,
   dispatcherCodexConfigPath,
   dispatcherCodexHome,
-  dispatcherCodexSkillsDir,
+  dispatcherWorkspaceCodexSkillsDir,
+  dispatcherWorkspaceSkillPath,
   dispatcherSocketPath,
   unixSocketPathFitsBudget,
 } from './paths.js';
@@ -23,7 +25,9 @@ export interface DispatcherCodexHomeDoctorContext {
   dispatcherId: string;
   codexHome: string;
   configPath: string;
+  dispatcherCwd: string;
   skillsDir: string;
+  skillPath: string;
   appServerControlDir: string;
   socketPath: string;
   codexCliArgs: string[];
@@ -41,6 +45,7 @@ export type DispatcherCodexHomeDoctor = (
 
 interface DoctorContextOptions {
   codexCliArgs?: string[];
+  dispatcherCwd?: string;
 }
 
 interface DoctorOptions {
@@ -52,11 +57,14 @@ export function dispatcherCodexHomeDoctorContext(
   dispatcherId: string,
   options: DoctorContextOptions = {},
 ): DispatcherCodexHomeDoctorContext {
+  const dispatcherCwd = options.dispatcherCwd ?? dispatcherCodexCwd(dispatcherId);
   return {
     dispatcherId,
     codexHome: dispatcherCodexHome(dispatcherId),
     configPath: dispatcherCodexConfigPath(dispatcherId),
-    skillsDir: dispatcherCodexSkillsDir(dispatcherId),
+    dispatcherCwd,
+    skillsDir: dispatcherWorkspaceCodexSkillsDir(dispatcherCwd),
+    skillPath: dispatcherWorkspaceSkillPath(dispatcherCwd),
     appServerControlDir: dispatcherAppServerControlDir(dispatcherId),
     socketPath: dispatcherSocketPath(dispatcherId),
     codexCliArgs: options.codexCliArgs ?? [],
@@ -104,8 +112,8 @@ export function validateDispatcherCodexHome(
       `dispatcher app-server socket path is too long for Unix sockets (${bytes} bytes > ${DISPATCHER_APP_SERVER_SOCKET_PATH_MAX_BYTES} safe bytes): ${context.socketPath}`,
     );
   }
-  if (!codexmuxDispatcherSkillExists(context.skillsDir)) {
-    errors.push(`missing codexmux dispatcher skill under: ${context.skillsDir}`);
+  if (!dispatcherSkillExists(context.skillPath)) {
+    errors.push(`missing dispatcher skill: ${context.skillPath}`);
   }
 
   if (!hasAuth(context.codexHome, env)) {
@@ -148,8 +156,8 @@ function formatTomlError(err: unknown, file: string): string {
   return `Codex config parse error in ${file}: ${msg}`;
 }
 
-function codexmuxDispatcherSkillExists(root: string): boolean {
-  return existsSync(join(root, 'codexmux-dispatcher', 'SKILL.md'));
+function dispatcherSkillExists(skillPath: string): boolean {
+  return existsSync(skillPath);
 }
 
 function hasAuth(codexHome: string, env: NodeJS.ProcessEnv): boolean {

--- a/packages/dreamux/src/runtime/paths.ts
+++ b/packages/dreamux/src/runtime/paths.ts
@@ -111,6 +111,14 @@ export function dispatcherCodexSkillsDir(id: string): string {
   return join(dispatcherCodexHome(id), 'skills');
 }
 
+export function dispatcherWorkspaceCodexSkillsDir(cwd: string): string {
+  return join(cwd, '.codex', 'skills');
+}
+
+export function dispatcherWorkspaceSkillPath(cwd: string): string {
+  return join(dispatcherWorkspaceCodexSkillsDir(cwd), 'dispatcher', 'SKILL.md');
+}
+
 export function dispatcherAppServerControlDir(id: string): string {
   return dispatcherDir(id);
 }

--- a/packages/dreamux/tests/dispatcher-codex-home.test.ts
+++ b/packages/dreamux/tests/dispatcher-codex-home.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { homedir } from 'node:os';
-import { join } from 'node:path';
+import { dirname, join } from 'node:path';
 
 import {
   DISPATCHER_APP_SERVER_SOCKET_PATH_MAX_BYTES,
@@ -12,8 +12,9 @@ import {
 import { BUILT_IN_DEFAULTS } from '../src/runtime/config.js';
 import {
   dispatcherAppServerControlDir,
+  dispatcherCodexCwd,
   dispatcherCodexHome,
-  dispatcherCodexSkillsDir,
+  dispatcherWorkspaceSkillPath,
   dispatcherSocketPath,
   resetRuntimeConfig,
   setRuntimeConfig,
@@ -56,7 +57,7 @@ describe('global Codex home doctor', () => {
     expect(result.errors).toEqual(
       expect.arrayContaining([
         expect.stringContaining('missing Codex home directory'),
-        expect.stringContaining('missing codexmux dispatcher skill'),
+        expect.stringContaining('missing dispatcher skill'),
         expect.stringContaining('missing Codex auth state'),
       ]),
     );
@@ -142,21 +143,21 @@ describe('global Codex home doctor', () => {
     );
   });
 
-  it('rejects global Codex homes without the dispatcher skill installed', () => {
-    writeDispatcherHome('flow', { installCodexmux: false });
+  it('rejects missing workspace-local dispatcher skills', () => {
+    writeDispatcherHome('flow', { installDispatcherSkill: false });
 
     const result = validateDispatcherCodexHome('flow', { env: {} });
 
     expect(result.ok).toBe(false);
     expect(formatDispatcherCodexHomeErrors(result)).toContain(
-      'missing codexmux dispatcher skill',
+      'missing dispatcher skill',
     );
   });
 });
 
 function writeDispatcherHome(
   dispatcherId: string,
-  options: { installCodexmux?: boolean; writeAuth?: boolean } = {},
+  options: { installDispatcherSkill?: boolean; writeAuth?: boolean } = {},
 ): void {
   mkdirSync(dispatcherCodexHome(dispatcherId), { recursive: true });
   if (options.writeAuth !== false) {
@@ -165,12 +166,10 @@ function writeDispatcherHome(
     });
   }
 
-  if (options.installCodexmux === false) return;
-  mkdirSync(join(dispatcherCodexSkillsDir(dispatcherId), 'codexmux-dispatcher'), {
+  if (options.installDispatcherSkill === false) return;
+  const skillPath = dispatcherWorkspaceSkillPath(dispatcherCodexCwd(dispatcherId));
+  mkdirSync(dirname(skillPath), {
     recursive: true,
   });
-  writeFileSync(
-    join(dispatcherCodexSkillsDir(dispatcherId), 'codexmux-dispatcher', 'SKILL.md'),
-    '# test skill\n',
-  );
+  writeFileSync(skillPath, '# test skill\n');
 }

--- a/packages/dreamux/tests/doctor.test.ts
+++ b/packages/dreamux/tests/doctor.test.ts
@@ -14,8 +14,9 @@ import { runDreamuxDoctor } from '../src/cli/doctor.js';
 import type { CommandRunner } from '../src/onboard/types.js';
 import {
   databasePath,
+  dispatcherCodexCwd,
   dispatcherCodexHome,
-  dispatcherCodexSkillsDir,
+  dispatcherWorkspaceSkillPath,
   resetRuntimeConfig,
   setRuntimeConfig,
   stateRoot,
@@ -220,13 +221,10 @@ describe('dreamux doctor command', () => {
         },
       },
     });
-    mkdirSync(join(dispatcherCodexSkillsDir('flow'), 'codexmux-dispatcher'), {
-      recursive: true,
-    });
-    writeFileSync(
-      join(dispatcherCodexSkillsDir('flow'), 'codexmux-dispatcher', 'SKILL.md'),
-      '# test skill\n',
-    );
+    const skillPath = dispatcherWorkspaceSkillPath(dispatcherCodexCwd('flow'));
+    mkdirSync(dirname(skillPath), { recursive: true });
+    writeFileSync(skillPath, '# test skill\n');
+    mkdirSync(dispatcherCodexHome('flow'), { recursive: true });
     if (options.auth) {
       writeFileSync(join(dispatcherCodexHome('flow'), 'auth.json'), '{}');
     }

--- a/packages/dreamux/tests/onboard.test.ts
+++ b/packages/dreamux/tests/onboard.test.ts
@@ -21,7 +21,7 @@ import type { CommandRunner, OnboardAnswers } from '../src/onboard/types.js';
 import {
   databasePath,
   dispatcherCodexHome,
-  dispatcherCodexSkillsDir,
+  dispatcherWorkspaceSkillPath,
   logsRoot,
   resetRuntimeConfig,
 } from '../src/runtime/paths.js';
@@ -163,10 +163,13 @@ describe('dreamux onboard', () => {
       app_secret: 'secret-test',
     });
     expect(
-      existsSync(
-        join(dispatcherCodexSkillsDir('flow'), 'codexmux-dispatcher', 'SKILL.md'),
-      ),
+      existsSync(dispatcherWorkspaceSkillPath(answers.dispatcherCwd)),
     ).toBe(true);
+    expect(
+      existsSync(
+        join(dispatcherCodexHome('flow'), 'skills', 'dispatcher', 'SKILL.md'),
+      ),
+    ).toBe(false);
 
     const db = openDatabase({ path: databasePath() });
     try {
@@ -193,9 +196,7 @@ describe('dreamux onboard', () => {
       'created',
     );
     expect(
-      ledger.get(
-        join(dispatcherCodexSkillsDir('flow'), 'codexmux-dispatcher', 'SKILL.md'),
-      )?.status,
+      ledger.get(dispatcherWorkspaceSkillPath(answers.dispatcherCwd))?.status,
     ).toBe('created');
     expect(
       ledger.get(
@@ -231,7 +232,7 @@ describe('dreamux onboard', () => {
     );
   });
 
-  it('rewrites global dispatcher skills and skips already-loaded launchd services on rerun', async () => {
+  it('rewrites workspace dispatcher skills and skips already-loaded launchd services on rerun', async () => {
     const runner = new FakeRunner();
     const answers = testAnswers({
       configDir: join(root, 'config'),

--- a/packages/dreamux/tests/runtime-paths.test.ts
+++ b/packages/dreamux/tests/runtime-paths.test.ts
@@ -14,6 +14,8 @@ import {
   dispatcherDir,
   dispatcherSocketPath,
   dispatcherStatusPath,
+  dispatcherWorkspaceCodexSkillsDir,
+  dispatcherWorkspaceSkillPath,
   dreamuxRoot,
   logsRoot,
   resetRuntimeConfig,
@@ -64,6 +66,13 @@ describe('runtime paths', () => {
     );
     expect(dispatcherSocketPath('dispatcher-a')).toBe(
       join(stateRoot(), 'dispatcher-a', 'codex.sock'),
+    );
+    const workspace = join(root, 'workspace');
+    expect(dispatcherWorkspaceCodexSkillsDir(workspace)).toBe(
+      join(workspace, '.codex', 'skills'),
+    );
+    expect(dispatcherWorkspaceSkillPath(workspace)).toBe(
+      join(workspace, '.codex', 'skills', 'dispatcher', 'SKILL.md'),
     );
   });
 

--- a/packages/dreamux/tests/smoke.test.ts
+++ b/packages/dreamux/tests/smoke.test.ts
@@ -20,7 +20,7 @@ import {
   writeFileSync,
 } from 'node:fs';
 import { homedir, tmpdir } from 'node:os';
-import { join } from 'node:path';
+import { dirname, join } from 'node:path';
 
 import { Server } from '../src/server.js';
 import { CodexProcess, type CodexProcessOptions } from '../src/codex/supervisor.js';
@@ -30,8 +30,9 @@ import { createAdminSocketServer } from '../src/admin/socket.js';
 import { BUILT_IN_DEFAULTS } from '../src/runtime/config.js';
 import {
   dispatcherAppServerControlDir,
+  dispatcherCodexCwd,
   dispatcherCodexHome,
-  dispatcherCodexSkillsDir,
+  dispatcherWorkspaceSkillPath,
   dispatcherSocketPath,
 } from '../src/runtime/paths.js';
 import { startFakeCodex, type FakeCodex } from './fake-codex.js';
@@ -115,18 +116,16 @@ function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
-function writeReadyDispatcherCodexHome(dispatcherId: string): void {
+function writeReadyDispatcherCodexHome(dispatcherId: string, dispatcherCwd?: string): void {
   mkdirSync(dispatcherCodexHome(dispatcherId), { recursive: true });
   writeFileSync(join(dispatcherCodexHome(dispatcherId), 'auth.json'), '{}', {
     mode: 0o600,
   });
-  mkdirSync(join(dispatcherCodexSkillsDir(dispatcherId), 'codexmux-dispatcher'), {
-    recursive: true,
-  });
-  writeFileSync(
-    join(dispatcherCodexSkillsDir(dispatcherId), 'codexmux-dispatcher', 'SKILL.md'),
-    '# test skill\n',
+  const skillPath = dispatcherWorkspaceSkillPath(
+    dispatcherCwd ?? dispatcherCodexCwd(dispatcherId),
   );
+  mkdirSync(dirname(skillPath), { recursive: true });
+  writeFileSync(skillPath, '# test skill\n');
 }
 
 describe('dreamux MVP smoke', () => {
@@ -224,8 +223,9 @@ describe('dreamux MVP smoke', () => {
       bot_app_id: 'app-smoke',
       bot_secret_ref: 'env:UNUSED',
       codex_args_json: JSON.stringify({ sandboxMode: 'danger-full-access' }),
+      codex_cwd: join(runtimeDir, 'workspace'),
     });
-    writeReadyDispatcherCodexHome('flow');
+    writeReadyDispatcherCodexHome('flow', join(runtimeDir, 'workspace'));
 
     expect(existsSync(dispatcherAppServerControlDir('flow'))).toBe(false);
     await server.start();

--- a/packages/dreamux/tests/uninstall.test.ts
+++ b/packages/dreamux/tests/uninstall.test.ts
@@ -9,18 +9,30 @@ import {
 import { homedir } from 'node:os';
 import { dirname, join } from 'node:path';
 
+import { DispatcherRepo } from '../src/db/repository.js';
+import { openDatabase } from '../src/db/schema.js';
 import { runUninstall } from '../src/onboard/uninstall.js';
 import type { CommandRunner } from '../src/onboard/types.js';
+import {
+  databasePath,
+  dispatcherWorkspaceSkillPath,
+  logsRoot,
+  resetRuntimeConfig,
+  stateRoot,
+} from '../src/runtime/paths.js';
 
 class FakeRunner implements CommandRunner {
+  launchdLoaded = false;
   readonly calls: Array<{ command: string; args: string[] }> = [];
 
   async run(command: string, args: string[]): Promise<void> {
     this.calls.push({ command, args });
   }
 
-  async check(): Promise<boolean> {
-    return false;
+  async check(command: string, args: string[]): Promise<boolean> {
+    return command === 'launchctl' &&
+      args[0] === 'print' &&
+      this.launchdLoaded;
   }
 
   async capture(): Promise<string> {
@@ -30,27 +42,45 @@ class FakeRunner implements CommandRunner {
 
 describe('dreamux uninstall', () => {
   let root: string;
+  let previousHome: string | undefined;
 
   beforeEach(() => {
     root = mkdtempSync(join(homedir(), '.dreamux-uninstall-'));
+    previousHome = process.env['HOME'];
+    process.env['HOME'] = join(root, 'home');
   });
 
   afterEach(() => {
+    if (previousHome === undefined) delete process.env['HOME'];
+    else process.env['HOME'] = previousHome;
+    resetRuntimeConfig();
     rmSync(root, { recursive: true, force: true });
   });
 
-  it('removes onboard-owned config, runtime, and user service files', async () => {
+  it('removes onboard-owned config, state, logs, and user service files', async () => {
     const configDir = join(root, 'config');
-    const runtimeDir = join(root, 'runtime');
     const homeDir = join(root, 'home');
     const servicePath = join(homeDir, '.config', 'systemd', 'user', 'dreamux.service');
+    const dispatcherCwd = join(root, 'workspace');
+    const workspaceSkillPath = dispatcherWorkspaceSkillPath(dispatcherCwd);
     mkdirSync(configDir, { recursive: true });
-    mkdirSync(runtimeDir, { recursive: true });
+    mkdirSync(stateRoot(), { recursive: true });
+    mkdirSync(logsRoot(), { recursive: true });
     mkdirSync(dirname(servicePath), { recursive: true });
+    mkdirSync(dirname(workspaceSkillPath), { recursive: true });
     writeFileSync(join(configDir, 'config.json'), JSON.stringify({
-      runtime_dir: runtimeDir,
+      feishu: {
+        bots: {
+          flow: {
+            app_id: 'app-test',
+            app_secret: 'secret-test',
+          },
+        },
+      },
     }), { mode: 0o600 });
-    writeFileSync(join(runtimeDir, 'state.db'), '');
+    writeFileSync(join(logsRoot(), 'dreamux-server.log'), '');
+    writeFileSync(workspaceSkillPath, '# workspace skill\n');
+    writeDispatcher('flow', dispatcherCwd);
     writeFileSync(servicePath, '[Service]\nExecStart=dreamux serve\n');
 
     const runner = new FakeRunner();
@@ -62,32 +92,76 @@ describe('dreamux uninstall', () => {
     });
 
     expect(existsSync(configDir)).toBe(false);
-    expect(existsSync(runtimeDir)).toBe(false);
+    expect(existsSync(stateRoot())).toBe(false);
+    expect(existsSync(logsRoot())).toBe(false);
     expect(existsSync(servicePath)).toBe(false);
-    expect(result.entries.map((entry) => [entry.status, entry.path])).toEqual([
-      ['removed', configDir],
-      ['removed', servicePath],
-      ['removed', runtimeDir],
-    ]);
+    expect(existsSync(workspaceSkillPath)).toBe(true);
+    expect(result.entries).toEqual(
+      expect.arrayContaining([
+        { status: 'removed', path: configDir, reason: 'dreamux config directory' },
+        { status: 'removed', path: servicePath, reason: 'systemd unit' },
+        { status: 'removed', path: stateRoot(), reason: 'dreamux state directory' },
+        { status: 'removed', path: logsRoot(), reason: 'dreamux logs directory' },
+        {
+          status: 'skipped',
+          path: workspaceSkillPath,
+          reason: 'workspace-local dispatcher skill (not removed)',
+        },
+      ]),
+    );
     expect(runner.calls.map((call) => [call.command, call.args])).toEqual([
       ['systemctl', ['--user', 'disable', '--now', 'dreamux.service']],
       ['systemctl', ['--user', 'daemon-reload']],
     ]);
   });
 
-  it('refuses to remove operator Codex or Claude state paths', async () => {
-    const runner = new FakeRunner();
+  it('unregisters launchd services and removes the plist', async () => {
     const configDir = join(root, 'config');
     const homeDir = join(root, 'home');
+    const servicePath = join(
+      homeDir,
+      'Library',
+      'LaunchAgents',
+      'dev.excited.dreamux.plist',
+    );
+    mkdirSync(configDir, { recursive: true });
+    mkdirSync(stateRoot(), { recursive: true });
+    mkdirSync(logsRoot(), { recursive: true });
+    mkdirSync(dirname(servicePath), { recursive: true });
+    writeFileSync(join(configDir, 'config.json'), JSON.stringify({}), {
+      mode: 0o600,
+    });
+    writeFileSync(servicePath, '<plist />\n');
 
-    for (const unsafeRuntimeDir of [
-      join(homedir(), '.codex'),
-      join(homedir(), '.claude'),
-    ]) {
+    const runner = new FakeRunner();
+    runner.launchdLoaded = true;
+    const result = await runUninstall({
+      configDir,
+      runner,
+      platform: 'darwin',
+      homeDir,
+      uid: 501,
+    });
+
+    expect(existsSync(servicePath)).toBe(false);
+    expect(result.entries).toEqual(
+      expect.arrayContaining([
+        { status: 'removed', path: servicePath, reason: 'launchd unit' },
+      ]),
+    );
+    expect(runner.calls.map((call) => [call.command, call.args])).toEqual([
+      ['launchctl', ['bootout', 'gui/501/dev.excited.dreamux']],
+    ]);
+  });
+
+  it('refuses to remove operator Codex or Claude state paths', async () => {
+    const runner = new FakeRunner();
+    const homeDir = join(root, 'home');
+
+    for (const unsafeConfigDir of [join(homedir(), '.codex'), join(homedir(), '.claude')]) {
       await expect(
         runUninstall({
-          configDir,
-          runtimeDir: unsafeRuntimeDir,
+          configDir: unsafeConfigDir,
           runner,
           platform: 'linux',
           homeDir,
@@ -98,7 +172,6 @@ describe('dreamux uninstall', () => {
     await expect(
       runUninstall({
         configDir: join(homedir(), '.claude'),
-        runtimeDir: join(root, 'runtime'),
         runner,
         platform: 'linux',
         homeDir,
@@ -137,8 +210,9 @@ describe('dreamux uninstall', () => {
     for (const testCase of cases) {
       const caseRoot = join(root, testCase.name.replaceAll(' ', '-'));
       const configDir = join(caseRoot, 'config');
-      const runtimeDir = join(caseRoot, 'runtime');
       const homeDir = join(caseRoot, 'home');
+      const previousCaseHome = process.env['HOME'];
+      process.env['HOME'] = homeDir;
       const servicePath = join(
         homeDir,
         '.config',
@@ -147,7 +221,8 @@ describe('dreamux uninstall', () => {
         'dreamux.service',
       );
       mkdirSync(configDir, { recursive: true });
-      mkdirSync(runtimeDir, { recursive: true });
+      mkdirSync(stateRoot(), { recursive: true });
+      mkdirSync(logsRoot(), { recursive: true });
       mkdirSync(dirname(servicePath), { recursive: true });
       if (testCase.file === 'config.json') {
         writeFileSync(join(configDir, testCase.file), testCase.content, {
@@ -156,23 +231,45 @@ describe('dreamux uninstall', () => {
       } else {
         writeFileSync(join(configDir, testCase.file), testCase.content);
       }
-      writeFileSync(join(runtimeDir, 'state.db'), '');
+      writeFileSync(join(stateRoot(), 'state.db'), '');
+      writeFileSync(join(logsRoot(), 'dreamux-server.log'), '');
       writeFileSync(servicePath, '[Service]\nExecStart=dreamux serve\n');
 
       const runner = new FakeRunner();
-      await expect(
-        runUninstall({
-          configDir,
-          runner,
-          platform: 'linux',
-          homeDir,
-        }),
-      ).rejects.toThrow(testCase.error);
+      try {
+        await expect(
+          runUninstall({
+            configDir,
+            runner,
+            platform: 'linux',
+            homeDir,
+          }),
+        ).rejects.toThrow(testCase.error);
 
-      expect(existsSync(configDir)).toBe(true);
-      expect(existsSync(runtimeDir)).toBe(true);
-      expect(existsSync(servicePath)).toBe(true);
-      expect(runner.calls).toEqual([]);
+        expect(existsSync(configDir)).toBe(true);
+        expect(existsSync(stateRoot())).toBe(true);
+        expect(existsSync(logsRoot())).toBe(true);
+        expect(existsSync(servicePath)).toBe(true);
+        expect(runner.calls).toEqual([]);
+      } finally {
+        process.env['HOME'] = previousCaseHome;
+      }
     }
   });
 });
+
+function writeDispatcher(dispatcherId: string, dispatcherCwd: string): void {
+  const db = openDatabase({ path: databasePath() });
+  try {
+    new DispatcherRepo(db).create({
+      dispatcher_id: dispatcherId,
+      bot_app_id: 'app-test',
+      bot_secret_ref: `config:${dispatcherId}`,
+      codex_cwd: dispatcherCwd,
+    });
+  } finally {
+    db.close();
+  }
+
+  expect(existsSync(databasePath())).toBe(true);
+}


### PR DESCRIPTION
## Summary
- Install the bundled dispatcher skill into `<dispatcher cwd>/.codex/skills/dispatcher/SKILL.md` and rename the bundled source/frontmatter to `dispatcher`.
- Keep Codex auth/config in the global Codex home while checking dispatcher skill readiness from the workspace cwd.
- Make uninstall remove dreamux-owned config/state/log/service files and report workspace-local dispatcher skills without deleting them.

## Tests
- `node common/scripts/install-run-rush.js build --to @excitedjs/dreamux`
- `node common/scripts/install-run-rush.js test --to @excitedjs/dreamux`
- `.agents/scripts/check.sh`
- `git diff --check`

Tracking: #36 Task 3.