### PR TITLE
Task 8: restart Codex child runtimes

### DIFF
--- a/packages/dreamux/src/codex/supervisor.ts
+++ b/packages/dreamux/src/codex/supervisor.ts
@@ -47,6 +47,13 @@ export interface CodexProcessOptions {
   readyTimeoutMs?: number;
 }
 
+export interface CodexProcessExit {
+  code: number | null;
+  signal: NodeJS.Signals | null;
+}
+
+export type CodexProcessExitHandler = (exit: CodexProcessExit) => void;
+
 /** A handle to one running codex app-server child process. */
 export class CodexProcess {
   readonly socketPath: string;
@@ -54,6 +61,7 @@ export class CodexProcess {
   private child: ChildProcess | null = null;
   private _pid: number | null = null;
   private reaped = false;
+  private readonly exitHandlers: CodexProcessExitHandler[] = [];
 
   constructor(private readonly opts: CodexProcessOptions) {
     this.socketPath = opts.socketPath;
@@ -62,6 +70,10 @@ export class CodexProcess {
 
   get pid(): number | null {
     return this._pid;
+  }
+
+  onExit(handler: CodexProcessExitHandler): void {
+    this.exitHandlers.push(handler);
   }
 
   /** Spawn the daemon and resolve once its listen socket is bound. */
@@ -129,6 +141,16 @@ export class CodexProcess {
     // Future post-spawn `error` emissions must not crash the supervisor.
     child.on('error', () => {
       /* daemon-side error, can no longer affect this process */
+    });
+    child.once('exit', (code, signal) => {
+      if (this.reaped) return;
+      for (const handler of this.exitHandlers) {
+        try {
+          handler({ code, signal });
+        } catch {
+          /* exit observers must not poison process event dispatch */
+        }
+      }
     });
 
     try {

--- a/packages/dreamux/src/dispatcher/runtime.ts
+++ b/packages/dreamux/src/dispatcher/runtime.ts
@@ -22,7 +22,11 @@ import { dirname } from 'node:path';
 
 import type { DispatcherRow, DispatcherStatus } from '../db/types.js';
 import type { DispatcherRepo } from '../db/repository.js';
-import { CodexProcess, type CodexProcessOptions } from '../codex/supervisor.js';
+import {
+  CodexProcess,
+  type CodexProcessExit,
+  type CodexProcessOptions,
+} from '../codex/supervisor.js';
 import { CodexWsClient } from '../codex/rpc.js';
 import { performInitializeHandshake } from '../codex/handshake.js';
 import type {
@@ -44,6 +48,9 @@ import {
 import { dispatcherProcessEnv } from '../runtime/package-bin.js';
 import type { OutboundSink } from '../channel/outbound.js';
 
+const DEFAULT_RESTART_BACKOFF_BASE_MS = 1000;
+const DEFAULT_RESTART_BACKOFF_MAX_MS = 30_000;
+
 export interface DispatcherRuntimeDeps {
   dispatchers: DispatcherRepo;
   outbound: OutboundSink;
@@ -63,6 +70,10 @@ export interface DispatcherRuntimeDeps {
   outboundRetries?: number;
   /** Outbound retry delay (ms). From ~/.dreamux/config.json. */
   outboundRetryDelayMs?: number;
+  /** Codex child/WS restart backoff base (tests may override). */
+  restartBackoffBaseMs?: number;
+  /** Codex child/WS restart backoff cap (tests may override). */
+  restartBackoffMaxMs?: number;
   log?: (level: 'info' | 'warn' | 'error', msg: string, err?: unknown) => void;
 }
 
@@ -74,6 +85,10 @@ export class DispatcherRuntime {
   private currentInboundChatId: string | null = null;
   private status: DispatcherStatus = 'declared';
   private readonly log: NonNullable<DispatcherRuntimeDeps['log']>;
+  private stopping = false;
+  private restarting = false;
+  private restartAttempts = 0;
+  private restartTimer: NodeJS.Timeout | null = null;
 
   constructor(
     public readonly row: DispatcherRow,
@@ -114,94 +129,17 @@ export class DispatcherRuntime {
    *  6. status = ready
    */
   async start(): Promise<void> {
+    this.stopping = false;
+    this.restarting = false;
+    this.clearRestartTimer();
     this.setStatus('starting');
     this.deps.dispatchers.setStatus(this.dispatcherId, 'starting', {
       last_started_at: Date.now(),
     });
 
     try {
-      const cwd = this.row.codex_cwd ?? dispatcherCodexCwd(this.dispatcherId);
-      const socketPath = dispatcherSocketPath(this.dispatcherId);
-      const extraArgs = this.deps.resolveExtraArgs?.(this.row) ?? [];
-      if (this.deps.codexHomeDoctor !== undefined) {
-        await this.deps.codexHomeDoctor(
-          dispatcherCodexHomeDoctorContext(this.dispatcherId, {
-            codexCliArgs: extraArgs,
-            dispatcherCwd: cwd,
-          }),
-        );
-      }
-
-      const factory = this.deps.codexProcessFactory ?? ((o) => new CodexProcess(o));
-      this.process = factory({
-        socketPath,
-        cwd,
-        stdoutLogPath: dispatcherStdoutLog(this.dispatcherId),
-        stderrLogPath: dispatcherStderrLog(this.dispatcherId),
-        binPath: this.deps.codexBinPath,
-        extraArgs,
-        env: dispatcherProcessEnv(),
-      });
-      mkdirSync(dirname(socketPath), { recursive: true });
-      await this.process.start();
-
-      const clientFactory =
-        this.deps.codexClientFactory ?? ((sock) => new CodexWsClient({ socketPath: sock }));
-      this.client = clientFactory(socketPath);
-      await this.client.ready();
-
-      const approvalHandler = createFailFastApprovalHandler({
-        onReject: async (req) => {
-          // Best-effort hint to the user, only if we know who is asking.
-          const chatId = this.currentInboundChatId;
-          if (chatId === null) return;
-          try {
-            await this.deps.outbound.send(
-              { conversationId: chatId },
-              `Codex 请求了一次审批（${req.method}），但当前 dispatcher 不支持审批 —— 本轮将失败。`,
-            );
-          } catch {
-            /* nothing useful to do */
-          }
-        },
-      });
-      this.client.setServerRequestHandler(approvalHandler);
-
-      // codex 0.134+ LSP-style handshake — must precede thread/start or
-      // any other RPC, otherwise codex answers everything with
-      // `Not initialized` (see src/codex/handshake.ts).
-      const initResponse = await performInitializeHandshake(this.client, {
-        ...(this.deps.handshakeTimeoutMs !== undefined
-          ? { timeoutMs: this.deps.handshakeTimeoutMs }
-          : {}),
-      });
-      this.log(
-        'info',
-        `codex initialized: ${initResponse.userAgent} (home=${initResponse.codexHome}, ${initResponse.platformOs})`,
-      );
-
-      await this.resolveThread();
-
-      this.turnManager = new TurnManager({
-        dispatcherId: this.dispatcherId,
-        getThreadId: () => this.threadId,
-        client: this.client,
-        outbound: this.deps.outbound,
-        onCurrentChat: (chatId) => this.setCurrentInboundChat(chatId),
-        log: this.log,
-        ...(this.deps.outboundRetries !== undefined
-          ? { outboundRetries: this.deps.outboundRetries }
-          : {}),
-        ...(this.deps.outboundRetryDelayMs !== undefined
-          ? { outboundRetryDelayMs: this.deps.outboundRetryDelayMs }
-          : {}),
-      });
-
-      this.setStatus('ready');
-      this.deps.dispatchers.setStatus(this.dispatcherId, 'ready', {
-        last_ready_at: Date.now(),
-        last_error: null,
-      });
+      await this.startCodexRuntime();
+      this.markReady();
 
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
@@ -215,9 +153,98 @@ export class DispatcherRuntime {
     }
   }
 
+  private async startCodexRuntime(): Promise<void> {
+    const cwd = this.row.codex_cwd ?? dispatcherCodexCwd(this.dispatcherId);
+    const socketPath = dispatcherSocketPath(this.dispatcherId);
+    const extraArgs = this.deps.resolveExtraArgs?.(this.row) ?? [];
+    if (this.deps.codexHomeDoctor !== undefined) {
+      await this.deps.codexHomeDoctor(
+        dispatcherCodexHomeDoctorContext(this.dispatcherId, {
+          codexCliArgs: extraArgs,
+          dispatcherCwd: cwd,
+        }),
+      );
+    }
+
+    const factory = this.deps.codexProcessFactory ?? ((o) => new CodexProcess(o));
+    const process = factory({
+      socketPath,
+      cwd,
+      stdoutLogPath: dispatcherStdoutLog(this.dispatcherId),
+      stderrLogPath: dispatcherStderrLog(this.dispatcherId),
+      binPath: this.deps.codexBinPath,
+      extraArgs,
+      env: dispatcherProcessEnv(),
+    });
+    this.process = process;
+    process.onExit((exit) => {
+      if (this.process !== process) return;
+      this.handleChildExit(exit);
+    });
+    mkdirSync(dirname(socketPath), { recursive: true });
+    await process.start();
+
+    const clientFactory =
+      this.deps.codexClientFactory ?? ((sock) => new CodexWsClient({ socketPath: sock }));
+    const client = clientFactory(socketPath);
+    this.client = client;
+    client.onClose((reason) => {
+      if (this.client !== client) return;
+      this.handleClientClose(reason);
+    });
+    await client.ready();
+
+    const approvalHandler = createFailFastApprovalHandler({
+      onReject: async (req) => {
+        // Best-effort hint to the user, only if we know who is asking.
+        const chatId = this.currentInboundChatId;
+        if (chatId === null) return;
+        try {
+          await this.deps.outbound.send(
+            { conversationId: chatId },
+            `Codex 请求了一次审批（${req.method}），但当前 dispatcher 不支持审批 —— 本轮将失败。`,
+          );
+        } catch {
+          /* nothing useful to do */
+        }
+      },
+    });
+    this.client.setServerRequestHandler(approvalHandler);
+
+    // codex 0.134+ LSP-style handshake — must precede thread/start or
+    // any other RPC, otherwise codex answers everything with
+    // `Not initialized` (see src/codex/handshake.ts).
+    const initResponse = await performInitializeHandshake(this.client, {
+      ...(this.deps.handshakeTimeoutMs !== undefined
+        ? { timeoutMs: this.deps.handshakeTimeoutMs }
+        : {}),
+    });
+    this.log(
+      'info',
+      `codex initialized: ${initResponse.userAgent} (home=${initResponse.codexHome}, ${initResponse.platformOs})`,
+    );
+
+    await this.resolveThread();
+
+    this.turnManager = new TurnManager({
+      dispatcherId: this.dispatcherId,
+      getThreadId: () => this.threadId,
+      client: this.client,
+      outbound: this.deps.outbound,
+      onCurrentChat: (chatId) => this.setCurrentInboundChat(chatId),
+      log: this.log,
+      ...(this.deps.outboundRetries !== undefined
+        ? { outboundRetries: this.deps.outboundRetries }
+        : {}),
+      ...(this.deps.outboundRetryDelayMs !== undefined
+        ? { outboundRetryDelayMs: this.deps.outboundRetryDelayMs }
+        : {}),
+    });
+  }
+
   private async resolveThread(): Promise<void> {
     if (this.client === null) throw new Error('client not initialized');
-    const existing = this.row.thread_id;
+    const existing = this.threadId ?? this.row.thread_id;
     if (existing === null) {
       // Fresh thread.
       const res = await this.client.request<ThreadStartResponse>(
@@ -271,37 +298,133 @@ export class DispatcherRuntime {
 
   /** Graceful stop: stop accepting work, reap codex child. */
   async stop(): Promise<void> {
+    this.stopping = true;
+    this.clearRestartTimer();
     this.setStatus('stopping');
     this.deps.dispatchers.setStatus(this.dispatcherId, 'stopping');
-    if (this.turnManager !== null) await this.turnManager.stop();
-    if (this.client !== null) {
-      try {
-        this.client.close();
-      } catch {
-        /* best effort */
-      }
-    }
-    if (this.process !== null) {
-      await this.process.reap();
-    }
+    await this.teardownCodexRuntime();
     this.setStatus('stopped');
     this.deps.dispatchers.setStatus(this.dispatcherId, 'stopped');
   }
 
   private async cleanupOnFailure(): Promise<void> {
-    if (this.client !== null) {
+    this.clearRestartTimer();
+    const wasStopping = this.stopping;
+    this.stopping = true;
+    try {
+      await this.teardownCodexRuntime();
+    } finally {
+      this.stopping = wasStopping;
+    }
+  }
+
+  private async teardownCodexRuntime(): Promise<void> {
+    const turnManager = this.turnManager;
+    this.turnManager = null;
+    if (turnManager !== null) await turnManager.stop();
+
+    const client = this.client;
+    this.client = null;
+    if (client !== null) {
       try {
-        this.client.close();
+        client.close();
       } catch {
         /* */
       }
-      this.client = null;
     }
-    if (this.process !== null) {
-      await this.process.reap();
-      this.process = null;
+
+    const process = this.process;
+    this.process = null;
+    if (process !== null) {
+      await process.reap();
     }
-    this.turnManager = null;
+    this.currentInboundChatId = null;
+  }
+
+  private handleChildExit(exit: CodexProcessExit): void {
+    const details =
+      exit.signal !== null ? `signal=${exit.signal}` : `code=${exit.code ?? 'null'}`;
+    this.scheduleRestart(`codex app-server child exited (${details})`);
+  }
+
+  private handleClientClose(reason: Error): void {
+    this.scheduleRestart(`codex app-server websocket closed: ${reason.message}`);
+  }
+
+  private scheduleRestart(reason: string): void {
+    if (this.stopping || this.restartTimer !== null || this.restarting) return;
+    const attempt = this.restartAttempts + 1;
+    this.restartAttempts = attempt;
+    const delay = this.restartDelayMs(attempt);
+    this.log('warn', `${reason}; restarting in ${delay}ms`);
+    this.setStatus('degraded');
+    this.deps.dispatchers.setStatus(this.dispatcherId, 'degraded', {
+      last_error: reason,
+    });
+    this.restartTimer = setTimeout(() => {
+      this.restartTimer = null;
+      void this.restartCodexRuntime(reason);
+    }, delay);
+  }
+
+  private async restartCodexRuntime(reason: string): Promise<void> {
+    if (this.stopping) return;
+    this.restarting = true;
+    let retryReason: string | null = null;
+    this.setStatus('starting');
+    this.deps.dispatchers.setStatus(this.dispatcherId, 'starting', {
+      last_started_at: Date.now(),
+    });
+    try {
+      await this.teardownCodexRuntime();
+      if (this.stopping) return;
+      await this.startCodexRuntime();
+      if (this.stopping) {
+        await this.teardownCodexRuntime();
+        return;
+      }
+      this.restartAttempts = 0;
+      this.markReady();
+      this.log('info', `restarted codex app-server after: ${reason}`);
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      this.log('error', `restart failed: ${msg}`, err);
+      this.setStatus('degraded');
+      this.deps.dispatchers.setStatus(this.dispatcherId, 'degraded', {
+        last_error: msg,
+      });
+      await this.teardownCodexRuntime();
+      retryReason = `codex app-server restart failed: ${msg}`;
+    } finally {
+      this.restarting = false;
+    }
+    if (retryReason !== null) this.scheduleRestart(retryReason);
+  }
+
+  private restartDelayMs(attempt: number): number {
+    const base = Math.max(
+      0,
+      this.deps.restartBackoffBaseMs ?? DEFAULT_RESTART_BACKOFF_BASE_MS,
+    );
+    const max = Math.max(
+      base,
+      this.deps.restartBackoffMaxMs ?? DEFAULT_RESTART_BACKOFF_MAX_MS,
+    );
+    return Math.min(max, base * 2 ** Math.max(0, attempt - 1));
+  }
+
+  private clearRestartTimer(): void {
+    if (this.restartTimer === null) return;
+    clearTimeout(this.restartTimer);
+    this.restartTimer = null;
+  }
+
+  private markReady(): void {
+    this.setStatus('ready');
+    this.deps.dispatchers.setStatus(this.dispatcherId, 'ready', {
+      last_ready_at: Date.now(),
+      last_error: null,
+    });
   }
 
   private setStatus(s: DispatcherStatus): void {

--- a/packages/dreamux/src/server.ts
+++ b/packages/dreamux/src/server.ts
@@ -70,6 +70,10 @@ export interface ServerOptions {
   codexHomeDoctor?: DispatcherCodexHomeDoctor;
   /** Skip resolving bot secret (tests with fake bot). */
   skipBotSecret?: boolean;
+  /** Codex child/WS restart backoff base override (tests). */
+  codexRestartBackoffBaseMs?: number;
+  /** Codex child/WS restart backoff cap override (tests). */
+  codexRestartBackoffMaxMs?: number;
 }
 
 export interface Repos {
@@ -213,6 +217,8 @@ export class Server {
       handshakeTimeoutMs: cfg.codex.initialize_timeout_ms,
       outboundRetries: cfg.outbound.retries,
       outboundRetryDelayMs: cfg.outbound.retry_delay_ms,
+      restartBackoffBaseMs: this.opts.codexRestartBackoffBaseMs,
+      restartBackoffMaxMs: this.opts.codexRestartBackoffMaxMs,
     });
 
     try {

--- a/packages/dreamux/tests/fake-codex.ts
+++ b/packages/dreamux/tests/fake-codex.ts
@@ -60,8 +60,11 @@ export async function startFakeCodex(opts: FakeCodexOptions = {}): Promise<FakeC
   let initializedAt: number | null = null;
   const methodLog: string[] = [];
   const enforceInit = opts.enforceInitHandshake !== false;
+  const clients = new Set<WebSocket>();
 
   wss.on('connection', (ws: WebSocket) => {
+    clients.add(ws);
+    ws.on('close', () => clients.delete(ws));
     ws.on('message', (data) => {
       let env: { method?: string; id?: number; params?: Record<string, unknown> };
       try {
@@ -199,6 +202,7 @@ export async function startFakeCodex(opts: FakeCodexOptions = {}): Promise<FakeC
       return methodLog;
     },
     async close(): Promise<void> {
+      for (const ws of clients) ws.terminate();
       await new Promise<void>((res) => wss.close(() => res()));
       await new Promise<void>((res) => http.close(() => res()));
     },

--- a/packages/dreamux/tests/smoke.test.ts
+++ b/packages/dreamux/tests/smoke.test.ts
@@ -22,7 +22,12 @@ import { homedir, tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
 
 import { RECEIVED_REACTION_EMOJI, Server } from '../src/server.js';
-import { CodexProcess, type CodexProcessOptions } from '../src/codex/supervisor.js';
+import {
+  CodexProcess,
+  type CodexProcessExit,
+  type CodexProcessExitHandler,
+  type CodexProcessOptions,
+} from '../src/codex/supervisor.js';
 import { CodexWsClient } from '../src/codex/rpc.js';
 import { createFakeFeishuBot, type FakeFeishuBot, type FeishuInboundEvent } from '../src/feishu/bot.js';
 import { createAdminSocketServer } from '../src/admin/socket.js';
@@ -63,6 +68,10 @@ function buildServer(opts: {
   spawnCounter?: { count: number };
   capturedCodexOptions?: CodexProcessOptions[];
   useDefaultCodexHomeDoctor?: boolean;
+  codexProcessFactory?: (opts: CodexProcessOptions) => CodexProcess;
+  codexClientFactory?: () => CodexWsClient;
+  codexRestartBackoffBaseMs?: number;
+  codexRestartBackoffMaxMs?: number;
 }): Server {
   return new Server({
     config: opts.config ?? { ...BUILT_IN_DEFAULTS, runtime_dir: opts.runtimeDir },
@@ -76,9 +85,12 @@ function buildServer(opts: {
     codexProcessFactory: (o) => {
       if (opts.spawnCounter !== undefined) opts.spawnCounter.count++;
       opts.capturedCodexOptions?.push(o);
-      return new NoopCodexProcess(o);
+      return opts.codexProcessFactory?.(o) ?? new NoopCodexProcess(o);
     },
-    codexClientFactory: () => new CodexWsClient({ url: opts.fake.url }),
+    codexClientFactory: () =>
+      opts.codexClientFactory?.() ?? new CodexWsClient({ url: opts.fake.url }),
+    codexRestartBackoffBaseMs: opts.codexRestartBackoffBaseMs,
+    codexRestartBackoffMaxMs: opts.codexRestartBackoffMaxMs,
     ...(opts.useDefaultCodexHomeDoctor === true
       ? {}
           : {
@@ -87,6 +99,28 @@ function buildServer(opts: {
           },
         }),
   });
+}
+
+class ControllableCodexProcess extends CodexProcess {
+  readonly exitHandlers: CodexProcessExitHandler[] = [];
+  startCount = 0;
+  reapCount = 0;
+
+  override async start(): Promise<void> {
+    this.startCount++;
+  }
+
+  override async reap(): Promise<void> {
+    this.reapCount++;
+  }
+
+  override onExit(handler: CodexProcessExitHandler): void {
+    this.exitHandlers.push(handler);
+  }
+
+  emitExit(exit: CodexProcessExit = { code: 1, signal: null }): void {
+    for (const handler of this.exitHandlers) handler(exit);
+  }
 }
 
 function fakeInbound(
@@ -670,6 +704,147 @@ describe('dreamux MVP smoke', () => {
     await Promise.all([a, b]);
     expect(counter.count).toBe(1);
     expect(server.getRuntime('flow')?.getStatus()).toBe('ready');
+  });
+
+  it('restarts the Codex child with backoff and resumes the saved thread after child exit', async () => {
+    const processes: ControllableCodexProcess[] = [];
+    server = buildServer({
+      runtimeDir,
+      fake,
+      bot,
+      codexProcessFactory: (opts) => {
+        const process = new ControllableCodexProcess(opts);
+        processes.push(process);
+        return process;
+      },
+      codexRestartBackoffBaseMs: 5,
+      codexRestartBackoffMaxMs: 5,
+    });
+    server.repos.dispatchers.create({
+      dispatcher_id: 'flow',
+      bot_app_id: 'app-smoke',
+      bot_secret_ref: 'env:UNUSED',
+    });
+    await server.start();
+    const firstThreadId = server.repos.dispatchers.get('flow')?.thread_id;
+    expect(firstThreadId).toMatch(/^thread_fake_/);
+    expect(processes).toHaveLength(1);
+
+    processes[0]!.emitExit({ code: 9, signal: null });
+
+    await waitFor(() => processes.length >= 2);
+    await waitFor(() => server.getRuntime('flow')?.getStatus() === 'ready');
+    expect(server.repos.dispatchers.get('flow')?.thread_id).toBe(firstThreadId);
+    expect(fake.methodLog.filter((method) => method === 'thread/resume'))
+      .toHaveLength(1);
+    expect(processes[0]?.reapCount).toBeGreaterThanOrEqual(1);
+  });
+
+  it('manual dispatcher stop cancels a pending restart and start resumes the thread', async () => {
+    const processes: ControllableCodexProcess[] = [];
+    server = buildServer({
+      runtimeDir,
+      fake,
+      bot,
+      codexProcessFactory: (opts) => {
+        const process = new ControllableCodexProcess(opts);
+        processes.push(process);
+        return process;
+      },
+      codexRestartBackoffBaseMs: 100,
+      codexRestartBackoffMaxMs: 100,
+    });
+    server.repos.dispatchers.create({
+      dispatcher_id: 'flow',
+      bot_app_id: 'app-smoke',
+      bot_secret_ref: 'env:UNUSED',
+    });
+    await server.start();
+    const firstThreadId = server.repos.dispatchers.get('flow')?.thread_id;
+    expect(firstThreadId).toMatch(/^thread_fake_/);
+
+    processes[0]!.emitExit({ code: 9, signal: null });
+    await waitFor(() => server.getRuntime('flow')?.getStatus() === 'degraded');
+
+    await server.stopDispatcher('flow');
+    await sleep(150);
+    expect(processes).toHaveLength(1);
+
+    await server.startDispatcher('flow');
+    await waitFor(() => server.getRuntime('flow')?.getStatus() === 'ready');
+    expect(processes).toHaveLength(2);
+    expect(server.repos.dispatchers.get('flow')?.thread_id).toBe(firstThreadId);
+    expect(fake.methodLog.filter((method) => method === 'thread/resume'))
+      .toHaveLength(1);
+  });
+
+  it('restarts and resumes when the Codex child WebSocket dies', async () => {
+    server = buildServer({
+      runtimeDir,
+      fake,
+      bot,
+      codexClientFactory: () => new CodexWsClient({ url: fake.url }),
+      codexRestartBackoffBaseMs: 5,
+      codexRestartBackoffMaxMs: 5,
+    });
+    server.repos.dispatchers.create({
+      dispatcher_id: 'flow',
+      bot_app_id: 'app-smoke',
+      bot_secret_ref: 'env:UNUSED',
+    });
+    await server.start();
+    const firstThreadId = server.repos.dispatchers.get('flow')?.thread_id;
+    expect(firstThreadId).toMatch(/^thread_fake_/);
+
+    const oldFake = fake;
+    codexInputs = [];
+    fake = await startFakeCodex({
+      replyFor: captureAndEchoCodexInput(codexInputs),
+    });
+    await oldFake.close();
+
+    await waitFor(() => fake.methodLog.includes('thread/resume'), 3000);
+    await waitFor(() => server.getRuntime('flow')?.getStatus() === 'ready');
+    expect(server.repos.dispatchers.get('flow')?.thread_id).toBe(firstThreadId);
+    expect(fake.methodLog).not.toContain('thread/start');
+  });
+
+  it('does not restart a dispatcher for a slow in-flight turn', async () => {
+    await fake.close();
+    codexInputs = [];
+    fake = await startFakeCodex({
+      turnDelayMs: 200,
+      replyFor: captureAndEchoCodexInput(codexInputs),
+    });
+    const processes: ControllableCodexProcess[] = [];
+    server = buildServer({
+      runtimeDir,
+      fake,
+      bot,
+      codexProcessFactory: (opts) => {
+        const process = new ControllableCodexProcess(opts);
+        processes.push(process);
+        return process;
+      },
+      codexRestartBackoffBaseMs: 5,
+      codexRestartBackoffMaxMs: 5,
+    });
+    server.repos.dispatchers.create({
+      dispatcher_id: 'flow',
+      bot_app_id: 'app-smoke',
+      bot_secret_ref: 'env:UNUSED',
+    });
+    await server.start();
+
+    await bot.inject(fakeInbound('chat-group-a', 'slow turn', 'msg-slow'));
+    await sleep(80);
+    expect(server.getRuntime('flow')?.getStatus()).toBe('ready');
+    expect(processes).toHaveLength(1);
+    expect(bot.sentMessages).toEqual([]);
+
+    await waitFor(() => bot.sentMessages.length >= 1, 1000);
+    expect(processes).toHaveLength(1);
+    expect(bot.sentMessages[0]?.text).toBe('echo: slow turn');
   });
 });
 


### PR DESCRIPTION
## Summary

- Add Codex child-process exit observation and dispatcher-owned restart scheduling.
- Restart a dispatcher Codex runtime with backoff only after child exit or child WebSocket close.
- Resume the saved/current thread id after restart instead of starting a fresh thread.
- Keep slow in-flight turns from triggering restarts; manual dispatcher stop/start cancels pending restart work and can resume the saved thread.
- Harden fake Codex teardown so tests can simulate WebSocket death.

## Tests

- `node common/scripts/install-run-rush.js build --to @excitedjs/dreamux`
- `node common/scripts/install-run-rush.js test --to @excitedjs/dreamux`
- `.agents/scripts/check.sh`
- `git diff --check`

Tracking: #36 Task 8.