### PR TITLE
Fix systemd service Node environment for nvm installs

### DIFF
--- a/.agents/decisions/global-bin-onboard-serve.md
+++ b/.agents/decisions/global-bin-onboard-serve.md
@@ -46,6 +46,14 @@ channel configuration, and registers a native service manager entry.
 `dreamux serve` runs the existing server in the foreground and lets launchd or
 systemd keep it alive.
 
+The generated service environment must be self-sufficient. It must not rely on
+interactive shell startup files such as `.zshrc` to make Node or Codex
+available. During onboarding, dreamux captures the Node executable that is
+running onboarding, validates that it satisfies the package's supported Node
+range, resolves the Codex executable to a runnable path for managed service use,
+seeds `HOME` for clean user-service probes, and renders those values into the
+user service environment.
+
 There is no public `dreamux daemon ...` command tree. The daemon form is
 foreground `dreamux serve` supervised by a native user-level service manager.
 After `dreamux onboard` registers that service, operators use native
@@ -119,6 +127,10 @@ status.
 - The `dreamux` launcher passes its resolved absolute path through
   `DREAMUX_BIN`; service generation uses that path so launchd and
   systemd execute the same global bin the operator invoked.
+- The `dreamux` launcher honors `DREAMUX_NODE_BIN` when present, falling back to
+  `node` for ordinary interactive and npm-bin use. Service generation sets
+  `DREAMUX_NODE_BIN` and a minimal `PATH` so nvm-installed Node works without
+  sourcing shell rc files.
 - Codex's global default home is intentionally reused, so login state, memory,
   and local Codex configuration follow the operator's machine. dreamux must not
   delete that home during uninstall.

--- a/common/changes/@excitedjs/dreamux/codex-systemd-nvm-service-env_2026-06-04-07-19.json
+++ b/common/changes/@excitedjs/dreamux/codex-systemd-nvm-service-env_2026-06-04-07-19.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Fix managed service startup when Node is provided by nvm.",
+      "type": "patch",
+      "packageName": "@excitedjs/dreamux"
+    }
+  ],
+  "packageName": "@excitedjs/dreamux",
+  "email": "15624809+YourWildDad@users.noreply.github.com"
+}

--- a/packages/dreamux/bin/dreamux
+++ b/packages/dreamux/bin/dreamux
@@ -30,4 +30,5 @@ if [ ! -f "$TARGET" ]; then
   echo "Build it first from the repo root: node common/scripts/install-run-rush.js build (rush build)." >&2
   exit 1
 fi
-exec env DREAMUX_BIN="$DREAMUX_BIN" node "$TARGET" "$@"
+NODE_BIN="${DREAMUX_NODE_BIN:-node}"
+exec env DREAMUX_BIN="$DREAMUX_BIN" "$NODE_BIN" "$TARGET" "$@"

--- a/packages/dreamux/src/cli/doctor.ts
+++ b/packages/dreamux/src/cli/doctor.ts
@@ -1,5 +1,7 @@
-import { existsSync } from 'node:fs';
+import { existsSync, readFileSync } from 'node:fs';
 import { homedir } from 'node:os';
