### PR TITLE
Task 9: add Feishu MCP stdio shim

### DIFF
--- a/.agents/decisions/top-level-design.md
+++ b/.agents/decisions/top-level-design.md
@@ -344,10 +344,12 @@ or a world-readable file. An unauthenticated HTTP fallback is not allowed.
 
 The MVP MCP tool surface is:
 
-- `reply`: send a message to a Feishu chat, using `chat_id` and optionally
-  `message_id` so topic-mode replies stay in the original topic when Feishu
-  supports it.
-- `react`: add a model-owned reaction to a Feishu message.
+- `reply`: send a message to a Feishu chat. Parameters are `chat_id`, `text`,
+  optional `message_id`, and optional `mention_user_ids`. The `message_id`
+  should be the inbound Feishu message id when the model wants Feishu to keep
+  topic-mode replies under the original topic.
+- `react`: add a model-owned reaction to a Feishu message. Parameters are
+  `message_id` and `emoji`.
 
 `edit_message` and model-owned `remove_reaction` are out of scope for the MVP.
 

--- a/packages/dreamux/src/admin/client.ts
+++ b/packages/dreamux/src/admin/client.ts
@@ -1,0 +1,119 @@
+import { connect, type Socket } from 'node:net';
+
+import { adminSocketPath as defaultAdminSocketPath } from '../runtime/paths.js';
+import type { AdminRequest, AdminResponse } from './protocol.js';
+
+export interface SendAdminRequestOptions {
+  socketPath?: string;
+  timeoutMs?: number;
+  requestId?: string;
+}
+
+export class AdminClientError extends Error {
+  constructor(
+    public readonly code: string,
+    message: string,
+  ) {
+    super(message);
+    this.name = 'AdminClientError';
+  }
+}
+
+const DEFAULT_TIMEOUT_MS = 10_000;
+let nextRequestId = 1;
+
+export function sendAdminRequest(
+  method: string,
+  params: Record<string, unknown>,
+  options: SendAdminRequestOptions = {},
+): Promise<unknown> {
+  const socketPath = options.socketPath ?? defaultAdminSocketPath();
+  const request: AdminRequest = {
+    id: options.requestId ?? adminRequestId(),
+    method,
+    params,
+  };
+  return sendOne(socketPath, request, options.timeoutMs ?? DEFAULT_TIMEOUT_MS);
+}
+
+export function sendOneAdminRequest(
+  socketPath: string,
+  request: AdminRequest,
+  timeoutMs: number = DEFAULT_TIMEOUT_MS,
+): Promise<unknown> {
+  return sendOne(socketPath, request, timeoutMs);
+}
+
+function sendOne(
+  socketPath: string,
+  request: AdminRequest,
+  timeoutMs: number,
+): Promise<unknown> {
+  return new Promise((resolve, reject) => {
+    let buf = '';
+    let settled = false;
+    let sock: Socket | null = null;
+    const timer = setTimeout(() => {
+      settle(new Error(`admin socket request timed out after ${timeoutMs}ms`));
+      try {
+        sock?.destroy();
+      } catch {
+        /* already gone */
+      }
+    }, timeoutMs);
+    timer.unref();
+
+    function settle(value: unknown, isError = true): void {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      if (isError) reject(value);
+      else resolve(value);
+    }
+
+    try {
+      sock = connect(socketPath);
+    } catch (err) {
+      settle(err);
+      return;
+    }
+    sock.setEncoding('utf8');
+    sock.on('connect', () => {
+      sock.write(`${JSON.stringify(request)}\n`);
+    });
+    sock.on('data', (chunk) => {
+      buf += chunk;
+      const nl = buf.indexOf('\n');
+      if (nl === -1 || settled) return;
+      const line = buf.slice(0, nl).trim();
+      try {
+        const response = JSON.parse(line) as AdminResponse;
+        if (response.ok) settle(response.result, false);
+        else settle(new AdminClientError(response.error.code, response.error.message));
+      } catch (err) {
+        settle(err);
+      }
+      sock.end();
+    });
+    sock.on('error', (err) => {
+      if (settled) return;
+      const code = (err as NodeJS.ErrnoException).code;
+      if (code === 'ENOENT' || code === 'ECONNREFUSED') {
+        settle(
+          new Error(
+            `cannot reach admin socket at ${socketPath} - is the server running?`,
+          ),
+        );
+      } else {
+        settle(err);
+      }
+    });
+    sock.on('close', () => {
+      settle(new Error('admin socket closed without a response'));
+    });
+  });
+}
+
+function adminRequestId(): string {
+  return `mcp-${process.pid}-${Date.now()}-${nextRequestId++}`;
+}

