### PR TITLE
Fix non-blocking Feishu inbound delivery

### DIFF
--- a/.agents/domains/non-blocking-dispatcher-inbound.md
+++ b/.agents/domains/non-blocking-dispatcher-inbound.md
@@ -1,0 +1,183 @@
+# Non-blocking dispatcher inbound
+
+- **Status:** Implemented runtime contract for issue #63
+- **Source:** https://github.com/excitedjs/dreamux/issues/63
+- **Affects:** `/packages/dreamux/src/dispatcher/turn-manager.ts`, `/packages/dreamux/src/dispatcher/runtime.ts`, `/packages/dreamux/src/codex/events.ts`, `/packages/dreamux/src/server.ts`, `/packages/dreamux/tests/fake-codex.ts`, `/packages/dreamux/tests/codex-live.test.ts`
+
+## Locked Scope
+
+The dispatcher teammate mechanism stays synchronous. There is no trigger-turn,
+mailbox wakeup, teammate-completion callback, idle polling redesign, or early
+turn completion in this issue. A dispatcher turn may stay open while the model
+waits on `send`, `wait`, or `spawn --prompt`.
+
+Issue #63 removes dreamux's application-level head-of-line queue. It does not
+eliminate long turns and does not make folded input visible to the model until
+the current synchronous operation returns and the ReAct loop advances.
+
+Do not add a dreamux submission mutex. Do not add a production turn observer.
+Do not call `turn/steer` for normal Feishu inbound. Do not maintain a local
+`activeTurnId`. Do not aggregate messages until turn completion.
+
+## Codex Contract
+
+Codex `turn/start` is the authoritative aggregate user-input RPC:
+
+- when a regular turn is active, `turn/start` folds the new input into that
+  active turn's pending input;
+- when the thread is idle, `turn/start` starts a new regular turn;
+- dreamux does not need to decide active versus idle itself.
+
+The source path is:
+
+- app-server `turn/start` creates `Op::UserInput` and submits it to the core
+  session;
+- core `user_input_or_turn_inner` first calls `steer_input` with no
+  `expectedTurnId`;
+- if `steer_input` succeeds, the input is pending input for the active turn;
+- only `NoActiveTurn` falls through to spawning a new regular turn.
+
+This dissolves the v2 stale-state gap. Since dreamux never calls `turn/steer`
+and never keeps an `activeTurnId`, there is no stale-id path that can produce
+`NoActiveTurn` and drop an accepted message.
+
+## Pre-Issue #63 Artifact
+
+Before issue #63, the dispatcher inbound path was a process-local serialized
+turn worker:
+
+```mermaid
+flowchart LR
+  Feishu["accepted Feishu inbound"] --> Queue["TurnManager queue"]
+  Queue --> RunTurn["runTurn"]
+  RunTurn --> Start["turn/start"]
+  Start --> Wait["await turn/completed"]
+  Wait --> Queue
+```
+
+`TurnManager.drainLoop()` awaits `processBatch()`, and `processBatch()` awaits
+`runTurn()`. `runTurn()` submits `turn/start` and resolves only after
+`turn/completed`. A long Codex turn therefore blocks later accepted Feishu
+messages from reaching Codex.
+
+The channel added one `RECEIVED_REACTION_EMOJI` after
+`DispatcherRuntime.enqueueInbound()` returned true. Issue #63 replaced this
+with a three-state channel-owned reaction flow.
+
+## Runtime Model
+
+```mermaid
+flowchart LR
+  Inbound["Feishu inbound"] --> Gate["access gate"]
+  Gate --> Dedupe["message_id dedupe"]
+  Dedupe --> Received["react: received"]
+  Received --> Start["turn/start"]
+  Start --> Doing["react: in progress"]
+  Doing --> Reply["MCP reply"]
+  Reply --> Clear["remove reaction"]
+```
+
+Every accepted, deduped inbound message submits exactly one `turn/start`.
+dreamux never waits for `turn/completed` before accepting or submitting the next
+inbound.
+
+## Code Changes
+
+`packages/dreamux/src/dispatcher/turn-manager.ts`
+
+- Remove same-chat coalescing and the completion-gated `drainLoop()` /
+  `processBatch()` queue as the inbound submission gate.
+- Keep process-local `message_id` dedupe.
+- Replace `enqueue(input): boolean` with an async per-message submission path:
+  accepted, deduped input is formatted as one prompt/envelope and submitted via
+  `turn/start` immediately.
+- Return a delivery result to the runtime/server so the channel can switch the
+  reaction to in-progress at the `turn/start` acceptance point.
+- Do not track active turn ids. Do not call `turn/steer`.
+
+`packages/dreamux/src/dispatcher/runtime.ts`
+
+- Keep owning the Codex client and thread id.
+- Replace the synchronous boolean `enqueueInbound()` result with an async
+  delivery result from `TurnManager.enqueue()`, including duplicate/submitted
+  information and submission errors.
+- Do not introduce a mutex, observer, or active/idle branch.
+
+`packages/dreamux/src/codex/events.ts`
+
+- Split the current `runTurn()` shape so production inbound can call a
+  `submitTurnStart()`-style helper that sends `turn/start` and resolves on the
+  RPC acceptance ack.
+- The old `runTurn()` shape (`turn/start` plus await `turn/completed`) must not
+  remain on the Feishu inbound path. It can remain only as a test/diagnostic
+  helper if still useful.
+- Do not add a `turn/steer` helper for normal Feishu inbound.
+
+`packages/dreamux/src/server.ts`
+
+- In `Server.startDispatcher()`'s `bot.start(async event)` handler, add the
+  received emoji immediately after the access gate passes and `message_id`
+  dedupe reports a miss. Do not react to dropped messages or duplicate
+  redeliveries.
+- After `runtime.enqueueInbound()` reports `turn/start` acceptance, replace the
+  received reaction with the in-progress emoji.
+- In `replyFromMcp()`, keep clearing the channel-owned reaction for
+  `input.messageId` after the model reply is sent.
+- Replace the single `receivedReactions` map with a channel-owned inbound
+  reaction ledger that stores the current reaction id and state per message id.
+  Feishu reactions are replaced by removing the previous channel-owned reaction
+  id and adding the new emoji.
+- Keep `pendingReceivedReactionClears`: an MCP reply can still clear before an
+  async add/replace reaction call finishes.
+
+`packages/dreamux/src/channel/feishu-message.ts`
+
+- Keep the existing discrete `<feishu_message>` envelope and routing metadata
+  (`chat_id`, `message_id`, `sender_id`, `sender_name`, `create_time`) so the
+  model can reply to the correct source message after interleaving.
+
+## Reaction Contract
+
+The channel-owned reaction has three visible states:
+
+- Feishu channel receives the message, after access-pass and dedupe-miss: add
+  `[received]`. "Immediately" means before Codex submission, not before
+  access/dedupe.
+- Codex accepts `turn/start`: replace with `[in progress]` immediately at
+  submission acceptance, not at model consumption.
+- The model replies through MCP `reply` for that `message_id`: remove the
+  channel-owned reaction.
+
+If `turn/start` rejects before Codex accepts the input, keep `[received]` and
+log the submission failure. If Codex accepts the input and the later turn fails,
+aborts, or is interrupted before a reply, a remaining `[in progress]` reaction
+is accepted. Do not add an observer or extra state machine only to clean it up.
+
+## Tests
+
+Fake-Codex tests must cover:
+
+- every accepted, deduped inbound calls `turn/start`;
+- while a fake turn is active, a later `turn/start` is accepted and folds into
+  that active fake turn rather than producing a second completed turn;
+- no mutex/backlog waits for `turn/completed`;
+- reaction path `[received] -> [in progress] -> removed`;
+- clear-before-add still prevents a late async reaction add from resurrecting a
+  cleared channel-owned reaction;
+- no stale-`activeTurnId` / `NoActiveTurn` fallback test remains, because
+  dreamux no longer calls `turn/steer`.
+
+The live Codex integration gate must start a real Codex app-server, put the
+dispatcher into a turn blocked on a short synchronous operation, inject a
+Feishu inbound during that mid-turn window, and prove:
+
+- dreamux submits the second inbound with `turn/start`;
+- Codex folds that input into the current active turn rather than rejecting,
+  queuing behind completion, or starting a parallel turn;
+- the folded marker is processed after the synchronous operation returns and
+  the ReAct loop advances;
+- the reaction sequence for that inbound is `[received] -> [in progress] ->
+  removed`.
+
+This live gate is the load-bearing proof. Static review and fake tests are not
+enough for issue #63.

