### PR TITLE
Make queued inbound reactions honest

### DIFF
--- a/.agents/decisions/top-level-design.md
+++ b/.agents/decisions/top-level-design.md
@@ -293,8 +293,10 @@ When no group chat allowlist or follow-user allowlist is configured, group
 messages are still mention-gated. This keeps bootstrap usable while preventing
 ambient group chatter from entering the dispatcher.
 
-The gate adds a channel-owned received reaction only after a message is accepted
-and enqueued. If the message is rejected, no reaction is added.
+The channel adds a channel-owned received reaction only when that message's
+batch starts moving into Codex. If a message is accepted but still queued behind
+an in-flight dispatcher turn, it does not get the same received marker yet. If
+the message is rejected, no reaction is added.
 
 When one dispatcher is configured for, or observes, multiple allowed chats, the
 gate records an operator warning that those chats share one Codex context.
@@ -447,6 +449,9 @@ resume path.
   cross-chat queue are in-memory and not globally size-bounded in the MVP. A
   stuck turn plus continued inbound traffic can grow memory until operator
   intervention or process restart.
+- Messages queued behind an in-flight dispatcher turn are accepted in memory but
+  are not marked with the channel-owned received reaction until their batch
+  starts moving into Codex.
 - Codex version drift can still break protocol behavior. `dreamux` detects and
   reports this through `doctor`, live tests, and version diagnostics instead of
   pinning Codex.
@@ -465,6 +470,8 @@ resume path.
 - Redelivered `message_id` values are deduped within one server process.
 - Unauthorized messages are dropped before entering Codex.
 - Multi-chat dispatcher access emits an operator-visible trust-domain warning.
+- Messages queued behind an in-flight dispatcher turn do not receive the same
+  channel-owned reaction used for batches that have started moving into Codex.
 - Codex receives a dispatcher-scoped Feishu MCP stdio shim, not a loopback HTTP
   listener, on the default path.
 - The live Codex compatibility gate starts a real Codex app-server with the

--- a/common/changes/@excitedjs/dreamux/codex-issue63-queued-status_2026-06-04-10-03.json
+++ b/common/changes/@excitedjs/dreamux/codex-issue63-queued-status_2026-06-04-10-03.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Make queued inbound reactions reflect Codex turn start.",
+      "type": "patch",
+      "packageName": "@excitedjs/dreamux"
+    }
+  ],
+  "packageName": "@excitedjs/dreamux",
+  "email": "053700@gmail.com"
+}

--- a/packages/dreamux/src/codex/events.ts
+++ b/packages/dreamux/src/codex/events.ts
@@ -26,6 +26,11 @@ export interface TurnCollector {
   awaitTurn(): Promise<CollectedTurn>;
 }
 
+export interface RunTurnOptions {
+  /** Called after Codex accepts `turn/start`, before waiting for completion. */
+  onStarted?: () => void;
+}
+
 /**
  * Subscribe to turn notifications for one thread. Returns a collector
  * whose `awaitTurn()` resolves on `turn/completed`. Items arriving on the
@@ -83,6 +88,7 @@ export async function runTurn(
   threadId: string,
   prompt: string,
   cwd: string | null,
+  opts: RunTurnOptions = {},
 ): Promise<CollectedTurn> {
   const collector = subscribeTurnCollection(client, threadId);
   const input: UserInput[] = [
@@ -92,6 +98,7 @@ export async function runTurn(
     'turn/start',
     cwd === null ? { threadId, input } : { threadId, input, cwd },
   );
+  opts.onStarted?.();
   return collector.awaitTurn();
 }
 

--- a/packages/dreamux/src/dispatcher/runtime.ts
+++ b/packages/dreamux/src/dispatcher/runtime.ts
@@ -72,6 +72,8 @@ export interface DispatcherRuntimeDeps {
   restartBackoffBaseMs?: number;
   /** Codex child/WS restart backoff cap (tests may override). */
   restartBackoffMaxMs?: number;
+  /** Channel-visible status hook for batches that are starting Codex delivery. */
+  onTurnBatchStart?: (messages: readonly InboundTurnInput[]) => void | Promise<void>;
   log?: (level: 'info' | 'warn' | 'error', msg: string, err?: unknown) => void;
 }
 
@@ -216,6 +218,7 @@ export class DispatcherRuntime {
       getThreadId: () => this.threadId,
       client: this.client,
       log: this.log,
+      onBatchStart: this.deps.onTurnBatchStart,
     });
   }
 