+
+import { parse as parsePlist, type PlistValue } from 'plist';
 
 import { codexArgsToCli, parseCodexArgs } from '../runtime/codex-args.js';
 import {
@@ -23,7 +25,8 @@ import {
 import { ExecaCommandRunner } from '../onboard/commands.js';
 import {
   LAUNCHD_LABEL,
-  managedServiceEnvironment,
+  MIN_SERVICE_NODE_VERSION,
+  nodeVersionSatisfies,
   serviceUnitPath,
   SYSTEMD_UNIT,
 } from '../onboard/service.js';
@@ -46,6 +49,8 @@ export interface ServiceStatus {
   enabled: boolean;
   pid: number | null;
   detail: string | null;
+  environment: Record<string, string> | null;
+  execStart: string[] | null;
 }
 
 export interface DoctorCheck {
@@ -103,6 +108,7 @@ export async function runDreamuxDoctor(
       ? `installed at ${service.unitPath}`
       : `not installed at ${service.unitPath}`,
   });
+  await addManagedServiceLaunchChecks(checks, service, runner);
 
   const dispatchers = readDispatchers(config, options.env ?? process.env, service);
   if (dispatchers.length === 0) {
@@ -187,16 +193,10 @@ function readDispatchers(
       env,
       codexCliArgs,
     });
+    const managedServiceEnv = service.environment ?? {};
     const managedService = service.installed
       ? validateDispatcherCodexHome(context, {
-          env: managedServiceEnvironment({
-            configDir: globalConfigDir(),
-            runtimeDir: stateRoot(),
-            codexBin: process.env['CODEX_HOST_CODEX_BIN'] || config.codex.bin,
-            dreamuxBin: process.env['DREAMUX_BIN'] ?? process.argv[1],
-            startService: false,
-            dryRun: false,
-          }),
+          env: managedServiceEnv,
           codexCliArgs,
         })
       : null;
@@ -236,6 +236,7 @@ async function launchdStatus(
   runner: CommandRunner,
   uid?: number,
 ): Promise<ServiceStatus> {
+  const installed = existsSync(unitPath);
   const target = launchdTarget(uid);
   let raw = '';
   let loaded = false;
@@ -246,15 +247,20 @@ async function launchdStatus(
     loaded = false;
   }
   const pid = parseLaunchdPid(raw);
+  const unitFile = installed
+    ? parseLaunchdPlist(readFileSync(unitPath, 'utf8'))
+    : { environment: null, execStart: null };
   return {
     platform: 'launchd',
     unitPath,
-    installed: existsSync(unitPath),
-    enabled: existsSync(unitPath),
+    installed,
+    enabled: installed,
     loaded,
     running: pid !== null || /\bstate = running\b/.test(raw),
     pid,
     detail: parseLaunchdDetail(raw),
+    environment: unitFile.environment,
+    execStart: unitFile.execStart,
   };
 }
 
@@ -283,6 +289,9 @@ async function systemdStatus(
   } catch {
     raw = '';
   }
+  const unitFile = existsSync(unitPath)
+    ? parseSystemdUnit(readFileSync(unitPath, 'utf8'))
+    : { environment: null, execStart: null };
   const props = parseSystemdProperties(raw);
   return {
     platform: 'systemd',
@@ -293,7 +302,237 @@ async function systemdStatus(
     running: active || props['ActiveState'] === 'active',
     pid: parsePositiveInt(props['MainPID']),
     detail: systemdDetail(props),
+    environment: unitFile.environment,
+    execStart: unitFile.execStart,
   };
+}
+
+async function addManagedServiceLaunchChecks(
+  checks: DoctorCheck[],
+  service: ServiceStatus,
+  runner: CommandRunner,
+): Promise<void> {
+  if (!service.installed) return;
+  const env = service.environment;
+  const missing: string[] = [];
+  if (env === null) {
+    missing.push('managed service environment');
+  } else {
+    for (const key of ['PATH', 'DREAMUX_NODE_BIN', 'CODEX_HOST_CODEX_BIN']) {
+      if (env[key] === undefined || env[key]?.trim() === '') missing.push(key);
+    }
+  }
+  if (missing.length > 0) {
+    checks.push({
+      name: 'managed service environment',
+      ok: false,
+      detail: `${missing.join(', ')} missing in ${service.unitPath}; rerun dreamux onboard`,
+    });
+    return;
+  }
+
+  const serviceEnv = env as Record<string, string>;
+  const nodeBin = serviceEnv['DREAMUX_NODE_BIN'];
+  checks.push(await checkNodeLaunch(nodeBin, serviceEnv, runner));
+
+  const dreamuxBin = service.execStart?.[0];
+  checks.push(
+    await checkHelpLaunch(
+      'managed service dreamux launcher',
+      dreamuxBin,
+      ['--help'],
+      serviceEnv,
+      runner,
+      'ExecStart is missing in the installed service; rerun dreamux onboard',
+    ),
+  );
+
+  checks.push(
+    await checkHelpLaunch(
+      'managed service Codex binary',
+      serviceEnv['CODEX_HOST_CODEX_BIN'],
+      ['--help'],
+      serviceEnv,
+      runner,
+      'CODEX_HOST_CODEX_BIN is missing in the installed service; rerun dreamux onboard',
+    ),
+  );
+}
+
+async function checkNodeLaunch(
+  nodeBin: string,
+  env: NodeJS.ProcessEnv,
+  runner: CommandRunner,
+): Promise<DoctorCheck> {
+  try {
+    const version = await runner.capture(nodeBin, ['--version'], { env });
+    const ok = nodeVersionSatisfies(version);
+    return {
+      name: 'managed service Node binary',
+      ok,
+      detail: ok
+        ? `${nodeBin} (${version.trim()})`
+        : `${nodeBin} reported ${version.trim() || '<empty>'}; expected >=${MIN_SERVICE_NODE_VERSION}`,
+    };
+  } catch (err) {
+    return {
+      name: 'managed service Node binary',
+      ok: false,
+      detail: `${nodeBin} failed: ${err instanceof Error ? err.message : String(err)}; rerun dreamux onboard`,
+    };
+  }
+}
+
+async function checkHelpLaunch(
+  name: string,
+  command: string | undefined,
+  args: string[],
+  env: NodeJS.ProcessEnv,
+  runner: CommandRunner,
+  missingDetail: string,
+): Promise<DoctorCheck> {
+  if (command === undefined || command.trim() === '') {
+    return { name, ok: false, detail: missingDetail };
+  }
+  const ok = await runner.check(command, args, { env });
+  return {
+    name,
+    ok,
+    detail: ok ? command : `${command} failed under installed service environment; rerun dreamux onboard`,
+  };
+}
+
+function parseSystemdUnit(content: string): {
+  environment: Record<string, string> | null;
+  execStart: string[] | null;
+} {
+  const environment: Record<string, string> = {};
+  let execStart: string[] | null = null;
+  for (const rawLine of content.split(/\r?\n/)) {
+    const line = rawLine.trim();
+    if (line.startsWith('Environment=')) {
+      const assignment = line.slice('Environment='.length);
+      const eq = assignment.indexOf('=');
+      if (eq > 0) {
+        environment[assignment.slice(0, eq)] = systemdUnescapeEnv(
+          assignment.slice(eq + 1),
+        );
+      }
+    } else if (line.startsWith('ExecStart=')) {
+      execStart = splitSystemdCommand(line.slice('ExecStart='.length));
+    }
+  }
+  return {
+    environment: Object.keys(environment).length > 0 ? environment : null,
+    execStart,
+  };
+}
+
+function systemdUnescapeEnv(value: string): string {
+  let out = '';
+  for (let index = 0; index < value.length; index += 1) {
+    const ch = value[index];
+    if (ch !== '\\') {
+      out += ch;
+      continue;
+    }
+    if (value.slice(index, index + 4) === '\\x20') {
+      out += ' ';
+      index += 3;
+      continue;
+    }
+    const next = value[index + 1];
+    if (next === '\\') {
+      out += '\\';
+      index += 1;
+      continue;
+    }
+    if (next === '"') {
+      out += '"';
+      index += 1;
+      continue;
+    }
+    out += ch;
+  }
+  return out;
+}
+
+function splitSystemdCommand(value: string): string[] {
+  const args: string[] = [];
+  let current = '';
+  let quoted = false;
+  let escaped = false;
+  for (const ch of value) {
+    if (escaped) {
+      current += ch;
+      escaped = false;
+      continue;
+    }
+    if (ch === '\\') {
+      escaped = true;
+      continue;
+    }
+    if (ch === '"') {
+      quoted = !quoted;
+      continue;
+    }
+    if (!quoted && /\s/.test(ch)) {
+      if (current !== '') {
+        args.push(current);
+        current = '';
+      }
+      continue;
+    }
+    current += ch;
+  }
+  if (current !== '') args.push(current);
+  return args;
+}
+
+function parseLaunchdPlist(content: string): {
+  environment: Record<string, string> | null;
+  execStart: string[] | null;
+} {
+  let parsed: PlistValue;
+  try {
+    parsed = parsePlist(content);
+  } catch {
+    return { environment: null, execStart: null };
+  }
+  if (!isPlistRecord(parsed)) {
+    return { environment: null, execStart: null };
+  }
+  return {
+    environment: parseLaunchdEnvironment(parsed['EnvironmentVariables']),
+    execStart: parseLaunchdProgramArguments(parsed['ProgramArguments']),
+  };
+}
+
+function parseLaunchdEnvironment(
+  value: PlistValue | undefined,
+): Record<string, string> | null {
+  if (!isPlistRecord(value)) return null;
+  const environment: Record<string, string> = {};
+  for (const [key, raw] of Object.entries(value)) {
+    if (typeof raw === 'string') environment[key] = raw;
+  }
+  return Object.keys(environment).length > 0 ? environment : null;
+}
+
+function parseLaunchdProgramArguments(
+  value: PlistValue | undefined,
+): string[] | null {
+  if (!Array.isArray(value)) return null;
+  if (!value.every((item): item is string => typeof item === 'string')) {
+    return null;
+  }
+  return value.length > 0 ? value : null;
+}
+
+function isPlistRecord(
+  value: PlistValue | undefined,
+): value is Record<string, PlistValue> {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
 }
 
 function launchdTarget(uid?: number): string {

--- a/packages/dreamux/src/onboard/commands.ts
+++ b/packages/dreamux/src/onboard/commands.ts
@@ -2,20 +2,21 @@ import { execa } from 'execa';
 
 import type { CommandRunner } from './types.js';
 
+interface CommandOptions {
+  cwd?: string;
+  env?: NodeJS.ProcessEnv;
+  dryRun?: boolean;
+}
+
 export class ExecaCommandRunner implements CommandRunner {
   async run(
     command: string,
     args: string[],
-    options: {
-      cwd?: string;
-      env?: NodeJS.ProcessEnv;
-      dryRun?: boolean;
-    } = {},
+    options: CommandOptions = {},
   ): Promise<void> {
     if (options.dryRun) return;
     await execa(command, args, {
-      cwd: options.cwd,
-      env: options.env,
+      ...execaEnvironment(options),
       stdio: 'inherit',
     });
   }
@@ -23,16 +24,11 @@ export class ExecaCommandRunner implements CommandRunner {
   async check(
     command: string,
     args: string[],
-    options: {
-      cwd?: string;
-      env?: NodeJS.ProcessEnv;
-      dryRun?: boolean;
-    } = {},
+    options: CommandOptions = {},
   ): Promise<boolean> {
     if (options.dryRun) return false;
     const result = await execa(command, args, {
-      cwd: options.cwd,
-      env: options.env,
+      ...execaEnvironment(options),
       reject: false,
       stdout: 'ignore',
       stderr: 'ignore',
@@ -43,17 +39,24 @@ export class ExecaCommandRunner implements CommandRunner {
   async capture(
     command: string,
     args: string[],
-    options: {
-      cwd?: string;
-      env?: NodeJS.ProcessEnv;
-      dryRun?: boolean;
-    } = {},
+    options: CommandOptions = {},
   ): Promise<string> {
     if (options.dryRun) return '';
     const result = await execa(command, args, {
-      cwd: options.cwd,
-      env: options.env,
+      ...execaEnvironment(options),
     });
     return result.stdout;
   }
+}
+
+function execaEnvironment(options: CommandOptions): {
+  cwd?: string;
+  env?: NodeJS.ProcessEnv;
+  extendEnv: boolean;
+} {
+  return {
+    cwd: options.cwd,
+    env: options.env,
+    extendEnv: options.env === undefined,
+  };
 }

--- a/packages/dreamux/src/onboard/run.ts
+++ b/packages/dreamux/src/onboard/run.ts
@@ -32,13 +32,20 @@ import {
   TransparentFileLedger,
   writeTextFile,
 } from './ledger.js';
-import { installUserService, managedServiceEnvironment } from './service.js';
+import {
+  installUserService,
+  managedServiceEnvironment,
+  resolveServiceExecutable,
+  validateManagedServiceLaunch,
+} from './service.js';
 import type {
   CommandRunner,
   OnboardAnswers,
   OnboardFileLedger,
   OnboardRunResult,
 } from './types.js';
+
+type EffectiveOnboardAnswers = OnboardAnswers & { nodeBin: string };
 
 export interface RunOnboardOptions {
   answers: OnboardAnswers;
@@ -60,10 +67,14 @@ export async function runOnboard(
   const configPath = globalConfigFile({ configDir: answers.configDir });
   const existingConfig = readExistingDreamuxConfig(answers.configDir);
   const dreamuxConfig = dreamuxConfigFromAnswers(answers, existingConfig);
+  const serviceCodexBin = answers.registerService && !answers.dryRun
+    ? resolveServiceExecutable(dreamuxConfig.codex.bin, env)
+    : dreamuxConfig.codex.bin;
   const effectiveAnswers = {
     ...answers,
     runtimeDir: stateRoot(),
-    codexBin: dreamuxConfig.codex.bin,
+    codexBin: serviceCodexBin,
+    nodeBin: process.execPath,
   };
   setRuntimeConfig(dreamuxConfig);
 
@@ -117,6 +128,15 @@ export async function runOnboard(
   if (!effectiveAnswers.dryRun && !doctor.ok) {
     throw new Error(formatDoctorFailure(effectiveAnswers, doctor));
   }
+  if (effectiveAnswers.registerService && !effectiveAnswers.dryRun) {
+    const serviceLaunch = await validateManagedServiceLaunch(
+      effectiveAnswers,
+      runner,
+    );
+    if (!serviceLaunch.ok) {
+      throw new Error(formatServiceLaunchFailure(serviceLaunch.errors));
+    }
+  }
 
   const service = effectiveAnswers.registerService
     ? await installUserService({
@@ -136,6 +156,14 @@ export async function runOnboard(
   };
 }
 
+function formatServiceLaunchFailure(errors: string[]): string {
+  return [
+    'dreamux managed service launch environment is not ready',
+    ...errors.map((error) => `- ${error}`),
+    '- rerun dreamux onboard from the desired Node/Codex install, or pass explicit --dreamux-bin / --codex-bin values',
+  ].join('\n');
+}
+
 function readExistingDreamuxConfig(configDir: string) {
   const configPath = globalConfigFile({ configDir });
   assertNoLegacyTomlOnly({ configDir });
@@ -144,7 +172,7 @@ function readExistingDreamuxConfig(configDir: string) {
 }
 
 function runDispatcherDoctor(
-  answers: OnboardAnswers,
+  answers: EffectiveOnboardAnswers,
   dreamuxConfig: ReturnType<typeof dreamuxConfigFromAnswers>,
   env: NodeJS.ProcessEnv,
 ): DispatcherCodexHomeDoctorResult {
@@ -175,7 +203,7 @@ function runDispatcherDoctor(
 }
 
 function formatDoctorFailure(
-  answers: OnboardAnswers,
+  answers: EffectiveOnboardAnswers,
   doctor: DispatcherCodexHomeDoctorResult,
 ): string {
   const lines = [

--- a/packages/dreamux/src/onboard/service.ts
+++ b/packages/dreamux/src/onboard/service.ts
@@ -1,7 +1,9 @@
+import { accessSync, constants } from 'node:fs';
 import { homedir } from 'node:os';
-import { join } from 'node:path';
+import { delimiter, dirname, isAbsolute, join, resolve } from 'node:path';
 
 import { build as buildPlist } from 'plist';
+import { expandHome } from '../runtime/config.js';
 import { logsRoot, stateRoot } from '../runtime/paths.js';
 
 import {
@@ -17,12 +19,15 @@ import type {
 
 export const LAUNCHD_LABEL = 'dev.excited.dreamux';
 export const SYSTEMD_UNIT = 'dreamux.service';
+export const MIN_SERVICE_NODE_VERSION = '22.7.0';
+export const SERVICE_PATH_DEFAULTS = ['/usr/local/bin', '/usr/bin', '/bin'];
 
 export interface ServiceInstallAnswers {
   configDir: string;
   runtimeDir: string;
   codexBin: string;
   dreamuxBin: string;
+  nodeBin: string;
   startService: boolean;
   dryRun: boolean;
 }
@@ -160,9 +165,133 @@ export function managedServiceEnvironment(
 ): Record<string, string> {
   const env: Record<string, string> = {
     DREAMUX_CONFIG_DIR: answers.configDir,
+    HOME: homedir(),
     CODEX_HOST_CODEX_BIN: answers.codexBin,
+    DREAMUX_NODE_BIN: answers.nodeBin,
+    PATH: managedServicePath(answers),
   };
   return env;
+}
+
+export interface ServiceLaunchValidationResult {
+  ok: boolean;
+  errors: string[];
+}
+
+export async function validateManagedServiceLaunch(
+  answers: ServiceInstallAnswers,
+  runner: CommandRunner,
+): Promise<ServiceLaunchValidationResult> {
+  const env = managedServiceEnvironment(answers);
+  const errors: string[] = [];
+
+  try {
+    const version = await runner.capture(answers.nodeBin, ['--version'], { env });
+    if (!nodeVersionSatisfies(version)) {
+      errors.push(
+        `managed service Node must be >=${MIN_SERVICE_NODE_VERSION}: ${answers.nodeBin} reported ${version.trim() || '<empty>'}`,
+      );
+    }
+  } catch (err) {
+    errors.push(
+      `managed service cannot execute Node at ${answers.nodeBin}: ${errorMessage(err)}`,
+    );
+  }
+
+  if (!(await runner.check(answers.dreamuxBin, ['--help'], { env }))) {
+    errors.push(
+      `managed service cannot execute dreamux launcher at ${answers.dreamuxBin}`,
+    );
+  }
+
+  if (!(await runner.check(answers.codexBin, ['--help'], { env }))) {
+    errors.push(
+      `managed service cannot execute Codex CLI at ${answers.codexBin}`,
+    );
+  }
+
+  return {
+    ok: errors.length === 0,
+    errors,
+  };
+}
+
+export function resolveServiceExecutable(
+  command: string,
+  env: NodeJS.ProcessEnv = process.env,
+): string {
+  const trimmed = command.trim();
+  if (trimmed === '') {
+    throw new Error('managed service executable path is empty');
+  }
+  if (trimmed.includes('/') || trimmed.startsWith('~')) {
+    const candidate = resolve(expandHome(trimmed));
+    assertExecutable(candidate, command);
+    return candidate;
+  }
+
+  for (const dir of (env['PATH'] ?? '').split(delimiter)) {
+    if (dir === '') continue;
+    const candidate = join(dir, trimmed);
+    if (isExecutable(candidate)) return candidate;
+  }
+
+  throw new Error(
+    `managed service cannot resolve executable '${command}' from PATH; pass an absolute path and rerun dreamux onboard`,
+  );
+}
+
+export function nodeVersionSatisfies(raw: string): boolean {
+  const match = raw.trim().match(/^v?(\d+)\.(\d+)\.(\d+)/);
+  if (match === null) return false;
+  const major = Number(match[1]);
+  const minor = Number(match[2]);
+  if (!Number.isInteger(major) || !Number.isInteger(minor)) return false;
+  if (major > 22) return true;
+  return major === 22 && minor >= 7;
+}
+
+function managedServicePath(answers: ServiceInstallAnswers): string {
+  const dirs = [
+    dirname(answers.nodeBin),
+    ...absoluteDir(answers.codexBin),
+    ...absoluteDir(answers.dreamuxBin),
+    ...SERVICE_PATH_DEFAULTS,
+  ];
+  return uniqueNonEmpty(dirs).join(delimiter);
+}
+
+function absoluteDir(path: string): string[] {
+  return isAbsolute(path) ? [dirname(path)] : [];
+}
+
+function uniqueNonEmpty(values: string[]): string[] {
+  const out: string[] = [];
+  const seen = new Set<string>();
+  for (const value of values) {
+    if (value === '' || seen.has(value)) continue;
+    seen.add(value);
+    out.push(value);
+  }
+  return out;
+}
+
+function assertExecutable(path: string, label: string): void {
+  if (isExecutable(path)) return;
+  throw new Error(`managed service executable is not runnable: ${label}`);
+}
+
+function isExecutable(path: string): boolean {
+  try {
+    accessSync(path, constants.X_OK);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function errorMessage(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
 }
 
 async function registerLaunchd(

--- a/packages/dreamux/tests/bin-launcher.test.ts
+++ b/packages/dreamux/tests/bin-launcher.test.ts
@@ -176,7 +176,8 @@ for (const c of LAUNCHERS) {
     if (c.execsNodeDirectly === true) {
       it('execs plain node against the compiled dist target', () => {
         const script = readFileSync(c.bin, 'utf8');
-        expect(script).toMatch(/exec env DREAMUX_BIN="\$DREAMUX_BIN" node "\$TARGET"/);
+        expect(script).toContain('NODE_BIN="${DREAMUX_NODE_BIN:-node}"');
+        expect(script).toMatch(/exec env DREAMUX_BIN="\$DREAMUX_BIN" "\$NODE_BIN" "\$TARGET"/);
       });
     }
 

--- a/packages/dreamux/tests/commands.test.ts
+++ b/packages/dreamux/tests/commands.test.ts
@@ -1,0 +1,35 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { ExecaCommandRunner } from '../src/onboard/commands.js';
+
+describe('ExecaCommandRunner', () => {
+  let previousLeakEnv: string | undefined;
+
+  beforeEach(() => {
+    previousLeakEnv = process.env['DREAMUX_TEST_LEAK'];
+  });
+
+  afterEach(() => {
+    if (previousLeakEnv === undefined) {
+      delete process.env['DREAMUX_TEST_LEAK'];
+    } else {
+      process.env['DREAMUX_TEST_LEAK'] = previousLeakEnv;
+    }
+  });
+
+  it('does not inherit ambient environment when explicit env is passed', async () => {
+    process.env['DREAMUX_TEST_LEAK'] = 'present';
+    const runner = new ExecaCommandRunner();
+
+    await expect(
+      runner.check(
+        process.execPath,
+        [
+          '-e',
+          'process.exit(process.env.DREAMUX_TEST_LEAK === undefined ? 0 : 1)',
+        ],
+        { env: {} },
+      ),
+    ).resolves.toBe(true);
+  });
+});

--- a/packages/dreamux/tests/doctor.test.ts
+++ b/packages/dreamux/tests/doctor.test.ts
@@ -8,6 +8,8 @@ import {
 import { homedir } from 'node:os';
 import { dirname, join } from 'node:path';
 
+import { build as buildPlist } from 'plist';
+
 import { runDreamuxDoctor } from '../src/cli/doctor.js';
 import type { CommandRunner } from '../src/onboard/types.js';
 import {
@@ -22,6 +24,8 @@ class FakeRunner implements CommandRunner {
   systemdEnabled = false;
   systemdActive = false;
   launchdLoaded = false;
+  readonly nodeVersions = new Map<string, string>();
+  readonly failedHelpCommands = new Set<string>();
   readonly calls: Array<{ command: string; args: string[] }> = [];
 
   async run(command: string, args: string[]): Promise<void> {
@@ -29,6 +33,8 @@ class FakeRunner implements CommandRunner {
   }
 
   async check(command: string, args: string[]): Promise<boolean> {
+    this.calls.push({ command, args });
+    if (args[0] === '--help') return !this.failedHelpCommands.has(command);
     if (command === 'codex' && args.join(' ') === '--help') return true;
     if (command === 'systemctl' && args.join(' ') === '--user is-enabled dreamux.service') {
       return this.systemdEnabled;
@@ -43,6 +49,10 @@ class FakeRunner implements CommandRunner {
   }
 
   async capture(command: string, args: string[]): Promise<string> {
+    this.calls.push({ command, args });
+    if (args[0] === '--version') {
+      return this.nodeVersions.get(command) ?? 'v22.7.0';
+    }
     if (command === 'systemctl' && args[0] === '--user' && args[1] === 'show') {
       return [
         'LoadState=loaded',
@@ -154,6 +164,112 @@ describe('dreamux doctor command', () => {
     expect(result.dispatchers[0]?.managedService?.errors.join('\n')).toContain(
       'missing Codex auth state',
     );
+  });
+
+  it('checks the installed systemd service environment instead of recomputing it', async () => {
+    const runner = new FakeRunner();
+    writeConfig();
+    writeDispatcherHome({ auth: true });
+    const servicePath = join(root, 'home', '.config', 'systemd', 'user', 'dreamux.service');
+    mkdirSync(dirname(servicePath), { recursive: true });
+    writeFileSync(
+      servicePath,
+      [
+        '[Service]',
+        'ExecStart=/service/dreamux serve',
+        'Environment=DREAMUX_NODE_BIN=/service/node',
+        'Environment=CODEX_HOST_CODEX_BIN=/service/codex\\\\x20literal',
+        'Environment=PATH=/service/bin:/usr/bin:/bin',
+        '',
+      ].join('\n'),
+    );
+    runner.nodeVersions.set('/service/node', 'v18.0.0');
+
+    const result = await runDreamuxDoctor({
+      runner,
+      platform: 'linux',
+      homeDir: join(root, 'home'),
+      env: {},
+    });
+
+    expect(result.ok).toBe(false);
+    expect(
+      result.checks.find((check) => check.name === 'managed service Node binary'),
+    ).toMatchObject({
+      ok: false,
+      detail: expect.stringContaining('/service/node'),
+    });
+    expect(runner.calls).toContainEqual({
+      command: '/service/node',
+      args: ['--version'],
+    });
+    expect(runner.calls).not.toContainEqual({
+      command: process.execPath,
+      args: ['--version'],
+    });
+    expect(result.service.environment?.['CODEX_HOST_CODEX_BIN']).toBe(
+      '/service/codex\\x20literal',
+    );
+  });
+
+  it('checks the installed launchd plist environment instead of failing unconditionally', async () => {
+    const runner = new FakeRunner();
+    runner.launchdLoaded = true;
+    writeConfig();
+    writeDispatcherHome({ auth: true });
+    const servicePath = join(
+      root,
+      'home',
+      'Library',
+      'LaunchAgents',
+      'dev.excited.dreamux.plist',
+    );
+    mkdirSync(dirname(servicePath), { recursive: true });
+    writeFileSync(
+      servicePath,
+      buildPlist({
+        Label: 'dev.excited.dreamux',
+        ProgramArguments: ['/service/dreamux', 'serve'],
+        RunAtLoad: true,
+        KeepAlive: true,
+        EnvironmentVariables: {
+          DREAMUX_CONFIG_DIR: join(root, 'config'),
+          HOME: join(root, 'home'),
+          DREAMUX_NODE_BIN: '/service/node',
+          CODEX_HOST_CODEX_BIN: '/service/codex',
+          PATH: '/service/bin:/usr/bin:/bin',
+        },
+      }),
+    );
+    runner.nodeVersions.set('/service/node', 'v22.7.0');
+
+    const result = await runDreamuxDoctor({
+      runner,
+      platform: 'darwin',
+      homeDir: join(root, 'home'),
+      uid: 501,
+      env: {},
+    });
+
+    expect(result.ok, JSON.stringify(result, null, 2)).toBe(true);
+    expect(result.service.environment).toMatchObject({
+      DREAMUX_NODE_BIN: '/service/node',
+      CODEX_HOST_CODEX_BIN: '/service/codex',
+      PATH: '/service/bin:/usr/bin:/bin',
+    });
+    expect(result.service.execStart).toEqual(['/service/dreamux', 'serve']);
+    expect(runner.calls).toContainEqual({
+      command: '/service/node',
+      args: ['--version'],
+    });
+    expect(runner.calls).toContainEqual({
+      command: '/service/dreamux',
+      args: ['--help'],
+    });
+    expect(runner.calls).toContainEqual({
+      command: '/service/codex',
+      args: ['--help'],
+    });
   });
 
   function writeConfig(): void {

--- a/packages/dreamux/tests/onboard.test.ts
+++ b/packages/dreamux/tests/onboard.test.ts
@@ -10,6 +10,8 @@ import {
 import { homedir } from 'node:os';
 import { dirname, join } from 'node:path';
 
+import { parse as parsePlist } from 'plist';
+
 import { runOnboard } from '../src/onboard/run.js';
 import {
   answersFromOptions,
@@ -25,6 +27,8 @@ import {
 
 class FakeRunner implements CommandRunner {
   launchdLoaded = false;
+  nodeVersion = 'v22.7.0';
+  readonly failedHelpCommands = new Set<string>();
   readonly calls: Array<{
     command: string;
     args: string[];
@@ -69,6 +73,9 @@ class FakeRunner implements CommandRunner {
     } = {},
   ): Promise<boolean> {
     void options;
+    if (args[0] === '--help') {
+      return !this.failedHelpCommands.has(command);
+    }
     return command === 'launchctl' &&
       args[0] === 'print' &&
       this.launchdLoaded;
@@ -84,6 +91,7 @@ class FakeRunner implements CommandRunner {
     } = {},
   ): Promise<string> {
     void options;
+    if (args[0] === '--version') return this.nodeVersion;
     throw new Error(`unexpected capture: ${command} ${args.join(' ')}`);
   }
 }
@@ -194,6 +202,14 @@ describe('dreamux onboard', () => {
         join(root, 'home', '.config', 'systemd', 'user', 'dreamux.service'),
       )?.status,
     ).toBe('created');
+    const serviceUnit = readFileSync(
+      join(root, 'home', '.config', 'systemd', 'user', 'dreamux.service'),
+      'utf8',
+    );
+    expect(serviceUnit).toContain(`Environment=DREAMUX_NODE_BIN=${process.execPath}`);
+    expect(serviceUnit).toContain(`Environment=CODEX_HOST_CODEX_BIN=${process.execPath}`);
+    expect(serviceUnit).toContain(`Environment=HOME=${join(root, 'home')}`);
+    expect(serviceUnit).toContain(`Environment=PATH=${dirname(process.execPath)}`);
     expect(
       ledger.get(join(logsRoot(), 'daemon.stdout.log'))?.status,
     ).toBe('created');
@@ -221,6 +237,31 @@ describe('dreamux onboard', () => {
     ).rejects.toThrow(
       'managed service environments do not inherit your interactive shell auth token',
     );
+  });
+
+  it('fails before systemd registration when the service cannot execute the launcher', async () => {
+    const runner = new FakeRunner();
+    const answers = testAnswers({
+      configDir: join(root, 'config'),
+      runtimeDir: join(root, 'runtime'),
+      registerService: true,
+      dreamuxBin: '/usr/local/bin/dreamux',
+    });
+    writeGlobalCodexAuth(answers);
+    runner.failedHelpCommands.add(answers.dreamuxBin);
+
+    await expect(
+      runOnboard({
+        answers,
+        runner,
+        platform: 'linux',
+        homeDir: join(root, 'home'),
+        env: {},
+      }),
+    ).rejects.toThrow('managed service cannot execute dreamux launcher');
+
+    expect(countCalls(runner, 'systemctl', ['--user', 'daemon-reload'])).toBe(0);
+    expect(countCalls(runner, 'systemctl', ['--user', 'enable'])).toBe(0);
   });
 
   it('rewrites workspace dispatcher skills and skips already-loaded launchd services on rerun', async () => {
@@ -255,6 +296,21 @@ describe('dreamux onboard', () => {
     expect(countCalls(runner, 'launchctl', ['bootstrap'])).toBe(1);
     expect(countCalls(runner, 'launchctl', ['bootout'])).toBe(0);
     expect(countCalls(runner, 'launchctl', ['kickstart'])).toBe(2);
+
+    const launchdPlist = parsePlist(
+      readFileSync(
+        join(root, 'home', 'Library', 'LaunchAgents', 'dev.excited.dreamux.plist'),
+        'utf8',
+      ),
+    ) as Record<string, any>;
+    expect(launchdPlist['EnvironmentVariables']).toMatchObject({
+      DREAMUX_NODE_BIN: process.execPath,
+      CODEX_HOST_CODEX_BIN: process.execPath,
+      HOME: join(root, 'home'),
+    });
+    expect(launchdPlist['EnvironmentVariables']['PATH']).toContain(
+      dirname(process.execPath),
+    );
   });
 
   it('preserves existing codex globals and other dispatchers on rerun', async () => {
@@ -444,7 +500,7 @@ function testAnswers(overrides: Partial<OnboardAnswers>): OnboardAnswers {
     runtimeDir: join(rootForTest(overrides), 'runtime'),
     dispatcherId: 'flow',
     dispatcherCwd: join(rootForTest(overrides), 'dispatcher-cwd'),
-    codexBin: 'codex',
+    codexBin: process.execPath,
     botAppId: 'app-test',
     botAppSecret: 'secret-test',
     registerService: true,


### PR DESCRIPTION
## Summary

- Capture a service-safe Node/Codex environment during `dreamux onboard`, including `DREAMUX_NODE_BIN`, absolute `CODEX_HOST_CODEX_BIN`, and a minimal PATH for managed services.
- Make the `dreamux` launcher honor `DREAMUX_NODE_BIN` before falling back to bare `node`.
- Validate the managed service launch environment before systemd registration, and teach `dreamux doctor` to inspect the installed systemd unit environment instead of reporting a false green from the interactive shell.
- Update the service-launch decision record and focused tests.

## Verification

- `node common/scripts/install-run-rush.js update`
- `./node_modules/.bin/tsc -p tsconfig.json --noEmit` from `packages/dreamux`
- `./node_modules/.bin/vitest run tests/onboard.test.ts tests/doctor.test.ts tests/bin-launcher.test.ts` from `packages/dreamux`
- `node common/scripts/install-run-rush.js build --to @excitedjs/dreamux`
- `.agents/scripts/check.sh`
- `node common/scripts/install-run-rush.js test`
- `node common/scripts/install-run-rush.js typecheck --to @excitedjs/dreamux`
- `env -i DREAMUX_NODE_BIN="$(command -v node)" PATH=/usr/bin:/bin packages/dreamux/bin/dreamux --help`
- `shellcheck packages/dreamux/bin/dreamux bin/dreamux`
- `node common/scripts/install-run-rush.js change --verify --no-fetch`
- pre-commit `gitleaks protect --staged`

Notes:
- Rush prints its standard Node-version warning for Node 22.16.0.
- `rush test` exits successfully; the dreamux test target reports warnings because test logs intentionally write to stderr.