--- a/.agents/root.md
+++ b/.agents/root.md
@@ -64,8 +64,12 @@ Background and older issue context:
   reconciliation, access surface, message-format, CLI/diagnostic robustness);
   groups the deferred epic follow-ups + the #58 ultracode findings into the next
   workstream.
-- `domains/`, `proposals/`, `research/`, `rules/` — empty for now; add
-  here when material grows past a single file's worth.
+- [`domains/non-blocking-dispatcher-inbound.md`](domains/non-blocking-dispatcher-inbound.md)
+  — final issue #63 runtime model for accepted Feishu inbound: every accepted
+  deduped message submits `turn/start`, and reactions move through the
+  received / in-progress / cleared states.
+- `proposals/`, `research/`, `rules/` — add here when material grows past a
+  single file's worth.
 - [`CONTRIBUTING.md`](CONTRIBUTING.md) — when to update this KB, how to
   format docs, the knowledge-delta protocol.
 - [`scripts/check.sh`](scripts/check.sh) — link / orphan checker. Run
@@ -87,6 +91,7 @@ Background and older issue context:
 | add / change a config key (`~/.dreamux/config.json`) | [`decisions/top-level-design.md`](decisions/top-level-design.md) first, then historical context in [`decisions/global-config-dir.md`](decisions/global-config-dir.md) |
 | touch the anti-leak guardrail (`.gitleaks.toml`, `.npmrc`, CI / hook) | [`decisions/anti-leak-guardrail.md`](decisions/anti-leak-guardrail.md) |
 | touch npm publishing / the release workflows | [`decisions/npm-release-oidc.md`](decisions/npm-release-oidc.md) |
+| change dispatcher inbound delivery, turn submission, or received-reaction timing | [`domains/non-blocking-dispatcher-inbound.md`](domains/non-blocking-dispatcher-inbound.md) + [`decisions/top-level-design.md`](decisions/top-level-design.md) + read the source |
 | add or verify Rush change files | [`components/repo-structure.md#rush-change-files`](components/repo-structure.md#rush-change-files) |
 | write a new decision record / new component doc | [`CONTRIBUTING.md`](CONTRIBUTING.md) |
 | modify the server runtime / Codex protocol handling | [`decisions/top-level-design.md`](decisions/top-level-design.md) + read the source |

--- a/common/changes/@excitedjs/dreamux/issue-63-non-blocking-inbound_2026-06-04-12-56.json
+++ b/common/changes/@excitedjs/dreamux/issue-63-non-blocking-inbound_2026-06-04-12-56.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@excitedjs/dreamux",
+      "comment": "Submit accepted Feishu inbound with non-blocking turn/start delivery and three-state reactions.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@excitedjs/dreamux",
+  "email": "YourWildDad@users.noreply.github.com"
+}

