### PR TITLE
Task 5: add Feishu access gate reactions

### DIFF
--- a/.agents/components/repo-structure.md
+++ b/.agents/components/repo-structure.md
@@ -36,6 +36,7 @@ verbatim through the move):
 | Path | Concern |
 |---|---|
 | `src/admin/` | Unix socket admin protocol + method handlers |
+| `src/channel/` | Host-side Feishu gate, access state, outbound target mapping, and received-reaction ownership |
 | `src/cli/` | Entry-point CLIs: `dreamux.ts` (single public command tree), `server.ts` and `server-ctl.ts` as internal delegated modules |
 | `src/codex/` | Codex WS+Unix JSON-RPC client, supervisor, turn collector, init handshake |
 | `src/db/` | Legacy SQLite schema + repository; targeted for removal by [top-level-design](../decisions/top-level-design.md) |

--- a/.agents/decisions/top-level-design.md
+++ b/.agents/decisions/top-level-design.md
@@ -162,9 +162,29 @@ time, admin socket path, and last error.
 child process status, and diagnostic timestamps. It must not contain Feishu
 credentials.
 
-`access.json` stores dispatcher-local access state such as observed chats, gate
-warning inputs, and last gate diagnostics. It must not contain credentials,
-queued inbound messages, or dedupe state.
+`access.json` stores dispatcher-local access state. The MVP shape is:
+
+```json
+{
+  "version": 1,
+  "dm": {
+    "allow_users": ["USER_ID"]
+  },
+  "group": {
+    "allow_chats": ["CHAT_ID"],
+    "follow_users": ["USER_ID"],
+    "require_mention": true
+  },
+  "observed_chats": ["CHAT_ID"],
+  "warnings": [
+    "dispatcher shares one Codex context across multiple Feishu chats"
+  ],
+  "last_gate": null
+}
+```
+
+It must not contain credentials, queued inbound messages, dedupe state, or a
+reaction ledger.
 
 `codex.sock` is the Codex app-server WebSocket-over-Unix-socket endpoint for the
 dispatcher. It is not the Feishu MCP transport. The Feishu MCP default transport
@@ -265,6 +285,10 @@ For group chats, the MVP follows the claudemux Feishu channel shape:
 - the chat must be allowed when a chat allowlist is configured;
 - the sender must be allowed when a follow-user allowlist is configured;
 - the bot must be mentioned for a group message to enter the dispatcher.
+
+When no group chat allowlist or follow-user allowlist is configured, group
+messages are still mention-gated. This keeps bootstrap usable while preventing
+ambient group chatter from entering the dispatcher.
 
 The gate adds a channel-owned received reaction only after a message is accepted
 and enqueued. If the message is rejected, no reaction is added.

--- a/packages/dreamux/README.md
+++ b/packages/dreamux/README.md
@@ -87,6 +87,7 @@ design (see [the top-level design](../../.agents/decisions/top-level-design.md))
 | dispatcher `codex_cwd`                   | Codex app-server cwd, configured during onboard or dispatcher registration | the operator |
 | `~/.codex/`                              | Codex global default home: auth, memory, and config | the operator / Codex |
 | `<dispatcher cwd>/.codex/skills/dispatcher/SKILL.md` | Dispatcher skill copied by `dreamux onboard`; reported but not deleted by `dreamux uninstall` | dreamux installer |
+| `~/.dreamux/state/<id>/access.json`      | Dispatcher-local access gate state: allowed DMs, optional group/chat follow-user allowlists, observed chats, and trust-domain warnings | the server |
 | `~/.dreamux/state/<id>/codex.sock`       | Codex app-server Unix socket              | the server |
 | `~/.dreamux/logs/codex-app-server/<id>.log` | Codex app-server stdout                 | the server |
 

--- a/packages/dreamux/src/channel/feishu-gate.ts
+++ b/packages/dreamux/src/channel/feishu-gate.ts
@@ -1,40 +1,334 @@
-import { isBotSenderType } from '@excitedjs/feishu-transport';
+import {
+  isBotMentioned,
+  isBotSenderType,
+  type Mention,
+} from '@excitedjs/feishu-transport';
+import {
+  chmodSync,
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  writeFileSync,
+} from 'node:fs';
+import { dirname } from 'node:path';
 
