### PR TITLE
Bound Feishu channel ingress delivery

### DIFF
--- a/.agents/decisions/top-level-design.md
+++ b/.agents/decisions/top-level-design.md
@@ -230,8 +230,17 @@ out of scope for the MVP.
 The MVP handles `im.message.receive_v1`. Other Feishu event kinds are ignored
 until a later decision adds them.
 
-Accepted messages enter one per-dispatcher in-memory queue. The queue is
-serialized: only one Codex turn runs per dispatcher at a time.
+After the access gate accepts a message, the channel layer applies a
+per-dispatcher delivery buffer before handing work to the dispatcher runtime:
+
+- a 1 second jitter window batches bursty inbound messages before delivery;
+- each dispatcher delivery thread accepts at most 10 messages per 10 seconds;
+- messages beyond that rate are explicitly rejected and logged by the channel
+  layer, do not enter Codex, and do not receive the channel-owned received
+  reaction.
+
+After channel flush, accepted messages enter one per-dispatcher in-memory queue.
+The queue is serialized: only one Codex turn runs per dispatcher at a time.
 
 Consecutive inbound messages from the same chat are coalesced into one Codex
 turn. If a chat already has a pending batch, new messages for that chat are
@@ -239,9 +248,10 @@ appended to that batch. If the chat has the running turn, new messages become
 the next batch for that chat. Cross-chat batches remain serialized through the
 single dispatcher thread.
 
-The dispatcher keeps an in-memory, bounded `message_id` dedupe window so Feishu
-redelivery does not create duplicate turns during the same server process
-lifetime. This window is safe to lose on restart.
+The channel keeps an in-memory, bounded `message_id` dedupe window so Feishu
+redelivery does not create duplicate turns or duplicate received reactions
+during the same server process lifetime. This window is safe to lose on
+restart.
 
 Each inbound message block passed to Codex includes:
 
@@ -441,10 +451,9 @@ resume path.
 - A stuck Codex turn can block that dispatcher queue until the child process or
   child WebSocket actually fails, or until the operator stops and starts that
   dispatcher through the admin socket.
-- Same-chat coalescing reduces turn count, but per-chat batches and the
-  cross-chat queue are in-memory and not globally size-bounded in the MVP. A
-  stuck turn plus continued inbound traffic can grow memory until operator
-  intervention or process restart.
+- Same-chat coalescing reduces turn count, and channel ingress is rate-bounded.
+  A stuck turn can still build an in-memory backlog at the accepted channel
+  rate until operator intervention or process restart.
 - Codex version drift can still break protocol behavior. `dreamux` detects and
   reports this through `doctor`, live tests, and version diagnostics instead of
   pinning Codex.
@@ -459,6 +468,9 @@ resume path.
   path budget.
 - `dreamux serve` starts one Feishu long-connection WebSocket per dispatcher.
 - A fake `im.message.receive_v1` event reaches the correct Codex thread.
+- Channel ingress applies a 1 second jitter buffer before dispatcher delivery.
+- Channel ingress rejects and logs messages beyond 10 accepted messages per 10
+  seconds per dispatcher delivery thread.
 - Same-chat message bursts are coalesced into one Codex turn.
 - Redelivered `message_id` values are deduped within one server process.
 - Unauthorized messages are dropped before entering Codex.