--- a/packages/dreamux/README.md
+++ b/packages/dreamux/README.md
@@ -214,15 +214,18 @@ node common/scripts/install-run-rush.js test
 ```
 
 - `tests/smoke.test.ts` — fake-Codex dispatcher behavior: access gate,
-  in-memory turn serialization/coalescing/dedupe, MCP reply-only outbound,
-  thread resume, app-server restart behavior, and approval fail-fast.
+  per-message turn/start inbound submission, process-local dedupe, reaction
+  tri-state, MCP reply-only outbound, thread resume, app-server restart
+  behavior, and approval fail-fast.
 - `tests/bin-launcher.test.ts` — real launcher and repo-root shim behavior from
   arbitrary cwd and through symlinks.
 - `tests/doctor.test.ts` — standalone doctor checks for config, Codex home,
   services, and dispatcher workspace skill state.
-- `tests/codex-0135-live.test.ts` and `tests/codex-0136-mcp-live.test.ts` —
-  real Codex app-server compatibility checks. Set `DREAMUX_SKIP_LIVE_CODEX=1`
-  only when no Codex binary is available locally.
+- `tests/codex-live.test.ts` — real Codex app-server compatibility checks,
+  plus the issue #63 mid-turn model gate. Set `DREAMUX_SKIP_LIVE_CODEX=1` only
+  when no Codex binary is available locally. Public CI loud-skips the model
+  gate unless `DREAMUX_RUN_LIVE_MODEL_GATE=1` is set in an environment with
+  usable Codex model auth.
 
 ## License
 

--- a/packages/dreamux/src/codex/events.ts
+++ b/packages/dreamux/src/codex/events.ts
@@ -75,6 +75,26 @@ export function subscribeTurnCollection(
 }
 
 /**
+ * Send a `turn/start` request and resolve once Codex accepts the submission.
+ * This is the production Feishu inbound primitive: it intentionally does not
+ * wait for `turn/completed`.
+ */
+export async function submitTurnStart(
+  client: CodexWsClient,
+  threadId: string,
+  prompt: string,
+  cwd: string | null,
+): Promise<TurnStartResponse> {
+  const input: UserInput[] = [
+    { type: 'text', text: prompt, text_elements: [] },
+  ];
+  return client.request<TurnStartResponse>(
+    'turn/start',
+    cwd === null ? { threadId, input } : { threadId, input, cwd },
+  );
+}
+
+/**
  * Send a `turn/start` request and await `turn/completed`.
  * Returns the collected turn, or throws on RPC failure.
  */
@@ -85,13 +105,7 @@ export async function runTurn(
   cwd: string | null,
 ): Promise<CollectedTurn> {
   const collector = subscribeTurnCollection(client, threadId);
-  const input: UserInput[] = [
-    { type: 'text', text: prompt, text_elements: [] },
-  ];
-  await client.request<TurnStartResponse>(
-    'turn/start',
-    cwd === null ? { threadId, input } : { threadId, input, cwd },
-  );
+  await submitTurnStart(client, threadId, prompt, cwd);
   return collector.awaitTurn();
 }
 

--- a/packages/dreamux/src/dispatcher/runtime.ts
+++ b/packages/dreamux/src/dispatcher/runtime.ts
@@ -35,7 +35,12 @@ import type {
   ThreadResumeResponse,
   ThreadStartResponse,
 } from '../codex/types.js';
-import { TurnManager, type InboundTurnInput } from './turn-manager.js';
+import {
+  TurnManager,
+  type InboundDeliveryHooks,
+  type InboundDeliveryResult,
+  type InboundTurnInput,
+} from './turn-manager.js';
 import { createFailFastApprovalHandler } from './approval.js';
 import {
   dispatcherCodexCwd,
@@ -264,13 +269,17 @@ export class DispatcherRuntime {
   }
 
   /**
-   * Queue any accepted inbound message arriving for this dispatcher. Called by
-   * the Feishu inbound layer. Returns false if this process already saw the
-   * message_id.
+   * Submit any accepted inbound message arriving for this dispatcher. Called by
+   * the Feishu inbound layer.
    */
-  enqueueInbound(input: InboundTurnInput): boolean {
-    if (this.turnManager === null) return false;
-    return this.turnManager.enqueue(input);
+  async enqueueInbound(
+    input: InboundTurnInput,
+    hooks: InboundDeliveryHooks = {},
+  ): Promise<InboundDeliveryResult> {
+    if (this.turnManager === null) {
+      return { status: 'failed', error: new Error('turn manager not initialized') };
+    }
+    return this.turnManager.enqueue(input, hooks);
   }
 
   /** Graceful stop: stop accepting work, reap codex child. */

--- a/packages/dreamux/src/dispatcher/turn-manager.ts
+++ b/packages/dreamux/src/dispatcher/turn-manager.ts
@@ -1,16 +1,14 @@
 /**
- * Per-dispatcher in-memory turn worker.
+ * Per-dispatcher in-memory inbound submitter.
  *
  * Contract:
- *   - one serialized worker per dispatcher;
  *   - accepted inbound messages are not persisted;
- *   - consecutive pending messages from the same chat are coalesced into one
- *     Codex turn;
  *   - Feishu message_id redelivery is deduped within this server process;
+ *   - one accepted inbound message becomes one Codex `turn/start` submission;
  *   - Codex text output alone does not send anything to Feishu.
  */
 
-import { runTurn } from '../codex/events.js';
+import { submitTurnStart } from '../codex/events.js';
 import type { CodexWsClient } from '../codex/rpc.js';
 
 export const DEFAULT_MESSAGE_ID_DEDUPE_WINDOW = 1024;
@@ -25,9 +23,18 @@ export interface InboundTurnInput extends InboundTurnSource {
   parsed_text: string;
 }
 
-interface TurnBatch extends InboundTurnSource {
-  id: number;
-  messages: InboundTurnInput[];
+export type InboundDeliveryResult =
+  | { status: 'duplicate' }
+  | { status: 'stopped' }
+  | { status: 'submitted'; turnId: string }
+  | { status: 'failed'; error: Error };
+
+export interface InboundDeliveryHooks {
+  /**
+   * Called after process-local dedupe accepts the message and before
+   * `turn/start` is submitted.
+   */
+  onAccepted?: (input: InboundTurnInput) => void | Promise<void>;
 }
 
 export interface TurnManagerOptions {
@@ -47,14 +54,9 @@ export interface TurnManagerOptions {
 }
 
 export class TurnManager {
-  private readonly queue: TurnBatch[] = [];
   private readonly seenMessageIds = new Set<string>();
   private readonly seenMessageIdOrder: string[] = [];
-  private running = false;
   private stopped = false;
-  private drainScheduled = false;
-  private wakeup: (() => void) | null = null;
-  private nextBatchId = 1;
   private readonly log: NonNullable<TurnManagerOptions['log']>;
   private readonly messageIdDedupeWindow: number;
 
@@ -71,103 +73,63 @@ export class TurnManager {
   }
 
   /**
-   * Queue one accepted inbound message. Returns false when the message_id was
-   * already seen in this server process.
+   * Submit one accepted inbound message to Codex. Returns duplicate when this
+   * process already saw the message_id.
    */
-  enqueue(input: InboundTurnInput): boolean {
-    if (this.stopped) return false;
-    if (!this.rememberMessageId(input.source_message_id)) return false;
-
-    const pending = this.queue.find(
-      (batch) => batch.source_chat_id === input.source_chat_id,
-    );
-    if (pending !== undefined) {
-      pending.messages.push(input);
-      pending.source_message_id = input.source_message_id;
-      pending.sender_id = input.sender_id;
-    } else {
-      this.queue.push({
-        id: this.nextBatchId++,
-        source_chat_id: input.source_chat_id,
-        source_message_id: input.source_message_id,
-        sender_id: input.sender_id,
-        messages: [input],
-      });
+  async enqueue(
+    input: InboundTurnInput,
+    hooks: InboundDeliveryHooks = {},
+  ): Promise<InboundDeliveryResult> {
+    if (this.stopped) return { status: 'stopped' };
+    if (!this.rememberMessageId(input.source_message_id)) {
+      return { status: 'duplicate' };
     }
 
-    this.notify();
-    return true;
-  }
+    await this.notifyAccepted(input, hooks);
 
-  /** Notify the worker that new work may be available. */
-  private notify(): void {
-    if (this.stopped) return;
-    if (this.wakeup !== null) {
-      const w = this.wakeup;
-      this.wakeup = null;
-      w();
-      return;
-    }
-    if (this.running || this.drainScheduled) return;
-    this.drainScheduled = true;
-    setTimeout(() => {
-      this.drainScheduled = false;
-      if (!this.stopped) void this.drainLoop();
-    }, 0);
-  }
-
-  /** Drain queued batches until the queue is empty or we're stopped. */
-  private async drainLoop(): Promise<void> {
-    if (this.running) return;
-    this.running = true;
-    try {
-      while (!this.stopped) {
-        const batch = this.queue.shift();
-        if (batch === undefined) {
-          await this.waitForNotify();
-          if (this.stopped) return;
-          continue;
-        }
-        await this.processBatch(batch);
-      }
-    } finally {
-      this.running = false;
-    }
-  }
-
-  private waitForNotify(): Promise<void> {
-    return new Promise<void>((res) => {
-      this.wakeup = res;
-    });
-  }
-
-  private async processBatch(batch: TurnBatch): Promise<void> {
     const threadId = this.opts.getThreadId();
     if (threadId === null) {
-      this.log('error', `turn batch ${batch.id} dequeued without thread_id`);
-      return;
+      const error = new Error('inbound submitted without thread_id');
+      this.log('error', error.message);
+      return { status: 'failed', error };
     }
 
     try {
-      await runTurn(
+      const res = await submitTurnStart(
         this.opts.client,
         threadId,
-        batchPrompt(batch),
+        input.parsed_text,
         this.opts.turnCwd ?? null,
       );
+      return { status: 'submitted', turnId: res.turn.id };
     } catch (err) {
-      const msg = err instanceof Error ? err.message : String(err);
-      this.log('error', `turn execution failed for batch ${batch.id}: ${msg}`);
+      const error = err instanceof Error ? err : new Error(String(err));
+      this.log(
+        'error',
+        `turn/start submission failed for message ${input.source_message_id ?? '<none>'}: ${error.message}`,
+        error,
+      );
+      return { status: 'failed', error };
     }
   }
 
   async stop(): Promise<void> {
     this.stopped = true;
-    this.queue.length = 0;
-    if (this.wakeup !== null) {
-      const w = this.wakeup;
-      this.wakeup = null;
-      w();
+  }
+
+  private async notifyAccepted(
+    input: InboundTurnInput,
+    hooks: InboundDeliveryHooks,
+  ): Promise<void> {
+    if (hooks.onAccepted === undefined) return;
+    try {
+      await hooks.onAccepted(input);
+    } catch (err) {
+      this.log(
+        'warn',
+        `accepted-inbound hook failed for message ${input.source_message_id ?? '<none>'}`,
+        err,
+      );
     }
   }
 
@@ -182,8 +144,4 @@ export class TurnManager {
     }
     return true;
   }
-}
-
-function batchPrompt(batch: TurnBatch): string {
-  return batch.messages.map((message) => message.parsed_text).join('\n\n');
 }

--- a/packages/dreamux/src/feishu/bot.ts
+++ b/packages/dreamux/src/feishu/bot.ts
@@ -8,8 +8,8 @@
  * the core's surface into the `FeishuBot` interface the server already wires:
  *   - `start(handler)` registers the `im.message.receive_v1` route, normalizes
  *     each raw event with the core's `parseInbound`, and forwards a
- *     `FeishuInboundEvent`. The route handler awaits `handler`, so the message
- *     reaches the server-owned in-memory queue before the SDK acks.
+ *     `FeishuInboundEvent`. The route handler awaits `handler`, so the server
+ *     gates and submits accepted inbound before the SDK acks.
  *   - `send(target, text)` delegates to the core transport, preserving reply
  *     threading / @-back metadata from the in-memory inbound batch.
  *   - `botOpenId` surfaces the core transport's `selfId`.
@@ -111,7 +111,7 @@ export function createFeishuBot(
 
     async start(handler: InboundHandler): Promise<void> {
       // The core opens the WebSocket and awaits this route handler before the
-      // SDK acks; awaiting `handler` here keeps gate/queue work before ACK.
+      // SDK acks; awaiting `handler` here keeps gate/submission work before ACK.
       // `start` rejects if the connection does not come up, so the server's
       // try/catch can fail the dispatcher loudly rather than leave it dark.
       await transport.start({

--- a/packages/dreamux/src/server.ts
+++ b/packages/dreamux/src/server.ts
@@ -9,10 +9,11 @@
  *   4. install SIGTERM/SIGINT handlers for graceful drain
  *
  * Current MVP: accepted inbound work is process-local. Restarting the server
- * drops queued and in-flight inbound messages instead of replaying them.
+ * drops in-flight inbound submissions instead of replaying them.
  */
 
 import { DispatcherRuntime } from './dispatcher/runtime.js';
+import type { InboundTurnInput } from './dispatcher/turn-manager.js';
 import type { CodexProcess, CodexProcessOptions } from './codex/supervisor.js';
 import type { CodexWsClient } from './codex/rpc.js';
 import {
@@ -45,6 +46,7 @@ import {
 import { createAdminSocketServer, type AdminSocketServer } from './admin/socket.js';
 
 export const RECEIVED_REACTION_EMOJI = 'GLANCE';
+export const IN_PROGRESS_REACTION_EMOJI = 'ON_IT';
 const MAX_PENDING_RECEIVED_REACTION_CLEARS = 1024;
 
 export interface ServerOptions {
@@ -87,8 +89,16 @@ interface DispatcherSlot {
 }
 
 interface DispatcherChannelState {
-  receivedReactions: Map<string, { chatId: string; reactionId: string }>;
+  inboundReactions: Map<string, InboundReactionLedgerEntry>;
   pendingReceivedReactionClears: Set<string>;
+}
+
+type InboundReactionState = 'received' | 'in_progress';
+
+interface InboundReactionLedgerEntry {
+  chatId: string;
+  reactionId: string;
+  state: InboundReactionState;
 }
 
 export interface ServerMcpReplyInput {
@@ -220,7 +230,7 @@ export class Server {
       ? this.opts.botFactory(row, botSecret)
       : createFeishuBot({ appId: row.bot_app_id, appSecret: botSecret });
     const channelState: DispatcherChannelState = {
-      receivedReactions: new Map(),
+      inboundReactions: new Map(),
       pendingReceivedReactionClears: new Set(),
     };
 
@@ -261,14 +271,37 @@ export class Server {
           );
           return;
         }
-        const queued = runtime.enqueueInbound({
+        const input: InboundTurnInput = {
           source_chat_id: event.chatId,
           source_message_id: event.messageId,
           sender_id: event.senderId,
           parsed_text: formatFeishuMessageForCodex(event),
+        };
+        const delivery = await runtime.enqueueInbound(input, {
+          onAccepted: async (acceptedInput) => {
+            await setInboundReaction(
+              id,
+              bot,
+              channelState,
+              acceptedInput,
+              RECEIVED_REACTION_EMOJI,
+              'received',
+            );
+          },
         });
-        if (queued) {
-          await addReceivedReaction(id, bot, channelState, event);
+        if (delivery.status === 'submitted') {
+          await setInboundReaction(
+            id,
+            bot,
+            channelState,
+            input,
+            IN_PROGRESS_REACTION_EMOJI,
+            'in_progress',
+          );
+        } else if (delivery.status === 'failed') {
+          console.error(
+            `[server] failed to submit Feishu inbound for dispatcher '${id}': ${delivery.error.message}`,
+          );
         }
       });
     } catch (err) {
@@ -327,7 +360,7 @@ export class Server {
       input.text,
     );
     if (input.messageId !== undefined) {
-      await clearReceivedReaction(
+      await clearInboundReaction(
         input.dispatcherId,
         slot.bot,
         slot.channelState,
@@ -386,63 +419,81 @@ export class Server {
   }
 }
 
-async function addReceivedReaction(
+async function setInboundReaction(
   dispatcherId: string,
   bot: FeishuBot,
   channelState: DispatcherChannelState,
-  event: FeishuInboundEvent,
+  input: InboundTurnInput,
+  emoji: string,
+  state: InboundReactionState,
 ): Promise<void> {
+  const messageId = input.source_message_id;
+  if (messageId === null || messageId === '') return;
+  if (channelState.pendingReceivedReactionClears.has(messageId)) return;
+
+  const previous = channelState.inboundReactions.get(messageId);
+  if (previous !== undefined) {
+    try {
+      await bot.removeReaction(messageId, previous.reactionId);
+    } catch (err) {
+      console.error(
+        `[server] failed to replace the ${previous.state} reaction for dispatcher '${dispatcherId}' message '${messageId}':`,
+        err,
+      );
+    }
+    channelState.inboundReactions.delete(messageId);
+  }
+  if (channelState.pendingReceivedReactionClears.has(messageId)) return;
+
   try {
-    const reactionId = await bot.addReaction(
-      event.messageId,
-      RECEIVED_REACTION_EMOJI,
-    );
+    const reactionId = await bot.addReaction(messageId, emoji);
     if (reactionId === '') {
       console.error(
-        `[server] Feishu returned no reaction_id for the received reaction in dispatcher '${dispatcherId}'`,
+        `[server] Feishu returned no reaction_id for the ${state} reaction in dispatcher '${dispatcherId}'`,
       );
-      channelState.pendingReceivedReactionClears.delete(event.messageId);
       return;
     }
-    channelState.receivedReactions.set(event.messageId, {
-      chatId: event.chatId,
-      reactionId,
-    });
-    if (channelState.pendingReceivedReactionClears.has(event.messageId)) {
-      await clearReceivedReaction(
-        dispatcherId,
-        bot,
-        channelState,
-        event.messageId,
-      );
+    if (channelState.pendingReceivedReactionClears.has(messageId)) {
+      try {
+        await bot.removeReaction(messageId, reactionId);
+      } catch (err) {
+        console.error(
+          `[server] failed to clear the late ${state} reaction for dispatcher '${dispatcherId}' message '${messageId}':`,
+          err,
+        );
+      }
+      return;
     }
+    channelState.inboundReactions.set(messageId, {
+      chatId: input.source_chat_id,
+      reactionId,
+      state,
+    });
   } catch (err) {
-    channelState.pendingReceivedReactionClears.delete(event.messageId);
     console.error(
-      `[server] failed to add the received reaction for dispatcher '${dispatcherId}':`,
+      `[server] failed to add the ${state} reaction for dispatcher '${dispatcherId}':`,
       err,
     );
   }
 }
 
-async function clearReceivedReaction(
+async function clearInboundReaction(
   dispatcherId: string,
   bot: FeishuBot,
   channelState: DispatcherChannelState,
   messageId: string,
 ): Promise<void> {
-  const reaction = channelState.receivedReactions.get(messageId);
+  rememberPendingReceivedReactionClear(channelState, messageId);
+  const reaction = channelState.inboundReactions.get(messageId);
   if (reaction === undefined) {
-    rememberPendingReceivedReactionClear(channelState, messageId);
     return;
   }
   try {
     await bot.removeReaction(messageId, reaction.reactionId);
-    channelState.receivedReactions.delete(messageId);
-    channelState.pendingReceivedReactionClears.delete(messageId);
+    channelState.inboundReactions.delete(messageId);
   } catch (err) {
     console.error(
-      `[server] failed to clear the received reaction for dispatcher '${dispatcherId}' message '${messageId}':`,
+      `[server] failed to clear the ${reaction.state} reaction for dispatcher '${dispatcherId}' message '${messageId}':`,
       err,
     );
   }

--- a/packages/dreamux/tests/codex-live.test.ts
+++ b/packages/dreamux/tests/codex-live.test.ts
@@ -16,6 +16,11 @@
  * **Escape hatch**: set `DREAMUX_SKIP_LIVE_CODEX=1` to explicitly opt out
  * (e.g. dev machines without codex, or pre-merge sandboxes). The skip
  * emits a loud `console.warn` so it's visible in test output.
+ *
+ * The issue #63 mid-turn model gate needs a usable Codex model login, not just
+ * the app-server binary. It runs by default outside CI. CI loud-skips that one
+ * gate unless `DREAMUX_RUN_LIVE_MODEL_GATE=1` is set, because public CI cannot
+ * assume an operator's interactive Codex auth is available.
  */
 
 import { describe, it, expect } from 'vitest';
@@ -25,14 +30,29 @@ import { homedir } from 'node:os';
 import { isAbsolute, join } from 'node:path';
 
 import { CodexProcess } from '../src/codex/supervisor.js';
-import { CodexWsClient } from '../src/codex/rpc.js';
+import { CodexWsClient, type CodexWsClientOptions } from '../src/codex/rpc.js';
 import { performInitializeHandshake } from '../src/codex/handshake.js';
 import { feishuMcpCodexArgs } from '../src/codex/mcp-config.js';
 import { codexArgsToCli, parseCodexArgs } from '../src/runtime/codex-args.js';
 import { dreamuxBinPath } from '../src/runtime/package-bin.js';
-import type { ThreadStartResponse } from '../src/codex/types.js';
+import {
+  IN_PROGRESS_REACTION_EMOJI,
+  RECEIVED_REACTION_EMOJI,
+  Server,
+} from '../src/server.js';
+import {
+  createFakeFeishuBot,
+  type FakeFeishuBot,
+  type FeishuInboundEvent,
+} from '../src/feishu/bot.js';
+import { BUILT_IN_DEFAULTS, type DreamuxConfig } from '../src/runtime/config.js';
+import type {
+  ServerNotification,
+  ThreadStartResponse,
+} from '../src/codex/types.js';
 
 export const SKIP_ENV = 'DREAMUX_SKIP_LIVE_CODEX';
+export const MODEL_GATE_ENV = 'DREAMUX_RUN_LIVE_MODEL_GATE';
 
 export type Detection =
   | { state: 'ok'; version: string }
@@ -88,9 +108,158 @@ interface McpServerStatusListResponse {
   }>;
 }
 
+interface RecordedRequest {
+  method: string;
+  params: unknown;
+  sentAt: number;
+  ackedAt: number | null;
+  result: unknown;
+  error: string | null;
+}
+
+interface RecordedNotification {
+  at: number;
+  notification: ServerNotification;
+}
+
+class RecordingCodexWsClient extends CodexWsClient {
+  readonly requests: RecordedRequest[] = [];
+  readonly notifications: RecordedNotification[] = [];
+
+  constructor(opts: CodexWsClientOptions) {
+    super(opts);
+    this.onNotification((notification) => {
+      this.notifications.push({ at: Date.now(), notification });
+    });
+  }
+
+  override async request<R = unknown>(
+    method: string,
+    params: unknown,
+  ): Promise<R> {
+    const record: RecordedRequest = {
+      method,
+      params,
+      sentAt: Date.now(),
+      ackedAt: null,
+      result: null,
+      error: null,
+    };
+    this.requests.push(record);
+    try {
+      const result = await super.request<R>(method, params);
+      record.ackedAt = Date.now();
+      record.result = result;
+      return result;
+    } catch (err) {
+      record.ackedAt = Date.now();
+      record.error = err instanceof Error ? err.message : String(err);
+      throw err;
+    }
+  }
+}
+
+function fakeInbound(
+  chatId: string,
+  text: string,
+  messageId: string,
+): FeishuInboundEvent {
+  return {
+    messageId,
+    chatId,
+    chatType: 'group',
+    senderId: 'sender-live',
+    senderType: 'user',
+    senderName: 'Live Tester',
+    messageType: 'text',
+    rawContent: JSON.stringify({ text }),
+    parsedText: text,
+    mentions: [
+      {
+        key: '@_user_1',
+        id: { open_id: 'fake-open-id-app-live' },
+        name: 'Dispatcher',
+      },
+    ],
+    createTime: String(Date.now()),
+    raw: { event: { message: { chat_id: chatId, message_id: messageId } } },
+  };
+}
+
+function liveConfig(dispatcherCwd: string, codexHomeEnv: string): DreamuxConfig {
+  return {
+    ...BUILT_IN_DEFAULTS,
+    codex: {
+      ...BUILT_IN_DEFAULTS.codex,
+      sandbox_mode: 'danger-full-access',
+      initialize_timeout_ms: 15_000,
+    },
+    dispatchers: [
+      {
+        id: 'live',
+        cwd: dispatcherCwd,
+        enabled: true,
+        feishu: {
+          app_id: 'app-live',
+          app_secret: 'secret-server-only',
+        },
+        codex: {
+          approval_policy: null,
+          sandbox_mode: null,
+          extra_args: [],
+          extra_env: {
+            HOME: codexHomeEnv,
+          },
+        },
+      },
+    ],
+  };
+}
+
+async function waitFor(
+  predicate: () => boolean,
+  timeoutMs = 10_000,
+  label = 'condition',
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (predicate()) return;
+    await new Promise((resolve) => setTimeout(resolve, 100));
+  }
+  throw new Error(`waitFor timed out: ${label}`);
+}
+
+function notifications(
+  client: RecordingCodexWsClient,
+  method: string,
+): RecordedNotification[] {
+  return client.notifications.filter(
+    (entry) => entry.notification.method === method,
+  );
+}
+
+function hasCommandExecutionStarted(client: RecordingCodexWsClient): boolean {
+  return notifications(client, 'item/started').some((entry) => {
+    const params = entry.notification.params;
+    if (params === null || typeof params !== 'object') return false;
+    const item = (params as Record<string, unknown>)['item'];
+    return (
+      item !== null &&
+      typeof item === 'object' &&
+      (item as Record<string, unknown>)['type'] === 'commandExecution'
+    );
+  });
+}
+
+function turnStartRequests(client: RecordingCodexWsClient): RecordedRequest[] {
+  return client.requests.filter((request) => request.method === 'turn/start');
+}
+
 describe('codex live integration', () => {
   const skipRequested = process.env[SKIP_ENV] === '1';
   const detection = detectCodex();
+  const runModelGate =
+    process.env[MODEL_GATE_ENV] === '1' || process.env['CI'] !== 'true';
 
   if (skipRequested) {
     // Opt-in skip — loud so it can't be missed in CI / local output.
@@ -118,6 +287,13 @@ describe('codex live integration', () => {
   }
 
   // From here on we know codex is on PATH and reports a parseable version.
+  if (!runModelGate) {
+    console.warn(
+      `[codex-live] issue #63 mid-turn model gate SKIPPED in CI. ` +
+        `Set ${MODEL_GATE_ENV}=1 in an environment with usable Codex model auth ` +
+        `to verify the real model/tool folding path.`,
+    );
+  }
 
   it(
     `spawns codex ${detection.version}, completes init handshake, starts a thread`,
@@ -235,6 +411,142 @@ describe('codex live integration', () => {
       }
     },
     30_000,
+  );
+
+  (runModelGate ? it : it.skip)(
+    `folds mid-turn Feishu inbound submitted via turn/start and completes reaction tri-state`,
+    async () => {
+      if (!versionAtLeast(detection.version, '0.136.0')) {
+        throw new Error(
+          `dreamux's issue #63 live gate requires codex >= 0.136.0; detected ${detection.version}`,
+        );
+      }
+
+      const dreamuxBin = dreamuxBinPath();
+      if (!isAbsolute(dreamuxBin) || !existsSync(dreamuxBin)) {
+        throw new Error(
+          `dreamux issue #63 live gate requires an absolute built dreamux bin path; got ${dreamuxBin}`,
+        );
+      }
+
+      const operatorHome = homedir();
+      const previousHome = process.env['HOME'];
+      const previousCodexHome = process.env['CODEX_HOME'];
+      const dir = mkdtempSync(join(operatorHome, '.dreamux-issue63-live-'));
+      const runtimeHome = join(dir, 'home');
+      const dispatcherCwd = join(dir, 'cwd');
+      const adminSocket = join(dir, 'admin.sock');
+      const bot = createFakeFeishuBot('app-live');
+      let client: RecordingCodexWsClient | null = null;
+      let server: Server | null = null;
+
+      process.env['HOME'] = runtimeHome;
+      process.env['CODEX_HOME'] = previousCodexHome ?? join(operatorHome, '.codex');
+
+      try {
+        server = new Server({
+          config: liveConfig(dispatcherCwd, operatorHome),
+          adminSocketPath: adminSocket,
+          skipBotSecret: true,
+          botFactory: () => bot,
+          codexClientFactory: (socketPath) => {
+            client = new RecordingCodexWsClient({ socketPath });
+            return client;
+          },
+          codexHomeDoctor: () => {
+            /* real Codex auth is supplied through CODEX_HOME above */
+          },
+        });
+        await server.start();
+        expect(client).not.toBeNull();
+        const liveClient = client!;
+        const marker = `ISSUE63_LIVE_MARKER_${Date.now()}`;
+        const startMessageId = 'msg-live-start';
+        const markerMessageId = 'msg-live-marker';
+        const startPrompt = [
+          'Integration gate for dreamux issue #63.',
+          'Do exactly this sequence:',
+          '1. First call exec_command with cmd "sleep 6; echo issue63-sleep-done" and wait until it completes.',
+          '2. After that command returns, inspect any later Feishu inbound message folded into this same turn.',
+          '3. When you see a later message containing a token that starts with ISSUE63_LIVE_MARKER_, call the Feishu MCP reply tool.',
+          '4. Reply to that later message, not this setup message, and include the marker token verbatim in the reply text.',
+          'Do not send any plain assistant answer before the Feishu MCP reply call.',
+        ].join('\n');
+
+        await bot.inject(fakeInbound('chat-live', startPrompt, startMessageId));
+        await waitFor(
+          () => turnStartRequests(liveClient).length === 1,
+          10_000,
+          'first turn/start accepted',
+        );
+        await waitFor(
+          () => hasCommandExecutionStarted(liveClient),
+          45_000,
+          'command execution started before marker injection',
+        );
+        expect(notifications(liveClient, 'turn/completed')).toHaveLength(0);
+
+        await bot.inject(
+          fakeInbound(
+            'chat-live',
+            `Please handle this folded marker now: ${marker}`,
+            markerMessageId,
+          ),
+        );
+        const markerTurnStart = turnStartRequests(liveClient)[1];
+        expect(markerTurnStart).toBeDefined();
+        expect(markerTurnStart!.ackedAt).not.toBeNull();
+        expect(notifications(liveClient, 'turn/completed')).toHaveLength(0);
+
+        await waitFor(
+          () => bot.sentMessages.some((message) => message.text.includes(marker)),
+          120_000,
+          'model replied through Feishu MCP with folded marker',
+        );
+
+        const markerReply = bot.sentMessages.find((message) =>
+          message.text.includes(marker),
+        );
+        expect(markerReply).toMatchObject({
+          chatId: 'chat-live',
+          target: {
+            chatId: 'chat-live',
+            replyToMessageId: markerMessageId,
+          },
+        });
+
+        await waitFor(
+          () => notifications(liveClient, 'turn/completed').length >= 1,
+          30_000,
+          'active turn completed',
+        );
+        await new Promise((resolve) => setTimeout(resolve, 500));
+        expect(turnStartRequests(liveClient)).toHaveLength(2);
+        expect(notifications(liveClient, 'turn/completed')).toHaveLength(1);
+
+        const markerReactions = bot.reactions.filter(
+          (reaction) => reaction.messageId === markerMessageId,
+        );
+        expect(markerReactions.map((reaction) => reaction.emoji)).toEqual([
+          RECEIVED_REACTION_EMOJI,
+          IN_PROGRESS_REACTION_EMOJI,
+        ]);
+        const markerRemoved = bot.removedReactions.filter(
+          (reaction) => reaction.messageId === markerMessageId,
+        );
+        expect(markerRemoved.map((reaction) => reaction.reactionId)).toEqual(
+          markerReactions.map((reaction) => reaction.reactionId),
+        );
+      } finally {
+        await server?.shutdown();
+        if (previousHome === undefined) delete process.env['HOME'];
+        else process.env['HOME'] = previousHome;
+        if (previousCodexHome === undefined) delete process.env['CODEX_HOME'];
+        else process.env['CODEX_HOME'] = previousCodexHome;
+        rmSync(dir, { recursive: true, force: true });
+      }
+    },
+    180_000,
   );
 });
 

