### PR TITLE
Implement serve-owned Feishu MCP outbound

### DIFF
--- a/packages/dreamux/src/admin/methods.ts
+++ b/packages/dreamux/src/admin/methods.ts
@@ -112,28 +112,42 @@ export const adminMethods: Record<string, AdminHandler> = {
     return { dispatcher_id: id, status: 'stopped' };
   },
 
-  'mcp.reply': (server, params) => {
+  'mcp.reply': async (server, params) => {
     const id = mustDispatcherId(params);
     mustExistingDispatcher(server, id);
-    mustString(params, 'chat_id');
-    mustString(params, 'text');
-    optionalString(params, 'message_id');
-    optionalStringArray(params, 'mention_user_ids');
-    throw new AdminError(
-      'NOT_IMPLEMENTED',
-      'mcp.reply IPC is reserved for Task 10 serve-owned outbound handling',
-    );
+    mustRunningDispatcher(server, id);
+    const chatId = mustString(params, 'chat_id');
+    const text = mustString(params, 'text');
+    const messageId = optionalString(params, 'message_id');
+    const mentionUserIds = optionalStringArray(params, 'mention_user_ids');
+    try {
+      return await server.replyFromMcp({
+        dispatcherId: id,
+        chatId,
+        text,
+        ...(messageId !== null ? { messageId } : {}),
+        ...(mentionUserIds !== null ? { mentionUserIds } : {}),
+      });
+    } catch (err) {
+      throw new AdminError('OUTBOUND_FAILED', parseMessage(err));
+    }
   },
 
-  'mcp.react': (server, params) => {
+  'mcp.react': async (server, params) => {
     const id = mustDispatcherId(params);
     mustExistingDispatcher(server, id);
-    mustString(params, 'message_id');
-    mustString(params, 'emoji');
-    throw new AdminError(
-      'NOT_IMPLEMENTED',
-      'mcp.react IPC is reserved for Task 10 serve-owned outbound handling',
-    );
+    mustRunningDispatcher(server, id);
+    const messageId = mustString(params, 'message_id');
+    const emoji = mustString(params, 'emoji');
+    try {
+      return await server.reactFromMcp({
+        dispatcherId: id,
+        messageId,
+        emoji,
+      });
+    } catch (err) {
+      throw new AdminError('REACTION_FAILED', parseMessage(err));
+    }
   },
 };
 
@@ -190,4 +204,17 @@ function mustExistingDispatcher(server: Server, id: string): void {
   if (row === null) {
     throw new AdminError('DISPATCHER_NOT_FOUND', `no dispatcher with id '${id}'`);
   }
+}
+
+function mustRunningDispatcher(server: Server, id: string): void {
+  if (server.getRuntime(id) === null) {
+    throw new AdminError(
+      'DISPATCHER_NOT_RUNNING',
+      `dispatcher '${id}' is not running`,
+    );
+  }
+}
+
+function parseMessage(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
 }

--- a/packages/dreamux/src/feishu/bot.ts
+++ b/packages/dreamux/src/feishu/bot.ts
@@ -69,6 +69,7 @@ export interface FeishuBot {
   start(handler: InboundHandler): Promise<void>;
   send(target: OutboundTarget, text: string): Promise<FeishuSendResult>;
   addReaction(messageId: string, emoji: string): Promise<string>;
+  removeReaction(messageId: string, reactionId: string): Promise<void>;
   close(): Promise<void>;
 }
 
@@ -120,6 +121,10 @@ export function createFeishuBot(
 
     addReaction(messageId: string, emoji: string): Promise<string> {
       return transport.addReaction(messageId, emoji);
+    },
+
+    removeReaction(messageId: string, reactionId: string): Promise<void> {
+      return transport.removeReaction(messageId, reactionId);
     },
 
     close(): Promise<void> {
@@ -235,9 +240,14 @@ export interface FakeFeishuBot extends FeishuBot {
     emoji: string;
     reactionId: string;
   }>;
+  readonly removedReactions: Array<{
+    messageId: string;
+    reactionId: string;
+  }>;
   inject(event: FeishuInboundEvent): Promise<void>;
   setSendError(err: Error | null): void;
   setReactionError(err: Error | null): void;
+  setRemoveReactionError(err: Error | null): void;
 }
 
 export function createFakeFeishuBot(appId: string = 'fake-bot'): FakeFeishuBot {
@@ -252,10 +262,15 @@ export function createFakeFeishuBot(appId: string = 'fake-bot'): FakeFeishuBot {
   let nextReactionId = 1;
   let sendError: Error | null = null;
   let reactionError: Error | null = null;
+  let removeReactionError: Error | null = null;
   const openId: string | undefined = `fake-open-id-${appId}`;
   const reactions: Array<{
     messageId: string;
     emoji: string;
+    reactionId: string;
+  }> = [];
+  const removedReactions: Array<{
+    messageId: string;
     reactionId: string;
   }> = [];
 
@@ -283,6 +298,12 @@ export function createFakeFeishuBot(appId: string = 'fake-bot'): FakeFeishuBot {
       reactions.push({ messageId, emoji, reactionId });
       return reactionId;
     },
+    async removeReaction(messageId: string, reactionId: string): Promise<void> {
+      if (removeReactionError !== null) {
+        throw removeReactionError;
+      }
+      removedReactions.push({ messageId, reactionId });
+    },
     async close(): Promise<void> {
       handler = null;
     },
@@ -291,6 +312,9 @@ export function createFakeFeishuBot(appId: string = 'fake-bot'): FakeFeishuBot {
     },
     get reactions() {
       return reactions;
+    },
+    get removedReactions() {
+      return removedReactions;
     },
     async inject(event: FeishuInboundEvent): Promise<void> {
       if (handler === null) throw new Error('fake bot not started');
@@ -301,6 +325,9 @@ export function createFakeFeishuBot(appId: string = 'fake-bot'): FakeFeishuBot {
     },
     setReactionError(err: Error | null): void {
       reactionError = err;
+    },
+    setRemoveReactionError(err: Error | null): void {
+      removeReactionError = err;
     },
   };
 }

--- a/packages/dreamux/src/server.ts
+++ b/packages/dreamux/src/server.ts
@@ -46,6 +46,7 @@ import {
 import { createAdminSocketServer, type AdminSocketServer } from './admin/socket.js';
 
 export const RECEIVED_REACTION_EMOJI = 'GLANCE';
+const MAX_PENDING_RECEIVED_REACTION_CLEARS = 1024;
 
 export interface ServerOptions {
   /**
@@ -91,6 +92,21 @@ interface DispatcherSlot {
 
 interface DispatcherChannelState {
   receivedReactions: Map<string, { chatId: string; reactionId: string }>;
+  pendingReceivedReactionClears: Set<string>;
+}
+
+export interface ServerMcpReplyInput {
+  dispatcherId: string;
+  chatId: string;
+  text: string;
+  messageId?: string;
+  mentionUserIds?: string[];
+}
+
+export interface ServerMcpReactInput {
+  dispatcherId: string;
+  messageId: string;
+  emoji: string;
 }
 
 export class Server {
@@ -209,6 +225,7 @@ export class Server {
       : createFeishuBot({ appId: row.bot_app_id, appSecret: botSecret });
     const channelState: DispatcherChannelState = {
       receivedReactions: new Map(),
+      pendingReceivedReactionClears: new Set(),
     };
 
     const runtime = new DispatcherRuntime(row, {
@@ -306,6 +323,43 @@ export class Server {
     return this.slots.get(id)?.runtime ?? null;
   }
 
+  async replyFromMcp(input: ServerMcpReplyInput): Promise<{ message_ids: string[] }> {
+    const slot = this.mustRunningSlot(input.dispatcherId);
+    const result = await slot.bot.send(
+      channelOutboundToFeishuTarget({
+        conversationId: input.chatId,
+        ...(input.messageId !== undefined ? { replyTo: input.messageId } : {}),
+        ...(input.mentionUserIds !== undefined
+          ? { mentionUsers: input.mentionUserIds }
+          : {}),
+      }),
+      input.text,
+    );
+    if (input.messageId !== undefined) {
+      await clearReceivedReaction(
+        input.dispatcherId,
+        slot.bot,
+        slot.channelState,
+        input.messageId,
+      );
+    }
+    return { message_ids: result.messageIds };
+  }
+
+  async reactFromMcp(input: ServerMcpReactInput): Promise<{ reaction_id: string }> {
+    const slot = this.mustRunningSlot(input.dispatcherId);
+    const reactionId = await slot.bot.addReaction(input.messageId, input.emoji);
+    return { reaction_id: reactionId };
+  }
+
+  private mustRunningSlot(id: string): DispatcherSlot {
+    const slot = this.slots.get(id);
+    if (slot === undefined) {
+      throw new Error(`dispatcher '${id}' is not running`);
+    }
+    return slot;
+  }
+
   /** Summary of every declared dispatcher (DB-backed, includes stopped). */
   summarize(): Array<{
     dispatcher_id: string;
@@ -361,16 +415,64 @@ async function addReceivedReaction(
       console.error(
         `[server] Feishu returned no reaction_id for the received reaction in dispatcher '${dispatcherId}'`,
       );
+      channelState.pendingReceivedReactionClears.delete(event.messageId);
       return;
     }
     channelState.receivedReactions.set(event.messageId, {
       chatId: event.chatId,
       reactionId,
     });
+    if (channelState.pendingReceivedReactionClears.has(event.messageId)) {
+      await clearReceivedReaction(
+        dispatcherId,
+        bot,
+        channelState,
+        event.messageId,
+      );
+    }
   } catch (err) {
+    channelState.pendingReceivedReactionClears.delete(event.messageId);
     console.error(
       `[server] failed to add the received reaction for dispatcher '${dispatcherId}':`,
       err,
     );
+  }
+}
+
+async function clearReceivedReaction(
+  dispatcherId: string,
+  bot: FeishuBot,
+  channelState: DispatcherChannelState,
+  messageId: string,
+): Promise<void> {
+  const reaction = channelState.receivedReactions.get(messageId);
+  if (reaction === undefined) {
+    rememberPendingReceivedReactionClear(channelState, messageId);
+    return;
+  }
+  try {
+    await bot.removeReaction(messageId, reaction.reactionId);
+    channelState.receivedReactions.delete(messageId);
+    channelState.pendingReceivedReactionClears.delete(messageId);
+  } catch (err) {
+    console.error(
+      `[server] failed to clear the received reaction for dispatcher '${dispatcherId}' message '${messageId}':`,
+      err,
+    );
+  }
+}
+
+function rememberPendingReceivedReactionClear(
+  channelState: DispatcherChannelState,
+  messageId: string,
+): void {
+  channelState.pendingReceivedReactionClears.add(messageId);
+  while (
+    channelState.pendingReceivedReactionClears.size >
+    MAX_PENDING_RECEIVED_REACTION_CLEARS
+  ) {
+    const oldest = channelState.pendingReceivedReactionClears.values().next().value;
+    if (typeof oldest !== 'string') return;
+    channelState.pendingReceivedReactionClears.delete(oldest);
   }
 }

--- a/packages/dreamux/tests/smoke.test.ts
+++ b/packages/dreamux/tests/smoke.test.ts
@@ -31,6 +31,7 @@ import {
 import { CodexWsClient } from '../src/codex/rpc.js';
 import { createFakeFeishuBot, type FakeFeishuBot, type FeishuInboundEvent } from '../src/feishu/bot.js';
 import { createAdminSocketServer } from '../src/admin/socket.js';
+import { sendAdminRequest } from '../src/admin/client.js';
 import {
   TRUST_DOMAIN_WARNING,
   loadDispatcherAccess,
@@ -361,6 +362,145 @@ describe('dreamux MVP smoke', () => {
     expect(args).toContain(
       `mcp_servers.feishu.args=["feishu-mcp", "--dispatcher", "flow", "--admin-socket", "${join(runtimeDir, 'admin.sock')}"]`,
     );
+  });
+
+  it('mcp.reply sends through the serve-owned bot and clears received reaction', async () => {
+    await fake.close();
+    codexInputs = [];
+    fake = await startFakeCodex({
+      turnDelayMs: 2000,
+      replyFor: captureAndEchoCodexInput(codexInputs),
+    });
+    server = buildServer({ runtimeDir, fake, bot });
+    server.repos.dispatchers.create({
+      dispatcher_id: 'flow',
+      bot_app_id: 'app-smoke',
+      bot_secret_ref: 'env:UNUSED',
+    });
+    await server.start();
+
+    await bot.inject(fakeInbound('chat-group-a', 'needs reply', 'msg-mcp-reply'));
+    await waitFor(() => bot.reactions.length === 1);
+
+    const result = await sendAdminRequest(
+      'mcp.reply',
+      {
+        dispatcher_id: 'flow',
+        chat_id: 'chat-group-a',
+        message_id: 'msg-mcp-reply',
+        text: 'manual mcp reply',
+        mention_user_ids: ['sender-test'],
+      },
+      { socketPath: join(runtimeDir, 'admin.sock') },
+    ) as { message_ids: string[] };
+
+    expect(result.message_ids).toEqual(['message-fake-1']);
+    expect(bot.sentMessages[0]).toMatchObject({
+      chatId: 'chat-group-a',
+      target: {
+        chatId: 'chat-group-a',
+        replyToMessageId: 'msg-mcp-reply',
+        mentionUserIds: ['sender-test'],
+      },
+      text: 'manual mcp reply',
+    });
+    expect(bot.removedReactions).toEqual([
+      {
+        messageId: 'msg-mcp-reply',
+        reactionId: 'reaction-fake-1',
+      },
+    ]);
+  });
+
+  it('mcp.reply clears a received reaction even when reply wins the add-reaction race', async () => {
+    await fake.close();
+    codexInputs = [];
+    fake = await startFakeCodex({
+      turnDelayMs: 2000,
+      replyFor: captureAndEchoCodexInput(codexInputs),
+    });
+
+    let releaseReaction!: () => void;
+    let markReactionStarted!: () => void;
+    const reactionStarted = new Promise<void>((resolve) => {
+      markReactionStarted = resolve;
+    });
+    const reactionBlocked = new Promise<void>((resolve) => {
+      releaseReaction = resolve;
+    });
+    const originalAddReaction = bot.addReaction.bind(bot);
+    bot.addReaction = async (messageId, emoji) => {
+      markReactionStarted();
+      await reactionBlocked;
+      return originalAddReaction(messageId, emoji);
+    };
+
+    server = buildServer({ runtimeDir, fake, bot });
+    server.repos.dispatchers.create({
+      dispatcher_id: 'flow',
+      bot_app_id: 'app-smoke',
+      bot_secret_ref: 'env:UNUSED',
+    });
+    await server.start();
+
+    const injected = bot.inject(
+      fakeInbound('chat-group-a', 'fast reply', 'msg-race-reaction'),
+    );
+    await reactionStarted;
+
+    const result = await sendAdminRequest(
+      'mcp.reply',
+      {
+        dispatcher_id: 'flow',
+        chat_id: 'chat-group-a',
+        message_id: 'msg-race-reaction',
+        text: 'manual race reply',
+      },
+      { socketPath: join(runtimeDir, 'admin.sock') },
+    ) as { message_ids: string[] };
+
+    expect(result.message_ids).toEqual(['message-fake-1']);
+    expect(bot.removedReactions).toEqual([]);
+
+    releaseReaction();
+    await injected;
+    await waitFor(() => bot.removedReactions.length === 1);
+    expect(bot.removedReactions).toEqual([
+      {
+        messageId: 'msg-race-reaction',
+        reactionId: 'reaction-fake-1',
+      },
+    ]);
+  });
+
+  it('mcp.react adds a model-owned reaction without clearing received reactions', async () => {
+    server = buildServer({ runtimeDir, fake, bot });
+    server.repos.dispatchers.create({
+      dispatcher_id: 'flow',
+      bot_app_id: 'app-smoke',
+      bot_secret_ref: 'env:UNUSED',
+    });
+    await server.start();
+
+    const result = await sendAdminRequest(
+      'mcp.react',
+      {
+        dispatcher_id: 'flow',
+        message_id: 'msg-model-react',
+        emoji: 'THUMBSUP',
+      },
+      { socketPath: join(runtimeDir, 'admin.sock') },
+    ) as { reaction_id: string };
+
+    expect(result.reaction_id).toBe('reaction-fake-1');
+    expect(bot.reactions).toEqual([
+      {
+        messageId: 'msg-model-react',
+        emoji: 'THUMBSUP',
+        reactionId: 'reaction-fake-1',
+      },
+    ]);
+    expect(bot.removedReactions).toEqual([]);
   });
 
   it('creates the app-server socket directory outside the global Codex home', async () => {


### PR DESCRIPTION
## Summary

Implements #36 Task 10: serve-owned outbound reply/react handling behind the Feishu MCP shim.

Changes:

- Replace the Task 9 `mcp.reply` / `mcp.react` admin placeholders with live serve-side handlers.
- Keep Feishu credentials and SDK calls in `dreamux serve`: the MCP shim still only forwards to the admin socket.
- Send MCP `reply` through the dispatcher-owned Feishu bot using `chat_id`, optional `message_id`, and optional mentions.
- Add MCP `react` as a model-owned reaction path that does not touch channel-owned received reactions.
- Expose `removeReaction` through the dreamux Feishu bot adapter and fake bot.
- Clear only current-process channel-owned received reactions after successful MCP `reply`.
- Cover the interleaving where `reply` wins the race before the async received `addReaction` has stored its `reaction_id`; the server records a pending clear and removes the reaction after the id arrives.

## Validation

- `node common/scripts/install-run-rush.js build --to @excitedjs/dreamux`
- `cd packages/dreamux && ./node_modules/.bin/vitest run tests/smoke.test.ts tests/feishu-bot.test.ts tests/feishu-mcp.test.ts`
- `node common/scripts/install-run-rush.js test --to @excitedjs/dreamux`
- `.agents/scripts/check.sh`
- `git diff --check`
- staged diff red-line scan for public-repo leak patterns

Refs #36.