--- a/packages/dreamux/src/channel/inbound-delivery.ts
+++ b/packages/dreamux/src/channel/inbound-delivery.ts
@@ -1,0 +1,167 @@
+import type { InboundOutboundSource } from './outbound.js';
+
+export const DEFAULT_CHANNEL_JITTER_MS = 1000;
+export const DEFAULT_CHANNEL_RATE_LIMIT_WINDOW_MS = 10_000;
+export const DEFAULT_CHANNEL_RATE_LIMIT_MAX_MESSAGES = 10;
+export const DEFAULT_CHANNEL_MESSAGE_ID_DEDUPE_WINDOW = 1024;
+
+export interface ChannelInboundDeliveryInput extends InboundOutboundSource {
+  parsed_text: string;
+}
+
+export interface ChannelInboundDeliveryBufferOptions {
+  /** Human-readable delivery thread id; for dreamux this is the dispatcher id. */
+  deliveryThreadId: string;
+  deliver(batch: ChannelInboundDeliveryInput[]): Promise<void>;
+  jitterMs?: number;
+  rateLimitWindowMs?: number;
+  rateLimitMaxMessages?: number;
+  messageIdDedupeWindow?: number;
+  now?: () => number;
+  log?: (level: 'info' | 'warn' | 'error', msg: string, err?: unknown) => void;
+}
+
+export interface ChannelInboundDeliveryAcceptResult {
+  accepted: boolean;
+  reason?: string;
+}
+
+/**
+ * Channel-side ingress buffer for one Codex delivery thread.
+ *
+ * It bounds what reaches the dispatcher runtime by applying process-local
+ * message_id dedupe, a sliding-window ingress rate limit, and a short jitter
+ * window that batches bursty chat messages before delivery.
+ */
+export class ChannelInboundDeliveryBuffer {
+  private readonly pending: ChannelInboundDeliveryInput[] = [];
+  private readonly acceptedAtMs: number[] = [];
+  private readonly seenMessageIds = new Set<string>();
+  private readonly seenMessageIdOrder: string[] = [];
+  private readonly jitterMs: number;
+  private readonly rateLimitWindowMs: number;
+  private readonly rateLimitMaxMessages: number;
+  private readonly messageIdDedupeWindow: number;
+  private readonly now: () => number;
+  private readonly log: NonNullable<ChannelInboundDeliveryBufferOptions['log']>;
+  private timer: NodeJS.Timeout | null = null;
+  private stopped = false;
+
+  constructor(private readonly opts: ChannelInboundDeliveryBufferOptions) {
+    this.jitterMs = Math.max(0, opts.jitterMs ?? DEFAULT_CHANNEL_JITTER_MS);
+    this.rateLimitWindowMs = Math.max(
+      0,
+      opts.rateLimitWindowMs ?? DEFAULT_CHANNEL_RATE_LIMIT_WINDOW_MS,
+    );
+    this.rateLimitMaxMessages = Math.max(
+      0,
+      opts.rateLimitMaxMessages ?? DEFAULT_CHANNEL_RATE_LIMIT_MAX_MESSAGES,
+    );
+    this.messageIdDedupeWindow = Math.max(
+      0,
+      opts.messageIdDedupeWindow ?? DEFAULT_CHANNEL_MESSAGE_ID_DEDUPE_WINDOW,
+    );
+    this.now = opts.now ?? (() => Date.now());
+    this.log = opts.log ?? ((level, msg, err) => {
+      const prefix = `[channel delivery ${opts.deliveryThreadId}] ${level}`;
+      if (err !== undefined) console.error(prefix, msg, err);
+      else console.error(prefix, msg);
+    });
+  }
+
+  accept(input: ChannelInboundDeliveryInput): ChannelInboundDeliveryAcceptResult {
+    if (this.stopped) {
+      return this.reject('delivery thread is stopped', input);
+    }
+    if (!this.rememberMessageId(input.source_message_id)) {
+      return this.reject('duplicate message_id within process window', input);
+    }
+    if (!this.allowByRateLimit(input)) {
+      return { accepted: false, reason: 'rate limit exceeded' };
+    }
+
+    this.pending.push(input);
+    this.ensureTimer();
+    return { accepted: true };
+  }
+
+  async flushNow(): Promise<void> {
+    if (this.timer !== null) {
+      clearTimeout(this.timer);
+      this.timer = null;
+    }
+    if (this.pending.length === 0) return;
+    const batch = this.pending.splice(0, this.pending.length);
+    try {
+      await this.opts.deliver(batch);
+    } catch (err) {
+      this.log(
+        'error',
+        `failed to deliver ${batch.length} inbound message(s)`,
+        err,
+      );
+    }
+  }
+
+  stop(): void {
+    this.stopped = true;
+    if (this.timer !== null) {
+      clearTimeout(this.timer);
+      this.timer = null;
+    }
+    if (this.pending.length > 0) {
+      this.log(
+        'warn',
+        `dropping ${this.pending.length} pending inbound message(s) on stop`,
+      );
+      this.pending.length = 0;
+    }
+  }
+
+  private ensureTimer(): void {
+    if (this.timer !== null) return;
+    this.timer = setTimeout(() => {
+      this.timer = null;
+      void this.flushNow();
+    }, this.jitterMs);
+  }
+
+  private allowByRateLimit(input: ChannelInboundDeliveryInput): boolean {
+    const now = this.now();
+    const cutoff = now - this.rateLimitWindowMs;
+    while (this.acceptedAtMs.length > 0 && this.acceptedAtMs[0]! <= cutoff) {
+      this.acceptedAtMs.shift();
+    }
+    if (this.acceptedAtMs.length >= this.rateLimitMaxMessages) {
+      const messageId = input.source_message_id ?? '<missing>';
+      this.log(
+        'warn',
+        `rejected inbound message ${messageId}: rate limit exceeded for delivery thread ${this.opts.deliveryThreadId} (${this.rateLimitMaxMessages} messages per ${this.rateLimitWindowMs}ms)`,
+      );
+      return false;
+    }
+    this.acceptedAtMs.push(now);
+    return true;
+  }
+
+  private rememberMessageId(messageId: string | null): boolean {
+    if (messageId === null || messageId === '') return true;
+    if (this.seenMessageIds.has(messageId)) return false;
+    this.seenMessageIds.add(messageId);
+    this.seenMessageIdOrder.push(messageId);
+    while (this.seenMessageIdOrder.length > this.messageIdDedupeWindow) {
+      const evicted = this.seenMessageIdOrder.shift();
+      if (evicted !== undefined) this.seenMessageIds.delete(evicted);
+    }
+    return true;
+  }
+
+  private reject(
+    reason: string,
+    input: ChannelInboundDeliveryInput,
+  ): ChannelInboundDeliveryAcceptResult {
+    const messageId = input.source_message_id ?? '<missing>';
+    this.log('warn', `rejected inbound message ${messageId}: ${reason}`);
+    return { accepted: false, reason };
+  }
+}