--- a/packages/dreamux/tests/e2e.test.ts
+++ b/packages/dreamux/tests/e2e.test.ts
@@ -9,7 +9,11 @@ import { tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
 import { PassThrough } from 'node:stream';
 
-import { RECEIVED_REACTION_EMOJI, Server } from '../src/server.js';
+import {
+  IN_PROGRESS_REACTION_EMOJI,
+  RECEIVED_REACTION_EMOJI,
+  Server,
+} from '../src/server.js';
 import { sendAdminRequest } from '../src/admin/client.js';
 import { loadDispatcherAccess } from '../src/channel/feishu-gate.js';
 import { CodexWsClient } from '../src/codex/rpc.js';
@@ -263,7 +267,7 @@ describe('dreamux cross-module e2e', () => {
     await bot.inject(fakeInbound('chat-group-a', 'please reply', 'msg-e2e-1'));
 
     await waitFor(() => codexInputs.length === 1);
-    await waitFor(() => bot.reactions.length === 1);
+    await waitFor(() => bot.reactions.length === 2);
     expect(codexInputs[0]).toContain('<feishu_message');
     expect(codexInputs[0]).toContain('sender_name="Ada"');
     expect(codexInputs[0]).toContain('please reply');
@@ -272,6 +276,11 @@ describe('dreamux cross-module e2e', () => {
         messageId: 'msg-e2e-1',
         emoji: RECEIVED_REACTION_EMOJI,
         reactionId: 'reaction-fake-1',
+      },
+      {
+        messageId: 'msg-e2e-1',
+        emoji: IN_PROGRESS_REACTION_EMOJI,
+        reactionId: 'reaction-fake-2',
       },
     ]);
 
@@ -309,6 +318,10 @@ describe('dreamux cross-module e2e', () => {
         messageId: 'msg-e2e-1',
         reactionId: 'reaction-fake-1',
       },
+      {
+        messageId: 'msg-e2e-1',
+        reactionId: 'reaction-fake-2',
+      },
     ]);
   });
 
