### PR TITLE
Add live gate for Feishu MCP injection

### DIFF
--- a/.agents/decisions/top-level-design.md
+++ b/.agents/decisions/top-level-design.md
@@ -307,11 +307,13 @@ Codex sends Feishu outbound actions only through a dispatcher-scoped MCP server.
 Model text is never automatically forwarded to Feishu.
 
 The default MCP transport between Codex and the Feishu MCP server is stdio.
-`dreamux` injects a per-dispatcher MCP server command into the Codex thread, for
-example:
+`dreamux` injects a per-dispatcher MCP server command into the Codex thread. The
+generated command path must be an absolute `dreamux` launcher path, resolved from
+the launcher-provided `DREAMUX_BIN` environment variable when available and from
+the package bin path otherwise. Schematically:
 
 ```text
-dreamux feishu-mcp --dispatcher dispatcher-a
+<dreamux-bin> feishu-mcp --dispatcher dispatcher-a
 ```
 
 The stdio process is a thin MCP shim. It is scoped to exactly one dispatcher,
@@ -467,6 +469,9 @@ resume path.
 - Multi-chat dispatcher access emits an operator-visible trust-domain warning.
 - Codex receives a dispatcher-scoped Feishu MCP stdio shim, not a loopback HTTP
   listener, on the default path.
+- The live Codex compatibility gate starts a real Codex app-server with the
+  injected stdio MCP config and asserts `mcpServerStatus/list` exposes the
+  Feishu `reply` and `react` tools.
 - The `feishu-mcp` shim forwards `reply` and `react` to `dreamux serve` through
   the local admin socket and never reads Feishu credentials.
 - If HTTP fallback is ever implemented, it refuses to start without a per-boot,