--- a/packages/dreamux/src/server.ts
+++ b/packages/dreamux/src/server.ts
@@ -31,6 +31,10 @@ import {
   loadDispatcherAccess,
   saveDispatcherAccess,
 } from './channel/feishu-gate.js';
+import {
+  ChannelInboundDeliveryBuffer,
+  type ChannelInboundDeliveryInput,
+} from './channel/inbound-delivery.js';
 import { formatFeishuMessageForCodex } from './channel/feishu-message.js';
 import { parseCodexArgs, codexArgsToCli } from './runtime/codex-args.js';
 import { resolveBotSecret } from './runtime/secrets.js';
@@ -70,6 +74,12 @@ export interface ServerOptions {
   codexHomeDoctor?: DispatcherCodexHomeDoctor;
   /** Skip resolving bot secret (tests with fake bot). */
   skipBotSecret?: boolean;
+  /** Channel ingress jitter override (tests). Production default is 1000ms. */
+  channelJitterMs?: number;
+  /** Channel ingress rate-limit window override (tests). */
+  channelRateLimitWindowMs?: number;
+  /** Channel ingress rate-limit max messages override (tests). */
+  channelRateLimitMaxMessages?: number;
 }
 
 export interface Repos {
@@ -81,6 +91,7 @@ interface DispatcherSlot {
   row: DispatcherRow;
   runtime: DispatcherRuntime;
   bot: FeishuBot;
+  inboundDelivery: ChannelInboundDeliveryBuffer;
   channelState: DispatcherChannelState;
 }
 
@@ -214,6 +225,22 @@ export class Server {
       outboundRetries: cfg.outbound.retries,
       outboundRetryDelayMs: cfg.outbound.retry_delay_ms,
     });
+    const inboundDelivery = new ChannelInboundDeliveryBuffer({
+      deliveryThreadId: id,
+      jitterMs: this.opts.channelJitterMs,
+      rateLimitWindowMs: this.opts.channelRateLimitWindowMs,
+      rateLimitMaxMessages: this.opts.channelRateLimitMaxMessages,
+      deliver: async (batch) => {
+        for (const input of batch) {
+          const queued = runtime.enqueueInbound(input);
+          if (!queued) {
+            console.error(
+              `[server] rejected feishu inbound for dispatcher '${id}' after channel flush: duplicate or unavailable message_id=${input.source_message_id ?? '<missing>'}`,
+            );
+          }
+        }
+      },
+    });
 
     try {
       await runtime.start();
@@ -239,13 +266,14 @@ export class Server {
           );
           return;
         }
-        const queued = runtime.enqueueInbound({
+        const input: ChannelInboundDeliveryInput = {
           source_chat_id: event.chatId,
           source_message_id: event.messageId,
           sender_id: event.senderId,
           parsed_text: formatFeishuMessageForCodex(event),
-        });
-        if (queued) {
+        };
+        const accepted = inboundDelivery.accept(input);
+        if (accepted.accepted) {
           await addReceivedReaction(id, bot, channelState, event);
         }
       });
@@ -262,10 +290,11 @@ export class Server {
       } catch {
         /* */
       }
+      inboundDelivery.stop();
       throw err;
     }
 