@@ -320,7 +333,7 @@ describe('dreamux cross-module e2e', () => {
       fakeInbound('chat-group-a', 'restart before reply', 'msg-restart'),
     );
     await waitFor(() => codexInputs.length === 1);
-    await waitFor(() => bot.reactions.length === 1);
+    await waitFor(() => bot.reactions.length === 2);
     expect(loadDispatcherAccess('flow').observed_chats).toEqual(['chat-group-a']);
 
     await server.shutdown();
@@ -342,12 +355,22 @@ describe('dreamux cross-module e2e', () => {
       },
     });
     expect(bot.sentMessages).toHaveLength(1);
-    expect(bot.removedReactions).toEqual([]);
+    expect(bot.removedReactions).toEqual([
+      {
+        messageId: 'msg-restart',
+        reactionId: 'reaction-fake-1',
+      },
+    ]);
     expect(bot.reactions).toEqual([
       {
         messageId: 'msg-restart',
         emoji: RECEIVED_REACTION_EMOJI,
         reactionId: 'reaction-fake-1',
+      },
+      {
+        messageId: 'msg-restart',
+        emoji: IN_PROGRESS_REACTION_EMOJI,
+        reactionId: 'reaction-fake-2',
       },
     ]);
   });

--- a/packages/dreamux/tests/fake-codex.ts
+++ b/packages/dreamux/tests/fake-codex.ts
@@ -8,8 +8,9 @@
  *                                 item/completed (agentMessage)
  *                                 turn/completed
  *
