### PR TITLE
Add Task 12 e2e and live Codex coverage

### DIFF
--- a/packages/dreamux/tests/e2e.test.ts
+++ b/packages/dreamux/tests/e2e.test.ts
@@ -1,0 +1,368 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import {
+  mkdirSync,
+  mkdtempSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { PassThrough } from 'node:stream';
+
+import { RECEIVED_REACTION_EMOJI, Server } from '../src/server.js';
+import { sendAdminRequest } from '../src/admin/client.js';
+import { loadDispatcherAccess } from '../src/channel/feishu-gate.js';
+import { CodexWsClient } from '../src/codex/rpc.js';
+import {
+  CodexProcess,
+  type CodexProcessOptions,
+} from '../src/codex/supervisor.js';
+import {
+  createFakeFeishuBot,
+  type FakeFeishuBot,
+  type FeishuInboundEvent,
+} from '../src/feishu/bot.js';
+import { runFeishuMcp } from '../src/mcp/feishu-mcp.js';
+import { BUILT_IN_DEFAULTS, type DreamuxConfig } from '../src/runtime/config.js';
+import {
+  dispatcherCodexCwd,
+  dispatcherCodexHome,
+  dispatcherWorkspaceSkillPath,
+} from '../src/runtime/paths.js';
+import { startFakeCodex, type FakeCodex } from './fake-codex.js';
+
+class NoopCodexProcess extends CodexProcess {
+  constructor(opts: CodexProcessOptions) {
+    super(opts);
+  }
+
+  override async start(): Promise<void> {
+    // No child process; e2e tests connect the runtime to fake Codex.
+  }
+
+  override async reap(): Promise<void> {
+    // Nothing to reap.
+  }
+}
+
+class JsonLineReader {
+  private buffer = '';
+  private readonly waiters: Array<(value: unknown) => void> = [];
+
+  constructor(stream: PassThrough) {
+    stream.setEncoding('utf8');
+    stream.on('data', (chunk: string) => {
+      this.buffer += chunk;
+      this.drain();
+    });
+  }
+
+  next(): Promise<unknown> {
+    const line = this.shiftLine();
+    if (line !== null) return Promise.resolve(JSON.parse(line));
+    return new Promise((resolve) => {
+      this.waiters.push(resolve);
+    });
+  }
+
+  private drain(): void {
+    while (this.waiters.length > 0) {
+      const line = this.shiftLine();
+      if (line === null) return;
+      this.waiters.shift()!(JSON.parse(line));
+    }
+  }
+
+  private shiftLine(): string | null {
+    const idx = this.buffer.indexOf('\n');
+    if (idx === -1) return null;
+    const line = this.buffer.slice(0, idx);
+    this.buffer = this.buffer.slice(idx + 1);
+    return line;
+  }
+}
+
+function configWithDispatcher(): DreamuxConfig {
+  return {
+    ...BUILT_IN_DEFAULTS,
+    dispatchers: [
+      {
+        id: 'flow',
+        cwd: null,
+        enabled: true,
+        feishu: {
+          app_id: 'app-e2e',
+          app_secret: 'secret-server-only',
+        },
+        codex: {
+          approval_policy: null,
+          sandbox_mode: null,
+          extra_args: [],
+          extra_env: {},
+        },
+      },
+    ],
+  };
+}
+
+function buildServer(opts: {
+  runtimeDir: string;
+  fake: FakeCodex;
+  bot: FakeFeishuBot;
+}): Server {
+  return new Server({
+    config: configWithDispatcher(),
+    adminSocketPath: join(opts.runtimeDir, 'admin.sock'),
+    skipBotSecret: true,
+    botFactory: () => opts.bot,
+    codexProcessFactory: (o) => new NoopCodexProcess(o),
+    codexClientFactory: () => new CodexWsClient({ url: opts.fake.url }),
+    codexHomeDoctor: () => {
+      /* fake Codex tests do not require real operator Codex auth */
+    },
+  });
+}
+
+function fakeInbound(
+  chatId: string,
+  text: string,
+  messageId: string,
+): FeishuInboundEvent {
+  return {
+    messageId,
+    chatId,
+    chatType: 'group',
+    senderId: 'sender-test',
+    senderType: 'user',
+    senderName: 'Ada',
+    messageType: 'text',
+    rawContent: JSON.stringify({ text }),
+    parsedText: text,
+    mentions: [
+      {
+        key: '@_user_1',
+        id: { open_id: 'fake-open-id-app-e2e' },
+        name: 'Dispatcher',
+      },
+    ],
+    createTime: '1710000000000',
+    raw: { event: { message: { chat_id: chatId, message_id: messageId } } },
+  };
+}
+
+function captureCodexInputs(inputs: string[]): (input: string) => string {
+  return (input) => {
+    inputs.push(input);
+    return 'assistant text must not be sent automatically';
+  };
+}
+
+async function callFeishuMcpTool(
+  runtimeDir: string,
+  params: Record<string, unknown>,
+): Promise<Record<string, unknown>> {
+  const input = new PassThrough();
+  const output = new PassThrough();
+  const reader = new JsonLineReader(output);
+  const run = runFeishuMcp({
+    dispatcherId: 'flow',
+    adminSocketPath: join(runtimeDir, 'admin.sock'),
+    input,
+    output,
+    log: () => {},
+  });
+
+  writeJson(input, {
+    jsonrpc: '2.0',
+    id: 1,
+    method: 'initialize',
+    params: { protocolVersion: '2025-06-18' },
+  });
+  expect(await reader.next()).toMatchObject({
+    id: 1,
+    result: { protocolVersion: '2025-06-18' },
+  });
+
+  writeJson(input, {
+    jsonrpc: '2.0',
+    id: 2,
+    method: 'tools/call',
+    params,
+  });
+  const response = await reader.next() as Record<string, unknown>;
+  input.end();
+  await run;
+  return response;
+}
+
+function writeJson(input: PassThrough, value: unknown): void {
+  input.write(`${JSON.stringify(value)}\n`);
+}
+
+async function waitFor(
+  predicate: () => boolean,
+  timeoutMs = 3000,
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (predicate()) return;
+    await new Promise((resolve) => setTimeout(resolve, 20));
+  }
+  throw new Error('waitFor timed out');
+}
+
+function writeReadyDispatcherWorkspace(dispatcherId: string): void {
+  mkdirSync(dispatcherCodexHome(dispatcherId), { recursive: true });
+  writeFileSync(join(dispatcherCodexHome(dispatcherId), 'auth.json'), '{}', {
+    mode: 0o600,
+  });
+  const skillPath = dispatcherWorkspaceSkillPath(
+    dispatcherCodexCwd(dispatcherId),
+  );
+  mkdirSync(dirname(skillPath), { recursive: true });
+  writeFileSync(skillPath, '# test skill\n');
+}
+
+describe('dreamux cross-module e2e', () => {
+  let runtimeDir: string;
+  let previousHome: string | undefined;
+  let fake: FakeCodex;
+  let bot: FakeFeishuBot;
+  let server: Server | null;
+  let codexInputs: string[];
+
+  beforeEach(async () => {
+    runtimeDir = mkdtempSync(join(tmpdir(), 'dreamux-e2e-'));
+    previousHome = process.env['HOME'];
+    process.env['HOME'] = join(runtimeDir, 'home');
+    writeReadyDispatcherWorkspace('flow');
+    codexInputs = [];
+    fake = await startFakeCodex({
+      replyFor: captureCodexInputs(codexInputs),
+    });
+    bot = createFakeFeishuBot('app-e2e');
+    server = null;
+  });
+
+  afterEach(async () => {
+    try {
+      await server?.shutdown();
+    } catch {
+      /* best-effort cleanup */
+    }
+    await fake?.close();
+    if (previousHome === undefined) delete process.env['HOME'];
+    else process.env['HOME'] = previousHome;
+    rmSync(runtimeDir, { recursive: true, force: true });
+  });
+
+  it('delivers fake Feishu inbound to Codex and replies through the stdio MCP shim', async () => {
+    server = buildServer({ runtimeDir, fake, bot });
+    await server.start();
+
+    await bot.inject(fakeInbound('chat-group-a', 'please reply', 'msg-e2e-1'));
+
+    await waitFor(() => codexInputs.length === 1);
+    await waitFor(() => bot.reactions.length === 1);
+    expect(codexInputs[0]).toContain('<feishu_message');
+    expect(codexInputs[0]).toContain('sender_name="Ada"');
+    expect(codexInputs[0]).toContain('please reply');
+    expect(bot.reactions).toEqual([
+      {
+        messageId: 'msg-e2e-1',
+        emoji: RECEIVED_REACTION_EMOJI,
+        reactionId: 'reaction-fake-1',
+      },
+    ]);
+
+    const response = await callFeishuMcpTool(runtimeDir, {
+      name: 'reply',
+      arguments: {
+        chat_id: 'chat-group-a',
+        message_id: 'msg-e2e-1',
+        text: 'reply from MCP',
+        mention_user_ids: ['sender-test'],
+      },
+    });
+
+    expect(response).toMatchObject({
+      jsonrpc: '2.0',
+      id: 2,
+      result: {
+        structuredContent: { message_ids: ['message-fake-1'] },
+      },
+    });
+    expect(bot.sentMessages).toEqual([
+      {
+        chatId: 'chat-group-a',
+        messageIds: ['message-fake-1'],
+        target: {
+          chatId: 'chat-group-a',
+          replyToMessageId: 'msg-e2e-1',
+          mentionUserIds: ['sender-test'],
+        },
+        text: 'reply from MCP',
+      },
+    ]);
+    expect(bot.removedReactions).toEqual([
+      {
+        messageId: 'msg-e2e-1',
+        reactionId: 'reaction-fake-1',
+      },
+    ]);
+  });
+
+  it('keeps received-reaction cleanup process-local across a server restart', async () => {
+    server = buildServer({ runtimeDir, fake, bot });
+    await server.start();
+
+    await bot.inject(
+      fakeInbound('chat-group-a', 'restart before reply', 'msg-restart'),
+    );
+    await waitFor(() => codexInputs.length === 1);
+    await waitFor(() => bot.reactions.length === 1);
+    expect(loadDispatcherAccess('flow').observed_chats).toEqual(['chat-group-a']);
+
+    await server.shutdown();
+    server = buildServer({ runtimeDir, fake, bot });
+    await server.start();
+
+    const response = await callFeishuMcpTool(runtimeDir, {
+      name: 'reply',
+      arguments: {
+        chat_id: 'chat-group-a',
+        message_id: 'msg-restart',
+        text: 'late reply',
+      },
+    });
+
+    expect(response).toMatchObject({
+      result: {
+        structuredContent: { message_ids: ['message-fake-1'] },
+      },
+    });
+    expect(bot.sentMessages).toHaveLength(1);
+    expect(bot.removedReactions).toEqual([]);
+    expect(bot.reactions).toEqual([
+      {
+        messageId: 'msg-restart',
+        emoji: RECEIVED_REACTION_EMOJI,
+        reactionId: 'reaction-fake-1',
+      },
+    ]);
+  });
+
+  it('surfaces server status without leaking Feishu secrets', async () => {
+    server = buildServer({ runtimeDir, fake, bot });
+    await server.start();
+
+    const status = await sendAdminRequest(
+      'server.status',
+      {},
+      { socketPath: join(runtimeDir, 'admin.sock') },
+    );
+
+    expect(JSON.stringify(status)).toContain('flow');
+    expect(JSON.stringify(status)).not.toContain('secret-server-only');
+  });
+});