-    this.slots.set(id, { row, runtime, bot, channelState });
+    this.slots.set(id, { row, runtime, bot, inboundDelivery, channelState });
     console.error(
       `[server] dispatcher '${id}' is ready (bot=${row.bot_app_id} cwd=${row.codex_cwd ?? dispatcherCodexCwd(id)})`,
     );
@@ -280,6 +309,7 @@ export class Server {
     } catch (err) {
       console.error(`[server] error closing bot for '${id}':`, err);
     }
+    slot.inboundDelivery.stop();
     try {
       await slot.runtime.stop();
     } catch (err) {

--- a/packages/dreamux/tests/channel-inbound-delivery.test.ts
+++ b/packages/dreamux/tests/channel-inbound-delivery.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  ChannelInboundDeliveryBuffer,
+  type ChannelInboundDeliveryInput,
+} from '../src/channel/inbound-delivery.js';
+
+describe('ChannelInboundDeliveryBuffer', () => {
+  it('jitter-buffers bursty inbound messages before one delivery flush', async () => {
+    const delivered: ChannelInboundDeliveryInput[][] = [];
+    const buffer = new ChannelInboundDeliveryBuffer({
+      deliveryThreadId: 'dispatcher-a',
+      jitterMs: 30,
+      deliver: async (batch) => {
+        delivered.push(batch);
+      },
+    });
+
+    expect(buffer.accept(input('msg-1', 'first')).accepted).toBe(true);
+    expect(buffer.accept(input('msg-2', 'second')).accepted).toBe(true);
+
+    await sleep(10);
+    expect(delivered).toEqual([]);
+
+    await waitFor(() => delivered.length === 1);
+    expect(delivered[0]?.map((item) => item.source_message_id)).toEqual([
+      'msg-1',
+      'msg-2',
+    ]);
+  });
+
+  it('rejects messages over the per-thread rate limit with a log', async () => {
+    let now = 1_000;
+    const logs: string[] = [];
+    const delivered: ChannelInboundDeliveryInput[][] = [];
+    const buffer = new ChannelInboundDeliveryBuffer({
+      deliveryThreadId: 'dispatcher-a',
+      jitterMs: 0,
+      rateLimitWindowMs: 100,
+      rateLimitMaxMessages: 2,
+      now: () => now,
+      log: (_level, msg) => logs.push(msg),
+      deliver: async (batch) => {
+        delivered.push(batch);
+      },
+    });
+
+    expect(buffer.accept(input('msg-1', 'one')).accepted).toBe(true);
+    expect(buffer.accept(input('msg-2', 'two')).accepted).toBe(true);
+    expect(buffer.accept(input('msg-3', 'three'))).toEqual({
+      accepted: false,
+      reason: 'rate limit exceeded',
+    });
+
+    await buffer.flushNow();
+    expect(delivered[0]?.map((item) => item.source_message_id)).toEqual([
+      'msg-1',
+      'msg-2',
+    ]);
+    expect(logs.some((line) => line.includes('rate limit exceeded'))).toBe(true);
+
+    now += 101;
+    expect(buffer.accept(input('msg-4', 'four')).accepted).toBe(true);
+  });
+
+  it('rejects duplicate message ids before they can receive a reaction', async () => {
+    const logs: string[] = [];
+    const delivered: ChannelInboundDeliveryInput[][] = [];
+    const buffer = new ChannelInboundDeliveryBuffer({
+      deliveryThreadId: 'dispatcher-a',
+      jitterMs: 0,
+      log: (_level, msg) => logs.push(msg),
+      deliver: async (batch) => {
+        delivered.push(batch);
+      },
+    });
+
+    expect(buffer.accept(input('msg-1', 'first')).accepted).toBe(true);
+    expect(buffer.accept(input('msg-1', 'redelivery'))).toEqual({
+      accepted: false,
+      reason: 'duplicate message_id within process window',
+    });
+
+    await buffer.flushNow();
+    expect(delivered[0]?.map((item) => item.parsed_text)).toEqual(['first']);
+    expect(logs.some((line) => line.includes('duplicate message_id'))).toBe(true);
+  });
+});
+
+function input(messageId: string, text: string): ChannelInboundDeliveryInput {
+  return {
+    source_chat_id: 'chat-a',
+    source_message_id: messageId,
+    sender_id: 'sender-a',
+    parsed_text: text,
+  };
+}
+
+async function waitFor(
+  predicate: () => boolean,
+  timeoutMs = 1000,
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (predicate()) return;
+    await sleep(10);
+  }
+  throw new Error('waitFor timed out');
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}

