### PR TITLE
Fix release workflow version-bump push

### DIFF
--- a/.agents/decisions/npm-release-oidc.md
+++ b/.agents/decisions/npm-release-oidc.md
@@ -32,10 +32,13 @@ Three hard constraints shaped the design:
   and sets `NPM_CONFIG_PROVENANCE=true` on the Rush publish step. That setting
   is inherited by the final npm publish process used by pnpm, where npm
   exchanges the GitHub Actions OIDC id-token for a short-lived publish token.
-- **Main is protected.** The [anti-leak guardrail](anti-leak-guardrail.md) makes the
-  `gitleaks` check required on `main`, so the workflow uses a GitHub App token
-  rather than the default `GITHUB_TOKEN` when it pushes the bot version-bump
-  commit to `main`.
+- **The release bot push should not need owner-only secrets by default.** Main
+  currently enforces linear history but does not require a release-specific
+  GitHub App bypass. The workflow therefore uses the built-in workflow token to
+  push the generated version-bump commit. If branch protection later adds
+  required checks or a PR-only gate that blocks `github-actions[bot]`, maintainers
+  must either allow that bot to bypass the rule or reintroduce a dedicated
+  release GitHub App.
 
 ## Decision
 
@@ -43,12 +46,12 @@ One workflow, `push: [main]` plus manual dispatch:
 
 - **`/.github/workflows/release.yml`** — the single release pipeline and the
   workflow every publishable package registers as its trusted publisher. On a
-  push to `main`, it first checks whether that push introduced new Rush change
-  files under `/common/changes/`. If not, it no-ops, which prevents the bot's
-  own release commit from looping. If yes, it installs through Rush and runs
+  push to `main`, it first checks whether pending Rush change files exist under
+  `/common/changes/`. If not, it no-ops, which prevents the bot's own release
+  commit from looping. If yes, it installs through Rush and runs
   `rush publish --apply` to consume those change files into package.json and
   CHANGELOG bumps across all changed packages. It commits those version
-  artifacts back to `main` with a GitHub App token, then a separate publish job
+  artifacts back to `main` with the workflow token, then a separate publish job
   checks out the updated branch, builds the monorepo, and runs
   `rush publish --include-all --publish --set-access-level public` against the
   public npm registry. Rush compares every publishable package against npm and
@@ -86,16 +89,22 @@ monorepo-wide.
   `workspace:` dependencies are valid in source package manifests, but raw
   `npm publish` from a package directory is forbidden; the release workflow must
   use Rush native publish so pnpm prepares the registry manifest.
-- **Required GitHub App secrets:** `DREAMUX_RELEASE_APP_ID` and
-  `DREAMUX_RELEASE_APP_PRIVATE_KEY`. The App must be allowed to push the
-  release bot commit to protected `main`.
+- **No release GitHub App secrets are required for the current branch
+  protection.** The repository action setting must keep workflow tokens writable
+  for contents, and `main` must keep allowing `github-actions[bot]` to push the
+  generated version-bump commit. If a future protection rule blocks that push,
+  this becomes an owner decision: grant the workflow bot a bypass or reintroduce
+  a release GitHub App.
 - **Optional hardening:** run the publish in a protected GitHub Environment with
   required reviewers (commented in the workflow); if enabled it must match the
   npm trusted-publisher Environment field of every package.
 - The workflow self-breaks its trigger loop: push-triggered runs proceed only
-  when the push added a Rush change file under `/common/changes/`. The bot
+  while pending Rush change files exist under `/common/changes/`. The bot
   version-bump commit consumes those files and includes `[skip ci]`, so it does
-  not start a redundant CI/release run. Manual dispatch on `main` skips this
+  not start a redundant CI/release run. Because the guard checks the current
+  branch contents rather than only files added by the triggering push, a later
+  workflow repair can automatically retry a release that previously failed after
+  change files had already landed. Manual dispatch on `main` skips this
   change-file guard so maintainers can retry publishing already-versioned
   packages after a transient npm or OIDC failure.
 
@@ -116,3 +125,7 @@ monorepo-wide.
   proved the operational shape: a merge to `main` should be enough to version
   and publish packages. The PR model avoided a GitHub App secret, but it made
   every release a second maintainer action.
+- **Dedicated release GitHub App for the version-bump commit** — deferred. It is
+  necessary only when branch protection prevents the built-in workflow token from
+  pushing the generated commit. The current repository settings do not require
+  that extra owner-managed credential.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,10 +34,10 @@
 # Manual dispatch is a retry hook for main only; npm publishes must not come
 # from feature branches.
 #