-export interface CompatibleFeishuGateInput {
-  senderId: string;
-  senderType?: string;
-  chatType: string;
-  botOpenId?: string;
+import { dispatcherAccessPath } from '../runtime/paths.js';
+
+export const TRUST_DOMAIN_WARNING =
+  'dispatcher shares one Codex context across multiple Feishu chats';
+
+export interface DispatcherAccessState {
+  version: 1;
+  dm: {
+    allow_users: string[];
+  };
+  group: {
+    allow_chats: string[];
+    follow_users: string[];
+    require_mention: boolean;
+  };
+  observed_chats: string[];
+  warnings: string[];
+  last_gate: GateDiagnostic | null;
 }
 
-export type CompatibleFeishuGateResult =
-  | { action: 'deliver' }
-  | { action: 'drop'; reason: string };
+export interface GateDiagnostic {
+  at: number;
+  action: 'deliver' | 'drop';
+  chat_id: string;
+  chat_type: string;
+  sender_id: string;
+  reason?: string;
+}
 
-/**
- * Compatibility-first inbound gate for dreamux's Feishu channel.
- *
- * This deliberately does not enable pairing or allowlists yet. The current
- * product behavior stays open, while the loop/ambiguity hazards that can make
- * a channel self-amplify are blocked before messages enter the durable FIFO.
- */
-export function compatibleFeishuGate(
-  input: CompatibleFeishuGateInput,
-): CompatibleFeishuGateResult {
-  if (input.senderId === '') {
-    return { action: 'drop', reason: 'missing sender id' };
+export interface DreamuxFeishuGateInput {
+  senderId: string;
+  senderType?: string;
+  chatId: string;
+  chatType: string;
+  mentions?: Mention[];
+  botOpenId?: string;
+  now?: number;
+}
+
+export type DreamuxFeishuGateResult =
+  | {
+      action: 'deliver';
+      access: DispatcherAccessState;
+      warning: string | null;
+    }
+  | {
+      action: 'drop';
+      access: DispatcherAccessState;
+      reason: string;
+      warning: null;
+    };
+
+export function defaultDispatcherAccessState(): DispatcherAccessState {
+  return {
+    version: 1,
+    dm: {
+      allow_users: [],
+    },
+    group: {
+      allow_chats: [],
+      follow_users: [],
+      require_mention: true,
+    },
+    observed_chats: [],
+    warnings: [],
+    last_gate: null,
+  };
+}
+
+export function loadDispatcherAccess(dispatcherId: string): DispatcherAccessState {
+  const path = dispatcherAccessPath(dispatcherId);
+  if (!existsSync(path)) return defaultDispatcherAccessState();
+  const raw = readFileSync(path, 'utf8');
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    throw new Error(`dispatcher access parse error in ${path}: ${msg}`);
   }
+  return readDispatcherAccess(parsed, path);
+}
+
+export function saveDispatcherAccess(
+  dispatcherId: string,
+  access: DispatcherAccessState,
+): void {
+  const path = dispatcherAccessPath(dispatcherId);
+  mkdirSync(dirname(path), { recursive: true });
+  writeFileSync(path, `${JSON.stringify(access, null, 2)}\n`, { mode: 0o600 });
+  chmodSync(path, 0o600);
+}
+
+export function dreamuxFeishuGate(
+  input: DreamuxFeishuGateInput,
+  access: DispatcherAccessState,
+): DreamuxFeishuGateResult {
+  const now = input.now ?? Date.now();
+  const drop = (reason: string): DreamuxFeishuGateResult => ({
+    action: 'drop',
+    reason,
+    warning: null,
+    access: withDiagnostic(access, input, now, 'drop', reason),
+  });
+
+  if (input.senderId === '') return drop('missing sender id');
   if (input.botOpenId !== undefined && input.senderId === input.botOpenId) {
-    return { action: 'drop', reason: 'message sent by this bot' };
+    return drop('message sent by this bot');
   }
   if (isBotSenderType(input.senderType)) {
-    return { action: 'drop', reason: `bot sender type: ${input.senderType}` };
+    return drop(`bot sender type: ${input.senderType}`);
   }
-  if (input.chatType === 'group' && input.botOpenId === undefined) {
-    return {
-      action: 'drop',
-      reason: 'group message received before bot open_id was resolved',
+
+  if (input.chatType === 'p2p') {
+    if (!access.dm.allow_users.includes(input.senderId)) {
+      return drop('direct sender not allowed');
+    }
+    return deliver(access, input, now);
+  }
+
+  if (input.chatType !== 'group') {
+    return drop(`unsupported chat type: ${input.chatType}`);
+  }
+
+  if (access.group.allow_chats.length > 0 &&
+    !access.group.allow_chats.includes(input.chatId)) {
+    return drop('group chat not allowed');
+  }
+  if (access.group.follow_users.length > 0 &&
+    !access.group.follow_users.includes(input.senderId)) {
+    return drop('sender not allowed by follow-user gate');
+  }
+  if (access.group.require_mention) {
+    if (input.botOpenId === undefined) {
+      return drop('group message requires a bot mention but bot open_id is unknown');
+    }
+    if (!isBotMentioned(input.mentions, input.botOpenId)) {
+      return drop('bot not mentioned');
+    }
+  }
+
+  return deliver(access, input, now);
+}
+
+function deliver(
+  access: DispatcherAccessState,
+  input: DreamuxFeishuGateInput,
+  now: number,
+): DreamuxFeishuGateResult {
+  let next = withDiagnostic(access, input, now, 'deliver');
+  if (!next.observed_chats.includes(input.chatId)) {
+    next = {
+      ...next,
+      observed_chats: [...next.observed_chats, input.chatId],
     };
   }
-  return { action: 'deliver' };
+
+  const needsWarning =
+    next.group.allow_chats.length > 1 || next.observed_chats.length > 1;
+  const warning =
+    needsWarning && !next.warnings.includes(TRUST_DOMAIN_WARNING)
+      ? TRUST_DOMAIN_WARNING
+      : null;
+  if (warning !== null) {
+    next = {
+      ...next,
+      warnings: [...next.warnings, warning],
+    };
+  }
+
+  return { action: 'deliver', access: next, warning };
+}
+
+function withDiagnostic(
+  access: DispatcherAccessState,
+  input: DreamuxFeishuGateInput,
+  now: number,
+  action: 'deliver' | 'drop',
+  reason?: string,
+): DispatcherAccessState {
+  return {
+    ...access,
+    last_gate: {
+      at: now,
+      action,
+      chat_id: input.chatId,
+      chat_type: input.chatType,
+      sender_id: input.senderId,
+      ...(reason !== undefined ? { reason } : {}),
+    },
+  };
+}
+
+function readDispatcherAccess(
+  raw: unknown,
+  path: string,
+): DispatcherAccessState {
+  if (!isRecord(raw)) {
+    throw new Error(`dispatcher access error in ${path}: top-level must be an object`);
+  }
+  const defaults = defaultDispatcherAccessState();
+  const dm = isRecord(raw['dm']) ? raw['dm'] : {};
+  const group = isRecord(raw['group']) ? raw['group'] : {};
+  const lastGate = raw['last_gate'];
+
+  return {
+    version: 1,
+    dm: {
+      allow_users: readStringArray(dm, 'allow_users', defaults.dm.allow_users, path),
+    },
+    group: {
+      allow_chats: readStringArray(
+        group,
+        'allow_chats',
+        defaults.group.allow_chats,
+        path,
+      ),
+      follow_users: readStringArray(
+        group,
+        'follow_users',
+        defaults.group.follow_users,
+        path,
+      ),
+      require_mention: readBoolean(
+        group,
+        'require_mention',
+        defaults.group.require_mention,
+        path,
+      ),
+    },
+    observed_chats: readStringArray(
+      raw,
+      'observed_chats',
+      defaults.observed_chats,
+      path,
+    ),
+    warnings: readStringArray(raw, 'warnings', defaults.warnings, path),
+    last_gate: lastGate === null || lastGate === undefined
+      ? null
+      : readGateDiagnostic(lastGate, path),
+  };
+}
+
+function readGateDiagnostic(raw: unknown, path: string): GateDiagnostic {
+  if (!isRecord(raw)) {
+    throw new Error(`dispatcher access error in ${path}: last_gate must be an object`);
+  }
+  const action = raw['action'];
+  if (action !== 'deliver' && action !== 'drop') {
+    throw new Error(
+      `dispatcher access error in ${path}: last_gate.action must be deliver or drop`,
+    );
+  }
+  return {
+    at: readNumber(raw, 'at', path),
+    action,
+    chat_id: readString(raw, 'chat_id', path),
+    chat_type: readString(raw, 'chat_type', path),
+    sender_id: readString(raw, 'sender_id', path),
+    ...(typeof raw['reason'] === 'string' ? { reason: raw['reason'] } : {}),
+  };
+}
+
+function readStringArray(
+  obj: Record<string, unknown>,
+  key: string,
+  fallback: string[],
+  path: string,
+): string[] {
+  const value = obj[key];
+  if (value === undefined) return [...fallback];
+  if (!Array.isArray(value) || !value.every((item) => typeof item === 'string')) {
+    throw new Error(
+      `dispatcher access error in ${path}: ${key} must be an array of strings`,
+    );
+  }
+  return [...new Set(value)];
+}
+
+function readBoolean(
+  obj: Record<string, unknown>,
+  key: string,
+  fallback: boolean,
+  path: string,
+): boolean {
+  const value = obj[key];
+  if (value === undefined) return fallback;
+  if (typeof value !== 'boolean') {
+    throw new Error(`dispatcher access error in ${path}: ${key} must be a boolean`);
+  }
+  return value;
+}
+
+function readNumber(
+  obj: Record<string, unknown>,
+  key: string,
+  path: string,
+): number {
+  const value = obj[key];
+  if (typeof value !== 'number') {
+    throw new Error(`dispatcher access error in ${path}: ${key} must be a number`);
+  }
+  return value;
+}
+
+function readString(
+  obj: Record<string, unknown>,
+  key: string,
+  path: string,
+): string {
+  const value = obj[key];
+  if (typeof value !== 'string') {
+    throw new Error(`dispatcher access error in ${path}: ${key} must be a string`);
+  }
+  return value;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
 }

--- a/packages/dreamux/src/feishu/bot.ts
+++ b/packages/dreamux/src/feishu/bot.ts
@@ -62,6 +62,7 @@ export interface FeishuBot {
   readonly botOpenId: string | undefined;
   start(handler: InboundHandler): Promise<void>;
   send(target: OutboundTarget, text: string): Promise<FeishuSendResult>;
+  addReaction(messageId: string, emoji: string): Promise<string>;
   close(): Promise<void>;
 }
 
@@ -109,6 +110,10 @@ export function createFeishuBot(
     async send(target: OutboundTarget, text: string): Promise<FeishuSendResult> {
       const { messageIds } = await transport.send(target, text);
       return { messageIds };
+    },
+
+    addReaction(messageId: string, emoji: string): Promise<string> {
+      return transport.addReaction(messageId, emoji);
     },
 
     close(): Promise<void> {
@@ -190,8 +195,14 @@ export interface FakeFeishuBot extends FeishuBot {
     text: string;
     messageIds: string[];
   }>;
+  readonly reactions: Array<{
+    messageId: string;
+    emoji: string;
+    reactionId: string;
+  }>;
   inject(event: FeishuInboundEvent): Promise<void>;
   setSendError(err: Error | null): void;
+  setReactionError(err: Error | null): void;
 }
 
 export function createFakeFeishuBot(appId: string = 'fake-bot'): FakeFeishuBot {
@@ -203,8 +214,15 @@ export function createFakeFeishuBot(appId: string = 'fake-bot'): FakeFeishuBot {
   }> = [];
   let handler: InboundHandler | null = null;
   let nextMessageId = 1;
+  let nextReactionId = 1;
   let sendError: Error | null = null;
+  let reactionError: Error | null = null;
   const openId: string | undefined = `fake-open-id-${appId}`;
+  const reactions: Array<{
+    messageId: string;
+    emoji: string;
+    reactionId: string;
+  }> = [];
 
   return {
     appId,
@@ -222,11 +240,22 @@ export function createFakeFeishuBot(appId: string = 'fake-bot'): FakeFeishuBot {
       sent.push({ chatId: target.chatId, target, text, messageIds: [id] });
       return { messageIds: [id] };
     },
+    async addReaction(messageId: string, emoji: string): Promise<string> {
+      if (reactionError !== null) {
+        throw reactionError;
+      }
+      const reactionId = `reaction-fake-${nextReactionId++}`;
+      reactions.push({ messageId, emoji, reactionId });
+      return reactionId;
+    },
     async close(): Promise<void> {
       handler = null;
     },
     get sentMessages() {
       return sent;
+    },
+    get reactions() {
+      return reactions;
     },
     async inject(event: FeishuInboundEvent): Promise<void> {
       if (handler === null) throw new Error('fake bot not started');
@@ -234,6 +263,9 @@ export function createFakeFeishuBot(appId: string = 'fake-bot'): FakeFeishuBot {
     },
     setSendError(err: Error | null): void {
       sendError = err;
+    },
+    setReactionError(err: Error | null): void {
+      reactionError = err;
     },
   };
 }

--- a/packages/dreamux/src/server.ts
+++ b/packages/dreamux/src/server.ts
@@ -28,7 +28,11 @@ import {
   type FeishuBot,
   type FeishuInboundEvent,
 } from './feishu/bot.js';
-import { compatibleFeishuGate } from './channel/feishu-gate.js';
+import {
+  dreamuxFeishuGate,
+  loadDispatcherAccess,
+  saveDispatcherAccess,
+} from './channel/feishu-gate.js';
 import { parseCodexArgs, codexArgsToCli } from './runtime/codex-args.js';
 import { resolveBotSecret } from './runtime/secrets.js';
 import { BUILT_IN_DEFAULTS, type DreamuxConfig } from './runtime/config.js';
@@ -40,6 +44,8 @@ import {
   setRuntimeConfig,
 } from './runtime/paths.js';
 import { createAdminSocketServer, type AdminSocketServer } from './admin/socket.js';
+
+export const RECEIVED_REACTION_EMOJI = 'GLANCE';
 
 export interface ServerOptions {
   /**
@@ -76,6 +82,11 @@ interface DispatcherSlot {
   row: DispatcherRow;
   runtime: DispatcherRuntime;
   bot: FeishuBot;
+  channelState: DispatcherChannelState;
+}
+
+interface DispatcherChannelState {
+  receivedReactions: Map<string, { chatId: string; reactionId: string }>;
 }
 
 export class Server {
@@ -185,6 +196,9 @@ export class Server {
     const bot = this.opts.botFactory
       ? this.opts.botFactory(row, botSecret)
       : createFeishuBot({ appId: row.bot_app_id, appSecret: botSecret });
+    const channelState: DispatcherChannelState = {
+      receivedReactions: new Map(),
+    };
 
     const runtime = new DispatcherRuntime(row, {
       dispatchers: this.repos.dispatchers,
@@ -206,25 +220,37 @@ export class Server {
     try {
       await runtime.start();
       await bot.start(async (event: FeishuInboundEvent) => {
-        const gate = compatibleFeishuGate({
+        const access = loadDispatcherAccess(id);
+        const gate = dreamuxFeishuGate({
           senderId: event.senderId,
           senderType: event.senderType,
+          chatId: event.chatId,
           chatType: event.chatType,
+          mentions: event.mentions,
           botOpenId: bot.botOpenId,
-        });
+        }, access);
+        saveDispatcherAccess(id, gate.access);
+        if (gate.warning !== null) {
+          console.error(
+            `[server] trust-domain warning for dispatcher '${id}': ${gate.warning}`,
+          );
+        }
         if (gate.action === 'drop') {
           console.error(
             `[server] dropped feishu inbound for dispatcher '${id}': ${gate.reason}`,
           );
           return;
         }
-        runtime.enqueueInbound({
+        const inboundId = runtime.enqueueInbound({
           source_chat_id: event.chatId,
           source_message_id: event.messageId,
           sender_id: event.senderId,
           feishu_event_json: safeStringify(event.raw),
           parsed_text: event.parsedText,
         });
+        if (inboundId !== null) {
+          await addReceivedReaction(id, bot, channelState, event);
+        }
       });
     } catch (err) {
       // Failed midway: undo any partial bring-up so a retry isn't
@@ -242,7 +268,7 @@ export class Server {
       throw err;
     }
 
-    this.slots.set(id, { row, runtime, bot });
+    this.slots.set(id, { row, runtime, bot, channelState });
     console.error(
       `[server] dispatcher '${id}' is ready (bot=${row.bot_app_id} cwd=${row.codex_cwd ?? dispatcherCodexCwd(id)})`,
     );
@@ -306,6 +332,35 @@ export class Server {
     } catch (err) {
       console.error('[server] db close error:', err);
     }
+  }
+}
+
+async function addReceivedReaction(
+  dispatcherId: string,
+  bot: FeishuBot,
+  channelState: DispatcherChannelState,
+  event: FeishuInboundEvent,
+): Promise<void> {
+  try {
+    const reactionId = await bot.addReaction(
+      event.messageId,
+      RECEIVED_REACTION_EMOJI,
+    );
+    if (reactionId === '') {
+      console.error(
+        `[server] Feishu returned no reaction_id for the received reaction in dispatcher '${dispatcherId}'`,
+      );
+      return;
+    }
+    channelState.receivedReactions.set(event.messageId, {
+      chatId: event.chatId,
+      reactionId,
+    });
+  } catch (err) {
+    console.error(
+      `[server] failed to add the received reaction for dispatcher '${dispatcherId}':`,
+      err,
+    );
   }
 }
 

--- a/packages/dreamux/tests/feishu-gate.test.ts
+++ b/packages/dreamux/tests/feishu-gate.test.ts
@@ -1,62 +1,192 @@
-import { describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import {
+  existsSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  statSync,
+} from 'node:fs';
+import { homedir, tmpdir } from 'node:os';
+import { join } from 'node:path';
 
-import { compatibleFeishuGate } from '../src/channel/feishu-gate.js';
+import {
+  TRUST_DOMAIN_WARNING,
+  defaultDispatcherAccessState,
+  dreamuxFeishuGate,
+  loadDispatcherAccess,
+  saveDispatcherAccess,
+  type DispatcherAccessState,
+} from '../src/channel/feishu-gate.js';
+import { dispatcherAccessPath, resetRuntimeConfig } from '../src/runtime/paths.js';
 
-describe('compatibleFeishuGate', () => {
-  it('keeps normal user messages deliverable', () => {
-    expect(
-      compatibleFeishuGate({
-        senderId: 'sender-user',
-        senderType: 'user',
-        chatType: 'group',
-        botOpenId: 'bot-open-id',
-      }),
-    ).toEqual({ action: 'deliver' });
+describe('dreamuxFeishuGate', () => {
+  it('delivers direct messages only from allowed senders', () => {
+    const access = state({
+      dm: { allow_users: ['sender-allowed'] },
+    });
+
+    expect(gate({ chatType: 'p2p', senderId: 'sender-allowed' }, access))
+      .toMatchObject({ action: 'deliver' });
+    expect(gate({ chatType: 'p2p', senderId: 'sender-other' }, access))
+      .toMatchObject({
+        action: 'drop',
+        reason: 'direct sender not allowed',
+      });
   });
 
-  it('drops missing sender id', () => {
-    expect(
-      compatibleFeishuGate({
-        senderId: '',
-        senderType: 'user',
-        chatType: 'p2p',
-        botOpenId: 'bot-open-id',
-      }),
-    ).toEqual({ action: 'drop', reason: 'missing sender id' });
-  });
+  it('drops self-sent, bot-sender, and missing-sender messages', () => {
+    const access = state();
 
-  it('drops self-sent bot-loop messages', () => {
-    expect(
-      compatibleFeishuGate({
-        senderId: 'bot-open-id',
-        senderType: 'user',
-        chatType: 'group',
-        botOpenId: 'bot-open-id',
-      }),
-    ).toEqual({ action: 'drop', reason: 'message sent by this bot' });
-  });
-
-  it('drops Feishu bot/app sender types', () => {
-    expect(
-      compatibleFeishuGate({
-        senderId: 'peer-bot',
-        senderType: 'app',
-        chatType: 'group',
-        botOpenId: 'bot-open-id',
-      }),
-    ).toEqual({ action: 'drop', reason: 'bot sender type: app' });
-  });
-
-  it('drops group messages when bot open_id is unknown', () => {
-    expect(
-      compatibleFeishuGate({
-        senderId: 'sender-user',
-        senderType: 'user',
-        chatType: 'group',
-      }),
-    ).toEqual({
+    expect(gate({ senderId: '' }, access)).toMatchObject({
       action: 'drop',
-      reason: 'group message received before bot open_id was resolved',
+      reason: 'missing sender id',
+    });
+    expect(gate({ senderId: 'bot-open-id' }, access)).toMatchObject({
+      action: 'drop',
+      reason: 'message sent by this bot',
+    });
+    expect(gate({ senderId: 'sender-bot', senderType: 'bot' }, access))
+      .toMatchObject({
+        action: 'drop',
+        reason: 'bot sender type: bot',
+      });
+  });
+
+  it('requires a bot mention before group delivery', () => {
+    const access = state();
+
+    expect(gate({}, access)).toMatchObject({ action: 'deliver' });
+    expect(gate({ mentions: [] }, access)).toMatchObject({
+      action: 'drop',
+      reason: 'bot not mentioned',
+    });
+    expect(gate({ botOpenId: undefined }, access)).toMatchObject({
+      action: 'drop',
+      reason: 'group message requires a bot mention but bot open_id is unknown',
     });
   });
+
+  it('enforces configured group chat allowlists', () => {
+    const access = state({
+      group: {
+        ...defaultDispatcherAccessState().group,
+        allow_chats: ['chat-group-a'],
+      },
+    });
+
+    expect(gate({ chatId: 'chat-group-a' }, access)).toMatchObject({
+      action: 'deliver',
+    });
+    expect(gate({ chatId: 'chat-group-b' }, access)).toMatchObject({
+      action: 'drop',
+      reason: 'group chat not allowed',
+    });
+  });
+
+  it('enforces follow-user allowlists across groups', () => {
+    const access = state({
+      group: {
+        ...defaultDispatcherAccessState().group,
+        follow_users: ['sender-allowed'],
+      },
+    });
+
+    expect(gate({ senderId: 'sender-allowed' }, access)).toMatchObject({
+      action: 'deliver',
+    });
+    expect(gate({ senderId: 'sender-other' }, access)).toMatchObject({
+      action: 'drop',
+      reason: 'sender not allowed by follow-user gate',
+    });
+  });
+
+  it('records a trust-domain warning when one dispatcher observes multiple chats', () => {
+    const first = gate({ chatId: 'chat-group-a' }, state());
+    expect(first.action).toBe('deliver');
+    if (first.action !== 'deliver') throw new Error('unreachable');
+    expect(first.warning).toBeNull();
+
+    const second = gate({ chatId: 'chat-group-b' }, first.access);
+
+    expect(second.action).toBe('deliver');
+    if (second.action !== 'deliver') throw new Error('unreachable');
+    expect(second.warning).toBe(TRUST_DOMAIN_WARNING);
+    expect(second.access.warnings).toEqual([TRUST_DOMAIN_WARNING]);
+    expect(second.access.observed_chats).toEqual([
+      'chat-group-a',
+      'chat-group-b',
+    ]);
+  });
 });
+
+describe('dispatcher access state files', () => {
+  let root: string;
+  let previousHome: string | undefined;
+
+  beforeEach(() => {
+    root = mkdtempSync(join(tmpdir(), 'dreamux-access-'));
+    previousHome = process.env['HOME'];
+    process.env['HOME'] = join(root, 'home');
+    resetRuntimeConfig();
+  });
+
+  afterEach(() => {
+    if (previousHome === undefined) delete process.env['HOME'];
+    else process.env['HOME'] = previousHome;
+    resetRuntimeConfig();
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  it('defaults missing access.json and writes owner-only access state', () => {
+    expect(loadDispatcherAccess('flow')).toEqual(defaultDispatcherAccessState());
+
+    const access = state({
+      dm: { allow_users: ['sender-allowed'] },
+      observed_chats: ['chat-group-a'],
+    });
+    saveDispatcherAccess('flow', access);
+
+    const path = dispatcherAccessPath('flow');
+    expect(existsSync(path)).toBe(true);
+    expect(statSync(path).mode & 0o777).toBe(0o600);
+    expect(JSON.parse(readFileSync(path, 'utf8'))).toMatchObject({
+      dm: { allow_users: ['sender-allowed'] },
+      observed_chats: ['chat-group-a'],
+    });
+    expect(loadDispatcherAccess('flow')).toEqual(access);
+  });
+});
+
+function state(
+  overrides: Partial<DispatcherAccessState> = {},
+): DispatcherAccessState {
+  return {
+    ...defaultDispatcherAccessState(),
+    ...overrides,
+  };
+}
+
+function gate(
+  overrides: Partial<Parameters<typeof dreamuxFeishuGate>[0]> = {},
+  access = state(),
+) {
+  return dreamuxFeishuGate(
+    {
+      senderId: 'sender-allowed',
+      senderType: 'user',
+      chatId: 'chat-group-a',
+      chatType: 'group',
+      botOpenId: 'bot-open-id',
+      mentions: [
+        {
+          key: '@_user_1',
+          id: { open_id: 'bot-open-id' },
+          name: 'Dispatcher',
+        },
+      ],
+      now: 1_700_000_000_000,
+      ...overrides,
+    },
+    access,
+  );
+}

--- a/packages/dreamux/tests/smoke.test.ts
+++ b/packages/dreamux/tests/smoke.test.ts
@@ -22,11 +22,15 @@ import {
 import { homedir, tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
 
-import { Server } from '../src/server.js';
+import { RECEIVED_REACTION_EMOJI, Server } from '../src/server.js';
 import { CodexProcess, type CodexProcessOptions } from '../src/codex/supervisor.js';
 import { CodexWsClient } from '../src/codex/rpc.js';
 import { createFakeFeishuBot, type FakeFeishuBot, type FeishuInboundEvent } from '../src/feishu/bot.js';
 import { createAdminSocketServer } from '../src/admin/socket.js';
+import {
+  TRUST_DOMAIN_WARNING,
+  loadDispatcherAccess,
+} from '../src/channel/feishu-gate.js';
 import { BUILT_IN_DEFAULTS } from '../src/runtime/config.js';
 import {
   dispatcherAppServerControlDir,
@@ -100,7 +104,13 @@ function fakeInbound(
     messageType: 'text',
     rawContent: JSON.stringify({ text }),
     parsedText: text,
-    mentions: [],
+    mentions: [
+      {
+        key: '@_user_1',
+        id: { open_id: 'fake-open-id-app-smoke' },
+        name: 'Dispatcher',
+      },
+    ],
     createTime: String(Date.now()),
     raw: { event: { message: { chat_id: chatId, message_id: msgId } } },
   };
@@ -186,6 +196,13 @@ describe('dreamux MVP smoke', () => {
     const row = server.repos.inbound.getById(1);
     expect(row?.state).toBe('completed');
     expect(row?.assistant_text).toBe('echo: hi');
+    expect(bot.reactions).toEqual([
+      {
+        messageId: 'msg-1-id',
+        emoji: RECEIVED_REACTION_EMOJI,
+        reactionId: 'reaction-fake-1',
+      },
+    ]);
 
     // Dispatcher's thread is persisted across server restart.
     const d = server.repos.dispatchers.get('flow');
@@ -277,7 +294,7 @@ describe('dreamux MVP smoke', () => {
     expect(dispatcherAppServerControlDir('flow')).not.toContain('codex-home');
   });
 
-  it('compatible Feishu gate drops bot-loop messages before durable enqueue', async () => {
+  it('access gate drops bot-loop messages before durable enqueue or reaction', async () => {
     server = buildServer({ runtimeDir, fake, bot });
     server.repos.dispatchers.create({
       dispatcher_id: 'flow',
@@ -295,9 +312,10 @@ describe('dreamux MVP smoke', () => {
     expect(server.repos.inbound.getById(1)).toBeNull();
     expect(fake.turnsHandled).toBe(0);
     expect(bot.sentMessages).toEqual([]);
+    expect(bot.reactions).toEqual([]);
   });
 
-  it('compatible Feishu gate drops Feishu bot/app sender types', async () => {
+  it('access gate drops Feishu bot/app sender types before durable enqueue or reaction', async () => {
     server = buildServer({ runtimeDir, fake, bot });
     server.repos.dispatchers.create({
       dispatcher_id: 'flow',
@@ -316,6 +334,50 @@ describe('dreamux MVP smoke', () => {
     expect(server.repos.inbound.getById(1)).toBeNull();
     expect(fake.turnsHandled).toBe(0);
     expect(bot.sentMessages).toEqual([]);
+    expect(bot.reactions).toEqual([]);
+  });
+
+  it('access gate drops unmentioned group messages before durable enqueue or reaction', async () => {
+    server = buildServer({ runtimeDir, fake, bot });
+    server.repos.dispatchers.create({
+      dispatcher_id: 'flow',
+      bot_app_id: 'app-smoke',
+      bot_secret_ref: 'env:UNUSED',
+    });
+    await server.start();
+
+    await bot.inject({
+      ...fakeInbound('chat-group-a', 'no mention', 'msg-no-mention'),
+      mentions: [],
+    });
+
+    await sleep(80);
+    expect(server.repos.inbound.getById(1)).toBeNull();
+    expect(fake.turnsHandled).toBe(0);
+    expect(bot.sentMessages).toEqual([]);
+    expect(bot.reactions).toEqual([]);
+  });
+
+  it('records a trust-domain warning when one dispatcher receives multiple chats', async () => {
+    server = buildServer({ runtimeDir, fake, bot });
+    server.repos.dispatchers.create({
+      dispatcher_id: 'flow',
+      bot_app_id: 'app-smoke',
+      bot_secret_ref: 'env:UNUSED',
+    });
+    await server.start();
+
+    await bot.inject(fakeInbound('chat-group-a', 'first chat', 'msg-chat-a'));
+    await bot.inject(fakeInbound('chat-group-b', 'second chat', 'msg-chat-b'));
+
+    const access = loadDispatcherAccess('flow');
+    expect(access.observed_chats).toEqual(['chat-group-a', 'chat-group-b']);
+    expect(access.warnings).toEqual([TRUST_DOMAIN_WARNING]);
+    expect(bot.reactions.map((reaction) => reaction.messageId)).toEqual([
+      'msg-chat-a',
+      'msg-chat-b',
+    ]);
+    await waitFor(() => bot.sentMessages.length >= 2);
   });
 
   it('FIFO: same-dispatcher messages process serially', async () => {


### PR DESCRIPTION
## Summary
- Add dispatcher-local `access.json` state for DM allowlists, group chat/follow-user gates, observed chats, last gate diagnostics, and trust-domain warnings.
- Wire `dreamux serve` so rejected Feishu inbound messages are dropped before enqueue, while accepted messages are enqueued and then receive a channel-owned `GLANCE` reaction.
- Keep received-reaction ownership in serve process memory only, ready for Task 10 cleanup.
- Cover DM/group/follow-user/mention gate paths, rejected-message no-reaction behavior, accepted-message reaction behavior, and multi-chat trust warnings.

## Tests
- `node common/scripts/install-run-rush.js build --to @excitedjs/dreamux`
- `node common/scripts/install-run-rush.js test --to @excitedjs/dreamux`
- `.agents/scripts/check.sh`
- `git diff --check`

Tracking: #36 Task 5.