- * Lets tests assert behavior (queueing, coalescing, MCP reply-only outbound,
- * approval fail-fast) without spawning a real codex binary.
+ * Lets tests assert behavior (inbound submission, optional active-turn folding,
+ * MCP reply-only outbound, approval fail-fast) without spawning a real codex
+ * binary.
  */
 
 import { createServer, type Server as HttpServer } from 'node:http';
@@ -28,6 +29,11 @@ export interface FakeCodexOptions {
   /** Delay between turn/start ack and the eventual turn/completed (ms). */
   turnDelayMs?: number;
   /**
+   * If true, additional turn/start requests while a fake turn is active are
+   * accepted and folded into that active turn instead of completing separately.
+   */
+  activeTurnFolding?: boolean;
+  /**
    * If true, mimic real codex 0.134 behavior: any non-`initialize` RPC
    * before the `initialized` notification arrives returns
    * `{error: {message: 'Not initialized'}}`. Default: true.
@@ -42,7 +48,10 @@ export interface FakeCodexOptions {
 
 export interface FakeCodex {
   readonly url: string;
+  /** Number of turn/start requests accepted by the fake. */
   readonly turnsHandled: number;
+  /** Number of turn/completed notifications emitted by the fake. */
+  readonly turnsCompleted: number;
   /** True once the client has completed the init handshake. */
   readonly initializedAt: number | null;
   /** Method names received in order — useful for asserting handshake order. */
@@ -56,11 +65,17 @@ export async function startFakeCodex(opts: FakeCodexOptions = {}): Promise<FakeC
   let nextThreadId = 1;
   let nextTurnId = 1;
   let turnsHandled = 0;
+  let turnsCompleted = 0;
   let nextSrvReqId = 100;
   let initializedAt: number | null = null;
   const methodLog: string[] = [];
   const enforceInit = opts.enforceInitHandshake !== false;
   const clients = new Set<WebSocket>();
+  let activeTurn: {
+    threadId: string;
+    turnId: string;
+    inputs: string[];
+  } | null = null;
 
   wss.on('connection', (ws: WebSocket) => {
     clients.add(ws);
@@ -146,12 +161,20 @@ export async function startFakeCodex(opts: FakeCodexOptions = {}): Promise<FakeC
         return;
       }
       const tid = String(params['threadId']);
+      const input = extractText(params['input']);
+      if (opts.activeTurnFolding === true && activeTurn !== null) {
+        const submissionId = `turn_fake_${nextTurnId++}`;
+        activeTurn.inputs.push(input);
+        send(ws, { id, result: { turn: { id: submissionId } } });
+        turnsHandled++;
+        return;
+      }
       const turnId = `turn_fake_${nextTurnId++}`;
       send(ws, { id, result: { turn: { id: turnId } } });
       turnsHandled++;
-
-      const input = extractText(params['input']);
-      const reply = opts.replyFor ? opts.replyFor(input) : `echo: ${input}`;
+      if (opts.activeTurnFolding === true) {
+        activeTurn = { threadId: tid, turnId, inputs: [input] };
+      }
 
       void (async () => {
         await delay(opts.turnDelayMs ?? 10);
@@ -164,6 +187,17 @@ export async function startFakeCodex(opts: FakeCodexOptions = {}): Promise<FakeC
           });
           await delay(20);
         }
+        const completionInputs =
+          opts.activeTurnFolding === true && activeTurn?.turnId === turnId
+            ? activeTurn.inputs.slice()
+            : [input];
+        if (opts.activeTurnFolding === true && activeTurn?.turnId === turnId) {
+          activeTurn = null;
+        }
+        const completionInput = completionInputs.join('\n\n');
+        const reply = opts.replyFor
+          ? opts.replyFor(completionInput)
+          : `echo: ${completionInput}`;
         if (reply !== null) {
           send(ws, {
             method: 'item/completed',
@@ -179,6 +213,7 @@ export async function startFakeCodex(opts: FakeCodexOptions = {}): Promise<FakeC
           method: 'turn/completed',
           params: { threadId: tid, turn: { id: turnId, items: [] } },
         });
+        turnsCompleted++;
       })();
       return;
     }
