### PR TITLE
Task 4: cover Feishu long-connection inbound

### DIFF
--- a/packages/dreamux/src/cli/dreamux.ts
+++ b/packages/dreamux/src/cli/dreamux.ts
@@ -265,6 +265,9 @@ function printOnboardResult(result: OnboardRunResult): void {
 }
 
 function printUninstallResult(result: UninstallRunResult): void {
+  for (const warning of result.warnings) {
+    console.error(`warning: ${warning}`);
+  }
   console.log('dreamux uninstall file ledger:');
   for (const entry of result.entries) {
     console.log(`${entry.status}\t${entry.path}\t${entry.reason}`);

--- a/packages/dreamux/src/feishu/bot.ts
+++ b/packages/dreamux/src/feishu/bot.ts
@@ -23,6 +23,7 @@ import {
   narrowMetaFromEvent,
   parseInbound,
   toChannelInbound,
+  type FeishuTransport,
   type Mention,
   type OutboundTarget,
 } from '@excitedjs/feishu-transport';
@@ -69,11 +70,19 @@ export interface CreateBotOptions {
   appSecret: string;
 }
 
-export function createFeishuBot(opts: CreateBotOptions): FeishuBot {
-  const transport = createFeishuTransport({
-    appId: opts.appId,
-    appSecret: opts.appSecret,
-  });
+export interface CreateFeishuBotDeps {
+  createTransport?: (opts: CreateBotOptions) => FeishuTransport;
+}
+
+export function createFeishuBot(
+  opts: CreateBotOptions,
+  deps: CreateFeishuBotDeps = {},
+): FeishuBot {
+  const transport = deps.createTransport?.(opts) ??
+    createFeishuTransport({
+      appId: opts.appId,
+      appSecret: opts.appSecret,
+    });
 
   return {
     get appId(): string {

--- a/packages/dreamux/src/onboard/uninstall.ts
+++ b/packages/dreamux/src/onboard/uninstall.ts
@@ -46,6 +46,7 @@ export interface RunUninstallOptions {
 
 export interface UninstallRunResult {
   entries: UninstallEntry[];
+  warnings: string[];
   service: {
     platform: ServicePlatform;
     unitPath: string;
@@ -59,8 +60,9 @@ export async function runUninstall(
   const dryRun = options.dryRun ?? false;
   const configDir = normalizePath(options.configDir ?? globalConfigDir());
   const entries: UninstallEntry[] = [];
+  const warnings: string[] = [];
   const unit = serviceUnitPath(options.platform, options.homeDir ?? homedir());
-  validateConfigIfPresent(configDir);
+  warnIfConfigIsNotReadable(configDir, warnings);
   const stateDir = normalizePath(stateRoot());
   const logDir = normalizePath(logsRoot());
 
@@ -89,6 +91,7 @@ export async function runUninstall(
 
   return {
     entries: entries.sort((a, b) => a.path.localeCompare(b.path)),
+    warnings,
     service: {
       platform: unit.platform,
       unitPath: unit.path,
@@ -96,10 +99,17 @@ export async function runUninstall(
   };
 }
 
-function validateConfigIfPresent(configDir: string): void {
-  assertNoLegacyTomlOnly({ configDir });
-  if (!existsSync(globalConfigFile({ configDir }))) return;
-  loadConfig({ configDir });
+function warnIfConfigIsNotReadable(configDir: string, warnings: string[]): void {
+  try {
+    assertNoLegacyTomlOnly({ configDir });
+    if (!existsSync(globalConfigFile({ configDir }))) return;
+    loadConfig({ configDir });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    warnings.push(
+      `could not validate dreamux config before uninstall; continuing with fixed state/log paths: ${message}`,
+    );
+  }
 }
 
 function collectWorkspaceSkillPaths(): string[] {

--- a/packages/dreamux/src/runtime/paths.ts
+++ b/packages/dreamux/src/runtime/paths.ts
@@ -107,10 +107,6 @@ export function dispatcherCodexConfigPath(id: string): string {
   return join(dispatcherCodexHome(id), 'config.toml');
 }
 
-export function dispatcherCodexSkillsDir(id: string): string {
-  return join(dispatcherCodexHome(id), 'skills');
-}
-
 export function dispatcherWorkspaceCodexSkillsDir(cwd: string): string {
   return join(cwd, '.codex', 'skills');
 }

--- a/packages/dreamux/tests/feishu-bot.test.ts
+++ b/packages/dreamux/tests/feishu-bot.test.ts
@@ -1,0 +1,171 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  createFeishuBot,
+  type CreateBotOptions,
+  type FeishuInboundEvent,
+} from '../src/feishu/bot.js';
+import type {
+  FeishuDocComment,
+  FeishuDocMeta,
+  FeishuSendResult,
+  FeishuTransport,
+  InboundRoutes,
+  OutboundTarget,
+} from '@excitedjs/feishu-transport';
+
+class FakeTransport implements FeishuTransport {
+  readonly appId = 'app-test';
+  readonly selfId = 'bot-open-id';
+  routes: InboundRoutes | null = null;
+  readonly sent: Array<{ target: OutboundTarget; text: string }> = [];
+  closed = false;
+
+  async start(routes: InboundRoutes): Promise<void> {
+    this.routes = routes;
+  }
+
+  async send(target: OutboundTarget, text: string): Promise<FeishuSendResult> {
+    this.sent.push({ target, text });
+    return { messageIds: ['message-sent'] };
+  }
+
+  async addReaction(): Promise<string> {
+    throw new Error('unused in this test');
+  }
+
+  async removeReaction(): Promise<void> {
+    throw new Error('unused in this test');
+  }
+
+  async editText(): Promise<void> {
+    throw new Error('unused in this test');
+  }
+
+  async fetchDocComment(): Promise<FeishuDocComment | null> {
+    throw new Error('unused in this test');
+  }
+
+  async fetchDocMeta(): Promise<FeishuDocMeta | null> {
+    throw new Error('unused in this test');
+  }
+
+  async close(): Promise<void> {
+    this.closed = true;
+  }
+
+  async dispatch(eventType: string, raw: unknown): Promise<boolean> {
+    const handler = this.routes?.[eventType];
+    if (handler === undefined) return false;
+    await handler(raw);
+    return true;
+  }
+}
+
+describe('createFeishuBot inbound channel', () => {
+  it('registers only im.message.receive_v1 and normalizes raw events', async () => {
+    const transport = new FakeTransport();
+    const createdWith: CreateBotOptions[] = [];
+    const bot = createFeishuBot(
+      { appId: 'app-test', appSecret: 'secret-test' },
+      {
+        createTransport: (opts) => {
+          createdWith.push(opts);
+          return transport;
+        },
+      },
+    );
+    const received: FeishuInboundEvent[] = [];
+
+    await bot.start(async (event) => {
+      received.push(event);
+    });
+
+    expect(createdWith).toEqual([
+      { appId: 'app-test', appSecret: 'secret-test' },
+    ]);
+    expect(Object.keys(transport.routes ?? {})).toEqual([
+      'im.message.receive_v1',
+    ]);
+    expect(bot.appId).toBe('app-test');
+    expect(bot.botOpenId).toBe('bot-open-id');
+
+    const ignored = await transport.dispatch('drive.file.comment_v1', {
+      event: {},
+    });
+    expect(ignored).toBe(false);
+
+    const delivered = await transport.dispatch('im.message.receive_v1', {
+      schema: '2.0',
+      header: {
+        event_type: 'im.message.receive_v1',
+      },
+      event: {
+        sender: {
+          sender_id: { open_id: 'sender-open-id' },
+          sender_type: 'user',
+        },
+        message: {
+          message_id: 'message-id-1',
+          chat_id: 'chat-id-1',
+          chat_type: 'group',
+          message_type: 'text',
+          content: JSON.stringify({ text: 'hello @_user_1' }),
+          create_time: '1710000000000',
+          mentions: [
+            {
+              key: '@_user_1',
+              id: { open_id: 'mentioned-open-id' },
+              name: 'Ada',
+            },
+          ],
+        },
+      },
+    });
+
+    expect(delivered).toBe(true);
+    expect(received).toHaveLength(1);
+    expect(received[0]).toMatchObject({
+      messageId: 'message-id-1',
+      chatId: 'chat-id-1',
+      chatType: 'group',
+      senderId: 'sender-open-id',
+      senderType: 'user',
+      messageType: 'text',
+      rawContent: JSON.stringify({ text: 'hello @_user_1' }),
+      parsedText: 'hello @Ada',
+      createTime: '1710000000000',
+    });
+    expect(received[0]?.mentions).toHaveLength(1);
+  });
+
+  it('drops unroutable receive_v1 events before calling the handler', async () => {
+    const transport = new FakeTransport();
+    const bot = createFeishuBot(
+      { appId: 'app-test', appSecret: 'secret-test' },
+      { createTransport: () => transport },
+    );
+    const received: FeishuInboundEvent[] = [];
+    await bot.start(async (event) => {
+      received.push(event);
+    });
+
+    const delivered = await transport.dispatch('im.message.receive_v1', {
+      event: {
+        sender: {
+          sender_id: { open_id: 'sender-open-id' },
+          sender_type: 'user',
+        },
+        message: {
+          message_id: '',
+          chat_id: 'chat-id-1',
+          message_type: 'text',
+          content: JSON.stringify({ text: 'missing id' }),
+        },
+      },
+    });
+
+    expect(delivered).toBe(true);
+    expect(received).toEqual([]);
+  });
+});

--- a/packages/dreamux/tests/smoke.test.ts
+++ b/packages/dreamux/tests/smoke.test.ts
@@ -53,17 +53,23 @@ function buildServer(opts: {
   runtimeDir: string;
   fake: FakeCodex;
   bot: FakeFeishuBot;
+  config?: typeof BUILT_IN_DEFAULTS;
+  skipBotSecret?: boolean;
+  capturedBotSecrets?: string[];
   /** Optional spawn counter — bumped each time a NoopCodexProcess is built. */
   spawnCounter?: { count: number };
   capturedCodexOptions?: CodexProcessOptions[];
   useDefaultCodexHomeDoctor?: boolean;
 }): Server {
   return new Server({
-    config: { ...BUILT_IN_DEFAULTS, runtime_dir: opts.runtimeDir },
+    config: opts.config ?? { ...BUILT_IN_DEFAULTS, runtime_dir: opts.runtimeDir },
     databasePath: join(opts.runtimeDir, 'state.db'),
     adminSocketPath: join(opts.runtimeDir, 'admin.sock'),
-    skipBotSecret: true,
-    botFactory: () => opts.bot,
+    skipBotSecret: opts.skipBotSecret ?? true,
+    botFactory: (_row, secret) => {
+      opts.capturedBotSecrets?.push(secret);
+      return opts.bot;
+    },
     codexProcessFactory: (o) => {
       if (opts.spawnCounter !== undefined) opts.spawnCounter.count++;
       opts.capturedCodexOptions?.push(o);
@@ -204,6 +210,41 @@ describe('dreamux MVP smoke', () => {
     expect(capturedCodexOptions[0]?.socketPath).toBe(
       dispatcherSocketPath('flow'),
     );
+  });
+
+  it('keeps Feishu app secrets in the serve process and out of Codex child options', async () => {
+    const capturedBotSecrets: string[] = [];
+    const capturedCodexOptions: CodexProcessOptions[] = [];
+    server = buildServer({
+      runtimeDir,
+      fake,
+      bot,
+      skipBotSecret: false,
+      capturedBotSecrets,
+      capturedCodexOptions,
+      config: {
+        ...BUILT_IN_DEFAULTS,
+        runtime_dir: runtimeDir,
+        feishu: {
+          bots: {
+            flow: {
+              app_id: 'app-smoke',
+              app_secret: 'secret-server-only',
+            },
+          },
+        },
+      },
+    });
+    server.repos.dispatchers.create({
+      dispatcher_id: 'flow',
+      bot_app_id: 'app-smoke',
+      bot_secret_ref: 'config:flow',
+    });
+
+    await server.start();
+
+    expect(capturedBotSecrets).toEqual(['secret-server-only']);
+    expect(JSON.stringify(capturedCodexOptions)).not.toContain('secret-server-only');
   });
 
   it('creates the app-server socket directory outside the global Codex home', async () => {

--- a/packages/dreamux/tests/uninstall.test.ts
+++ b/packages/dreamux/tests/uninstall.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import {
+  chmodSync,
   existsSync,
   mkdirSync,
   mkdtempSync,
@@ -180,30 +181,47 @@ describe('dreamux uninstall', () => {
     expect(runner.calls).toEqual([]);
   });
 
-  it('fails fast on legacy or invalid config instead of falling back to the default runtime', async () => {
+  it('warns on legacy, invalid, or non-owner-only config and still uninstalls', async () => {
     const cases: Array<{
       name: string;
       file: string;
       content: string;
-      error: RegExp;
+      warning: RegExp;
+      mode?: number;
     }> = [
       {
         name: 'legacy TOML only',
         file: 'config.toml',
         content: 'runtime_dir = "/tmp/old-runtime"\n',
-        error: /legacy dreamux config/,
+        warning: /legacy dreamux config/,
       },
       {
         name: 'invalid JSON syntax',
         file: 'config.json',
         content: '{"runtime_dir": ',
-        error: /dreamux config parse error/,
+        warning: /dreamux config parse error/,
       },
       {
         name: 'invalid JSON value',
         file: 'config.json',
         content: JSON.stringify({ runtime_dir: 42 }),
-        error: /runtime_dir must be a string/,
+        warning: /runtime_dir must be a string/,
+      },
+      {
+        name: 'world-readable JSON config',
+        file: 'config.json',
+        content: JSON.stringify({
+          feishu: {
+            bots: {
+              flow: {
+                app_id: 'app-test',
+                app_secret: 'secret-test',
+              },
+            },
+          },
+        }),
+        warning: /must be mode 0600/,
+        mode: 0o644,
       },
     ];
 
@@ -225,9 +243,11 @@ describe('dreamux uninstall', () => {
       mkdirSync(logsRoot(), { recursive: true });
       mkdirSync(dirname(servicePath), { recursive: true });
       if (testCase.file === 'config.json') {
-        writeFileSync(join(configDir, testCase.file), testCase.content, {
+        const configPath = join(configDir, testCase.file);
+        writeFileSync(configPath, testCase.content, {
           mode: 0o600,
         });
+        if (testCase.mode !== undefined) chmodSync(configPath, testCase.mode);
       } else {
         writeFileSync(join(configDir, testCase.file), testCase.content);
       }
@@ -237,20 +257,23 @@ describe('dreamux uninstall', () => {
 
       const runner = new FakeRunner();
       try {
-        await expect(
-          runUninstall({
-            configDir,
-            runner,
-            platform: 'linux',
-            homeDir,
-          }),
-        ).rejects.toThrow(testCase.error);
+        const result = await runUninstall({
+          configDir,
+          runner,
+          platform: 'linux',
+          homeDir,
+        });
 
-        expect(existsSync(configDir)).toBe(true);
-        expect(existsSync(stateRoot())).toBe(true);
-        expect(existsSync(logsRoot())).toBe(true);
-        expect(existsSync(servicePath)).toBe(true);
-        expect(runner.calls).toEqual([]);
+        expect(result.warnings).toHaveLength(1);
+        expect(result.warnings[0]).toMatch(testCase.warning);
+        expect(existsSync(configDir)).toBe(false);
+        expect(existsSync(stateRoot())).toBe(false);
+        expect(existsSync(logsRoot())).toBe(false);
+        expect(existsSync(servicePath)).toBe(false);
+        expect(runner.calls.map((call) => [call.command, call.args])).toEqual([
+          ['systemctl', ['--user', 'disable', '--now', 'dreamux.service']],
+          ['systemctl', ['--user', 'daemon-reload']],
+        ]);
       } finally {
         process.env['HOME'] = previousCaseHome;
       }


### PR DESCRIPTION
## Summary
- Add a Feishu bot transport factory seam so tests can drive the same inbound route table that the long-connection transport uses.
- Cover the `im.message.receive_v1` raw-event path: only that event type is registered, non-message events are ignored, routable messages are normalized and dispatched, and unroutable message events are dropped before the handler.
- Assert Feishu app secrets are resolved in `dreamux serve` and do not appear in Codex child options.
- Include the Task 3 follow-up cleanup: remove the obsolete global Codex skills path helper and make `uninstall` warn, then continue, when config permissions or contents are invalid.

## Tests
- `node common/scripts/install-run-rush.js build --to @excitedjs/dreamux`
- `node common/scripts/install-run-rush.js test --to @excitedjs/dreamux`
- `.agents/scripts/check.sh`
- `git diff --check`

Tracking: #36 Task 4.