--- a/packages/dreamux/src/codex/mcp-config.ts
+++ b/packages/dreamux/src/codex/mcp-config.ts
@@ -1,15 +1,18 @@
+import { dreamuxBinPath } from '../runtime/package-bin.js';
+
 export const FEISHU_MCP_SERVER_NAME = 'feishu';
 
 export interface FeishuMcpCodexArgsOptions {
   dispatcherId: string;
   adminSocketPath: string;
   command?: string;
+  env?: NodeJS.ProcessEnv;
 }
 
 export function feishuMcpCodexArgs(
   opts: FeishuMcpCodexArgsOptions,
 ): string[] {
-  const command = opts.command ?? 'dreamux';
+  const command = opts.command ?? dreamuxBinPath(opts.env);
   return [
     '-c',
     `mcp_servers.${FEISHU_MCP_SERVER_NAME}.command=${tomlString(command)}`,

--- a/packages/dreamux/src/mcp/feishu-mcp.ts
+++ b/packages/dreamux/src/mcp/feishu-mcp.ts
@@ -29,7 +29,12 @@ interface ToolCallParams {
 }
 
 const JSONRPC_VERSION = '2.0';
-const MCP_PROTOCOL_VERSION = '2024-11-05';
+const DEFAULT_MCP_PROTOCOL_VERSION = '2024-11-05';
+const SUPPORTED_MCP_PROTOCOL_VERSIONS = new Set([
+  '2025-06-18',
+  '2025-03-26',
+  '2024-11-05',
+]);
 
 export async function runFeishuMcp(opts: FeishuMcpOptions): Promise<void> {
   const dispatcherId = validateDispatcherId(opts.dispatcherId);
@@ -78,7 +83,10 @@ async function handleRequest(
   switch (request.method) {
     case 'initialize':
       if (request.id !== undefined) {
-        write(ctx.output, okResponse(request.id, initializeResult()));
+        write(
+          ctx.output,
+          okResponse(request.id, initializeResult(request.params)),
+        );
       }
       return;
     case 'initialized':
@@ -111,9 +119,9 @@ async function handleRequest(
   }
 }
 
-function initializeResult(): Record<string, unknown> {
+function initializeResult(params: unknown): Record<string, unknown> {
   return {
-    protocolVersion: MCP_PROTOCOL_VERSION,
+    protocolVersion: negotiateProtocolVersion(params),
     capabilities: {
       tools: {},
     },
@@ -180,30 +188,48 @@ async function callTool(
   params: unknown,
   ctx: { dispatcherId: string; socketPath: string },
 ): Promise<Record<string, unknown>> {
-  const call = asToolCallParams(params);
-  if (call.name === 'reply') {
-    return forwardToolCall(
-      'mcp.reply',
-      {
-        dispatcher_id: ctx.dispatcherId,
-        ...replyArgs(call.arguments),
-      },
-      ctx.socketPath,
-      'reply',
-    );
+  try {
+    const call = asToolCallParams(params);
+    if (call.name === 'reply') {
+      return forwardToolCall(
+        'mcp.reply',
+        {
+          dispatcher_id: ctx.dispatcherId,
+          ...replyArgs(call.arguments),
+        },
+        ctx.socketPath,
+        'reply',
+      );
+    }
+    if (call.name === 'react') {
+      return forwardToolCall(
+        'mcp.react',
+        {
+          dispatcher_id: ctx.dispatcherId,
+          ...reactArgs(call.arguments),
+        },
+        ctx.socketPath,
+        'react',
+      );
+    }
+    return toolError(`unknown Feishu tool '${String(call.name)}'`);
+  } catch (err) {
+    return toolError(parseMessage(err));
   }
-  if (call.name === 'react') {
-    return forwardToolCall(
-      'mcp.react',
-      {
-        dispatcher_id: ctx.dispatcherId,
-        ...reactArgs(call.arguments),
-      },
-      ctx.socketPath,
-      'react',
-    );
+}
+
+function negotiateProtocolVersion(params: unknown): string {
+  const requested =
+    params !== null && typeof params === 'object' && !Array.isArray(params)
+      ? (params as Record<string, unknown>)['protocolVersion']
+      : undefined;
+  if (
+    typeof requested === 'string' &&
+    SUPPORTED_MCP_PROTOCOL_VERSIONS.has(requested)
+  ) {
+    return requested;
   }
-  return toolError(`unknown Feishu tool '${String(call.name)}'`);
+  return DEFAULT_MCP_PROTOCOL_VERSION;
 }
 
 async function forwardToolCall(

--- a/packages/dreamux/src/runtime/package-bin.ts
+++ b/packages/dreamux/src/runtime/package-bin.ts
@@ -1,9 +1,19 @@
-import { dirname, join } from 'node:path';
+import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 const HERE = dirname(fileURLToPath(import.meta.url));
 const PACKAGE_ROOT = dirname(dirname(HERE));
 const PACKAGE_BIN_DIR = join(PACKAGE_ROOT, 'bin');
+const DREAMUX_BIN = join(PACKAGE_BIN_DIR, 'dreamux');
+
+export function dreamuxBinPath(
+  env: NodeJS.ProcessEnv = process.env,
+): string {
+  const fromEnv = env['DREAMUX_BIN'];
+  return fromEnv !== undefined && fromEnv !== ''
+    ? resolve(fromEnv)
+    : DREAMUX_BIN;
+}
 
 export function dispatcherProcessEnv(
   baseEnv: NodeJS.ProcessEnv = process.env,
@@ -18,10 +28,7 @@ export function dispatcherProcessEnv(
 
 function packageBinDirs(env: NodeJS.ProcessEnv): string[] {
   const dirs = [PACKAGE_BIN_DIR];
-  const dreamuxBin = env['DREAMUX_BIN'];
-  if (dreamuxBin !== undefined && dreamuxBin !== '') {
-    dirs.push(dirname(dreamuxBin));
-  }
+  dirs.push(dirname(dreamuxBinPath(env)));
   return dirs;
 }
 

--- a/packages/dreamux/tests/bin-launcher.test.ts
+++ b/packages/dreamux/tests/bin-launcher.test.ts
@@ -20,6 +20,8 @@ import { tmpdir } from 'node:os';
 import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
+import { dreamuxBinPath } from '../src/runtime/package-bin.js';
+
 const PACKAGE_ROOT = resolve(
   dirname(fileURLToPath(import.meta.url)),
   '..',
@@ -92,6 +94,18 @@ describe('package bin manifest', () => {
       dreamux: './bin/dreamux',
       tm: './bin/tm',
     });
+  });
+});
+
+describe('runtime dreamux bin resolution', () => {
+  it('uses an absolute package bin path by default', () => {
+    expect(dreamuxBinPath({})).toBe(PKG_BIN_DREAMUX);
+  });
+
+  it('normalizes DREAMUX_BIN overrides to absolute paths', () => {
+    expect(dreamuxBinPath({ DREAMUX_BIN: 'relative/dreamux' })).toBe(
+      resolve('relative/dreamux'),
+    );
   });
 });
 

--- a/packages/dreamux/tests/codex-live.test.ts
+++ b/packages/dreamux/tests/codex-live.test.ts
@@ -20,14 +20,16 @@
 
 import { describe, it, expect } from 'vitest';
 import { execSync } from 'node:child_process';
-import { mkdtempSync, rmSync } from 'node:fs';
+import { existsSync, mkdtempSync, rmSync } from 'node:fs';
 import { homedir } from 'node:os';
-import { join } from 'node:path';
+import { isAbsolute, join } from 'node:path';
 
 import { CodexProcess } from '../src/codex/supervisor.js';
 import { CodexWsClient } from '../src/codex/rpc.js';
 import { performInitializeHandshake } from '../src/codex/handshake.js';
+import { feishuMcpCodexArgs } from '../src/codex/mcp-config.js';
 import { codexArgsToCli, parseCodexArgs } from '../src/runtime/codex-args.js';
+import { dreamuxBinPath } from '../src/runtime/package-bin.js';
 import type { ThreadStartResponse } from '../src/codex/types.js';
 
 export const SKIP_ENV = 'DREAMUX_SKIP_LIVE_CODEX';
@@ -65,6 +67,25 @@ function detectCodex(): Detection {
     return { state: 'missing', reason };
   }
   return classifyDetection(out);
+}
+
+function versionAtLeast(version: string, min: string): boolean {
+  const actualParts = version.split('.').map((part) => Number.parseInt(part, 10));
+  const minParts = min.split('.').map((part) => Number.parseInt(part, 10));
+  for (let i = 0; i < Math.max(actualParts.length, minParts.length); i += 1) {
+    const actual = actualParts[i] ?? 0;
+    const expected = minParts[i] ?? 0;
+    if (actual > expected) return true;
+    if (actual < expected) return false;
+  }
+  return true;
+}
+
+interface McpServerStatusListResponse {
+  data: Array<{
+    name: string;
+    tools?: Record<string, { name: string }>;
+  }>;
 }
 
 describe('codex live integration', () => {
@@ -151,6 +172,70 @@ describe('codex live integration', () => {
     },
     30_000,
   );
+
+  it(
+    `spawns codex ${detection.version} with the Feishu stdio MCP shim`,
+    async () => {
+      if (!versionAtLeast(detection.version, '0.136.0')) {
+        throw new Error(
+          `dreamux's Feishu MCP injection gate requires codex >= 0.136.0; detected ${detection.version}`,
+        );
+      }
+
+      const dreamuxBin = dreamuxBinPath();
+      if (!isAbsolute(dreamuxBin) || !existsSync(dreamuxBin)) {
+        throw new Error(
+          `dreamux Feishu MCP live test requires an absolute built dreamux bin path; got ${dreamuxBin}`,
+        );
+      }
+
+      const dir = mkdtempSync(join(homedir(), '.dreamux-e2e-'));
+      const socketPath = join(dir, 'codex.sock');
+      const cwd = join(dir, 'cwd');
+      const extraArgs = [
+        ...codexArgsToCli(
+          parseCodexArgs('{"sandboxMode":"danger-full-access"}'),
+        ),
+        ...feishuMcpCodexArgs({
+          dispatcherId: 'dispatcher-a',
+          adminSocketPath: join(dir, 'admin.sock'),
+          command: dreamuxBin,
+        }),
+      ];
+
+      const proc = new CodexProcess({
+        socketPath,
+        cwd,
+        stdoutLogPath: join(dir, 'stdout.log'),
+        stderrLogPath: join(dir, 'stderr.log'),
+        extraArgs,
+        readyTimeoutMs: 15_000,
+      });
+
+      try {
+        await proc.start();
+        const client = new CodexWsClient({ socketPath });
+        try {
+          await client.ready();
+          await performInitializeHandshake(client);
+          const status = await client.request<McpServerStatusListResponse>(
+            'mcpServerStatus/list',
+            {},
+          );
+          const feishu = status.data.find((server) => server.name === 'feishu');
+          expect(feishu).toBeDefined();
+          expect(feishu?.tools?.['reply']?.name).toBe('reply');
+          expect(feishu?.tools?.['react']?.name).toBe('react');
+        } finally {
+          client.close();
+        }
+      } finally {
+        await proc.reap();
+        rmSync(dir, { recursive: true, force: true });
+      }
+    },
+    30_000,
+  );
 });
 
 // Unit coverage of the classification logic itself — these run regardless of
@@ -176,5 +261,11 @@ describe('codex detection logic', () => {
     expect(classifyDetection(null).state).toBe('missing');
     expect(classifyDetection('not a version string').state).toBe('missing');
     expect(classifyDetection('').state).toBe('missing');
+  });
+
+  it('compares codex semver versions', () => {
+    expect(versionAtLeast('0.136.0', '0.136.0')).toBe(true);
+    expect(versionAtLeast('0.137.0', '0.136.0')).toBe(true);
+    expect(versionAtLeast('0.135.9', '0.136.0')).toBe(false);
   });
 });

--- a/packages/dreamux/tests/feishu-mcp.test.ts
+++ b/packages/dreamux/tests/feishu-mcp.test.ts
@@ -110,6 +110,7 @@ describe('feishu-mcp stdio shim', () => {
       jsonrpc: '2.0',
       id: 1,
       result: {
+        protocolVersion: '2024-11-05',
         capabilities: { tools: {} },
         serverInfo: { name: 'dreamux-feishu' },
       },
@@ -118,6 +119,44 @@ describe('feishu-mcp stdio shim', () => {
     writeJson(input, { jsonrpc: '2.0', id: 2, method: 'tools/list', params: {} });
     const tools = await reader.next() as { result: { tools: Array<{ name: string }> } };
     expect(tools.result.tools.map((tool) => tool.name)).toEqual(['reply', 'react']);
+
+    input.end();
+    await run;
+  });
+
+  it('negotiates supported MCP protocol versions and falls back safely', async () => {
+    const input = new PassThrough();
+    const output = new PassThrough();
+    const reader = new JsonLineReader(output);
+    const run = runFeishuMcp({
+      dispatcherId: 'dispatcher-a',
+      adminSocketPath: '/tmp/not-used.sock',
+      input,
+      output,
+      log: () => {},
+    });
+
+    writeJson(input, {
+      jsonrpc: '2.0',
+      id: 1,
+      method: 'initialize',
+      params: { protocolVersion: '2025-06-18' },
+    });
+    expect(await reader.next()).toMatchObject({
+      id: 1,
+      result: { protocolVersion: '2025-06-18' },
+    });
+
+    writeJson(input, {
+      jsonrpc: '2.0',
+      id: 2,
+      method: 'initialize',
+      params: { protocolVersion: '2099-01-01' },
+    });
+    expect(await reader.next()).toMatchObject({
+      id: 2,
+      result: { protocolVersion: '2024-11-05' },
+    });
 
     input.end();
     await run;
@@ -182,6 +221,42 @@ describe('feishu-mcp stdio shim', () => {
     } finally {
       await admin.close();
     }
+  });
+
+  it('returns tool argument validation failures as MCP tool errors', async () => {
+    const input = new PassThrough();
+    const output = new PassThrough();
+    const reader = new JsonLineReader(output);
+    const run = runFeishuMcp({
+      dispatcherId: 'dispatcher-a',
+      adminSocketPath: '/tmp/not-used.sock',
+      input,
+      output,
+      log: () => {},
+    });
+
+    writeJson(input, {
+      jsonrpc: '2.0',
+      id: 1,
+      method: 'tools/call',
+      params: {
+        name: 'reply',
+        arguments: { chat_id: 'chat-a' },
+      },
+    });
+    const response = await reader.next() as Record<string, unknown>;
+    expect(response).not.toHaveProperty('error');
+    expect(response).toMatchObject({
+      jsonrpc: '2.0',
+      id: 1,
+      result: {
+        isError: true,
+        content: [{ type: 'text', text: 'text must be a non-empty string' }],
+      },
+    });
+
+    input.end();
+    await run;
   });
 
   it('forwards react tool calls and returns admin errors as MCP tool errors', async () => {

--- a/packages/dreamux/tests/smoke.test.ts
+++ b/packages/dreamux/tests/smoke.test.ts
@@ -43,6 +43,7 @@ import {
   dispatcherWorkspaceSkillPath,
   dispatcherSocketPath,
 } from '../src/runtime/paths.js';
+import { dreamuxBinPath } from '../src/runtime/package-bin.js';
 import { startFakeCodex, type FakeCodex } from './fake-codex.js';
 
 class NoopCodexProcess extends CodexProcess {
@@ -351,10 +352,12 @@ describe('dreamux MVP smoke', () => {
     await server.start();
 
     const args = capturedCodexOptions[0]?.extraArgs ?? [];
+    const dreamuxCommand = `mcp_servers.feishu.command=${JSON.stringify(dreamuxBinPath())}`;
     expect(args).toContain('mcp_servers.feishu.command="operator-feishu"');
     const operatorIdx = args.indexOf('mcp_servers.feishu.command="operator-feishu"');
-    const dreamuxIdx = args.indexOf('mcp_servers.feishu.command="dreamux"');
+    const dreamuxIdx = args.indexOf(dreamuxCommand);
     expect(dreamuxIdx).toBeGreaterThan(operatorIdx);
+    expect(dreamuxBinPath()).toMatch(/\/dreamux$/);
     expect(args).toContain(
       `mcp_servers.feishu.args=["feishu-mcp", "--dispatcher", "flow", "--admin-socket", "${join(runtimeDir, 'admin.sock')}"]`,
     );


### PR DESCRIPTION
## Summary

This is the Task 9 gate follow-up for #36 before Task 10. It turns the manual Codex 0.136 MCP injection spike into an automated live compatibility test.

Changes:

- Add a live Codex app-server test that injects the Feishu stdio MCP shim and asserts `mcpServerStatus/list` exposes `reply` and `react`.
- Resolve the generated MCP command to an absolute `dreamux` launcher path, preferring `DREAMUX_BIN` when present.
- Return `tools/call` argument validation failures as MCP tool errors instead of JSON-RPC protocol errors.
- Negotiate supported MCP `protocolVersion` values and fall back safely.
- Update the top-level design record to document the absolute launcher path contract and the live compatibility gate.

## Codex MCP live result

Verified locally with `codex-cli 0.136.0`: a real `codex app-server` accepted the injected `mcp_servers.feishu` stdio config, completed initialize, started the shim, and returned the Feishu `reply` and `react` tools from `mcpServerStatus/list`.

## Validation

- `node common/scripts/install-run-rush.js build --to @excitedjs/dreamux`
- `cd packages/dreamux && ./node_modules/.bin/vitest run tests/bin-launcher.test.ts tests/feishu-mcp.test.ts tests/codex-live.test.ts tests/smoke.test.ts`
- `node common/scripts/install-run-rush.js test --to @excitedjs/dreamux`
- `.agents/scripts/check.sh`
- `git diff --check`
- staged diff red-line scan for public-repo leak patterns

Refs #36.