### PR TITLE
Task 6: format Feishu inbound for Codex

### DIFF
--- a/.agents/decisions/top-level-design.md
+++ b/.agents/decisions/top-level-design.md
@@ -271,6 +271,11 @@ When rich content parsing fails, the dispatcher still passes `message_id`,
 `chat_id`, `sender_id`, and `sender_name` into the Codex turn and instructs Codex
 to use the Feishu skill and `lark-cli` fallback to fetch message text.
 
+`sender_name` is a best-effort seam. Feishu `im.message.receive_v1` does not
+provide a sender display name in the native event envelope today, so the MVP
+emits `sender_name=""` unless a later channel enricher supplies one. Codex should
+use the Feishu skill fallback when it needs a human-readable sender name.
+
 Messages rejected by the access gate are discarded. Rejected messages do not
 enter the Codex thread.
 

--- a/packages/dreamux/src/channel/feishu-message.ts
+++ b/packages/dreamux/src/channel/feishu-message.ts
@@ -1,0 +1,105 @@
+import type { Mention } from '@excitedjs/feishu-transport';
+
+import type { FeishuInboundEvent } from '../feishu/bot.js';
+
+export const FEISHU_SKILL_FALLBACK_NOTE =
+  'Parser note: message text may be incomplete. Use the Feishu skill with the chat_id and message_id above to fetch the original message when needed.';
+
+export function formatFeishuMessageForCodex(event: FeishuInboundEvent): string {
+  const attrs: Array<[string, string]> = [
+    ['chat_id', event.chatId],
+    ['chat_type', event.chatType],
+    ['message_id', event.messageId],
+    ['sender_id', event.senderId],
+    ['sender_name', event.senderName],
+    ['create_time', formatFeishuCreateTime(event.createTime)],
+  ];
+  const body = renderMessageBody(event);
+  const fallback = shouldAddFallbackNote(event)
+    ? `\n\n${FEISHU_SKILL_FALLBACK_NOTE}`
+    : '';
+
+  const attrLines = attrs.map(
+    ([key, value]) => `  ${key}="${escapeXmlAttribute(value)}"`,
+  );
+  attrLines[attrLines.length - 1] = `${attrLines[attrLines.length - 1]}>`;
+
+  return [
+    '<feishu_message',
+    ...attrLines,
+    `${body}${fallback}`,
+    '</feishu_message>',
+  ].join('\n');
+}
+
+export function formatFeishuCreateTime(value: string): string {
+  const trimmed = value.trim();
+  if (trimmed === '') return '';
+
+  const numeric = Number(trimmed);
+  if (Number.isFinite(numeric)) {
+    const epochMs = Math.abs(numeric) < 1_000_000_000_000
+      ? numeric * 1000
+      : numeric;
+    const date = new Date(epochMs);
+    if (!Number.isNaN(date.getTime())) return date.toISOString();
+  }
+
+  const date = new Date(trimmed);
+  if (!Number.isNaN(date.getTime())) return date.toISOString();
+  return trimmed;
+}
+
+function renderMessageBody(event: FeishuInboundEvent): string {
+  const rawText = extractRawText(event);
+  if (rawText !== null) {
+    return renderTextWithMentions(rawText, event.mentions);
+  }
+  return escapeXmlText(event.parsedText);
+}
+
+function extractRawText(event: FeishuInboundEvent): string | null {
+  if (event.messageType !== 'text') return null;
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(event.rawContent);
+  } catch {
+    return null;
+  }
+  if (parsed === null || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    return null;
+  }
+  const text = (parsed as Record<string, unknown>)['text'];
+  return typeof text === 'string' ? text : null;
+}
+
+function renderTextWithMentions(text: string, mentions: Mention[]): string {
+  let out = escapeXmlText(text);
+  for (const mention of mentions) {
+    const id = mention.id?.open_id ?? mention.id?.union_id ?? mention.id?.user_id;
+    if (mention.key === '' || id === undefined || mention.name === undefined) {
+      continue;
+    }
+    out = out.split(escapeXmlText(mention.key)).join(
+      `<at id="${escapeXmlAttribute(id)}">${escapeXmlText(mention.name)}</at>`,
+    );
+  }
+  return out;
+}
+
+function shouldAddFallbackNote(event: FeishuInboundEvent): boolean {
+  if (event.parsedText === '(unparseable message)') return true;
+  if (event.messageType === 'text' && extractRawText(event) === null) return true;
+  return event.parsedText === `(${event.messageType} message)`;
+}
+
+function escapeXmlAttribute(value: string): string {
+  return escapeXmlText(value).replaceAll('"', '&quot;');
+}
+
+function escapeXmlText(value: string): string {
+  return value
+    .replaceAll('&', '&amp;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;');
+}

