### PR TITLE
Task 7: use in-memory dispatcher turn queue

### DIFF
--- a/packages/dreamux/src/channel/outbound.ts
+++ b/packages/dreamux/src/channel/outbound.ts
@@ -1,5 +1,3 @@
-import type { InboundRow } from '../db/types.js';
-
 export interface ChannelOutboundTarget {
   /** Stable channel-local conversation id. */
   conversationId: string;
@@ -16,7 +14,15 @@ export interface OutboundSink {
   send(target: ChannelOutboundTarget, text: string): Promise<string[]>;
 }
 
-export function outboundTargetForInbound(row: InboundRow): ChannelOutboundTarget {
+export interface InboundOutboundSource {
+  source_chat_id: string;
+  source_message_id: string | null;
+  sender_id: string | null;
+}
+
+export function outboundTargetForInbound(
+  row: InboundOutboundSource,
+): ChannelOutboundTarget {
   return {
     conversationId: row.source_chat_id,
     ...(row.source_message_id !== null

--- a/packages/dreamux/src/dispatcher/runtime.ts
+++ b/packages/dreamux/src/dispatcher/runtime.ts
@@ -10,9 +10,8 @@
  *
  * Lifecycle: declared → starting → ready → (degraded) → stopping → stopped.
  *
- * Issue #2 §"崩溃与异常恢复":
- *   - On startup, mark stale `running` rows as `unknown` before opening
- *     inbound — at-most-once.
+ * Current MVP:
+ *   - accepted inbound work is process-local and is dropped on restart;
  *   - thread/resume failure does not degrade the whole dispatcher; we
  *     start a fresh thread, record the lost one in last_lost_thread_id,
  *     and post a visible warning to the next source chat.
@@ -22,10 +21,7 @@ import { mkdirSync } from 'node:fs';
 import { dirname } from 'node:path';
 
 import type { DispatcherRow, DispatcherStatus } from '../db/types.js';
-import type {
-  DispatcherRepo,
-  InboundRepo,
-} from '../db/repository.js';
+import type { DispatcherRepo } from '../db/repository.js';
 import { CodexProcess, type CodexProcessOptions } from '../codex/supervisor.js';
 import { CodexWsClient } from '../codex/rpc.js';
 import { performInitializeHandshake } from '../codex/handshake.js';
@@ -33,7 +29,7 @@ import type {
   ThreadResumeResponse,
   ThreadStartResponse,
 } from '../codex/types.js';
-import { TurnManager } from './turn-manager.js';
+import { TurnManager, type InboundTurnInput } from './turn-manager.js';
 import { createFailFastApprovalHandler } from './approval.js';
 import {
   dispatcherCodexCwd,
@@ -46,11 +42,10 @@ import {
   type DispatcherCodexHomeDoctor,
 } from '../runtime/dispatcher-codex-home.js';
 import { dispatcherProcessEnv } from '../runtime/package-bin.js';
-import { outboundTargetForInbound, type OutboundSink } from '../channel/outbound.js';
+import type { OutboundSink } from '../channel/outbound.js';
 
 export interface DispatcherRuntimeDeps {
   dispatchers: DispatcherRepo;
-  inbound: InboundRepo;
   outbound: OutboundSink;
   /** Optional bin path override for tests. */
   codexBinPath?: string;
@@ -100,7 +95,7 @@ export class DispatcherRuntime {
     return this.status;
   }
 
-  /** Called by Feishu inbound right before enqueuing into inbound_buffer. */
+  /** Current running inbound chat, used for approval rejection hints. */
   setCurrentInboundChat(chatId: string | null): void {
     this.currentInboundChatId = chatId;
   }
@@ -111,13 +106,12 @@ export class DispatcherRuntime {
 
   /**
    * Bring the dispatcher up. Order:
-   *  1. crash recovery sweep on inbound_buffer (running → unknown)
-   *  2. spawn codex app-server child
-   *  3. open WS client
-   *  4. install fail-fast approval handler
-   *  5. thread/start (new) or thread/resume (existing)
-   *  6. install turn manager + retry pending outbound
-   *  7. status = ready
+   *  1. spawn codex app-server child
+   *  2. open WS client
+   *  3. install fail-fast approval handler
+   *  4. thread/start (new) or thread/resume (existing)
+   *  5. install turn manager
+   *  6. status = ready
    */
   async start(): Promise<void> {
     this.setStatus('starting');
@@ -126,8 +120,6 @@ export class DispatcherRuntime {
     });
 
     try {
-      await this.recoverInboundOnStartup();
-
       const cwd = this.row.codex_cwd ?? dispatcherCodexCwd(this.dispatcherId);
       const socketPath = dispatcherSocketPath(this.dispatcherId);
       const extraArgs = this.deps.resolveExtraArgs?.(this.row) ?? [];
@@ -192,10 +184,10 @@ export class DispatcherRuntime {
 
       this.turnManager = new TurnManager({
         dispatcherId: this.dispatcherId,
-        inbound: this.deps.inbound,
         getThreadId: () => this.threadId,
         client: this.client,
         outbound: this.deps.outbound,
+        onCurrentChat: (chatId) => this.setCurrentInboundChat(chatId),
         log: this.log,
         ...(this.deps.outboundRetries !== undefined
           ? { outboundRetries: this.deps.outboundRetries }
@@ -204,7 +196,6 @@ export class DispatcherRuntime {
           ? { outboundRetryDelayMs: this.deps.outboundRetryDelayMs }
           : {}),
       });
-      await this.turnManager.retryPendingOutbound();
 
       this.setStatus('ready');
       this.deps.dispatchers.setStatus(this.dispatcherId, 'ready', {
@@ -212,15 +203,6 @@ export class DispatcherRuntime {
         last_error: null,
       });
 
-      // Issue #2 + PR #3 review #1: the durable inbound buffer's contract
-      // says nothing is dropped across a server crash. retryPendingOutbound
-      // covers awaiting_outbound / outbound_failed rows; recoverInboundOnStartup
-      // covers running → unknown. But rows persisted in 'queued' before the
-      // crash are only drained when notify() is invoked, and at startup no
-      // new inbound has arrived yet. Kick the worker once so any
-      // already-queued backlog drains immediately instead of stalling until
-      // the next live message lands.
-      this.turnManager.notify();
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
       this.log('error', `start failed: ${msg}`, err);
@@ -278,43 +260,13 @@ export class DispatcherRuntime {
   }
 
   /**
-   * Drain any inbound message arriving for this dispatcher. Called by the
-   * Feishu inbound layer. Returns the assigned inbound row id, or null if
-   * the message was a duplicate.
+   * Queue any accepted inbound message arriving for this dispatcher. Called by
+   * the Feishu inbound layer. Returns false if this process already saw the
+   * message_id.
    */
-  enqueueInbound(input: {
-    source_chat_id: string;
-    source_message_id: string | null;
-    sender_id: string | null;
-    feishu_event_json: string;
-    parsed_text: string;
-  }): number | null {
-    const row = this.deps.inbound.enqueue({
-      dispatcher_id: this.dispatcherId,
-      ...input,
-    });
-    if (row === null) return null;
-    this.setCurrentInboundChat(input.source_chat_id);
-    this.turnManager?.notify();
-    return row.id;
-  }
-
-  private async recoverInboundOnStartup(): Promise<void> {
-    const stale = this.deps.inbound.markRunningAsUnknown(this.dispatcherId);
-    for (const row of stale) {
-      this.log(
-        'warn',
-        `inbound ${row.id} was 'running' at restart — marked unknown (at-most-once); chat=${row.source_chat_id}`,
-      );
-      try {
-        await this.deps.outbound.send(
-          outboundTargetForInbound(row),
-          `上一次的执行结果未知（server 重启时正在进行）。请确认是否需要重新发送：\n> ${row.parsed_text.slice(0, 200)}`,
-        );
-      } catch (err) {
-        this.log('warn', `failed to notify chat about unknown inbound`, err);
-      }
-    }
+  enqueueInbound(input: InboundTurnInput): boolean {
+    if (this.turnManager === null) return false;
+    return this.turnManager.enqueue(input);
   }
 
   /** Graceful stop: stop accepting work, reap codex child. */

--- a/packages/dreamux/src/dispatcher/turn-manager.ts
+++ b/packages/dreamux/src/dispatcher/turn-manager.ts
@@ -1,33 +1,35 @@
 /**
- * Per-dispatcher FIFO turn worker.
+ * Per-dispatcher in-memory turn worker.
  *
- * Issue #2 §"Codex 协议处理": the queue worker is the single executor for one
- * dispatcher's Codex thread. Holds an in-memory FIFO; pulls from
- * `inbound_buffer` lazily so we never lose messages across crashes.
- *
- * State machine (transitions are the only ones this worker performs):
- *   queued
- *     └─[worker]→ running
- *           └─[turn/completed]→ awaiting_outbound
- *                   ├─[feishu send OK]→ completed
- *                   └─[feishu send fail]→ outbound_failed → retry → completed
- *           └─[turn/start RPC failure]→ failed
- *
- * Server crash recovery is handled separately by `recoverDispatcher()`:
- *   running          → unknown (at-most-once, see issue #2 §"崩溃与异常恢复")
- *   awaiting_outbound → safe to retry the outbound
- *   outbound_failed   → safe to retry the outbound
+ * Task 7 / top-level design contract:
+ *   - one serialized worker per dispatcher;
+ *   - accepted inbound messages are not persisted;
+ *   - consecutive pending messages from the same chat are coalesced into one
+ *     Codex turn;
+ *   - Feishu message_id redelivery is deduped within this server process.
  */
 
-import type { InboundRepo } from '../db/repository.js';
-import type { InboundRow } from '../db/types.js';
 import type { CodexWsClient } from '../codex/rpc.js';
 import { extractAssistantText, runTurn } from '../codex/events.js';
-import { outboundTargetForInbound, type OutboundSink } from '../channel/outbound.js';
+import {
+  outboundTargetForInbound,
+  type InboundOutboundSource,
+  type OutboundSink,
+} from '../channel/outbound.js';
+
+export const DEFAULT_MESSAGE_ID_DEDUPE_WINDOW = 1024;
+
+export interface InboundTurnInput extends InboundOutboundSource {
+  parsed_text: string;
+}
+
+interface TurnBatch extends InboundOutboundSource {
+  id: number;
+  messages: InboundTurnInput[];
+}
 
 export interface TurnManagerOptions {
   dispatcherId: string;
-  inbound: InboundRepo;
   /** Lazily resolved Codex thread id (set after thread/start | resume). */
   getThreadId(): string | null;
   client: CodexWsClient;
@@ -43,6 +45,10 @@ export interface TurnManagerOptions {
    */
   outboundRetries?: number;
   outboundRetryDelayMs?: number;
+  /** Process-local Feishu message_id dedupe window size. */
+  messageIdDedupeWindow?: number;
+  /** Tracks the currently running chat for approval rejection hints. */
+  onCurrentChat?: (chatId: string | null) => void;
   /** Optional logger; defaults to console.error. */
   log?: (level: 'info' | 'warn' | 'error', msg: string, err?: unknown) => void;
   /**
@@ -53,12 +59,18 @@ export interface TurnManagerOptions {
 }
 
 export class TurnManager {
+  private readonly queue: TurnBatch[] = [];
+  private readonly seenMessageIds = new Set<string>();
+  private readonly seenMessageIdOrder: string[] = [];
   private running = false;
   private stopped = false;
+  private drainScheduled = false;
   private wakeup: (() => void) | null = null;
+  private nextBatchId = 1;
   private readonly log: NonNullable<TurnManagerOptions['log']>;
   private readonly outboundRetries: number;
   private readonly outboundRetryDelayMs: number;
+  private readonly messageIdDedupeWindow: number;
   private readonly emptyTurnPlaceholder: string;
 
   constructor(private readonly opts: TurnManagerOptions) {
@@ -69,37 +81,73 @@ export class TurnManager {
     });
     this.outboundRetries = opts.outboundRetries ?? 3;
     this.outboundRetryDelayMs = opts.outboundRetryDelayMs ?? 1000;
+    this.messageIdDedupeWindow = Math.max(
+      0,
+      opts.messageIdDedupeWindow ?? DEFAULT_MESSAGE_ID_DEDUPE_WINDOW,
+    );
     this.emptyTurnPlaceholder =
       opts.emptyTurnPlaceholder ?? '本轮没有文本回复。';
   }
 
   /**
-   * Notify the worker that new work may be available.
-   * Idempotent — multiple wakeups collapse into the next loop iteration.
+   * Queue one accepted inbound message. Returns false when the message_id was
+   * already seen in this server process.
    */
-  notify(): void {
+  enqueue(input: InboundTurnInput): boolean {
+    if (this.stopped) return false;
+    if (!this.rememberMessageId(input.source_message_id)) return false;
+
+    const pending = this.queue.find(
+      (batch) => batch.source_chat_id === input.source_chat_id,
+    );
+    if (pending !== undefined) {
+      pending.messages.push(input);
+      pending.source_message_id = input.source_message_id;
+      pending.sender_id = input.sender_id;
+    } else {
+      this.queue.push({
+        id: this.nextBatchId++,
+        source_chat_id: input.source_chat_id,
+        source_message_id: input.source_message_id,
+        sender_id: input.sender_id,
+        messages: [input],
+      });
+    }
+
+    this.notify();
+    return true;
+  }
+
+  /** Notify the worker that new work may be available. */
+  private notify(): void {
     if (this.stopped) return;
     if (this.wakeup !== null) {
       const w = this.wakeup;
       this.wakeup = null;
       w();
+      return;
     }
-    void this.drainLoop();
+    if (this.running || this.drainScheduled) return;
+    this.drainScheduled = true;
+    setTimeout(() => {
+      this.drainScheduled = false;
+      if (!this.stopped) void this.drainLoop();
+    }, 0);
   }
 
-  /** Drain queued rows until the queue is empty or we're stopped. */
+  /** Drain queued batches until the queue is empty or we're stopped. */
   private async drainLoop(): Promise<void> {
     if (this.running) return;
     this.running = true;
     try {
       while (!this.stopped) {
-        const row = this.opts.inbound.takeNextQueued(this.opts.dispatcherId);
-        if (row === null) {
+        const batch = this.queue.shift();
+        if (batch === undefined) {
           await this.waitForNotify();
           if (this.stopped) return;
           continue;
         }
-        await this.processInbound(row);
+        await this.processBatch(batch);
       }
     } finally {
       this.running = false;
@@ -112,60 +160,52 @@ export class TurnManager {
     });
   }
 
-  private async processInbound(row: InboundRow): Promise<void> {
+  private async processBatch(batch: TurnBatch): Promise<void> {
     const threadId = this.opts.getThreadId();
     if (threadId === null) {
       // Should not happen — dispatcher is "ready" only after thread is set.
-      this.log('error', `inbound row ${row.id} dequeued without thread_id`);
-      this.opts.inbound.markFailed(row.id, 'dispatcher has no thread_id');
+      this.log('error', `turn batch ${batch.id} dequeued without thread_id`);
       return;
     }
 
-    // Mark running first (before turn/start) so a crash mid-RPC still
-    // leaves a recoverable trace.
-    this.opts.inbound.markRunning(row.id, null);
-
+    this.opts.onCurrentChat?.(batch.source_chat_id);
     let assistantText: string;
     try {
       const turn = await runTurn(
         this.opts.client,
         threadId,
-        row.parsed_text,
+        batchPrompt(batch),
         this.opts.turnCwd ?? null,
       );
-      // Record the turn id for diagnostics — non-fatal if this column
-      // can't be updated (e.g. row was already advanced by another path).
-      this.opts.inbound.markRunning(row.id, turn.turnId);
       assistantText =
         extractAssistantText(turn) ?? this.emptyTurnPlaceholder;
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
-      this.log('error', `turn execution failed for inbound ${row.id}: ${msg}`);
-      this.opts.inbound.markFailed(row.id, msg);
+      this.log('error', `turn execution failed for batch ${batch.id}: ${msg}`);
       // Best-effort tell the user something went wrong.
       try {
         await this.opts.outbound.send(
-          outboundTargetForInbound(row),
+          outboundTargetForInbound(batch),
           `本次请求执行失败：${msg}`,
         );
       } catch (sendErr) {
         this.log('warn', `error notification also failed`, sendErr);
       }
+      this.opts.onCurrentChat?.(null);
       return;
     }
 
-    this.opts.inbound.markAwaitingOutbound(row.id, assistantText);
-    await this.sendOutbound(row, assistantText);
+    this.opts.onCurrentChat?.(null);
+    await this.sendOutbound(batch, assistantText);
   }
 
-  /** Send assistant text to feishu with bounded retry. */
-  private async sendOutbound(row: InboundRow, text: string): Promise<void> {
+  /** Send assistant text to feishu with bounded in-process retry. */
+  private async sendOutbound(batch: TurnBatch, text: string): Promise<void> {
     let lastError: unknown;
-    const target = outboundTargetForInbound(row);
+    const target = outboundTargetForInbound(batch);
     for (let attempt = 0; attempt <= this.outboundRetries; attempt++) {
       try {
-        const ids = await this.opts.outbound.send(target, text);
-        this.opts.inbound.markCompleted(row.id, ids);
+        await this.opts.outbound.send(target, text);
         return;
       } catch (err) {
         lastError = err;
@@ -177,42 +217,33 @@ export class TurnManager {
       }
     }
     const msg = lastError instanceof Error ? lastError.message : String(lastError);
-    this.log('error', `outbound send failed for inbound ${row.id}: ${msg}`);
-    this.opts.inbound.markOutboundFailed(row.id, msg);
-  }
-
-  /**
-   * Retry rows previously left in awaiting_outbound / outbound_failed
-   * (no Codex turn re-runs — assistant_text is already in the DB).
-   * Called once at dispatcher startup, after thread/resume succeeds.
-   */
-  async retryPendingOutbound(): Promise<void> {
-    const pending = this.opts.inbound.listAwaitingOrFailedOutbound(
-      this.opts.dispatcherId,
-    );
-    for (const row of pending) {
-      if (row.assistant_text === null) {
-        // Should not happen — awaiting_outbound implies assistant_text was set.
-        this.log(
-          'warn',
-          `pending outbound ${row.id} has no assistant_text; marking failed`,
-        );
-        this.opts.inbound.markFailed(
-          row.id,
-          'awaiting_outbound row missing assistant_text',
-        );
-        continue;
-      }
-      await this.sendOutbound(row, row.assistant_text);
-    }
+    this.log('error', `outbound send failed for batch ${batch.id}: ${msg}`);
   }
 
   async stop(): Promise<void> {
     this.stopped = true;
+    this.queue.length = 0;
+    this.opts.onCurrentChat?.(null);
     if (this.wakeup !== null) {
       const w = this.wakeup;
       this.wakeup = null;
       w();
     }
   }
+
+  private rememberMessageId(messageId: string | null): boolean {
+    if (messageId === null || messageId === '') return true;
+    if (this.seenMessageIds.has(messageId)) return false;
+    this.seenMessageIds.add(messageId);
+    this.seenMessageIdOrder.push(messageId);
+    while (this.seenMessageIdOrder.length > this.messageIdDedupeWindow) {
+      const evicted = this.seenMessageIdOrder.shift();
+      if (evicted !== undefined) this.seenMessageIds.delete(evicted);
+    }
+    return true;
+  }
+}
+
+function batchPrompt(batch: TurnBatch): string {
+  return batch.messages.map((message) => message.parsed_text).join('\n\n');
 }

--- a/packages/dreamux/src/feishu/bot.ts
+++ b/packages/dreamux/src/feishu/bot.ts
@@ -8,10 +8,10 @@
  * the core's surface into the `FeishuBot` interface the server already wires:
  *   - `start(handler)` registers the `im.message.receive_v1` route, normalizes
  *     each raw event with the core's `parseInbound`, and forwards a
- *     `FeishuInboundEvent`. The route handler awaits `handler`, so the message is
- *     durably enqueued before the SDK acks (the deferred-ACK invariant).
+ *     `FeishuInboundEvent`. The route handler awaits `handler`, so the message
+ *     reaches the server-owned in-memory queue before the SDK acks.
  *   - `send(target, text)` delegates to the core transport, preserving reply
- *     threading / @-back metadata from the durable inbound row.
+ *     threading / @-back metadata from the in-memory inbound batch.
  *   - `botOpenId` surfaces the core transport's `selfId`.
  *
  * Tests inject a `FakeFeishuBot` via `createFakeFeishuBot()` instead of opening
@@ -101,7 +101,7 @@ export function createFeishuBot(
 
     async start(handler: InboundHandler): Promise<void> {
       // The core opens the WebSocket and awaits this route handler before the
-      // SDK acks; awaiting `handler` here keeps the enqueue durable-before-ACK.
+      // SDK acks; awaiting `handler` here keeps gate/queue work before ACK.
       // `start` rejects if the connection does not come up, so the server's
       // try/catch can fail the dispatcher loudly rather than leave it dark.
       await transport.start({

--- a/packages/dreamux/src/server.ts
+++ b/packages/dreamux/src/server.ts
@@ -8,10 +8,8 @@
  *   3. for each enabled dispatcher: spawn codex, open feishu, start turn worker
  *   4. install SIGTERM/SIGINT handlers for graceful drain
  *
- * Issue #2 §"D1": crash recovery does NOT replay running turns. Per dispatcher,
- * the runtime's startup sweep flips stale `running` → `unknown` before
- * Feishu inbound is opened, so the user gets a visible prompt instead of a
- * silent duplicate turn.
+ * Current MVP: accepted inbound work is process-local. Restarting the server
+ * drops queued and in-flight inbound messages instead of replaying them.
  */
 
 import type Database from 'better-sqlite3';
@@ -203,7 +201,6 @@ export class Server {
 
     const runtime = new DispatcherRuntime(row, {
       dispatchers: this.repos.dispatchers,
-      inbound: this.repos.inbound,
       outbound: {
         send: async (target, text) =>
           (await bot.send(channelOutboundToFeishuTarget(target), text)).messageIds,
@@ -242,14 +239,13 @@ export class Server {
           );
           return;
         }
-        const inboundId = runtime.enqueueInbound({
+        const queued = runtime.enqueueInbound({
           source_chat_id: event.chatId,
           source_message_id: event.messageId,
           sender_id: event.senderId,
-          feishu_event_json: safeStringify(event.raw),
           parsed_text: formatFeishuMessageForCodex(event),
         });
-        if (inboundId !== null) {
+        if (queued) {
           await addReceivedReaction(id, bot, channelState, event);
         }
       });
@@ -362,13 +358,5 @@ async function addReceivedReaction(
       `[server] failed to add the received reaction for dispatcher '${dispatcherId}':`,
       err,
     );
-  }
-}
-
-function safeStringify(value: unknown): string {
-  try {
-    return JSON.stringify(value);
-  } catch {
-    return '{}';
   }
 }

--- a/packages/dreamux/tests/fake-codex.ts
+++ b/packages/dreamux/tests/fake-codex.ts
@@ -8,7 +8,7 @@
  *                                 item/completed (agentMessage)
  *                                 turn/completed
  *
- * Lets tests assert behavior (FIFO, crash recovery, outbound retry, approval
+ * Lets tests assert behavior (queueing, coalescing, outbound retry, approval
  * fail-fast) without spawning a real codex binary.
  */
 

--- a/packages/dreamux/tests/smoke.test.ts
+++ b/packages/dreamux/tests/smoke.test.ts
@@ -3,10 +3,9 @@
  *
  * Covers the issue #2 verification path against a fake codex + fake feishu:
  *   - happy path: inbound → turn → outbound
- *   - FIFO: two inbound messages process serially in the same thread
+ *   - in-memory queue: same-chat coalescing + serialized turns
  *   - thread/resume on restart (in-process)
  *   - thread/resume failure → visible degradation (last_lost_thread_id set)
- *   - crash recovery: running rows become 'unknown' on restart, user notified
  *   - outbound retry: send fails N times then succeeds
  *   - approval fail-fast: codex server-request causes the turn to fail
  */
@@ -140,6 +139,17 @@ function echoReadableCodexInput(input: string): string {
   return `echo: ${(match?.[1] ?? input).trim()}`;
 }
 
+function captureAndEchoCodexInput(inputs: string[]): (input: string) => string {
+  return (input) => {
+    inputs.push(input);
+    return echoReadableCodexInput(input);
+  };
+}
+
+function feishuMessageBlockCount(input: string): number {
+  return input.match(/<feishu_message\b/g)?.length ?? 0;
+}
+
 function writeReadyDispatcherCodexHome(dispatcherId: string, dispatcherCwd?: string): void {
   mkdirSync(dispatcherCodexHome(dispatcherId), { recursive: true });
   writeFileSync(join(dispatcherCodexHome(dispatcherId), 'auth.json'), '{}', {
@@ -158,12 +168,16 @@ describe('dreamux MVP smoke', () => {
   let bot: FakeFeishuBot;
   let server: Server;
   let previousHome: string | undefined;
+  let codexInputs: string[];
 
   beforeEach(async () => {
     runtimeDir = mkdtempSync(join(tmpdir(), 'dreamux-'));
     previousHome = process.env['HOME'];
     process.env['HOME'] = join(runtimeDir, 'home');
-    fake = await startFakeCodex({ replyFor: echoReadableCodexInput });
+    codexInputs = [];
+    fake = await startFakeCodex({
+      replyFor: captureAndEchoCodexInput(codexInputs),
+    });
     bot = createFakeFeishuBot('app-smoke');
   });
 
@@ -201,13 +215,12 @@ describe('dreamux MVP smoke', () => {
       text: 'echo: hi',
     });
 
-    const row = server.repos.inbound.getById(1);
-    expect(row?.state).toBe('completed');
-    expect(row?.parsed_text).toContain('<feishu_message');
-    expect(row?.parsed_text).toContain('  sender_name=""');
-    expect(row?.parsed_text).toContain('  create_time=');
-    expect(row?.parsed_text).toContain('hi');
-    expect(row?.assistant_text).toBe('echo: hi');
+    expect(server.repos.inbound.getById(1)).toBeNull();
+    expect(codexInputs).toHaveLength(1);
+    expect(codexInputs[0]).toContain('<feishu_message');
+    expect(codexInputs[0]).toContain('  sender_name=""');
+    expect(codexInputs[0]).toContain('  create_time=');
+    expect(codexInputs[0]).toContain('hi');
     expect(bot.reactions).toEqual([
       {
         messageId: 'msg-1-id',
@@ -306,7 +319,7 @@ describe('dreamux MVP smoke', () => {
     expect(dispatcherAppServerControlDir('flow')).not.toContain('codex-home');
   });
 
-  it('access gate drops bot-loop messages before durable enqueue or reaction', async () => {
+  it('access gate drops bot-loop messages before queue or reaction', async () => {
     server = buildServer({ runtimeDir, fake, bot });
     server.repos.dispatchers.create({
       dispatcher_id: 'flow',
@@ -327,7 +340,7 @@ describe('dreamux MVP smoke', () => {
     expect(bot.reactions).toEqual([]);
   });
 
-  it('access gate drops Feishu bot/app sender types before durable enqueue or reaction', async () => {
+  it('access gate drops Feishu bot/app sender types before queue or reaction', async () => {
     server = buildServer({ runtimeDir, fake, bot });
     server.repos.dispatchers.create({
       dispatcher_id: 'flow',
@@ -349,7 +362,7 @@ describe('dreamux MVP smoke', () => {
     expect(bot.reactions).toEqual([]);
   });
 
-  it('access gate drops unmentioned group messages before durable enqueue or reaction', async () => {
+  it('access gate drops unmentioned group messages before queue or reaction', async () => {
     server = buildServer({ runtimeDir, fake, bot });
     server.repos.dispatchers.create({
       dispatcher_id: 'flow',
@@ -392,12 +405,13 @@ describe('dreamux MVP smoke', () => {
     await waitFor(() => bot.sentMessages.length >= 2);
   });
 
-  it('FIFO: same-dispatcher messages process serially', async () => {
+  it('in-memory queue coalesces pending same-chat messages behind a running turn', async () => {
     // Restart fake with a slow turn so messages can actually pile up.
     await fake.close();
+    codexInputs = [];
     fake = await startFakeCodex({
       turnDelayMs: 80,
-      replyFor: echoReadableCodexInput,
+      replyFor: captureAndEchoCodexInput(codexInputs),
     });
 
     server = buildServer({ runtimeDir, fake, bot });
@@ -408,17 +422,49 @@ describe('dreamux MVP smoke', () => {
     });
     await server.start();
 
-    await bot.inject(fakeInbound('chat-group-a', 'msg-1', 'msg-a'));
-    await bot.inject(fakeInbound('chat-group-a', 'msg-2', 'msg-b'));
+    await bot.inject(fakeInbound('chat-group-a', 'running', 'msg-a'));
+    await bot.inject(fakeInbound('chat-group-b', 'batch-1', 'msg-b1'));
+    await bot.inject(fakeInbound('chat-group-b', 'batch-2', 'msg-b2'));
 
     await waitFor(() => bot.sentMessages.length >= 2, 6000);
+    expect(fake.turnsHandled).toBe(2);
+    expect(codexInputs).toHaveLength(2);
+    expect(codexInputs[0]).toContain('running');
+    expect(feishuMessageBlockCount(codexInputs[1] ?? '')).toBe(2);
+    expect(codexInputs[1]).toContain('batch-1');
+    expect(codexInputs[1]).toContain('batch-2');
+    expect(bot.sentMessages[1]?.target).toMatchObject({
+      chatId: 'chat-group-b',
+      replyToMessageId: 'msg-b2',
+      mentionUserIds: ['sender-test'],
+    });
     expect(bot.sentMessages.map((m) => m.text)).toEqual([
-      'echo: msg-1',
-      'echo: msg-2',
+      'echo: running',
+      'echo: batch-1',
     ]);
   });
 
-  it('crash recovery: running rows become unknown + user notified', async () => {
+  it('process-local dedupe drops Feishu redelivery before turn and reaction', async () => {
+    server = buildServer({ runtimeDir, fake, bot });
+    server.repos.dispatchers.create({
+      dispatcher_id: 'flow',
+      bot_app_id: 'app-smoke',
+      bot_secret_ref: 'env:UNUSED',
+    });
+    await server.start();
+
+    await bot.inject(fakeInbound('chat-group-a', 'redelivered', 'msg-same'));
+    await bot.inject(fakeInbound('chat-group-a', 'redelivered again', 'msg-same'));
+
+    await waitFor(() => bot.sentMessages.length >= 1);
+    await sleep(120);
+    expect(fake.turnsHandled).toBe(1);
+    expect(bot.reactions).toHaveLength(1);
+    expect(bot.reactions[0]?.messageId).toBe('msg-same');
+    expect(server.repos.inbound.getById(1)).toBeNull();
+  });
+
+  it('ignores legacy persisted running rows on startup', async () => {
     server = buildServer({ runtimeDir, fake, bot });
     server.repos.dispatchers.create({
       dispatcher_id: 'flow',
@@ -426,31 +472,22 @@ describe('dreamux MVP smoke', () => {
       bot_secret_ref: 'env:UNUSED',
     });
 
-    // Pre-seed an inbound row stuck in 'running' as if the previous server
-    // crashed mid-turn.
-    const insert = (server as unknown as { db?: never }); // satisfy TS
-    void insert;
     const row = server.repos.inbound.enqueue({
       dispatcher_id: 'flow',
       source_chat_id: 'chat-group-a',
       source_message_id: 'message-pre-crash',
       sender_id: 'sender',
       feishu_event_json: '{}',
-      parsed_text: 'pretend-this-was-running',
+      parsed_text: 'legacy-running',
     });
     expect(row).not.toBeNull();
     server.repos.inbound.markRunning(row!.id, null);
 
     await server.start();
 
-    // After start, the pre-crashed row is 'unknown' and the chat got a
-    // "result unknown" message.
     const after = server.repos.inbound.getById(row!.id);
-    expect(after?.state).toBe('unknown');
-    expect(after?.error).toMatch(/server restarted/);
-    expect(bot.sentMessages.some((m) => m.text.includes('上一次的执行结果未知'))).toBe(
-      true,
-    );
+    expect(after?.state).toBe('running');
+    expect(bot.sentMessages).toEqual([]);
   });
 
   it('thread/resume failure produces visible degradation, not silent loss', async () => {
@@ -465,9 +502,10 @@ describe('dreamux MVP smoke', () => {
 
     await server.shutdown();
     await fake.close();
+    codexInputs = [];
     fake = await startFakeCodex({
       failResume: true,
-      replyFor: echoReadableCodexInput,
+      replyFor: captureAndEchoCodexInput(codexInputs),
     });
 
     server = buildServer({ runtimeDir, fake, bot });
@@ -509,9 +547,10 @@ describe('dreamux MVP smoke', () => {
 
   it('approval fail-fast: server-request causes the turn to fail', async () => {
     await fake.close();
+    codexInputs = [];
     fake = await startFakeCodex({
       triggerApprovalOnTurn: true,
-      replyFor: echoReadableCodexInput,
+      replyFor: captureAndEchoCodexInput(codexInputs),
     });
 
     server = buildServer({ runtimeDir, fake, bot });
@@ -537,8 +576,7 @@ describe('dreamux MVP smoke', () => {
     ).toBe(true);
   });
 
-  // PR #3 review #1
-  it('queued backlog drains on restart even with no fresh inbound', async () => {
+  it('does not drain legacy persisted queued rows on startup', async () => {
     server = buildServer({ runtimeDir, fake, bot });
     server.repos.dispatchers.create({
       dispatcher_id: 'flow',
@@ -546,8 +584,6 @@ describe('dreamux MVP smoke', () => {
       bot_secret_ref: 'env:UNUSED',
     });
 
-    // Pre-seed a 'queued' inbound row — as if the previous server crashed
-    // *after* accepting the inbound but *before* the worker dequeued it.
     const row = server.repos.inbound.enqueue({
       dispatcher_id: 'flow',
       source_chat_id: 'chat-backlog',
@@ -561,12 +597,9 @@ describe('dreamux MVP smoke', () => {
 
     await server.start();
 
-    // The fix: startup must notify() the turn worker so this row is drained
-    // immediately, not stranded until the next live inbound arrives.
-    await waitFor(() => bot.sentMessages.length >= 1);
-    expect(bot.sentMessages[0]?.text).toBe('echo: queued-before-crash');
     const after = server.repos.inbound.getById(row!.id);
-    expect(after?.state).toBe('completed');
+    expect(after?.state).toBe('queued');
+    expect(bot.sentMessages).toEqual([]);
   });
 
   // PR fix/codex-0134-compat: the daemon expects an LSP-style init handshake

--- a/packages/dreamux/tests/turn-manager.test.ts
+++ b/packages/dreamux/tests/turn-manager.test.ts
@@ -1,0 +1,138 @@
+import { describe, expect, it } from 'vitest';
+
+import { TurnManager } from '../src/dispatcher/turn-manager.js';
+import type { NotificationHandler } from '../src/codex/rpc.js';
+import type { ServerNotification, TurnStartResponse } from '../src/codex/types.js';
+import type { ChannelOutboundTarget } from '../src/channel/outbound.js';
+
+describe('TurnManager in-memory queue', () => {
+  it('coalesces same-chat messages enqueued in the same tick', async () => {
+    const client = new FakeCodexClient();
+    const sent: Array<{ target: ChannelOutboundTarget; text: string }> = [];
+    const manager = new TurnManager({
+      dispatcherId: 'flow',
+      getThreadId: () => 'thread-1',
+      client: client as never,
+      outbound: {
+        async send(target, text) {
+          sent.push({ target, text });
+          return ['sent-message'];
+        },
+      },
+    });
+
+    expect(manager.enqueue(input('msg-1', 'first'))).toBe(true);
+    expect(manager.enqueue(input('msg-2', 'second'))).toBe(true);
+
+    await waitFor(() => sent.length === 1);
+    expect(client.inputs).toEqual(['first\n\nsecond']);
+    expect(sent[0]?.target).toMatchObject({
+      conversationId: 'chat-a',
+      replyTo: 'msg-2',
+      mentionUsers: ['sender-a'],
+    });
+  });
+
+  it('bounds the process-local message_id dedupe window', async () => {
+    const client = new FakeCodexClient();
+    const sent: Array<{ target: ChannelOutboundTarget; text: string }> = [];
+    const manager = new TurnManager({
+      dispatcherId: 'flow',
+      getThreadId: () => 'thread-1',
+      client: client as never,
+      outbound: {
+        async send(target, text) {
+          sent.push({ target, text });
+          return ['sent-message'];
+        },
+      },
+      messageIdDedupeWindow: 2,
+    });
+
+    expect(manager.enqueue(input('msg-1', 'first'))).toBe(true);
+    await waitFor(() => sent.length === 1);
+
+    expect(manager.enqueue(input('msg-2', 'second'))).toBe(true);
+    await waitFor(() => sent.length === 2);
+
+    expect(manager.enqueue(input('msg-3', 'third'))).toBe(true);
+    await waitFor(() => sent.length === 3);
+
+    expect(manager.enqueue(input('msg-2', 'second still in window'))).toBe(false);
+    expect(manager.enqueue(input('msg-1', 'first redelivered after eviction')))
+      .toBe(true);
+
+    await waitFor(() => sent.length === 4);
+    expect(client.inputs).toEqual([
+      'first',
+      'second',
+      'third',
+      'first redelivered after eviction',
+    ]);
+  });
+});
+
+function input(messageId: string, text: string) {
+  return {
+    source_chat_id: 'chat-a',
+    source_message_id: messageId,
+    sender_id: 'sender-a',
+    parsed_text: text,
+  };
+}
+
+class FakeCodexClient {
+  readonly inputs: string[] = [];
+  private readonly handlers: NotificationHandler[] = [];
+  private nextTurnId = 1;
+
+  onNotification(handler: NotificationHandler): void {
+    this.handlers.push(handler);
+  }
+
+  async request<R>(method: string, params: unknown): Promise<R> {
+    if (method !== 'turn/start') throw new Error(`unexpected method ${method}`);
+    const p = params as {
+      threadId: string;
+      input: Array<{ text: string }>;
+    };
+    const text = p.input[0]?.text ?? '';
+    this.inputs.push(text);
+    const turnId = `turn-${this.nextTurnId++}`;
+    queueMicrotask(() => {
+      this.emit({
+        method: 'item/completed',
+        params: {
+          threadId: p.threadId,
+          turnId,
+          completedAtMs: Date.now(),
+          item: { type: 'agentMessage', id: `item-${turnId}`, text },
+        },
+      });
+      this.emit({
+        method: 'turn/completed',
+        params: {
+          threadId: p.threadId,
+          turn: { id: turnId, items: [] },
+        },
+      });
+    });
+    return { turn: { id: turnId } } as TurnStartResponse as R;
+  }
+
+  private emit(notification: ServerNotification): void {
+    for (const handler of this.handlers) handler(notification);
+  }
+}
+
+async function waitFor(
+  predicate: () => boolean,
+  timeoutMs = 1000,
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (predicate()) return;
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+  throw new Error('waitFor timed out');
+}


### PR DESCRIPTION
## Summary
- Move accepted Feishu inbound work from the legacy SQLite inbound buffer into a process-local dispatcher turn queue.
- Serialize one turn per dispatcher, coalesce pending same-chat bursts into one Codex turn, and reply to the newest message in a coalesced batch.
- Add a bounded process-local `message_id` dedupe window so Feishu redelivery does not enqueue duplicate turns or received reactions in the same server process.
- Stop replaying legacy persisted inbound rows at dispatcher startup; the old table remains for the later legacy cleanup task.

## Tests
- `node common/scripts/install-run-rush.js build --to @excitedjs/dreamux`
- `node common/scripts/install-run-rush.js test --to @excitedjs/dreamux`
- `.agents/scripts/check.sh`
- `git diff --check`

Tracking: #36 Task 7.