### PR DESCRIPTION
## Summary

Implements Task 12 from #36.

- Add cross-module e2e coverage for fake Feishu inbound reaching Codex, then replying through the Feishu MCP stdio shim, admin socket, and serve-owned outbound path.
- Cover the accepted restart limitation: received-reaction cleanup is process-local, so a server restart does not remove reactions added by a previous process.
- Keep live Codex coverage on the established compatibility gate: real Codex app-server startup plus injected Feishu MCP stdio config exposing `reply` and `react` via `mcpServerStatus/list`.
- Add an e2e status redaction assertion so the cross-module path does not leak Feishu secrets.

## Tests

- `pnpm --dir packages/dreamux exec vitest run tests/e2e.test.ts tests/codex-live.test.ts`
- `pnpm --dir packages/dreamux build`
- `pnpm --dir packages/dreamux test`
- `node common/scripts/install-run-rush.js build`
- `node common/scripts/install-run-rush.js test`
- `.agents/scripts/check.sh`
- `git diff --check`
- `git diff --cached --check`
- `gitleaks protect --staged --redact --config .gitleaks.toml`
- staged public-repo red-line scan for internal IDs, registry URLs, hostnames, and local absolute paths

Notes:

- The live Codex test ran against `codex-cli 0.136.0` without `DREAMUX_SKIP_LIVE_CODEX=1`.
- Rush still warns that it cannot hash the untracked `.claude/` worktree for repo-state caching, and Rush reports test stderr as warnings; both commands completed successfully.