### PR TITLE
Fix Feishu reaction emoji_type values

### DIFF
--- a/common/changes/@excitedjs/dreamux/fix-reaction-emoji-types_2026-06-04-14-05.json
+++ b/common/changes/@excitedjs/dreamux/fix-reaction-emoji-types_2026-06-04-14-05.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@excitedjs/dreamux",
+      "comment": "Fix Feishu inbound reaction emoji type values.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@excitedjs/dreamux"
+}

--- a/packages/dreamux/src/server.ts
+++ b/packages/dreamux/src/server.ts
@@ -45,8 +45,8 @@ import {
 } from './runtime/paths.js';
 import { createAdminSocketServer, type AdminSocketServer } from './admin/socket.js';
 
-export const RECEIVED_REACTION_EMOJI = 'GLANCE';
-export const IN_PROGRESS_REACTION_EMOJI = 'ON_IT';
+export const RECEIVED_REACTION_EMOJI = 'Get';
+export const IN_PROGRESS_REACTION_EMOJI = 'OnIt';
 const MAX_PENDING_RECEIVED_REACTION_CLEARS = 1024;
 
 export interface ServerOptions {


### PR DESCRIPTION
## Summary
- Use `Get` for the received reaction emoji_type instead of `GLANCE`
- Use `OnIt` for the in-progress reaction emoji_type instead of `ON_IT`
- Add the required Rush change file for `@excitedjs/dreamux`

## Notes
Feishu API validation confirms `Get` and `OnIt` are the accepted reaction emoji_type keys for these statuses. The previous `ON_IT` value is not accepted by the API, which prevents the in-progress reaction from being added.

## Verification
- `node common/scripts/install-run-rush.js update`
- `node common/scripts/install-run-rush.js build`
- `node common/scripts/install-run-rush.js typecheck`
- `node ../../common/scripts/install-run-rushx.js test tests/smoke.test.ts tests/e2e.test.ts` from `packages/dreamux`
- `node common/scripts/install-run-rush.js change --verify`
- `gitleaks protect --staged --redact --verbose`