@@ -194,6 +229,9 @@ export async function startFakeCodex(opts: FakeCodexOptions = {}): Promise<FakeC
     url,
     get turnsHandled() {
       return turnsHandled;
+    },
+    get turnsCompleted() {
+      return turnsCompleted;
     },
     get initializedAt() {
       return initializedAt;

--- a/packages/dreamux/tests/smoke.test.ts
+++ b/packages/dreamux/tests/smoke.test.ts
@@ -3,7 +3,7 @@
  *
  * Covers the issue #2 verification path against a fake codex + fake feishu:
  *   - happy path: inbound → turn injection, with MCP reply as the only outbound
- *   - in-memory queue: same-chat coalescing + serialized turns
+ *   - inbound delivery: one accepted Feishu message → one turn/start
  *   - thread/resume on restart (in-process)
  *   - thread/resume failure → visible degradation (last_lost_thread_id set)
  *   - MCP reply sends through the serve-owned bot
@@ -21,7 +21,11 @@ import {
 import { homedir, tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
 
-import { RECEIVED_REACTION_EMOJI, Server } from '../src/server.js';
+import {
+  IN_PROGRESS_REACTION_EMOJI,
+  RECEIVED_REACTION_EMOJI,
+  Server,
+} from '../src/server.js';
 import {
   CodexProcess,
   type CodexProcessExit,
@@ -281,6 +285,17 @@ describe('dreamux MVP smoke', () => {
         emoji: RECEIVED_REACTION_EMOJI,
         reactionId: 'reaction-fake-1',
       },
+      {
+        messageId: 'msg-1-id',
+        emoji: IN_PROGRESS_REACTION_EMOJI,
+        reactionId: 'reaction-fake-2',
+      },
+    ]);
+    expect(bot.removedReactions).toEqual([
+      {
+        messageId: 'msg-1-id',
+        reactionId: 'reaction-fake-1',
+      },
     ]);
 
     // Dispatcher's thread is persisted across server restart.
@@ -416,7 +431,7 @@ describe('dreamux MVP smoke', () => {
     await server.start();
 
     await bot.inject(fakeInbound('chat-group-a', 'needs reply', 'msg-mcp-reply'));
-    await waitFor(() => bot.reactions.length === 1);
+    await waitFor(() => bot.reactions.length === 2);
 
     const result = await sendAdminRequest(
       'mcp.reply',
@@ -447,6 +462,10 @@ describe('dreamux MVP smoke', () => {
       {
         messageId: 'msg-mcp-reply',
         reactionId: 'reaction-fake-1',
+      },
+      {
+        messageId: 'msg-mcp-reply',
+        reactionId: 'reaction-fake-2',
       },
     ]);
   });
@@ -507,6 +526,13 @@ describe('dreamux MVP smoke', () => {
     expect(bot.removedReactions).toEqual([
       {
         messageId: 'msg-race-reaction',
+        reactionId: 'reaction-fake-1',
+      },
+    ]);
+    expect(bot.reactions).toEqual([
+      {
+        messageId: 'msg-race-reaction',
+        emoji: RECEIVED_REACTION_EMOJI,
         reactionId: 'reaction-fake-1',
       },
     ]);
@@ -670,6 +696,11 @@ describe('dreamux MVP smoke', () => {
     expect(access.observed_chats).toEqual(['chat-dm']);
     expect(bot.reactions.map((reaction) => reaction.messageId)).toEqual([
       'msg-dm',
+      'msg-dm',
+    ]);
+    expect(bot.reactions.map((reaction) => reaction.emoji)).toEqual([
+      RECEIVED_REACTION_EMOJI,
+      IN_PROGRESS_REACTION_EMOJI,
     ]);
   });
 
@@ -690,18 +721,21 @@ describe('dreamux MVP smoke', () => {
     expect(access.warnings).toEqual([TRUST_DOMAIN_WARNING]);
     expect(bot.reactions.map((reaction) => reaction.messageId)).toEqual([
       'msg-chat-a',
+      'msg-chat-a',
+      'msg-chat-b',
       'msg-chat-b',
     ]);
     await waitFor(() => fake.turnsHandled === 2);
     expect(bot.sentMessages).toEqual([]);
   });
 
-  it('in-memory queue coalesces pending same-chat messages behind a running turn', async () => {
-    // Restart fake with a slow turn so messages can actually pile up.
+  it('submits each pending inbound with turn/start while Codex folds active-turn input', async () => {
+    // Restart fake with a slow active turn so later submissions fold into it.
     await fake.close();
     codexInputs = [];
     fake = await startFakeCodex({
-      turnDelayMs: 80,
+      activeTurnFolding: true,
+      turnDelayMs: 300,
       replyFor: captureAndEchoCodexInput(codexInputs),
     });
 
@@ -717,13 +751,16 @@ describe('dreamux MVP smoke', () => {
     await bot.inject(fakeInbound('chat-group-b', 'batch-1', 'msg-b1'));
     await bot.inject(fakeInbound('chat-group-b', 'batch-2', 'msg-b2'));
 
-    await waitFor(() => fake.turnsHandled === 2, 6000);
-    expect(fake.turnsHandled).toBe(2);
-    expect(codexInputs).toHaveLength(2);
+    await waitFor(() => fake.turnsHandled === 3, 6000);
+    await waitFor(() => fake.turnsCompleted === 1, 6000);
+    expect(fake.turnsHandled).toBe(3);
+    expect(fake.methodLog.filter((method) => method === 'turn/start'))
+      .toHaveLength(3);
+    expect(codexInputs).toHaveLength(1);
     expect(codexInputs[0]).toContain('running');
-    expect(feishuMessageBlockCount(codexInputs[1] ?? '')).toBe(2);
-    expect(codexInputs[1]).toContain('batch-1');
-    expect(codexInputs[1]).toContain('batch-2');
+    expect(feishuMessageBlockCount(codexInputs[0] ?? '')).toBe(3);
+    expect(codexInputs[0]).toContain('batch-1');
+    expect(codexInputs[0]).toContain('batch-2');
     expect(bot.sentMessages).toEqual([]);
   });
 
@@ -742,8 +779,12 @@ describe('dreamux MVP smoke', () => {
     await waitFor(() => fake.turnsHandled === 1);
     await sleep(120);
     expect(fake.turnsHandled).toBe(1);
-    expect(bot.reactions).toHaveLength(1);
+    expect(bot.reactions).toHaveLength(2);
     expect(bot.reactions[0]?.messageId).toBe('msg-same');
+    expect(bot.reactions[1]).toMatchObject({
+      messageId: 'msg-same',
+      emoji: IN_PROGRESS_REACTION_EMOJI,
+    });
   });
 
   it('thread/resume failure produces visible degradation, not silent loss', async () => {
@@ -793,6 +834,36 @@ describe('dreamux MVP smoke', () => {
     await waitFor(() => fake.turnsHandled === 1);
     await sleep(120);
     expect(bot.sentMessages).toEqual([]);
+  });
+
+  it('keeps only the received reaction when turn/start is refused before accept', async () => {
+    await fake.close();
+    codexInputs = [];
+    fake = await startFakeCodex({
+      failTurnStart: true,
+      replyFor: captureAndEchoCodexInput(codexInputs),
+    });
+
+    server = buildServer({ runtimeDir, fake, bot });
+    server.repos.dispatchers.create({
+      dispatcher_id: 'flow',
+      bot_app_id: 'app-smoke',
+      bot_secret_ref: 'env:UNUSED',
+    });
+    await server.start();
+
+    await bot.inject(fakeInbound('chat-group-a', 'will fail', 'msg-start-fail'));
+
+    await sleep(120);
+    expect(fake.turnsHandled).toBe(0);
+    expect(bot.reactions).toEqual([
+      {
+        messageId: 'msg-start-fail',
+        emoji: RECEIVED_REACTION_EMOJI,
+        reactionId: 'reaction-fake-1',
+      },
+    ]);
+    expect(bot.removedReactions).toEqual([]);
   });
 
   // PR fix/codex-0134-compat: the daemon expects an LSP-style init handshake

--- a/packages/dreamux/tests/turn-manager.test.ts
+++ b/packages/dreamux/tests/turn-manager.test.ts
@@ -4,20 +4,34 @@ import { TurnManager } from '../src/dispatcher/turn-manager.js';
 import type { NotificationHandler } from '../src/codex/rpc.js';
 import type { ServerNotification, TurnStartResponse } from '../src/codex/types.js';
 
-describe('TurnManager in-memory queue', () => {
-  it('coalesces same-chat messages enqueued in the same tick without outbound', async () => {
+describe('TurnManager inbound submission', () => {
+  it('submits every accepted message through turn/start without coalescing', async () => {
     const client = new FakeCodexClient();
     const manager = new TurnManager({
       dispatcherId: 'flow',
       getThreadId: () => 'thread-1',
       client: client as never,
     });
+    const accepted: string[] = [];
 
-    expect(manager.enqueue(input('msg-1', 'first'))).toBe(true);
-    expect(manager.enqueue(input('msg-2', 'second'))).toBe(true);
+    await expect(
+      manager.enqueue(input('msg-1', 'first'), {
+        onAccepted: (acceptedInput) => {
+          accepted.push(acceptedInput.source_message_id);
+        },
+      }),
+    ).resolves.toEqual({ status: 'submitted', turnId: 'turn-1' });
+    await expect(
+      manager.enqueue(input('msg-2', 'second'), {
+        onAccepted: (acceptedInput) => {
+          accepted.push(acceptedInput.source_message_id);
+        },
+      }),
+    ).resolves.toEqual({ status: 'submitted', turnId: 'turn-2' });
 
-    await waitFor(() => client.inputs.length === 1);
-    expect(client.inputs).toEqual(['first\n\nsecond']);
+    expect(accepted).toEqual(['msg-1', 'msg-2']);
+    expect(client.methods).toEqual(['turn/start', 'turn/start']);
+    expect(client.inputs).toEqual(['first', 'second']);
   });
 
   it('bounds the process-local message_id dedupe window', async () => {
@@ -29,20 +43,21 @@ describe('TurnManager in-memory queue', () => {
       messageIdDedupeWindow: 2,
     });
 
-    expect(manager.enqueue(input('msg-1', 'first'))).toBe(true);
-    await waitFor(() => client.inputs.length === 1);
+    await expect(manager.enqueue(input('msg-1', 'first'))).resolves
+      .toMatchObject({ status: 'submitted' });
 
-    expect(manager.enqueue(input('msg-2', 'second'))).toBe(true);
-    await waitFor(() => client.inputs.length === 2);
+    await expect(manager.enqueue(input('msg-2', 'second'))).resolves
+      .toMatchObject({ status: 'submitted' });
 
-    expect(manager.enqueue(input('msg-3', 'third'))).toBe(true);
-    await waitFor(() => client.inputs.length === 3);
+    await expect(manager.enqueue(input('msg-3', 'third'))).resolves
+      .toMatchObject({ status: 'submitted' });
 
-    expect(manager.enqueue(input('msg-2', 'second still in window'))).toBe(false);
-    expect(manager.enqueue(input('msg-1', 'first redelivered after eviction')))
-      .toBe(true);
+    await expect(manager.enqueue(input('msg-2', 'second still in window')))
+      .resolves.toEqual({ status: 'duplicate' });
+    await expect(
+      manager.enqueue(input('msg-1', 'first redelivered after eviction')),
+    ).resolves.toMatchObject({ status: 'submitted' });
 
-    await waitFor(() => client.inputs.length === 4);
     expect(client.inputs).toEqual([
       'first',
       'second',
@@ -63,6 +78,7 @@ function input(messageId: string, text: string) {
 
 class FakeCodexClient {
   readonly inputs: string[] = [];
+  readonly methods: string[] = [];
   private readonly handlers: NotificationHandler[] = [];
   private nextTurnId = 1;
 
@@ -72,6 +88,7 @@ class FakeCodexClient {
 
   async request<R>(method: string, params: unknown): Promise<R> {
     if (method !== 'turn/start') throw new Error(`unexpected method ${method}`);
+    this.methods.push(method);
     const p = params as {
       threadId: string;
       input: Array<{ text: string }>;
@@ -103,16 +120,4 @@ class FakeCodexClient {
   private emit(notification: ServerNotification): void {
     for (const handler of this.handlers) handler(notification);
   }
-}
-
-async function waitFor(
-  predicate: () => boolean,
-  timeoutMs = 1000,
-): Promise<void> {
-  const deadline = Date.now() + timeoutMs;
-  while (Date.now() < deadline) {
-    if (predicate()) return;
-    await new Promise((resolve) => setTimeout(resolve, 10));
-  }
-  throw new Error('waitFor timed out');
 }


### PR DESCRIPTION
## Summary
- Submit every accepted, deduped Feishu inbound via aggregate `turn/start` without waiting for `turn/completed`.
- Replace the old completion-gated queue/coalescing path with per-message delivery and process-local dedupe.
- Implement the channel-owned reaction tri-state: received -> in progress -> cleared on MCP reply, including reply-before-add reconciliation.
- Add fake Codex active-turn folding coverage and a real Codex app-server live gate for issue #63.
- Document the issue #63 runtime contract in `.agents/domains/non-blocking-dispatcher-inbound.md`.

## Verification
- `node common/scripts/install-run-rush.js update`
- `node common/scripts/install-run-rush.js build`
- `node common/scripts/install-run-rush.js typecheck`
- `cd packages/dreamux && pnpm exec vitest run tests/turn-manager.test.ts tests/smoke.test.ts tests/e2e.test.ts`
- `cd packages/dreamux && pnpm exec vitest run tests/codex-live.test.ts` (real Codex 0.137.0; issue #63 mid-turn model gate passed)
- `cd packages/dreamux && CI=true pnpm exec vitest run tests/codex-live.test.ts` (CI-mode loud-skip for model-auth-only gate)
- `node common/scripts/install-run-rush.js test` (full suite; local run includes the real issue #63 model gate; Rush exits successfully with expected stderr logs)
- `.agents/scripts/check.sh`
- `gitleaks protect --staged --redact --verbose`

Fixes #63