--- a/packages/dreamux/src/admin/methods.ts
+++ b/packages/dreamux/src/admin/methods.ts
@@ -111,6 +111,30 @@ export const adminMethods: Record<string, AdminHandler> = {
     await server.stopDispatcher(id);
     return { dispatcher_id: id, status: 'stopped' };
   },
+
+  'mcp.reply': (server, params) => {
+    const id = mustDispatcherId(params);
+    mustExistingDispatcher(server, id);
+    mustString(params, 'chat_id');
+    mustString(params, 'text');
+    optionalString(params, 'message_id');
+    optionalStringArray(params, 'mention_user_ids');
+    throw new AdminError(
+      'NOT_IMPLEMENTED',
+      'mcp.reply IPC is reserved for Task 10 serve-owned outbound handling',
+    );
+  },
+
+  'mcp.react': (server, params) => {
+    const id = mustDispatcherId(params);
+    mustExistingDispatcher(server, id);
+    mustString(params, 'message_id');
+    mustString(params, 'emoji');
+    throw new AdminError(
+      'NOT_IMPLEMENTED',
+      'mcp.react IPC is reserved for Task 10 serve-owned outbound handling',
+    );
+  },
 };
 
 function mustString(
@@ -146,4 +170,24 @@ function optionalString(
     throw new AdminError('BAD_REQUEST', `param '${key}' must be a string`);
   }
   return v;
+}
+
+function optionalStringArray(
+  params: Record<string, unknown> | undefined,
+  key: string,
+): string[] | null {
+  if (params === undefined) return null;
+  const v = params[key];
+  if (v === undefined || v === null) return null;
+  if (!Array.isArray(v) || v.some((item) => typeof item !== 'string')) {
+    throw new AdminError('BAD_REQUEST', `param '${key}' must be an array of strings`);
+  }
+  return v as string[];
+}
+
+function mustExistingDispatcher(server: Server, id: string): void {
+  const row = server.repos.dispatchers.get(id);
+  if (row === null) {
+    throw new AdminError('DISPATCHER_NOT_FOUND', `no dispatcher with id '${id}'`);
+  }
 }

--- a/packages/dreamux/src/cli/dreamux.ts
+++ b/packages/dreamux/src/cli/dreamux.ts
@@ -31,6 +31,7 @@ import {
 } from '../onboard/wizard.js';
 import type { OnboardRunResult } from '../onboard/types.js';
 import { printDoctorResult, runDreamuxDoctor } from './doctor.js';
+import { runFeishuMcp } from '../mcp/feishu-mcp.js';
 
 const HERE = dirname(fileURLToPath(import.meta.url));
 const SERVER_ENTRY = join(HERE, 'server.js');
@@ -305,6 +306,21 @@ function buildConfigCommands(y: Argv): Argv {
     .strict();
 }
 