--- a/packages/dreamux/src/dispatcher/turn-manager.ts
+++ b/packages/dreamux/src/dispatcher/turn-manager.ts
@@ -44,6 +44,11 @@ export interface TurnManagerOptions {
   messageIdDedupeWindow?: number;
   /** Optional logger; defaults to console.error. */
   log?: (level: 'info' | 'warn' | 'error', msg: string, err?: unknown) => void;
+  /**
+   * Called when a queued batch starts moving into Codex. This is intentionally
+   * fire-and-forget so channel status updates cannot block turn injection.
+   */
+  onBatchStart?: (messages: readonly InboundTurnInput[]) => void | Promise<void>;
 }
 
 export class TurnManager {
@@ -154,10 +159,28 @@ export class TurnManager {
         threadId,
         batchPrompt(batch),
         this.opts.turnCwd ?? null,
+        { onStarted: () => this.notifyBatchStart(batch) },
       );
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
       this.log('error', `turn execution failed for batch ${batch.id}: ${msg}`);
+    }
+  }
+
+  private notifyBatchStart(batch: TurnBatch): void {
+    try {
+      const result = this.opts.onBatchStart?.(batch.messages);
+      if (result !== undefined) {
+        void Promise.resolve(result).catch((err: unknown) => {
+          this.log(
+            'warn',
+            `batch-start hook failed for batch ${batch.id}`,
+            err,
+          );
+        });
+      }
+    } catch (err) {
+      this.log('warn', `batch-start hook failed for batch ${batch.id}`, err);
     }
   }
 

--- a/packages/dreamux/src/server.ts
+++ b/packages/dreamux/src/server.ts
@@ -13,6 +13,7 @@
  */
 
 import { DispatcherRuntime } from './dispatcher/runtime.js';
+import type { InboundTurnInput } from './dispatcher/turn-manager.js';
 import type { CodexProcess, CodexProcessOptions } from './codex/supervisor.js';
 import type { CodexWsClient } from './codex/rpc.js';
 import {
@@ -235,6 +236,11 @@ export class Server {
       extraEnv: dispatcherConfig?.codex.extra_env ?? {},
       restartBackoffBaseMs: this.opts.codexRestartBackoffBaseMs,
       restartBackoffMaxMs: this.opts.codexRestartBackoffMaxMs,
+      onTurnBatchStart: (messages) => {
+        for (const message of messages) {
+          void addReceivedReaction(id, bot, channelState, message);
+        }
+      },
     });
 
     try {
@@ -261,15 +267,12 @@ export class Server {
           );
           return;
         }