-# When a version bump is needed, the release job needs a GitHub App token that
-# is allowed to push the version-bump commit to protected main:
-#   DREAMUX_RELEASE_APP_ID
-#   DREAMUX_RELEASE_APP_PRIVATE_KEY
+# When a version bump is needed, the release job pushes the generated
+# package.json / CHANGELOG commit back to main with the workflow GITHUB_TOKEN.
+# This repository's main protection must continue to allow that bot push, or a
+# future stricter protection rule must grant github-actions[bot] a bypass.
 
 name: release
 
@@ -78,18 +78,18 @@ jobs:
         id: version
         env:
           EVENT: ${{ github.event_name }}
-          PUSH_BEFORE: ${{ github.event.before }}
-          PUSH_SHA: ${{ github.sha }}
         run: |
           set -euo pipefail
 
-          # Push-triggered releases only run when this push introduced a Rush
-          # change file. The bot's own version-bump commit deletes change files
-          # and contains [skip ci], so it cannot loop back into another release.
+          # Push-triggered releases run whenever main has pending Rush change
+          # files. This covers the normal merge path and lets a later workflow
+          # repair retry a release that previously failed after the change files
+          # had already landed. The bot's own version-bump commit deletes those
+          # files and contains [skip ci], so it cannot loop.
           if [ "$EVENT" = push ]; then
-            added="$(git diff --name-only --diff-filter=A "$PUSH_BEFORE" "$PUSH_SHA" -- common/changes | grep -E '^common/changes/.+\.json$' || true)"
-            if [ -z "$added" ]; then
-              echo 'No newly added Rush change files in this push; skipping.'
+            pending="$(find common/changes -type f -name '*.json' -print -quit 2>/dev/null || true)"
+            if [ -z "$pending" ]; then
+              echo 'No pending Rush change files on main; skipping.'
               echo "should_publish=false" >> "$GITHUB_OUTPUT"
               exit 0
             fi
@@ -113,25 +113,17 @@ jobs:
           echo "changed=true" >> "$GITHUB_OUTPUT"
           echo "should_publish=true" >> "$GITHUB_OUTPUT"
 
-      - name: Create dreamux release app token
-        if: steps.version.outputs.changed == 'true'
-        id: app-token
-        uses: actions/create-github-app-token@v1
-        with:
-          app-id: ${{ secrets.DREAMUX_RELEASE_APP_ID }}
-          private-key: ${{ secrets.DREAMUX_RELEASE_APP_PRIVATE_KEY }}
-
       - name: Push version bump
         if: steps.version.outputs.changed == 'true'
         env:
-          APP_TOKEN: ${{ steps.app-token.outputs.token }}
+          GITHUB_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
           git config user.name 'github-actions[bot]'
           git config user.email 'github-actions[bot]@users.noreply.github.com'
           git add packages common/changes
           git commit -m "chore(release): version packages [skip ci]"
-          git remote set-url origin "https://x-access-token:${APP_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+          git remote set-url origin "https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
           git push origin HEAD:"${GITHUB_REF_NAME}"
 
   publish:


### PR DESCRIPTION
## Summary

Fix the release workflow failure seen after PR #58 merged to `main`.

The failed run reached `Create dreamux release app token` and stopped because the repository does not define `DREAMUX_RELEASE_APP_ID`. Current `main` protection only enforces linear history, and Actions workflow permissions allow `contents: write`, so this release path does not need an owner-managed GitHub App secret.

## Changes

- Use the built-in workflow token to push the Rush version-bump commit back to `main`.
- Retry push-triggered releases whenever `main` still has pending Rush change files, instead of only when the triggering push newly added them. This lets a workflow repair recover a previously failed release that left change files on `main`.
- Update the release decision record to document the current credential model and the future decision point if branch protection becomes stricter.

## Validation

- Confirmed the failing run root cause from run `26930647702`: missing `app-id` input for `actions/create-github-app-token`.
- Confirmed current branch protection and Actions settings allow this token model:
  - `main` protection: linear history only.
  - workflow token default permission: write.
- Parsed `.github/workflows/release.yml` with PyYAML.
- Syntax-checked the changed shell snippets.
- Verified the pending change-file guard detects the existing release change files.
- Ran `.agents/scripts/check.sh`.
- Ran `git diff --check` / `git diff --cached --check`.
- Ran `gitleaks protect --staged --redact --config .gitleaks.toml`.
- In a temporary worktree, ran:
  - `node common/scripts/install-run-rush.js install`
  - `node common/scripts/install-run-rush.js publish --apply`
  - `node common/scripts/install-run-rush.js build`
- The release apply produced the expected next versions:
  - `@excitedjs/dreamux@0.3.0`
  - `@excitedjs/feishu-transport@0.1.0`

## Remaining setup

This removes the GitHub App secret requirement. npm trusted publishing still must be configured per package for `release.yml` on npmjs.com, which is outside repository code.