+function buildFeishuMcpCommand(
+  y: Argv,
+): Argv<{ dispatcher: string; adminSocket?: string }> {
+  return y
+    .option('dispatcher', {
+      type: 'string',
+      demandOption: true,
+      describe: 'Dispatcher id this MCP shim is scoped to',
+    })
+    .option('admin-socket', {
+      type: 'string',
+      describe: 'dreamux serve admin socket path',
+    }) as Argv<{ dispatcher: string; adminSocket?: string }>;
+}
+
 async function main(): Promise<void> {
   await yargs(hideBin(process.argv))
     .scriptName('dreamux')
@@ -355,6 +371,17 @@ async function main(): Promise<void> {
       'dispatcher <command>',
       'Manage dispatchers',
       buildDispatcherCommands,
+    )
+    .command(
+      'feishu-mcp',
+      'Run the dispatcher-scoped Feishu MCP stdio shim',
+      buildFeishuMcpCommand,
+      async (argv) => {
+        await runFeishuMcp({
+          dispatcherId: validateDispatcherId(argv.dispatcher),
+          adminSocketPath: argv.adminSocket,
+        });
+      },
     )
     .command('config <command>', 'Inspect config', buildConfigCommands)
     .demandCommand(1, 'Choose a command')

--- a/packages/dreamux/src/codex/mcp-config.ts
+++ b/packages/dreamux/src/codex/mcp-config.ts
@@ -1,0 +1,33 @@
+export const FEISHU_MCP_SERVER_NAME = 'feishu';
+
+export interface FeishuMcpCodexArgsOptions {
+  dispatcherId: string;
+  adminSocketPath: string;
+  command?: string;
+}
+
+export function feishuMcpCodexArgs(
+  opts: FeishuMcpCodexArgsOptions,
+): string[] {
+  const command = opts.command ?? 'dreamux';
+  return [
+    '-c',
+    `mcp_servers.${FEISHU_MCP_SERVER_NAME}.command=${tomlString(command)}`,
+    '-c',
+    `mcp_servers.${FEISHU_MCP_SERVER_NAME}.args=${tomlStringArray([
+      'feishu-mcp',
+      '--dispatcher',
+      opts.dispatcherId,
+      '--admin-socket',
+      opts.adminSocketPath,
+    ])}`,
+  ];
+}
+
+function tomlStringArray(values: string[]): string {
+  return `[${values.map(tomlString).join(', ')}]`;
+}
+
+function tomlString(value: string): string {
+  return JSON.stringify(value);
+}

--- a/packages/dreamux/src/mcp/feishu-mcp.ts
+++ b/packages/dreamux/src/mcp/feishu-mcp.ts
@@ -1,0 +1,329 @@
+import { createInterface } from 'node:readline';
+import type { Readable, Writable } from 'node:stream';
+
+import {
+  AdminClientError,
+  sendAdminRequest,
+} from '../admin/client.js';
+import { adminSocketPath as defaultAdminSocketPath } from '../runtime/paths.js';
+import { validateDispatcherId } from '../runtime/dispatcher-id.js';
+
+export interface FeishuMcpOptions {
+  dispatcherId: string;
+  adminSocketPath?: string;
+  input?: Readable;
+  output?: Writable;
+  log?: (message: string) => void;
+}
+
+interface JsonRpcRequest {
+  jsonrpc?: string;
+  id?: string | number | null;
+  method?: string;
+  params?: unknown;
+}
+
+interface ToolCallParams {
+  name?: unknown;
+  arguments?: unknown;
+}
+
+const JSONRPC_VERSION = '2.0';
+const MCP_PROTOCOL_VERSION = '2024-11-05';
+
+export async function runFeishuMcp(opts: FeishuMcpOptions): Promise<void> {
+  const dispatcherId = validateDispatcherId(opts.dispatcherId);
+  const socketPath = opts.adminSocketPath ?? defaultAdminSocketPath();
+  const input = opts.input ?? process.stdin;
+  const output = opts.output ?? process.stdout;
+  const log = opts.log ?? ((message) => console.error(message));
+  const lines = createInterface({ input, crlfDelay: Infinity });
+
+  for await (const line of lines) {
+    const trimmed = line.trim();
+    if (trimmed === '') continue;
+    let request: JsonRpcRequest;
+    try {
+      request = JSON.parse(trimmed) as JsonRpcRequest;
+    } catch (err) {
+      write(output, errorResponse(null, -32700, parseMessage(err)));
+      continue;
+    }
+    try {
+      await handleRequest(request, {
+        dispatcherId,
+        socketPath,
+        output,
+      });
+    } catch (err) {
+      log(`feishu-mcp: ${parseMessage(err)}`);
+      if (request.id !== undefined) {
+        write(output, errorResponse(request.id, -32603, parseMessage(err)));
+      }
+    }
+  }
+}
+
+async function handleRequest(
+  request: JsonRpcRequest,
+  ctx: { dispatcherId: string; socketPath: string; output: Writable },
+): Promise<void> {
+  if (typeof request.method !== 'string') {
+    if (request.id !== undefined) {
+      write(ctx.output, errorResponse(request.id, -32600, 'missing method'));
+    }
+    return;
+  }
+
+  switch (request.method) {
+    case 'initialize':
+      if (request.id !== undefined) {
+        write(ctx.output, okResponse(request.id, initializeResult()));
+      }
+      return;
+    case 'initialized':
+    case 'notifications/initialized':
+      return;
+    case 'tools/list':
+      if (request.id !== undefined) {
+        write(ctx.output, okResponse(request.id, { tools: feishuTools() }));
+      }
+      return;
+    case 'tools/call':
+      if (request.id !== undefined) {
+        write(
+          ctx.output,
+          okResponse(request.id, await callTool(request.params, ctx)),
+        );
+      }
+      return;
+    default:
+      if (request.id !== undefined) {
+        write(
+          ctx.output,
+          errorResponse(
+            request.id,
+            -32601,
+            `unknown MCP method '${request.method}'`,
+          ),
+        );
+      }
+  }
+}
+
+function initializeResult(): Record<string, unknown> {
+  return {
+    protocolVersion: MCP_PROTOCOL_VERSION,
+    capabilities: {
+      tools: {},
+    },
+    serverInfo: {
+      name: 'dreamux-feishu',
+      version: '0.2.0',
+    },
+  };
+}
+
+function feishuTools(): Array<Record<string, unknown>> {
+  return [
+    {
+      name: 'reply',
+      description: 'Send a Feishu message through this dispatcher channel.',
+      inputSchema: {
+        type: 'object',
+        additionalProperties: false,
+        properties: {
+          chat_id: {
+            type: 'string',
+            description: 'Feishu chat id from the inbound feishu_message block.',
+          },
+          message_id: {
+            type: 'string',
+            description: 'Optional source message id to reply under.',
+          },
+          text: {
+            type: 'string',
+            description: 'Message text to send.',
+          },
+          mention_user_ids: {
+            type: 'array',
+            items: { type: 'string' },
+            description: 'Optional Feishu user ids to mention.',
+          },
+        },
+        required: ['chat_id', 'text'],
+      },
+    },
+    {
+      name: 'react',
+      description: 'Add a model-owned Feishu reaction through this dispatcher channel.',
+      inputSchema: {
+        type: 'object',
+        additionalProperties: false,
+        properties: {
+          message_id: {
+            type: 'string',
+            description: 'Feishu message id to react to.',
+          },
+          emoji: {
+            type: 'string',
+            description: 'Feishu reaction emoji key.',
+          },
+        },
+        required: ['message_id', 'emoji'],
+      },
+    },
+  ];
+}
+
+async function callTool(
+  params: unknown,
+  ctx: { dispatcherId: string; socketPath: string },
+): Promise<Record<string, unknown>> {
+  const call = asToolCallParams(params);
+  if (call.name === 'reply') {
+    return forwardToolCall(
+      'mcp.reply',
+      {
+        dispatcher_id: ctx.dispatcherId,
+        ...replyArgs(call.arguments),
+      },
+      ctx.socketPath,
+      'reply',
+    );
+  }
+  if (call.name === 'react') {
+    return forwardToolCall(
+      'mcp.react',
+      {
+        dispatcher_id: ctx.dispatcherId,
+        ...reactArgs(call.arguments),
+      },
+      ctx.socketPath,
+      'react',
+    );
+  }
+  return toolError(`unknown Feishu tool '${String(call.name)}'`);
+}
+
+async function forwardToolCall(
+  method: string,
+  params: Record<string, unknown>,
+  socketPath: string,
+  label: string,
+): Promise<Record<string, unknown>> {
+  try {
+    const result = await sendAdminRequest(method, params, { socketPath });
+    return {
+      content: [{ type: 'text', text: `${label} forwarded to dreamux serve` }],
+      structuredContent: result,
+    };
+  } catch (err) {
+    const prefix = err instanceof AdminClientError ? `[${err.code}] ` : '';
+    return toolError(`${prefix}${parseMessage(err)}`);
+  }
+}
+
+function asToolCallParams(params: unknown): Required<ToolCallParams> {
+  const obj = asRecord(params, 'tools/call params');
+  const name = obj['name'];
+  if (typeof name !== 'string' || name === '') {
+    throw new Error('tools/call params.name must be a non-empty string');
+  }
+  return {
+    name,
+    arguments: obj['arguments'] ?? {},
+  };
+}
+
+function replyArgs(value: unknown): Record<string, unknown> {
+  const obj = asRecord(value, 'reply arguments');
+  const chatId = requireString(obj, 'chat_id');
+  const text = requireString(obj, 'text');
+  const messageId = optionalString(obj, 'message_id');
+  const mentionUserIds = optionalStringArray(obj, 'mention_user_ids');
+  return {
+    chat_id: chatId,
+    text,
+    ...(messageId !== null ? { message_id: messageId } : {}),
+    ...(mentionUserIds !== null ? { mention_user_ids: mentionUserIds } : {}),
+  };
+}
+
+function reactArgs(value: unknown): Record<string, unknown> {
+  const obj = asRecord(value, 'react arguments');
+  return {
+    message_id: requireString(obj, 'message_id'),
+    emoji: requireString(obj, 'emoji'),
+  };
+}
+
+function asRecord(value: unknown, label: string): Record<string, unknown> {
+  if (value === null || typeof value !== 'object' || Array.isArray(value)) {
+    throw new Error(`${label} must be an object`);
+  }
+  return value as Record<string, unknown>;
+}
+
+function requireString(obj: Record<string, unknown>, key: string): string {
+  const value = obj[key];
+  if (typeof value !== 'string' || value === '') {
+    throw new Error(`${key} must be a non-empty string`);
+  }
+  return value;
+}
+
+function optionalString(
+  obj: Record<string, unknown>,
+  key: string,
+): string | null {
+  const value = obj[key];
+  if (value === undefined || value === null || value === '') return null;
+  if (typeof value !== 'string') {
+    throw new Error(`${key} must be a string`);
+  }
+  return value;
+}
+
+function optionalStringArray(
+  obj: Record<string, unknown>,
+  key: string,
+): string[] | null {
+  const value = obj[key];
+  if (value === undefined || value === null) return null;
+  if (!Array.isArray(value) || value.some((item) => typeof item !== 'string')) {
+    throw new Error(`${key} must be an array of strings`);
+  }
+  return value as string[];
+}
+
+function toolError(message: string): Record<string, unknown> {
+  return {
+    isError: true,
+    content: [{ type: 'text', text: message }],
+  };
+}
+
+function okResponse(id: JsonRpcRequest['id'], result: unknown): Record<string, unknown> {
+  return { jsonrpc: JSONRPC_VERSION, id, result };
+}
+
+function errorResponse(
+  id: JsonRpcRequest['id'],
+  code: number,
+  message: string,
+): Record<string, unknown> {
+  return {
+    jsonrpc: JSONRPC_VERSION,
+    id,
+    error: { code, message },
+  };
+}
+
+function write(output: Writable, message: Record<string, unknown>): void {
+  output.write(`${JSON.stringify(message)}\n`);
+}
+
+function parseMessage(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}

--- a/packages/dreamux/src/server.ts
+++ b/packages/dreamux/src/server.ts
@@ -33,6 +33,7 @@ import {
 } from './channel/feishu-gate.js';
 import { formatFeishuMessageForCodex } from './channel/feishu-message.js';
 import { parseCodexArgs, codexArgsToCli } from './runtime/codex-args.js';
+import { feishuMcpCodexArgs } from './codex/mcp-config.js';
 import { resolveBotSecret } from './runtime/secrets.js';
 import { BUILT_IN_DEFAULTS, type DreamuxConfig } from './runtime/config.js';
 import type { DispatcherCodexHomeDoctor } from './runtime/dispatcher-codex-home.js';
@@ -193,6 +194,13 @@ export class Server {
       sandboxMode: cfg.codex.sandbox_mode,
       extraArgs: cfg.codex.extra_args,
     });