--- a/packages/dreamux/tests/smoke.test.ts
+++ b/packages/dreamux/tests/smoke.test.ts
@@ -63,6 +63,9 @@ function buildServer(opts: {
   spawnCounter?: { count: number };
   capturedCodexOptions?: CodexProcessOptions[];
   useDefaultCodexHomeDoctor?: boolean;
+  channelJitterMs?: number;
+  channelRateLimitWindowMs?: number;
+  channelRateLimitMaxMessages?: number;
 }): Server {
   return new Server({
     config: opts.config ?? { ...BUILT_IN_DEFAULTS, runtime_dir: opts.runtimeDir },
@@ -78,6 +81,9 @@ function buildServer(opts: {
       opts.capturedCodexOptions?.push(o);
       return new NoopCodexProcess(o);
     },
+    channelJitterMs: opts.channelJitterMs ?? 1,
+    channelRateLimitWindowMs: opts.channelRateLimitWindowMs,
+    channelRateLimitMaxMessages: opts.channelRateLimitMaxMessages,
     codexClientFactory: () => new CodexWsClient({ url: opts.fake.url }),
     ...(opts.useDefaultCodexHomeDoctor === true
       ? {}
@@ -462,6 +468,39 @@ describe('dreamux MVP smoke', () => {
     expect(bot.reactions).toHaveLength(1);
     expect(bot.reactions[0]?.messageId).toBe('msg-same');
     expect(server.repos.inbound.getById(1)).toBeNull();
+  });
+
+  it('channel ingress rate limit rejects overflow before turn and reaction', async () => {
+    server = buildServer({
+      runtimeDir,
+      fake,
+      bot,
+      channelRateLimitWindowMs: 10_000,
+      channelRateLimitMaxMessages: 2,
+    });
+    server.repos.dispatchers.create({
+      dispatcher_id: 'flow',
+      bot_app_id: 'app-smoke',
+      bot_secret_ref: 'env:UNUSED',
+    });
+    await server.start();
+
+    await bot.inject(fakeInbound('chat-group-a', 'one', 'msg-limit-1'));
+    await bot.inject(fakeInbound('chat-group-a', 'two', 'msg-limit-2'));
+    await bot.inject(fakeInbound('chat-group-a', 'three', 'msg-limit-3'));
+
+    await waitFor(() => bot.sentMessages.length >= 1);
+    await sleep(80);
+    expect(bot.reactions.map((reaction) => reaction.messageId)).toEqual([
+      'msg-limit-1',
+      'msg-limit-2',
+    ]);
+    expect(fake.turnsHandled).toBe(1);
+    expect(codexInputs).toHaveLength(1);
+    expect(feishuMessageBlockCount(codexInputs[0] ?? '')).toBe(2);
+    expect(codexInputs[0]).toContain('one');
+    expect(codexInputs[0]).toContain('two');
+    expect(codexInputs[0]).not.toContain('three');
   });
 
   it('ignores legacy persisted running rows on startup', async () => {


### PR DESCRIPTION
## Summary
- Add a channel-side per-dispatcher delivery buffer for Feishu inbound messages.
- Apply a 1 second jitter window before dispatcher delivery.
- Enforce a per-delivery-thread ingress limit of 10 accepted messages per 10 seconds; overflow is rejected with a log, does not enter Codex, and receives no channel-owned received reaction.
- Move process-local `message_id` dedupe to the channel layer so redelivery is rejected before received reactions.
- Update the top-level design record and tests for the new channel contract.

## Codex steering research
- Codex app-server's steering primitive is `turn/steer`: it appends user input to an already in-flight regular turn and returns the active `turnId`.
- dreamux currently drives Codex through `runTurn()`, which sends `turn/start` with `[{ type: "text", text, text_elements: [] }]` and waits for `turn/completed`.
- Directly using `turn/steer` as the only delivery path is not viable for channel flushes: it requires an active regular turn and a non-empty matching `expectedTurnId`; it fails when the thread is idle, when the active turn id has changed, when the active turn is non-steerable such as review/compact, or when input is too large. It also does not accept turn settings overrides.
- This PR therefore bounds channel ingress before the existing dispatcher turn path. Active-turn steering can be added later as a separate optimization, after outbound semantics are moved to the MCP reply path so steered cross-chat input does not inherit the current temporary automatic outbound target.

## Tests
- `node common/scripts/install-run-rush.js build --to @excitedjs/dreamux`
- `node common/scripts/install-run-rush.js test --to @excitedjs/dreamux`
- `.agents/scripts/check.sh`
- `git diff --check`

Related: #46.