--- a/packages/dreamux/src/feishu/bot.ts
+++ b/packages/dreamux/src/feishu/bot.ts
@@ -39,6 +39,12 @@ export interface FeishuInboundEvent {
   chatType: string; // 'p2p' | 'group' | ...
   senderId: string;
   senderType: string;
+  /**
+   * Best-effort display name seam for future enrichers. Feishu
+   * im.message.receive_v1 does not provide this in the native event envelope,
+   * so the normal value is intentionally an empty string.
+   */
+  senderName: string;
   messageType: string;
   /** Raw JSON-encoded content as Feishu delivered it. */
   rawContent: string;
@@ -168,6 +174,7 @@ function normalizeInboundEvent(raw: unknown): FeishuInboundEvent | null {
   const senderId = payload.meta['sender_id'] ?? '';
   const senderType = payload.meta['sender_type'] ?? '';
   const createTime = payload.meta['create_time'] ?? '';
+  const senderName = extractSenderName(raw);
 
   if (messageId === '' || chatId === '') return null;
 
@@ -177,6 +184,7 @@ function normalizeInboundEvent(raw: unknown): FeishuInboundEvent | null {
     chatType,
     senderId,
     senderType,
+    senderName,
     messageType,
     rawContent,
     parsedText: payload.text,
@@ -184,6 +192,33 @@ function normalizeInboundEvent(raw: unknown): FeishuInboundEvent | null {
     createTime,
     raw,
   };
+}
+
+function extractSenderName(raw: unknown): string {
+  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) return '';
+  const root = raw as Record<string, unknown>;
+  const event = asRecord(root['event']) ?? root;
+  const sender = asRecord(event['sender']);
+  if (sender === undefined) return '';
+  return firstString(
+    sender['sender_name'],
+    sender['display_name'],
+    sender['name'],
+    sender['user_name'],
+  );
+}
+
+function firstString(...values: unknown[]): string {
+  for (const value of values) {
+    if (typeof value === 'string') return value;
+  }
+  return '';
+}
+
+function asRecord(value: unknown): Record<string, unknown> | undefined {
+  return value !== null && typeof value === 'object' && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : undefined;
 }
 
 // -------------------------------------------------------------- fake (tests)

--- a/packages/dreamux/src/server.ts
+++ b/packages/dreamux/src/server.ts
@@ -33,6 +33,7 @@ import {
   loadDispatcherAccess,
   saveDispatcherAccess,
 } from './channel/feishu-gate.js';
+import { formatFeishuMessageForCodex } from './channel/feishu-message.js';
 import { parseCodexArgs, codexArgsToCli } from './runtime/codex-args.js';
 import { resolveBotSecret } from './runtime/secrets.js';
 import { BUILT_IN_DEFAULTS, type DreamuxConfig } from './runtime/config.js';
@@ -246,7 +247,7 @@ export class Server {
           source_message_id: event.messageId,
           sender_id: event.senderId,
           feishu_event_json: safeStringify(event.raw),
-          parsed_text: event.parsedText,
+          parsed_text: formatFeishuMessageForCodex(event),
         });
         if (inboundId !== null) {
           await addReceivedReaction(id, bot, channelState, event);

--- a/packages/dreamux/tests/feishu-bot.test.ts
+++ b/packages/dreamux/tests/feishu-bot.test.ts
@@ -131,12 +131,46 @@ describe('createFeishuBot inbound channel', () => {
       chatType: 'group',
       senderId: 'sender-open-id',
       senderType: 'user',
+      senderName: '',
       messageType: 'text',
       rawContent: JSON.stringify({ text: 'hello @_user_1' }),
       parsedText: 'hello @Ada',
       createTime: '1710000000000',
     });
     expect(received[0]?.mentions).toHaveLength(1);
+  });
+
+  it('uses best-effort sender display name fields when present', async () => {
+    const transport = new FakeTransport();
+    const bot = createFeishuBot(
+      { appId: 'app-test', appSecret: 'secret-test' },
+      { createTransport: () => transport },
+    );
+    const received: FeishuInboundEvent[] = [];
+
+    await bot.start(async (event) => {
+      received.push(event);
+    });
+
+    await transport.dispatch('im.message.receive_v1', {
+      event: {
+        sender: {
+          sender_id: { open_id: 'sender-open-id' },
+          sender_type: 'user',
+          sender_name: 'Ada Sender',
+        },
+        message: {
+          message_id: 'message-id-1',
+          chat_id: 'chat-id-1',
+          chat_type: 'group',
+          message_type: 'text',
+          content: JSON.stringify({ text: 'hello' }),
+          create_time: '1710000000000',
+        },
+      },
+    });
+
+    expect(received[0]?.senderName).toBe('Ada Sender');
   });
 
   it('drops unroutable receive_v1 events before calling the handler', async () => {

--- a/packages/dreamux/tests/feishu-message.test.ts
+++ b/packages/dreamux/tests/feishu-message.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  FEISHU_SKILL_FALLBACK_NOTE,
+  formatFeishuCreateTime,
+  formatFeishuMessageForCodex,
+} from '../src/channel/feishu-message.js';
+import type { FeishuInboundEvent } from '../src/feishu/bot.js';
+
+describe('formatFeishuMessageForCodex', () => {
+  it('formats text events with routable ids, empty sender_name, ISO time, and mention tags', () => {
+    expect(formatFeishuMessageForCodex(event())).toBe([
+      '<feishu_message',
+      '  chat_id="chat-group-a"',
+      '  chat_type="group"',
+      '  message_id="message-1"',
+      '  sender_id="sender-user"',
+      '  sender_name=""',
+      '  create_time="2024-03-09T16:00:00.000Z">',
+      'hello <at id="mentioned-user">Ada</at> &amp; &lt;ok&gt;',
+      '</feishu_message>',
+    ].join('\n'));
+  });
+
+  it('uses a best-effort senderName seam when the adapter supplies one', () => {
+    const block = formatFeishuMessageForCodex(
+      event({ senderName: 'Ada & Bob' }),
+    );
+
+    expect(block).toContain('  sender_name="Ada &amp; Bob"');
+  });
+
+  it('adds a Feishu skill fallback note when text content cannot be parsed', () => {
+    const block = formatFeishuMessageForCodex(
+      event({
+        rawContent: 'not json',
+        parsedText: 'not json',
+      }),
+    );
+
+    expect(block).toContain('not json');
+    expect(block).toContain(FEISHU_SKILL_FALLBACK_NOTE);
+    expect(block).toContain('message_id="message-1"');
+    expect(block).toContain('chat_id="chat-group-a"');
+  });
+});
+
+describe('formatFeishuCreateTime', () => {
+  it('normalizes Feishu epoch milliseconds and seconds to ISO strings', () => {
+    expect(formatFeishuCreateTime('1710000000000')).toBe(
+      '2024-03-09T16:00:00.000Z',
+    );
+    expect(formatFeishuCreateTime('1710000000')).toBe(
+      '2024-03-09T16:00:00.000Z',
+    );
+  });
+});
+
+function event(
+  overrides: Partial<FeishuInboundEvent> = {},
+): FeishuInboundEvent {
+  return {
+    messageId: 'message-1',
+    chatId: 'chat-group-a',
+    chatType: 'group',
+    senderId: 'sender-user',
+    senderType: 'user',
+    senderName: '',
+    messageType: 'text',
+    rawContent: JSON.stringify({ text: 'hello @_user_1 & <ok>' }),
+    parsedText: 'hello @Ada & <ok>',
+    mentions: [
+      {
+        key: '@_user_1',
+        id: { open_id: 'mentioned-user' },
+        name: 'Ada',
+      },
+    ],
+    createTime: '1710000000000',
+    raw: {},
+    ...overrides,
+  };
+}

--- a/packages/dreamux/tests/smoke.test.ts
+++ b/packages/dreamux/tests/smoke.test.ts
@@ -101,6 +101,7 @@ function fakeInbound(
     chatType: 'group',
     senderId: 'sender-test',
     senderType: 'user',
+    senderName: '',
     messageType: 'text',
     rawContent: JSON.stringify({ text }),
     parsedText: text,
@@ -132,6 +133,13 @@ function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
+function echoReadableCodexInput(input: string): string {
+  const match = input.match(
+    /<feishu_message\b[^>]*>\n([\s\S]*?)\n<\/feishu_message>/,
+  );
+  return `echo: ${(match?.[1] ?? input).trim()}`;
+}
+
 function writeReadyDispatcherCodexHome(dispatcherId: string, dispatcherCwd?: string): void {
   mkdirSync(dispatcherCodexHome(dispatcherId), { recursive: true });
   writeFileSync(join(dispatcherCodexHome(dispatcherId), 'auth.json'), '{}', {
@@ -155,7 +163,7 @@ describe('dreamux MVP smoke', () => {
     runtimeDir = mkdtempSync(join(tmpdir(), 'dreamux-'));
     previousHome = process.env['HOME'];
     process.env['HOME'] = join(runtimeDir, 'home');
-    fake = await startFakeCodex();
+    fake = await startFakeCodex({ replyFor: echoReadableCodexInput });
     bot = createFakeFeishuBot('app-smoke');
   });
 
@@ -195,6 +203,10 @@ describe('dreamux MVP smoke', () => {
 
     const row = server.repos.inbound.getById(1);
     expect(row?.state).toBe('completed');
+    expect(row?.parsed_text).toContain('<feishu_message');
+    expect(row?.parsed_text).toContain('  sender_name=""');
+    expect(row?.parsed_text).toContain('  create_time=');
+    expect(row?.parsed_text).toContain('hi');
     expect(row?.assistant_text).toBe('echo: hi');
     expect(bot.reactions).toEqual([
       {
@@ -383,7 +395,10 @@ describe('dreamux MVP smoke', () => {
   it('FIFO: same-dispatcher messages process serially', async () => {
     // Restart fake with a slow turn so messages can actually pile up.
     await fake.close();
-    fake = await startFakeCodex({ turnDelayMs: 80 });
+    fake = await startFakeCodex({
+      turnDelayMs: 80,
+      replyFor: echoReadableCodexInput,
+    });
 
     server = buildServer({ runtimeDir, fake, bot });
     server.repos.dispatchers.create({
@@ -450,7 +465,10 @@ describe('dreamux MVP smoke', () => {
 
     await server.shutdown();
     await fake.close();
-    fake = await startFakeCodex({ failResume: true });
+    fake = await startFakeCodex({
+      failResume: true,
+      replyFor: echoReadableCodexInput,
+    });
 
     server = buildServer({ runtimeDir, fake, bot });
     await server.start();
@@ -491,7 +509,10 @@ describe('dreamux MVP smoke', () => {
 
   it('approval fail-fast: server-request causes the turn to fail', async () => {
     await fake.close();
-    fake = await startFakeCodex({ triggerApprovalOnTurn: true });
+    fake = await startFakeCodex({
+      triggerApprovalOnTurn: true,
+      replyFor: echoReadableCodexInput,
+    });
 
     server = buildServer({ runtimeDir, fake, bot });
     server.repos.dispatchers.create({


### PR DESCRIPTION
## Summary
- Format accepted Feishu inbound events as Codex-facing `<feishu_message>` blocks before enqueueing them into the dispatcher turn path.
- Normalize Feishu `create_time` values to ISO strings and render Feishu mention placeholders as `<at id="...">Display Name</at>` tags.
- Add a best-effort `senderName` seam; native `im.message.receive_v1` events without a display name intentionally emit `sender_name=""`.
- Include a Feishu skill fallback note when message text cannot be parsed from the inbound content.

## Tests
- `node common/scripts/install-run-rush.js build --to @excitedjs/dreamux`
- `node common/scripts/install-run-rush.js test --to @excitedjs/dreamux`
- `.agents/scripts/check.sh`
- `git diff --check`

Tracking: #36 Task 6.