+    const codexCliArgs = [
+      ...codexArgsToCli(codexArgs),
+      ...feishuMcpCodexArgs({
+        dispatcherId: id,
+        adminSocketPath: this.opts.adminSocketPath ?? adminSocketPath(),
+      }),
+    ];
     const botSecret = this.opts.skipBotSecret
       ? ''
       : resolveBotSecret(row.bot_secret_ref, cfg);
@@ -213,7 +221,7 @@ export class Server {
       codexProcessFactory: this.opts.codexProcessFactory,
       codexClientFactory: this.opts.codexClientFactory,
       codexHomeDoctor: this.opts.codexHomeDoctor,
-      resolveExtraArgs: () => codexArgsToCli(codexArgs),
+      resolveExtraArgs: () => codexCliArgs,
       handshakeTimeoutMs: cfg.codex.initialize_timeout_ms,
       outboundRetries: cfg.outbound.retries,
       outboundRetryDelayMs: cfg.outbound.retry_delay_ms,

--- a/packages/dreamux/tests/feishu-mcp.test.ts
+++ b/packages/dreamux/tests/feishu-mcp.test.ts
@@ -1,0 +1,243 @@
+import { describe, expect, it } from 'vitest';
+import { createServer, type Server as NetServer } from 'node:net';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { PassThrough } from 'node:stream';
+
+import { runFeishuMcp } from '../src/mcp/feishu-mcp.js';
+import type { AdminRequest, AdminResponse } from '../src/admin/protocol.js';
+
+class JsonLineReader {
+  private buffer = '';
+  private waiters: Array<(value: unknown) => void> = [];
+
+  constructor(stream: PassThrough) {
+    stream.setEncoding('utf8');
+    stream.on('data', (chunk: string) => {
+      this.buffer += chunk;
+      this.drain();
+    });
+  }
+
+  next(): Promise<unknown> {
+    const line = this.shiftLine();
+    if (line !== null) return Promise.resolve(JSON.parse(line));
+    return new Promise((resolve) => {
+      this.waiters.push(resolve);
+    });
+  }
+
+  private drain(): void {
+    while (this.waiters.length > 0) {
+      const line = this.shiftLine();
+      if (line === null) return;
+      this.waiters.shift()!(JSON.parse(line));
+    }
+  }
+
+  private shiftLine(): string | null {
+    const idx = this.buffer.indexOf('\n');
+    if (idx === -1) return null;
+    const line = this.buffer.slice(0, idx);
+    this.buffer = this.buffer.slice(idx + 1);
+    return line;
+  }
+}
+
+interface FakeAdminServer {
+  socketPath: string;
+  requests: AdminRequest[];
+  close(): Promise<void>;
+}
+
+async function startFakeAdminServer(
+  respond: (request: AdminRequest) => AdminResponse,
+): Promise<FakeAdminServer> {
+  const dir = mkdtempSync(join(tmpdir(), 'dreamux-mcp-admin-'));
+  const socketPath = join(dir, 'admin.sock');
+  const requests: AdminRequest[] = [];
+  const server: NetServer = createServer((socket) => {
+    let buffer = '';
+    socket.setEncoding('utf8');
+    socket.on('data', (chunk) => {
+      buffer += chunk;
+      let idx: number;
+      while ((idx = buffer.indexOf('\n')) !== -1) {
+        const line = buffer.slice(0, idx).trim();
+        buffer = buffer.slice(idx + 1);
+        if (line === '') continue;
+        const request = JSON.parse(line) as AdminRequest;
+        requests.push(request);
+        socket.write(`${JSON.stringify(respond(request))}\n`);
+      }
+    });
+  });
+  await new Promise<void>((resolve, reject) => {
+    server.once('error', reject);
+    server.listen(socketPath, () => resolve());
+  });
+  return {
+    socketPath,
+    requests,
+    async close(): Promise<void> {
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+      rmSync(dir, { recursive: true, force: true });
+    },
+  };
+}
+
+function writeJson(input: PassThrough, value: unknown): void {
+  input.write(`${JSON.stringify(value)}\n`);
+}
+
+describe('feishu-mcp stdio shim', () => {
+  it('announces reply/react tools without reading dreamux config', async () => {
+    const input = new PassThrough();
+    const output = new PassThrough();
+    const reader = new JsonLineReader(output);
+    const run = runFeishuMcp({
+      dispatcherId: 'dispatcher-a',
+      adminSocketPath: '/tmp/not-used.sock',
+      input,
+      output,
+      log: () => {},
+    });
+
+    writeJson(input, { jsonrpc: '2.0', id: 1, method: 'initialize', params: {} });
+    const init = await reader.next();
+    expect(init).toMatchObject({
+      jsonrpc: '2.0',
+      id: 1,
+      result: {
+        capabilities: { tools: {} },
+        serverInfo: { name: 'dreamux-feishu' },
+      },
+    });
+
+    writeJson(input, { jsonrpc: '2.0', id: 2, method: 'tools/list', params: {} });
+    const tools = await reader.next() as { result: { tools: Array<{ name: string }> } };
+    expect(tools.result.tools.map((tool) => tool.name)).toEqual(['reply', 'react']);
+
+    input.end();
+    await run;
+  });
+
+  it('forwards reply tool calls to the dispatcher-scoped admin IPC method', async () => {
+    const admin = await startFakeAdminServer((request) => ({
+      id: request.id,
+      ok: true,
+      result: { message_ids: ['message-out'] },
+    }));
+    try {
+      const input = new PassThrough();
+      const output = new PassThrough();
+      const reader = new JsonLineReader(output);
+      const run = runFeishuMcp({
+        dispatcherId: 'dispatcher-a',
+        adminSocketPath: admin.socketPath,
+        input,
+        output,
+        log: () => {},
+      });
+
+      writeJson(input, {
+        jsonrpc: '2.0',
+        id: 1,
+        method: 'tools/call',
+        params: {
+          name: 'reply',
+          arguments: {
+            chat_id: 'chat-a',
+            message_id: 'message-in',
+            text: 'hello',
+            mention_user_ids: ['sender-a'],
+          },
+        },
+      });
+      const response = await reader.next();
+      expect(response).toMatchObject({
+        jsonrpc: '2.0',
+        id: 1,
+        result: {
+          structuredContent: { message_ids: ['message-out'] },
+        },
+      });
+      expect(admin.requests).toEqual([
+        {
+          id: expect.any(String) as string,
+          method: 'mcp.reply',
+          params: {
+            dispatcher_id: 'dispatcher-a',
+            chat_id: 'chat-a',
+            message_id: 'message-in',
+            text: 'hello',
+            mention_user_ids: ['sender-a'],
+          },
+        },
+      ]);
+
+      input.end();
+      await run;
+    } finally {
+      await admin.close();
+    }
+  });
+
+  it('forwards react tool calls and returns admin errors as MCP tool errors', async () => {
+    const admin = await startFakeAdminServer((request) => ({
+      id: request.id,
+      ok: false,
+      error: { code: 'NOT_IMPLEMENTED', message: 'serve handler pending' },
+    }));
+    try {
+      const input = new PassThrough();
+      const output = new PassThrough();
+      const reader = new JsonLineReader(output);
+      const run = runFeishuMcp({
+        dispatcherId: 'dispatcher-a',
+        adminSocketPath: admin.socketPath,
+        input,
+        output,
+        log: () => {},
+      });
+
+      writeJson(input, {
+        jsonrpc: '2.0',
+        id: 1,
+        method: 'tools/call',
+        params: {
+          name: 'react',
+          arguments: { message_id: 'message-in', emoji: 'THUMBSUP' },
+        },
+      });
+      const response = await reader.next();
+      expect(response).toMatchObject({
+        jsonrpc: '2.0',
+        id: 1,
+        result: {
+          isError: true,
+          content: [
+            {
+              type: 'text',
+              text: '[NOT_IMPLEMENTED] serve handler pending',
+            },
+          ],
+        },
+      });
+      expect(admin.requests[0]).toMatchObject({
+        method: 'mcp.react',
+        params: {
+          dispatcher_id: 'dispatcher-a',
+          message_id: 'message-in',
+          emoji: 'THUMBSUP',
+        },
+      });
+
+      input.end();
+      await run;
+    } finally {
+      await admin.close();
+    }
+  });
+});

--- a/packages/dreamux/tests/smoke.test.ts
+++ b/packages/dreamux/tests/smoke.test.ts
@@ -323,6 +323,43 @@ describe('dreamux MVP smoke', () => {
     expect(JSON.stringify(capturedCodexOptions)).not.toContain('secret-server-only');
   });
 
+  it('injects dispatcher-scoped Feishu MCP config after operator Codex args', async () => {
+    const capturedCodexOptions: CodexProcessOptions[] = [];
+    server = buildServer({
+      runtimeDir,
+      fake,
+      bot,
+      capturedCodexOptions,
+      config: {
+        ...BUILT_IN_DEFAULTS,
+        runtime_dir: runtimeDir,
+        codex: {
+          ...BUILT_IN_DEFAULTS.codex,
+          extra_args: [
+            '-c',
+            'mcp_servers.feishu.command="operator-feishu"',
+          ],
+        },
+      },
+    });
+    server.repos.dispatchers.create({
+      dispatcher_id: 'flow',
+      bot_app_id: 'app-smoke',
+      bot_secret_ref: 'env:UNUSED',
+    });
+
+    await server.start();
+
+    const args = capturedCodexOptions[0]?.extraArgs ?? [];
+    expect(args).toContain('mcp_servers.feishu.command="operator-feishu"');
+    const operatorIdx = args.indexOf('mcp_servers.feishu.command="operator-feishu"');
+    const dreamuxIdx = args.indexOf('mcp_servers.feishu.command="dreamux"');
+    expect(dreamuxIdx).toBeGreaterThan(operatorIdx);
+    expect(args).toContain(
+      `mcp_servers.feishu.args=["feishu-mcp", "--dispatcher", "flow", "--admin-socket", "${join(runtimeDir, 'admin.sock')}"]`,
+    );
+  });
+
   it('creates the app-server socket directory outside the global Codex home', async () => {
     rmSync(runtimeDir, { recursive: true, force: true });
     runtimeDir = mkdtempSync(join(previousHome ?? homedir(), '.dreamux-smoke-'));


### PR DESCRIPTION
## Summary

- Add `dreamux feishu-mcp --dispatcher <id>` as a dispatcher-scoped stdio MCP shim.
- Expose `reply` and `react` MCP tools and forward tool calls over the local admin socket with dispatcher routing metadata only.
- Inject `mcp_servers.feishu` Codex config overrides after operator Codex args when starting a dispatcher app-server.
- Add explicit `mcp.reply` / `mcp.react` admin IPC placeholders; Task 10 will attach these to serve-owned Feishu outbound and reaction cleanup.
- Document the MVP MCP tool parameter shape in the top-level design.

## Codex MCP spike

Before coding, I validated the default stdio path against `codex-cli 0.136.0`: `codex app-server` accepted `mcp_servers.<name>.command` and `mcp_servers.<name>.args` config overrides, completed the app-server initialize handshake, then `mcpServerStatus/list` started the injected stdio MCP server and returned its `reply` tool. This keeps Task 9 on the STDIO design path; no HTTP fallback is needed.

## Tests

- `node common/scripts/install-run-rush.js build --to @excitedjs/dreamux`
- `node common/scripts/install-run-rush.js test --to @excitedjs/dreamux`
- `.agents/scripts/check.sh`
- `git diff --check`
- staged diff red-line scan
- local `dreamux feishu-mcp` initialize smoke

Tracking: #36 Task 9.