-        const queued = runtime.enqueueInbound({
+        runtime.enqueueInbound({
           source_chat_id: event.chatId,
           source_message_id: event.messageId,
           sender_id: event.senderId,
           parsed_text: formatFeishuMessageForCodex(event),
         });
-        if (queued) {
-          await addReceivedReaction(id, bot, channelState, event);
-        }
       });
     } catch (err) {
       // Failed midway: undo any partial bring-up so a retry isn't
@@ -390,34 +393,38 @@ async function addReceivedReaction(
   dispatcherId: string,
   bot: FeishuBot,
   channelState: DispatcherChannelState,
-  event: FeishuInboundEvent,
+  message: InboundTurnInput,
 ): Promise<void> {
+  const messageId = message.source_message_id;
+  if (messageId === null || messageId === '') {
+    return;
+  }
   try {
     const reactionId = await bot.addReaction(
-      event.messageId,
+      messageId,
       RECEIVED_REACTION_EMOJI,
     );
     if (reactionId === '') {
       console.error(
         `[server] Feishu returned no reaction_id for the received reaction in dispatcher '${dispatcherId}'`,
       );
-      channelState.pendingReceivedReactionClears.delete(event.messageId);
+      channelState.pendingReceivedReactionClears.delete(messageId);
       return;
     }
-    channelState.receivedReactions.set(event.messageId, {
-      chatId: event.chatId,
+    channelState.receivedReactions.set(messageId, {
+      chatId: message.source_chat_id,
       reactionId,
     });
-    if (channelState.pendingReceivedReactionClears.has(event.messageId)) {
+    if (channelState.pendingReceivedReactionClears.has(messageId)) {
       await clearReceivedReaction(
         dispatcherId,
         bot,
         channelState,
-        event.messageId,
+        messageId,
       );
     }
   } catch (err) {
-    channelState.pendingReceivedReactionClears.delete(event.messageId);
+    channelState.pendingReceivedReactionClears.delete(messageId);
     console.error(
       `[server] failed to add the received reaction for dispatcher '${dispatcherId}':`,
       err,

--- a/packages/dreamux/tests/fake-codex.ts
+++ b/packages/dreamux/tests/fake-codex.ts
@@ -27,6 +27,8 @@ export interface FakeCodexOptions {
   triggerApprovalOnTurn?: boolean;
   /** Delay between turn/start ack and the eventual turn/completed (ms). */
   turnDelayMs?: number;
+  /** Acknowledge turn/start but never emit turn/completed. */
+  holdTurns?: boolean;
   /**
    * If true, mimic real codex 0.134 behavior: any non-`initialize` RPC
    * before the `initialized` notification arrives returns
@@ -152,6 +154,7 @@ export async function startFakeCodex(opts: FakeCodexOptions = {}): Promise<FakeC
 
       const input = extractText(params['input']);
       const reply = opts.replyFor ? opts.replyFor(input) : `echo: ${input}`;
+      if (opts.holdTurns === true) return;
 
       void (async () => {
         await delay(opts.turnDelayMs ?? 10);

--- a/packages/dreamux/tests/smoke.test.ts
+++ b/packages/dreamux/tests/smoke.test.ts
@@ -688,6 +688,7 @@ describe('dreamux MVP smoke', () => {
     const access = loadDispatcherAccess('flow');
     expect(access.observed_chats).toEqual(['chat-group-a', 'chat-group-b']);
     expect(access.warnings).toEqual([TRUST_DOMAIN_WARNING]);
+    await waitFor(() => bot.reactions.length === 2);
     expect(bot.reactions.map((reaction) => reaction.messageId)).toEqual([
       'msg-chat-a',
       'msg-chat-b',
@@ -725,6 +726,42 @@ describe('dreamux MVP smoke', () => {
     expect(codexInputs[1]).toContain('batch-1');
     expect(codexInputs[1]).toContain('batch-2');
     expect(bot.sentMessages).toEqual([]);
+  });
+
+  it('does not add received reactions while inbound is queued behind a running turn', async () => {
+    await fake.close();
+    codexInputs = [];
+    fake = await startFakeCodex({
+      holdTurns: true,
+      replyFor: captureAndEchoCodexInput(codexInputs),
+    });
+
+    server = buildServer({ runtimeDir, fake, bot });
+    server.repos.dispatchers.create({
+      dispatcher_id: 'flow',
+      bot_app_id: 'app-smoke',
+      bot_secret_ref: 'env:UNUSED',
+    });
+    await server.start();
+
+    await bot.inject(fakeInbound('chat-group-a', 'running', 'msg-running'));
+    await waitFor(() => fake.turnsHandled === 1);
+    await waitFor(() => bot.reactions.length === 1);
+
+    expect(codexInputs).toHaveLength(1);
+    expect(codexInputs[0]).toContain('running');
+    expect(bot.reactions.map((reaction) => reaction.messageId)).toEqual([
+      'msg-running',
+    ]);
+
+    await bot.inject(fakeInbound('chat-group-b', 'queued', 'msg-queued'));
+    await sleep(120);
+
+    expect(fake.turnsHandled).toBe(1);
+    expect(codexInputs).toHaveLength(1);
+    expect(bot.reactions.map((reaction) => reaction.messageId)).toEqual([
+      'msg-running',
+    ]);
   });
 
   it('process-local dedupe drops Feishu redelivery before turn and reaction', async () => {


### PR DESCRIPTION
## Summary

- Move the channel-owned received reaction from Feishu enqueue time to after Codex accepts `turn/start` for a batch.
- Leave messages queued behind an in-flight dispatcher turn without the same received marker until their batch actually starts moving into Codex.
- Add stuck-turn smoke coverage and update the documented invariant.

Refs #63.

## Testing

- `node common/scripts/install-run-rush.js update`
- `./node_modules/.bin/vitest run tests/smoke.test.ts`
- `./node_modules/.bin/vitest run tests/turn-manager.test.ts`
- `./node_modules/.bin/tsc -p tsconfig.json --noEmit`
- `./node_modules/.bin/vitest run`
- `node common/scripts/install-run-rush.js build`
- `.agents/scripts/check.sh`
- `node common/scripts/install-run-rush.js test`
