### PR TITLE
feat(feishu): event-registry seam + group /introduce (issue #62, phase 1)

### DIFF
--- a/.agents/decisions/top-level-design.md
+++ b/.agents/decisions/top-level-design.md
@@ -144,6 +144,7 @@ State and logs are server-owned. They are not operator-editable config.
     dispatcher-a/
       status.json
       access.json
+      chat-bots.json
       codex.sock
   logs/
     dreamux-server.log
@@ -183,6 +184,15 @@ credentials.
 
 It must not contain credentials, queued inbound messages, dedupe state, or a
 reaction ledger.
+
+`chat-bots.json` stores per-dispatcher peer-bot discovery state, keyed by
+chat_id (issue #62). Each chat tracks a `known` set (bots passively observed in
+an authorized chat — awareness only) and a `trusted` set (bots introduced by an
+allowlisted `/introduce` — the only set the gate consults to let a peer bot's
+group message through). The two sets must never be conflated: observation never
+grants trust. It also records bot-added baseline bookkeeping (`needsBaseline`,
+`seenEventIds` for idempotent `im.chat.member.bot.added_v1` handling). It is
+server-owned discovery state, safe to delete; it holds no credentials.
 
 `codex.sock` is the Codex app-server WebSocket-over-Unix-socket endpoint for the
 dispatcher. It is not the Feishu MCP transport. The Feishu MCP default transport

--- a/.agents/domains/feishu-introduce.md
+++ b/.agents/domains/feishu-introduce.md
@@ -1,0 +1,72 @@
+# Feishu event-registry seam + group `/introduce`
+
+- **Status:** Implemented (issue #62, first increment). Invite-code/pairing and
+  rich attachments are deferred to follow-up PRs — see Deferred below.
+- **Source:** https://github.com/excitedjs/dreamux/issues/62
+- **Affects:** `/packages/dreamux/src/feishu/bot.ts`,
+  `/packages/dreamux/src/channel/introduce.ts`,
+  `/packages/dreamux/src/channel/chat-bots-store.ts`,
+  `/packages/dreamux/src/channel/feishu-gate.ts`,
+  `/packages/dreamux/src/server.ts`,
+  `/packages/dreamux/src/runtime/paths.ts`
+
+## Event-registry seam (Phase 1)
+
+`FeishuBot.start` takes a `FeishuInboundRoutes` object — one handler per Feishu
+event type — instead of a single message handler. The bot builds the transport
+route table from it and registers `im.message.receive_v1` always and
+`im.chat.member.bot.added_v1` when an `onBotMemberAdded` handler is supplied.
+Each route still awaits its handler before the SDK acks, preserving the
+queue-before-ACK invariant. New event types register here without growing
+branches in `Server` or the transport.
+
+`im.chat.member.bot.added_v1` is recorded idempotently by Feishu event id and
+flags the chat for a future baseline injection; it emits no model notification.
+
+## `/introduce` hard contract
+
+In a group, a `/introduce` message triggers **if and only if the sender is on
+the allowlist**. No `@`-mention of our bot is required, and the group's
+`require_mention` setting is ignored on this path.
+
+The authorization is sender-scoped, not group-scoped. `canRunIntroduce`
+(`channel/introduce.ts`) requires the chat to be explicitly in
+`group.allow_chats` **and** the sender to be explicitly in `group.follow_users`.
+An empty `follow_users` authorizes nobody — "any member of an allowlisted group"
+is deliberately **not** a path, and `canRunIntroduce` never reuses a broad
+group-authorization predicate that would trust the group without checking the
+sender's identity. A bot sender is never on the human allowlist, so ambient
+self-introduction by an arbitrary bot does not trigger introduce.
+
+Detection (`detectIntroduce`) is text-only and strips leading Feishu mention
+placeholder tokens before matching `^/introduce`, so an `@`-prefixed
+`/introduce` still matches regardless of who was mentioned. The peer bots being
+introduced are the message's other mentions; they are recorded as **trusted**
+for that chat and the `/introduce` message is consumed (never delivered to Codex
+as a turn).
+
+## Awareness vs trust
+
+`chat-bots.json` tracks two sets per chat that must never be conflated:
+
+- **known** — bots passively observed sending messages in an authorized chat.
+  Awareness only; observing a bot never grants it trust.
+- **trusted** — bots introduced by an allowlisted `/introduce`. Only this set
+  lets a peer bot's group message through the gate.
+
+`dreamuxFeishuGate` drops every bot sender except one whose open_id is in the
+chat's trusted set (passed as `trustedBotIds`); a trusted bot is delivered
+without an `@`-mention because a bot cannot mention us. When `trustedBotIds` is
+omitted, no bot sender is ever delivered — preserving prior behavior. Recording
+a human open_id as "trusted" is harmless: the gate only bypasses for a bot
+*sender*, so a human entry never widens access.
+
+## Deferred to follow-up PRs
+
+Not in this increment, tracked on issue #62:
+
+- Invite-code pairing, the shared `Access` contract migration, and the
+  operator approve/deny surface (`access.*` admin methods + CLI).
+- Rich inbound attachments (bounded authorized downloads, token references).
+- One-shot baseline discovery-context injection and a list-known-bots tool.
+- `doc_comment` handling.

--- a/.agents/domains/feishu-introduce.md
+++ b/.agents/domains/feishu-introduce.md
@@ -1,24 +1,25 @@
-# Feishu event-registry seam + group `/introduce`
+# Feishu event-route seam + group `/introduce`
 
 - **Status:** Implemented (issue #62, first increment). Invite-code/pairing and
   rich attachments are deferred to follow-up PRs — see Deferred below.
 - **Source:** https://github.com/excitedjs/dreamux/issues/62
-- **Affects:** `/packages/dreamux/src/feishu/bot.ts`,
-  `/packages/dreamux/src/channel/introduce.ts`,
-  `/packages/dreamux/src/channel/chat-bots-store.ts`,
-  `/packages/dreamux/src/channel/feishu-gate.ts`,
-  `/packages/dreamux/src/server.ts`,
-  `/packages/dreamux/src/runtime/paths.ts`
+- **Affects:** `packages/dreamux/src/feishu/bot.ts`,
+  `packages/dreamux/src/channel/introduce.ts`,
+  `packages/dreamux/src/channel/chat-bots-store.ts`,
+  `packages/dreamux/src/channel/feishu-gate.ts`,
+  `packages/dreamux/src/server.ts`,
+  `packages/dreamux/src/runtime/paths.ts`
 
-## Event-registry seam (Phase 1)
+## Event-route seam (Phase 1)
 
 `FeishuBot.start` takes a `FeishuInboundRoutes` object — one handler per Feishu
 event type — instead of a single message handler. The bot builds the transport
 route table from it and registers `im.message.receive_v1` always and
 `im.chat.member.bot.added_v1` when an `onBotMemberAdded` handler is supplied.
 Each route still awaits its handler before the SDK acks, preserving the
-queue-before-ACK invariant. New event types register here without growing
-branches in `Server` or the transport.
+queue-before-ACK invariant. This is a small typed seam, not yet a generic
+`eventType -> handler` registry; a third event type is the cue to promote it to
+a map so `FeishuBot` does not grow one optional field per event.
 
 `im.chat.member.bot.added_v1` is recorded idempotently by Feishu event id and
 flags the chat for a future baseline injection; it emits no model notification.

--- a/.agents/root.md
+++ b/.agents/root.md
@@ -68,6 +68,10 @@ Background and older issue context:
   — final issue #63 runtime model for accepted Feishu inbound: every accepted
   deduped message submits `turn/start`, and reactions move through the
   received / in-progress / cleared states.
+- [`domains/feishu-introduce.md`](domains/feishu-introduce.md)
+  — issue #62 first increment: the Feishu event-registry seam, and the group
+  `/introduce` hard contract (no `@`-mention required; the sender must be
+  allowlisted; awareness never grants trust).
 - `proposals/`, `research/`, `rules/` — add here when material grows past a
   single file's worth.
 - [`CONTRIBUTING.md`](CONTRIBUTING.md) — when to update this KB, how to

--- a/.agents/root.md
+++ b/.agents/root.md
@@ -69,7 +69,7 @@ Background and older issue context:
   deduped message submits `turn/start`, and reactions move through the
   received / in-progress / cleared states.
 - [`domains/feishu-introduce.md`](domains/feishu-introduce.md)
-  — issue #62 first increment: the Feishu event-registry seam, and the group
+  — issue #62 first increment: the Feishu typed event-route seam, and the group
   `/introduce` hard contract (no `@`-mention required; the sender must be
   allowlisted; awareness never grants trust).
 - `proposals/`, `research/`, `rules/` — add here when material grows past a

--- a/common/changes/@excitedjs/dreamux/feat-dx62-feishu-channel_2026-06-04-23-25.json
+++ b/common/changes/@excitedjs/dreamux/feat-dx62-feishu-channel_2026-06-04-23-25.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@excitedjs/dreamux",
+      "comment": "Add the Feishu event-registry seam (FeishuBot.start now takes a route object with onMessage + optional onBotMemberAdded) and the group /introduce hard contract: /introduce triggers only when the sender is allowlisted, with no @-mention of the bot required. A new chat-bots.json store separates passive bot awareness from introduced trust.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@excitedjs/dreamux"
+}

--- a/packages/dreamux/src/channel/chat-bots-store.ts
+++ b/packages/dreamux/src/channel/chat-bots-store.ts
@@ -1,0 +1,216 @@
+/**
+ * Per-dispatcher peer-bot awareness/trust store.
+ *
+ * Two sets are tracked separately, per chat_id, and they must never be
+ * conflated (issue #62 hard contract):
+ *
+ *   - `known`   — bots passively observed sending messages in an authorized
+ *                 chat. Awareness only; observing a bot NEVER grants it trust.
+ *   - `trusted` — bots introduced by an allowlisted sender running `/introduce`.
+ *                 The gate consults this set (and only this set) when deciding
+ *                 whether a peer bot's group message may be delivered.
+ *
+ * `baseline` bookkeeping records `im.chat.member.bot.added_v1` events so the
+ * host can later inject a one-shot "bots in this group" context; it is
+ * idempotent by Feishu event id. (The one-shot context injection itself is a
+ * follow-up; this store keeps the durable bookkeeping the contract needs.)
+ *
+ * One JSON file per dispatcher, keyed by chat_id, so no chat_id ever has to be
+ * sanitized into a path segment. Owner-only (0600); writes are atomic.
+ */
+
+import {
+  chmodSync,
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  renameSync,
+  writeFileSync,
+} from 'node:fs';
+import { dirname } from 'node:path';
+
+import { dispatcherChatBotsPath } from '../runtime/paths.js';
+
+/** Retain at most this many recent bot-added event ids per chat for dedupe. */
+const MAX_SEEN_EVENT_IDS = 200;
+
+export interface ChatBotsEntry {
+  /** Passively observed peer-bot open_ids — awareness only, never trust. */
+  known: string[];
+  /** Introduced peer-bot open_ids — the gate's trust set for this chat. */
+  trusted: string[];
+  /** Best-effort open_id → display name map for known/trusted bots. */
+  names: Record<string, string>;
+  /** Set when the bot is added to this chat; consumed by a later baseline inject. */
+  needsBaseline: boolean;
+  /** Recent bot-added event ids, for idempotent member-event handling. */
+  seenEventIds: string[];
+}
+
+export interface ChatBotsState {
+  version: 1;
+  chats: Record<string, ChatBotsEntry>;
+}
+
+export interface PeerBot {
+  openId: string;
+  name?: string;
+}
+
+export function defaultChatBotsState(): ChatBotsState {
+  return { version: 1, chats: {} };
+}
+
+function emptyEntry(): ChatBotsEntry {
+  return { known: [], trusted: [], names: {}, needsBaseline: false, seenEventIds: [] };
+}
+
+/**
+ * Load the store. Unlike the access store, a corrupt or unreadable chat-bots
+ * file is not security-critical — it only affects peer-bot discovery — so a
+ * load failure degrades to an empty store rather than throwing.
+ */
+export function loadChatBots(dispatcherId: string): ChatBotsState {
+  const path = dispatcherChatBotsPath(dispatcherId);
+  if (!existsSync(path)) return defaultChatBotsState();
+  try {
+    const parsed = JSON.parse(readFileSync(path, 'utf8')) as unknown;
+    return normalizeChatBots(parsed);
+  } catch {
+    return defaultChatBotsState();
+  }
+}
+
+export function saveChatBots(dispatcherId: string, state: ChatBotsState): void {
+  const path = dispatcherChatBotsPath(dispatcherId);
+  mkdirSync(dirname(path), { recursive: true });
+  const tmp = `${path}.tmp-${process.pid}`;
+  writeFileSync(tmp, `${JSON.stringify(state, null, 2)}\n`, { mode: 0o600 });
+  chmodSync(tmp, 0o600);
+  renameSync(tmp, path);
+}
+
+function entryFor(state: ChatBotsState, chatId: string): ChatBotsEntry {
+  const existing = state.chats[chatId];
+  if (existing !== undefined) return existing;
+  const created = emptyEntry();
+  state.chats[chatId] = created;
+  return created;
+}
+
+/** Record a passively observed peer bot as *known* (awareness only). */
+export function observeKnownBot(
+  dispatcherId: string,
+  chatId: string,
+  bot: PeerBot,
+): void {
+  if (bot.openId === '') return;
+  const state = loadChatBots(dispatcherId);
+  const entry = entryFor(state, chatId);
+  let changed = recordName(entry, bot);
+  if (!entry.known.includes(bot.openId)) {
+    entry.known.push(bot.openId);
+    changed = true;
+  }
+  if (changed) saveChatBots(dispatcherId, state);
+}
+
+/**
+ * Record peer bots introduced by an allowlisted `/introduce` as *trusted*.
+ * Trusted bots are also known. Returns the open_ids newly added to trust.
+ */
+export function trustIntroducedBots(
+  dispatcherId: string,
+  chatId: string,
+  bots: PeerBot[],
+): string[] {
+  const state = loadChatBots(dispatcherId);
+  const entry = entryFor(state, chatId);
+  const added: string[] = [];
+  let changed = false;
+  for (const bot of bots) {
+    if (bot.openId === '') continue;
+    if (recordName(entry, bot)) changed = true;
+    if (!entry.known.includes(bot.openId)) {
+      entry.known.push(bot.openId);
+      changed = true;
+    }
+    if (!entry.trusted.includes(bot.openId)) {
+      entry.trusted.push(bot.openId);
+      added.push(bot.openId);
+      changed = true;
+    }
+  }
+  if (changed) saveChatBots(dispatcherId, state);
+  return added;
+}
+
+/** The trust set the gate consults for one chat. */
+export function trustedBotIds(dispatcherId: string, chatId: string): Set<string> {
+  return new Set(loadChatBots(dispatcherId).chats[chatId]?.trusted ?? []);
+}
+
+/**
+ * Record an `im.chat.member.bot.added_v1` event: mark the chat as needing a
+ * baseline injection. Idempotent by event id — a redelivered event is a no-op.
+ * Returns true when the event was newly recorded.
+ */
+export function recordBotAdded(
+  dispatcherId: string,
+  chatId: string,
+  eventId: string,
+): boolean {
+  const state = loadChatBots(dispatcherId);
+  const entry = entryFor(state, chatId);
+  if (eventId !== '' && entry.seenEventIds.includes(eventId)) return false;
+  if (eventId !== '') {
+    entry.seenEventIds.push(eventId);
+    while (entry.seenEventIds.length > MAX_SEEN_EVENT_IDS) entry.seenEventIds.shift();
+  }
+  entry.needsBaseline = true;
+  saveChatBots(dispatcherId, state);
+  return true;
+}
+
+function recordName(entry: ChatBotsEntry, bot: PeerBot): boolean {
+  if (bot.name === undefined || bot.name === '') return false;
+  if (entry.names[bot.openId] === bot.name) return false;
+  entry.names[bot.openId] = bot.name;
+  return true;
+}
+
+function normalizeChatBots(raw: unknown): ChatBotsState {
+  if (raw === null || typeof raw !== 'object' || Array.isArray(raw)) {
+    return defaultChatBotsState();
+  }
+  const chatsRaw = (raw as Record<string, unknown>)['chats'];
+  const chats: Record<string, ChatBotsEntry> = {};
+  if (chatsRaw !== null && typeof chatsRaw === 'object' && !Array.isArray(chatsRaw)) {
+    for (const [chatId, value] of Object.entries(chatsRaw as Record<string, unknown>)) {
+      chats[chatId] = normalizeEntry(value);
+    }
+  }
+  return { version: 1, chats };
+}
+
+function normalizeEntry(raw: unknown): ChatBotsEntry {
+  const entry = emptyEntry();
+  if (raw === null || typeof raw !== 'object' || Array.isArray(raw)) return entry;
+  const obj = raw as Record<string, unknown>;
+  entry.known = stringArray(obj['known']);
+  entry.trusted = stringArray(obj['trusted']);
+  entry.seenEventIds = stringArray(obj['seenEventIds']);
+  entry.needsBaseline = obj['needsBaseline'] === true;
+  const names = obj['names'];
+  if (names !== null && typeof names === 'object' && !Array.isArray(names)) {
+    for (const [k, v] of Object.entries(names as Record<string, unknown>)) {
+      if (typeof v === 'string') entry.names[k] = v;
+    }
+  }
+  return entry;
+}
+
+function stringArray(value: unknown): string[] {
+  if (!Array.isArray(value)) return [];
+  return [...new Set(value.filter((item): item is string => typeof item === 'string'))];
+}

--- a/packages/dreamux/src/channel/chat-bots-store.ts
+++ b/packages/dreamux/src/channel/chat-bots-store.ts
@@ -34,6 +34,9 @@ import { dispatcherChatBotsPath } from '../runtime/paths.js';
 /** Retain at most this many recent bot-added event ids per chat for dedupe. */
 const MAX_SEEN_EVENT_IDS = 200;
 
+/** Monotonic per-process counter so concurrent writes never share a temp path. */
+let tmpCounter = 0;
+
 export interface ChatBotsEntry {
   /** Passively observed peer-bot open_ids — awareness only, never trust. */
   known: string[];
@@ -84,7 +87,7 @@ export function loadChatBots(dispatcherId: string): ChatBotsState {
 export function saveChatBots(dispatcherId: string, state: ChatBotsState): void {
   const path = dispatcherChatBotsPath(dispatcherId);
   mkdirSync(dirname(path), { recursive: true });
-  const tmp = `${path}.tmp-${process.pid}`;
+  const tmp = `${path}.tmp-${process.pid}-${tmpCounter++}`;
   writeFileSync(tmp, `${JSON.stringify(state, null, 2)}\n`, { mode: 0o600 });
   chmodSync(tmp, 0o600);
   renameSync(tmp, path);

--- a/packages/dreamux/src/channel/feishu-gate.ts
+++ b/packages/dreamux/src/channel/feishu-gate.ts
@@ -49,6 +49,14 @@ export interface DreamuxFeishuGateInput {
   mentions?: Mention[];
   botOpenId?: string;
   now?: number;
+  /**
+   * Peer-bot open_ids trusted in this chat via an allowlisted `/introduce`
+   * (issue #62). A bot sender is normally dropped; a trusted bot's group
+   * message is delivered without an @-mention (bots cannot @-mention us).
+   * `undefined` for direct messages and for callers that do not track trust,
+   * in which case no bot sender is ever delivered — preserving prior behavior.
+   */
+  trustedBotIds?: ReadonlySet<string>;
 }
 
 export type DreamuxFeishuGateResult =
@@ -121,11 +129,10 @@ export function dreamuxFeishuGate(
   if (input.botOpenId !== undefined && input.senderId === input.botOpenId) {
     return drop('message sent by this bot');
   }
-  if (isBotSenderType(input.senderType)) {
-    return drop(`bot sender type: ${input.senderType}`);
-  }
+  const senderIsBot = isBotSenderType(input.senderType);
 
   if (input.chatType === 'p2p') {
+    if (senderIsBot) return drop(`bot sender type: ${input.senderType}`);
     if (!access.dm.allow_users.includes(input.senderId)) {
       return drop('direct sender not allowed');
     }
@@ -140,6 +147,17 @@ export function dreamuxFeishuGate(
     !access.group.allow_chats.includes(input.chatId)) {
     return drop('group chat not allowed');
   }
+
+  if (senderIsBot) {
+    // A peer bot speaks only if it was introduced (trusted) for this chat by an
+    // allowlisted `/introduce`. Trusted bots bypass the mention gate because a
+    // bot cannot @-mention us; untrusted bots are dropped as before.
+    if (input.trustedBotIds?.has(input.senderId) ?? false) {
+      return deliver(access, input, now);
+    }
+    return drop(`bot sender type: ${input.senderType}`);
+  }
+
   if (access.group.follow_users.length > 0 &&
     !access.group.follow_users.includes(input.senderId)) {
     return drop('sender not allowed by follow-user gate');

--- a/packages/dreamux/src/channel/introduce.ts
+++ b/packages/dreamux/src/channel/introduce.ts
@@ -1,0 +1,118 @@
+/**
+ * Group `/introduce` — peer-bot introduction, issue #62 hard contract.
+ *
+ * Trigger rule (deliberately different from claudemux):
+ *
+ *   In a group, a `/introduce` message triggers **if and only if the sender is
+ *   on the allowlist**. No `@`-mention of our bot is required, and the group's
+ *   `require_mention` setting is ignored on this path.
+ *
+ *   "Sender on the allowlist" is sender-scoped, NOT group-scoped: it is not
+ *   enough for the chat to be authorized — the *sender* must be explicitly
+ *   allowlisted for the chat. An open group (no per-sender allowlist) does NOT
+ *   authorize introduce. `canRunIntroduce` therefore never reuses a broad
+ *   group-authorization predicate that would trust the group without checking
+ *   the sender's identity.
+ *
+ * The peer bots being introduced are the message's @-mentions (excluding our
+ * own bot); the host records them as *trusted* for the chat. Recording a human
+ * mention is harmless: the gate only lets a trusted entry bypass when the
+ * *sender* is a bot, so a human open_id in the trust set never widens access.
+ */
+
+import type { Mention } from '@excitedjs/feishu-transport';
+
+import type { DispatcherAccessState } from './feishu-gate.js';
+import type { PeerBot } from './chat-bots-store.js';
+
+const INTRODUCE_RE = /^\/introduce(?:\s|$)/i;
+
+export interface IntroduceAuthInput {
+  chatType: string;
+  chatId: string;
+  senderId: string;
+}
+
+/**
+ * True when `senderId` may run `/introduce` in this chat.
+ *
+ * Sender-scoped, not group-scoped (the issue #62 hard contract): the chat must
+ * be explicitly allowlisted AND the sender must be on the per-chat sender
+ * allowlist. Empty allowlists do not authorize anyone — there is no "any member
+ * of an allowlisted group" path.
+ */
+export function canRunIntroduce(
+  access: DispatcherAccessState,
+  input: IntroduceAuthInput,
+): boolean {
+  if (input.chatType !== 'group') return false;
+  if (input.senderId === '') return false;
+  // The chat must be explicitly allowlisted. An empty allow_chats means "every
+  // chat" for normal delivery, but for a trust-changing command we require the
+  // chat to be named, so introduce never fires in an incidental group.
+  if (!access.group.allow_chats.includes(input.chatId)) return false;
+  // The sender must be explicitly allowlisted. An empty follow_users authorizes
+  // nobody for introduce — this is the line that makes the rule sender-scoped
+  // rather than "any member of an allowlisted group".
+  if (!access.group.follow_users.includes(input.senderId)) return false;
+  return true;
+}
+
+/**
+ * Detect a `/introduce` command. Text messages only; leading Feishu mention
+ * placeholder tokens (e.g. `@_user_1 `) are stripped first so an `@`-prefixed
+ * `/introduce` still matches — the trigger does not depend on who, if anyone,
+ * was mentioned.
+ */
+export function detectIntroduce(
+  messageType: string,
+  rawContent: string,
+  mentions: Mention[],
+): boolean {
+  if (messageType !== 'text') return false;
+  let text: string;
+  try {
+    const parsed = JSON.parse(rawContent) as unknown;
+    text =
+      parsed !== null && typeof parsed === 'object' && !Array.isArray(parsed)
+        ? typeof (parsed as Record<string, unknown>)['text'] === 'string'
+          ? ((parsed as Record<string, unknown>)['text'] as string)
+          : ''
+        : '';
+  } catch {
+    return false;
+  }
+  let remaining = text.trimStart();
+  let progress = true;
+  while (progress) {
+    progress = false;
+    for (const m of mentions) {
+      if (m.key !== '' && remaining.startsWith(m.key)) {
+        remaining = remaining.slice(m.key.length).trimStart();
+        progress = true;
+        break;
+      }
+    }
+  }
+  return INTRODUCE_RE.test(remaining);
+}
+
+/**
+ * The peer bots an `/introduce` names — every @-mention except our own bot.
+ * The sender-type check in the gate is what actually scopes trust to bots, so
+ * a stray human mention recorded here can never widen access.
+ */
+export function introducedPeers(
+  mentions: Mention[],
+  selfOpenId: string | undefined,
+): PeerBot[] {
+  const peers: PeerBot[] = [];
+  const seen = new Set<string>();
+  for (const m of mentions) {
+    const openId = m.id?.open_id ?? m.id?.union_id ?? '';
+    if (openId === '' || openId === selfOpenId || seen.has(openId)) continue;
+    seen.add(openId);
+    peers.push(m.name !== undefined ? { openId, name: m.name } : { openId });
+  }
+  return peers;
+}

--- a/packages/dreamux/src/channel/introduce.ts
+++ b/packages/dreamux/src/channel/introduce.ts
@@ -82,13 +82,21 @@ export function detectIntroduce(
   } catch {
     return false;
   }
+  // Strip leading Feishu mention keys longest-first: keys can be prefixes of
+  // one another (`@_user_1` vs `@_user_10`), so checking the shorter key first
+  // would consume a partial token and leave a stray suffix, false-negating an
+  // `@`-prefixed `/introduce`. (Same longest-key-first rule used for rendering.)
+  const keys = mentions
+    .map((m) => m.key)
+    .filter((key) => key !== '')
+    .sort((a, b) => b.length - a.length);
   let remaining = text.trimStart();
   let progress = true;
   while (progress) {
     progress = false;
-    for (const m of mentions) {
-      if (m.key !== '' && remaining.startsWith(m.key)) {
-        remaining = remaining.slice(m.key.length).trimStart();
+    for (const key of keys) {
+      if (remaining.startsWith(key)) {
+        remaining = remaining.slice(key.length).trimStart();
         progress = true;
         break;
       }

--- a/packages/dreamux/src/feishu/bot.ts
+++ b/packages/dreamux/src/feishu/bot.ts
@@ -66,10 +66,13 @@ export type BotMemberAddedHandler = (
 ) => void | Promise<void>;
 
 /**
- * The event-registry seam (issue #62 Phase 1). `start` takes one handler per
- * Feishu event type instead of a single message handler, so new event types
- * register here without growing branches in `Server` or the transport. Each
- * route still awaits its handler before the SDK acks (queue-before-ACK).
+ * The typed event-route seam (issue #62 Phase 1). `start` takes one handler per
+ * Feishu event type instead of a single message handler, so a new event type is
+ * wired by adding a field here and a transport route, without growing branches
+ * in `Server`. This is a small typed seam, not yet a generic
+ * `eventType -> handler` registry; if a third event type lands, promote this to
+ * a map. Each route still awaits its handler before the SDK acks
+ * (queue-before-ACK).
  */
 export interface FeishuInboundRoutes {
   /** `im.message.receive_v1` — a chat message. */

--- a/packages/dreamux/src/feishu/bot.ts
+++ b/packages/dreamux/src/feishu/bot.ts
@@ -6,10 +6,12 @@
  * markdown→card render, content parse, the outbound message API — lives in the
  * core, the single importer of `@larksuiteoapi/node-sdk`. This file only shapes
  * the core's surface into the `FeishuBot` interface the server already wires:
- *   - `start(handler)` registers the `im.message.receive_v1` route, normalizes
- *     each raw event with the core's `parseInbound`, and forwards a
- *     `FeishuInboundEvent`. The route handler awaits `handler`, so the server
- *     gates and submits accepted inbound before the SDK acks.
+ *   - `start(routes)` takes one handler per Feishu event type (issue #62 seam):
+ *     `onMessage` for `im.message.receive_v1` (normalized via the core's
+ *     `parseInbound` into a `FeishuInboundEvent`) and an optional
+ *     `onBotMemberAdded` for `im.chat.member.bot.added_v1`. Each route awaits
+ *     its handler, so the server gates and submits accepted inbound before the
+ *     SDK acks.
  *   - `send(target, text)` delegates to the core transport, preserving reply
  *     threading / @-back metadata from the in-memory inbound batch.
  *   - `botOpenId` surfaces the core transport's `selfId`.
@@ -19,10 +21,13 @@
  */
 
 import {
+  BOT_MEMBER_ADDED_EVENT_TYPE,
   createFeishuTransport,
   narrowMetaFromEvent,
+  normalizeBotMemberAddedEvent,
   parseInbound,
   toChannelInbound,
+  type FeishuBotMemberAddedEvent,
   type FeishuTransport,
   type Mention,
   type OutboundTarget,
@@ -56,6 +61,23 @@ export interface FeishuInboundEvent {
 
 export type InboundHandler = (event: FeishuInboundEvent) => void | Promise<void>;
 
+export type BotMemberAddedHandler = (
+  event: FeishuBotMemberAddedEvent,
+) => void | Promise<void>;
+
+/**
+ * The event-registry seam (issue #62 Phase 1). `start` takes one handler per
+ * Feishu event type instead of a single message handler, so new event types
+ * register here without growing branches in `Server` or the transport. Each
+ * route still awaits its handler before the SDK acks (queue-before-ACK).
+ */
+export interface FeishuInboundRoutes {
+  /** `im.message.receive_v1` — a chat message. */
+  onMessage: InboundHandler;
+  /** `im.chat.member.bot.added_v1` — the bot was added to a chat. Optional. */
+  onBotMemberAdded?: BotMemberAddedHandler;
+}
+
 export interface FeishuSendResult {
   /** message_id of each card sent, in order. Empty if Feishu omitted ids. */
   messageIds: string[];
@@ -64,7 +86,7 @@ export interface FeishuSendResult {
 export interface FeishuBot {
   readonly appId: string;
   readonly botOpenId: string | undefined;
-  start(handler: InboundHandler): Promise<void>;
+  start(routes: FeishuInboundRoutes): Promise<void>;
   send(target: OutboundTarget, text: string): Promise<FeishuSendResult>;
   addReaction(messageId: string, emoji: string): Promise<string>;
   removeReaction(messageId: string, reactionId: string): Promise<void>;
@@ -109,18 +131,27 @@ export function createFeishuBot(
       return transport.selfId;
     },
 
-    async start(handler: InboundHandler): Promise<void> {
-      // The core opens the WebSocket and awaits this route handler before the
-      // SDK acks; awaiting `handler` here keeps gate/submission work before ACK.
+    async start(routes: FeishuInboundRoutes): Promise<void> {
+      // The core opens the WebSocket and awaits each route handler before the
+      // SDK acks; awaiting here keeps gate/submission work before ACK.
       // `start` rejects if the connection does not come up, so the server's
       // try/catch can fail the dispatcher loudly rather than leave it dark.
-      await transport.start({
+      const table: Record<string, (raw: unknown) => Promise<void>> = {
         [IM_MESSAGE_EVENT_TYPE]: async (raw: unknown) => {
           const event = normalizeInboundEvent(raw);
           if (event === null) return;
-          await handler(event);
+          await routes.onMessage(event);
         },
-      });
+      };
+      if (routes.onBotMemberAdded !== undefined) {
+        const onBotMemberAdded = routes.onBotMemberAdded;
+        table[BOT_MEMBER_ADDED_EVENT_TYPE] = async (raw: unknown) => {
+          const event = normalizeBotMemberAddedEvent(raw);
+          if (event === null) return;
+          await onBotMemberAdded(event);
+        };
+      }
+      await transport.start(table);
     },
 
     async send(target: OutboundTarget, text: string): Promise<FeishuSendResult> {
@@ -254,6 +285,7 @@ export interface FakeFeishuBot extends FeishuBot {
     reactionId: string;
   }>;
   inject(event: FeishuInboundEvent): Promise<void>;
+  injectBotMemberAdded(event: FeishuBotMemberAddedEvent): Promise<void>;
   setSendError(err: Error | null): void;
   setReactionError(err: Error | null): void;
   setRemoveReactionError(err: Error | null): void;
@@ -266,7 +298,7 @@ export function createFakeFeishuBot(appId: string = 'fake-bot'): FakeFeishuBot {
     text: string;
     messageIds: string[];
   }> = [];
-  let handler: InboundHandler | null = null;
+  let routes: FeishuInboundRoutes | null = null;
   let nextMessageId = 1;
   let nextReactionId = 1;
   let sendError: Error | null = null;
@@ -288,8 +320,8 @@ export function createFakeFeishuBot(appId: string = 'fake-bot'): FakeFeishuBot {
     get botOpenId(): string | undefined {
       return openId;
     },
-    async start(h: InboundHandler): Promise<void> {
-      handler = h;
+    async start(r: FeishuInboundRoutes): Promise<void> {
+      routes = r;
     },
     async send(target: OutboundTarget, text: string): Promise<FeishuSendResult> {
       if (sendError !== null) {
@@ -314,7 +346,7 @@ export function createFakeFeishuBot(appId: string = 'fake-bot'): FakeFeishuBot {
       removedReactions.push({ messageId, reactionId });
     },
     async close(): Promise<void> {
-      handler = null;
+      routes = null;
     },
     get sentMessages() {
       return sent;
@@ -326,8 +358,12 @@ export function createFakeFeishuBot(appId: string = 'fake-bot'): FakeFeishuBot {
       return removedReactions;
     },
     async inject(event: FeishuInboundEvent): Promise<void> {
-      if (handler === null) throw new Error('fake bot not started');
-      await handler(event);
+      if (routes === null) throw new Error('fake bot not started');
+      await routes.onMessage(event);
+    },
+    async injectBotMemberAdded(event: FeishuBotMemberAddedEvent): Promise<void> {
+      if (routes === null) throw new Error('fake bot not started');
+      await routes.onBotMemberAdded?.(event);
     },
     setSendError(err: Error | null): void {
       sendError = err;

--- a/packages/dreamux/src/runtime/paths.ts
+++ b/packages/dreamux/src/runtime/paths.ts
@@ -157,6 +157,16 @@ export function dispatcherAccessPath(id: string): string {
   return join(dispatcherDir(id), 'access.json');
 }
 
+/**
+ * Per-dispatcher peer-bot awareness/trust store. One file per dispatcher,
+ * keyed internally by chat_id, holds the *known* (passively observed) and
+ * *trusted* (introduced via an allowlisted `/introduce`) peer-bot open_ids
+ * plus the bot-added baseline bookkeeping. Server-owned state; safe to delete.
+ */
+export function dispatcherChatBotsPath(id: string): string {
+  return join(dispatcherDir(id), 'chat-bots.json');
+}
+
 export function unixSocketPathFitsBudget(path: string): boolean {
   return Buffer.byteLength(path, 'utf8') <= DREAMUX_UNIX_SOCKET_PATH_MAX_BYTES;
 }

--- a/packages/dreamux/src/server.ts
+++ b/packages/dreamux/src/server.ts
@@ -22,11 +22,23 @@ import {
   type FeishuBot,
   type FeishuInboundEvent,
 } from './feishu/bot.js';
+import { isBotSenderType } from '@excitedjs/feishu-transport';
 import {
   dreamuxFeishuGate,
   loadDispatcherAccess,
   saveDispatcherAccess,
 } from './channel/feishu-gate.js';
+import {
+  canRunIntroduce,
+  detectIntroduce,
+  introducedPeers,
+} from './channel/introduce.js';
+import {
+  observeKnownBot,
+  recordBotAdded,
+  trustIntroducedBots,
+  trustedBotIds,
+} from './channel/chat-bots-store.js';
 import { formatFeishuMessageForCodex } from './channel/feishu-message.js';
 import { parseCodexArgs, codexArgsToCli } from './runtime/codex-args.js';
 import { feishuMcpCodexArgs } from './codex/mcp-config.js';
@@ -249,60 +261,99 @@ export class Server {
 
     try {
       await runtime.start();
-      await bot.start(async (event: FeishuInboundEvent) => {
-        const access = loadDispatcherAccess(id);
-        const gate = dreamuxFeishuGate({
-          senderId: event.senderId,
-          senderType: event.senderType,
-          chatId: event.chatId,
-          chatType: event.chatType,
-          mentions: event.mentions,
-          botOpenId: bot.botOpenId,
-        }, access);
-        saveDispatcherAccess(id, gate.access);
-        if (gate.warning !== null) {
-          console.error(
-            `[server] trust-domain warning for dispatcher '${id}': ${gate.warning}`,
-          );
-        }
-        if (gate.action === 'drop') {
-          console.error(
-            `[server] dropped feishu inbound for dispatcher '${id}': ${gate.reason}`,
-          );
-          return;
-        }
-        const input: InboundTurnInput = {
-          source_chat_id: event.chatId,
-          source_message_id: event.messageId,
-          sender_id: event.senderId,
-          parsed_text: formatFeishuMessageForCodex(event),
-        };
-        const delivery = await runtime.enqueueInbound(input, {
-          onAccepted: async (acceptedInput) => {
+      await bot.start({
+        onBotMemberAdded: (added) => {
+          // Issue #62 Phase 1/4: record that the bot joined a chat so a later
+          // baseline can be injected. Idempotent by event id; no notification.
+          recordBotAdded(id, added.chatId, added.eventId);
+        },
+        onMessage: async (event: FeishuInboundEvent) => {
+          const access = loadDispatcherAccess(id);
+
+          // Issue #62: peer-bot awareness + `/introduce`, evaluated before the
+          // delivery gate. A bot seen in an authorized chat becomes *known*
+          // (awareness only, never trust). `/introduce` from an allowlisted
+          // sender records the named peer bots as *trusted* and is consumed —
+          // it never reaches Codex as a normal turn. No `@`-mention is required.
+          if (
+            event.chatType === 'group' &&
+            isBotSenderType(event.senderType) &&
+            access.group.allow_chats.includes(event.chatId)
+          ) {
+            observeKnownBot(id, event.chatId, {
+              openId: event.senderId,
+              ...(event.senderName !== '' ? { name: event.senderName } : {}),
+            });
+          }
+          if (
+            detectIntroduce(event.messageType, event.rawContent, event.mentions) &&
+            canRunIntroduce(access, {
+              chatType: event.chatType,
+              chatId: event.chatId,
+              senderId: event.senderId,
+            })
+          ) {
+            const peers = introducedPeers(event.mentions, bot.botOpenId);
+            if (peers.length > 0) trustIntroducedBots(id, event.chatId, peers);
+            return;
+          }
+
+          const gate = dreamuxFeishuGate({
+            senderId: event.senderId,
+            senderType: event.senderType,
+            chatId: event.chatId,
+            chatType: event.chatType,
+            mentions: event.mentions,
+            botOpenId: bot.botOpenId,
+            ...(event.chatType === 'group'
+              ? { trustedBotIds: trustedBotIds(id, event.chatId) }
+              : {}),
+          }, access);
+          saveDispatcherAccess(id, gate.access);
+          if (gate.warning !== null) {
+            console.error(
+              `[server] trust-domain warning for dispatcher '${id}': ${gate.warning}`,
+            );
+          }
+          if (gate.action === 'drop') {
+            console.error(
+              `[server] dropped feishu inbound for dispatcher '${id}': ${gate.reason}`,
+            );
+            return;
+          }
+          const input: InboundTurnInput = {
+            source_chat_id: event.chatId,
+            source_message_id: event.messageId,
+            sender_id: event.senderId,
+            parsed_text: formatFeishuMessageForCodex(event),
+          };
+          const delivery = await runtime.enqueueInbound(input, {
+            onAccepted: async (acceptedInput) => {
+              await setInboundReaction(
+                id,
+                bot,
+                channelState,
+                acceptedInput,
+                RECEIVED_REACTION_EMOJI,
+                'received',
+              );
+            },
+          });
+          if (delivery.status === 'submitted') {
             await setInboundReaction(
               id,
               bot,
               channelState,
-              acceptedInput,
-              RECEIVED_REACTION_EMOJI,
-              'received',
+              input,
+              IN_PROGRESS_REACTION_EMOJI,
+              'in_progress',
             );
-          },
-        });
-        if (delivery.status === 'submitted') {
-          await setInboundReaction(
-            id,
-            bot,
-            channelState,
-            input,
-            IN_PROGRESS_REACTION_EMOJI,
-            'in_progress',
-          );
-        } else if (delivery.status === 'failed') {
-          console.error(
-            `[server] failed to submit Feishu inbound for dispatcher '${id}': ${delivery.error.message}`,
-          );
-        }
+          } else if (delivery.status === 'failed') {
+            console.error(
+              `[server] failed to submit Feishu inbound for dispatcher '${id}': ${delivery.error.message}`,
+            );
+          }
+        },
       });
     } catch (err) {
       // Failed midway: undo any partial bring-up so a retry isn't

--- a/packages/dreamux/tests/feishu-bot.test.ts
+++ b/packages/dreamux/tests/feishu-bot.test.ts
@@ -77,8 +77,10 @@ describe('createFeishuBot inbound channel', () => {
     );
     const received: FeishuInboundEvent[] = [];
 
-    await bot.start(async (event) => {
-      received.push(event);
+    await bot.start({
+      onMessage: async (event) => {
+        received.push(event);
+      },
     });
 
     expect(createdWith).toEqual([
@@ -148,8 +150,10 @@ describe('createFeishuBot inbound channel', () => {
     );
     const received: FeishuInboundEvent[] = [];
 
-    await bot.start(async (event) => {
-      received.push(event);
+    await bot.start({
+      onMessage: async (event) => {
+        received.push(event);
+      },
     });
 
     await transport.dispatch('im.message.receive_v1', {
@@ -180,8 +184,10 @@ describe('createFeishuBot inbound channel', () => {
       { createTransport: () => transport },
     );
     const received: FeishuInboundEvent[] = [];
-    await bot.start(async (event) => {
-      received.push(event);
+    await bot.start({
+      onMessage: async (event) => {
+        received.push(event);
+      },
     });
 
     const delivered = await transport.dispatch('im.message.receive_v1', {
@@ -201,5 +207,31 @@ describe('createFeishuBot inbound channel', () => {
 
     expect(delivered).toBe(true);
     expect(received).toEqual([]);
+  });
+
+  it('registers the bot-added route only when a handler is provided (issue #62 seam)', async () => {
+    const transport = new FakeTransport();
+    const bot = createFeishuBot(
+      { appId: 'app-test', appSecret: 'secret-test' },
+      { createTransport: () => transport },
+    );
+    const added: Array<{ chatId: string; eventId: string }> = [];
+    await bot.start({
+      onMessage: async () => {},
+      onBotMemberAdded: (event) => {
+        added.push({ chatId: event.chatId, eventId: event.eventId });
+      },
+    });
+
+    expect(Object.keys(transport.routes ?? {})).toEqual([
+      'im.message.receive_v1',
+      'im.chat.member.bot.added_v1',
+    ]);
+
+    await transport.dispatch('im.chat.member.bot.added_v1', {
+      header: { event_id: 'evt-1' },
+      event: { chat_id: 'chat-id-1' },
+    });
+    expect(added).toEqual([{ chatId: 'chat-id-1', eventId: 'evt-1' }]);
   });
 });

--- a/packages/dreamux/tests/feishu-introduce.test.ts
+++ b/packages/dreamux/tests/feishu-introduce.test.ts
@@ -89,6 +89,18 @@ describe('detectIntroduce — no @-mention required', () => {
     ).toBe(true);
   });
 
+  it('strips the longest mention key first when keys overlap', () => {
+    // `@_user_1` is a prefix of `@_user_10`; checking the shorter key first
+    // would consume a partial token and false-negate the command.
+    const mentions: Mention[] = [
+      { key: '@_user_1', id: { open_id: 'a' } },
+      { key: '@_user_10', id: { open_id: 'b' } },
+    ];
+    expect(
+      detectIntroduce('text', textContent('@_user_10 /introduce'), mentions),
+    ).toBe(true);
+  });
+
   it('does not match /introduce in the middle of a message', () => {
     expect(detectIntroduce('text', textContent('hello /introduce'), [])).toBe(false);
   });

--- a/packages/dreamux/tests/feishu-introduce.test.ts
+++ b/packages/dreamux/tests/feishu-introduce.test.ts
@@ -1,0 +1,184 @@
+/**
+ * Issue #62 — group `/introduce` hard contract.
+ *
+ * The rule under test: in a group, `/introduce` triggers if and only if the
+ * sender is on the allowlist; no `@`-mention of our bot is required, and being
+ * "any member of an allowlisted group" is NOT enough.
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import {
+  defaultDispatcherAccessState,
+  dreamuxFeishuGate,
+  type DispatcherAccessState,
+} from '../src/channel/feishu-gate.js';
+import {
+  canRunIntroduce,
+  detectIntroduce,
+  introducedPeers,
+} from '../src/channel/introduce.js';
+import {
+  loadChatBots,
+  observeKnownBot,
+  recordBotAdded,
+  trustIntroducedBots,
+  trustedBotIds,
+} from '../src/channel/chat-bots-store.js';
+import { resetRuntimeConfig } from '../src/runtime/paths.js';
+import type { Mention } from '@excitedjs/feishu-transport';
+
+function state(group: Partial<DispatcherAccessState['group']> = {}): DispatcherAccessState {
+  const base = defaultDispatcherAccessState();
+  return { ...base, group: { ...base.group, ...group } };
+}
+
+function textContent(text: string): string {
+  return JSON.stringify({ text });
+}
+
+describe('canRunIntroduce — sender-scoped, not group-scoped', () => {
+  it('authorizes an allowlisted sender in an allowlisted chat', () => {
+    const access = state({ allow_chats: ['chat-a'], follow_users: ['user-a'] });
+    expect(
+      canRunIntroduce(access, { chatType: 'group', chatId: 'chat-a', senderId: 'user-a' }),
+    ).toBe(true);
+  });
+
+  it('rejects a non-allowlisted sender even in an allowlisted chat', () => {
+    const access = state({ allow_chats: ['chat-a'], follow_users: ['user-a'] });
+    expect(
+      canRunIntroduce(access, { chatType: 'group', chatId: 'chat-a', senderId: 'user-x' }),
+    ).toBe(false);
+  });
+
+  it('rejects an allowlisted sender in a chat that is not allowlisted', () => {
+    const access = state({ allow_chats: ['chat-a'], follow_users: ['user-a'] });
+    expect(
+      canRunIntroduce(access, { chatType: 'group', chatId: 'chat-other', senderId: 'user-a' }),
+    ).toBe(false);
+  });
+
+  it('does NOT treat "any member of an allowlisted group" as authorized (empty allowlist)', () => {
+    const access = state({ allow_chats: ['chat-a'], follow_users: [] });
+    expect(
+      canRunIntroduce(access, { chatType: 'group', chatId: 'chat-a', senderId: 'anyone' }),
+    ).toBe(false);
+  });
+
+  it('never fires for direct messages', () => {
+    const access = state({ allow_chats: ['chat-a'], follow_users: ['user-a'] });
+    expect(
+      canRunIntroduce(access, { chatType: 'p2p', chatId: 'chat-a', senderId: 'user-a' }),
+    ).toBe(false);
+  });
+});
+
+describe('detectIntroduce — no @-mention required', () => {
+  it('matches a bare /introduce', () => {
+    expect(detectIntroduce('text', textContent('/introduce'), [])).toBe(true);
+  });
+
+  it('matches /introduce after stripping a leading mention token', () => {
+    const mentions: Mention[] = [{ key: '@_user_1', id: { open_id: 'bot' }, name: 'Bot' }];
+    expect(
+      detectIntroduce('text', textContent('@_user_1 /introduce @_user_2'), mentions),
+    ).toBe(true);
+  });
+
+  it('does not match /introduce in the middle of a message', () => {
+    expect(detectIntroduce('text', textContent('hello /introduce'), [])).toBe(false);
+  });
+
+  it('does not match a longer word like /introducer', () => {
+    expect(detectIntroduce('text', textContent('/introducer'), [])).toBe(false);
+  });
+
+  it('ignores non-text messages and malformed content', () => {
+    expect(detectIntroduce('post', textContent('/introduce'), [])).toBe(false);
+    expect(detectIntroduce('text', 'not-json', [])).toBe(false);
+  });
+});
+
+describe('introducedPeers', () => {
+  it('returns mentioned peers excluding our own bot, deduplicated', () => {
+    const mentions: Mention[] = [
+      { key: '@_user_1', id: { open_id: 'self-bot' }, name: 'Us' },
+      { key: '@_user_2', id: { open_id: 'peer-a' }, name: 'Peer A' },
+      { key: '@_user_3', id: { open_id: 'peer-a' }, name: 'Peer A again' },
+      { key: '@_user_4', id: { union_id: 'peer-b' } },
+    ];
+    expect(introducedPeers(mentions, 'self-bot')).toEqual([
+      { openId: 'peer-a', name: 'Peer A' },
+      { openId: 'peer-b' },
+    ]);
+  });
+});
+
+describe('gate trust — only introduced bots may speak in a group', () => {
+  const base = {
+    senderId: 'peer-bot',
+    senderType: 'bot',
+    chatId: 'chat-a',
+    chatType: 'group',
+    botOpenId: 'self-bot',
+    now: 1_700_000_000_000,
+  };
+
+  it('drops a bot sender that has not been introduced', () => {
+    const access = state({ allow_chats: ['chat-a'] });
+    expect(dreamuxFeishuGate(base, access)).toMatchObject({ action: 'drop' });
+  });
+
+  it('delivers a bot sender that was introduced (trusted), without a mention', () => {
+    const access = state({ allow_chats: ['chat-a'] });
+    expect(
+      dreamuxFeishuGate({ ...base, trustedBotIds: new Set(['peer-bot']) }, access),
+    ).toMatchObject({ action: 'deliver' });
+  });
+});
+
+describe('chat-bots store — awareness vs trust are separate', () => {
+  let root: string;
+  let previousHome: string | undefined;
+
+  beforeEach(() => {
+    root = mkdtempSync(join(tmpdir(), 'dreamux-chatbots-'));
+    previousHome = process.env['HOME'];
+    process.env['HOME'] = join(root, 'home');
+    resetRuntimeConfig();
+  });
+
+  afterEach(() => {
+    if (previousHome === undefined) delete process.env['HOME'];
+    else process.env['HOME'] = previousHome;
+    resetRuntimeConfig();
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  it('observing a bot records awareness but never trust', () => {
+    observeKnownBot('d1', 'chat-a', { openId: 'peer-a', name: 'Peer A' });
+    const entry = loadChatBots('d1').chats['chat-a'];
+    expect(entry?.known).toEqual(['peer-a']);
+    expect(entry?.trusted ?? []).toEqual([]);
+    expect(trustedBotIds('d1', 'chat-a').has('peer-a')).toBe(false);
+  });
+
+  it('introducing a bot records trust (and awareness)', () => {
+    const added = trustIntroducedBots('d1', 'chat-a', [{ openId: 'peer-a', name: 'Peer A' }]);
+    expect(added).toEqual(['peer-a']);
+    const entry = loadChatBots('d1').chats['chat-a'];
+    expect(entry?.trusted).toEqual(['peer-a']);
+    expect(entry?.known).toEqual(['peer-a']);
+    expect(trustedBotIds('d1', 'chat-a').has('peer-a')).toBe(true);
+  });
+
+  it('recordBotAdded is idempotent by event id and flags a baseline', () => {
+    expect(recordBotAdded('d1', 'chat-a', 'evt-1')).toBe(true);
+    expect(recordBotAdded('d1', 'chat-a', 'evt-1')).toBe(false);
+    expect(loadChatBots('d1').chats['chat-a']?.needsBaseline).toBe(true);
+  });
+});

--- a/packages/dreamux/tests/smoke.test.ts
+++ b/packages/dreamux/tests/smoke.test.ts
@@ -41,6 +41,7 @@ import {
   loadDispatcherAccess,
   saveDispatcherAccess,
 } from '../src/channel/feishu-gate.js';
+import { loadChatBots } from '../src/channel/chat-bots-store.js';
 import { BUILT_IN_DEFAULTS, type DreamuxConfig } from '../src/runtime/config.js';
 import {
   dispatcherAppServerControlDir,
@@ -702,6 +703,82 @@ describe('dreamux MVP smoke', () => {
       RECEIVED_REACTION_EMOJI,
       IN_PROGRESS_REACTION_EMOJI,
     ]);
+  });
+
+  it('consumes a no-@ /introduce from an allowlisted sender and records trust without enqueue or reactions', async () => {
+    saveDispatcherAccess('flow', {
+      version: 1,
+      dm: { allow_users: [] },
+      group: {
+        allow_chats: ['chat-group-a'],
+        follow_users: ['sender-test'],
+        require_mention: true,
+      },
+      observed_chats: [],
+      warnings: [],
+      last_gate: null,
+    });
+    server = buildServer({ runtimeDir, fake, bot });
+    server.repos.dispatchers.create({
+      dispatcher_id: 'flow',
+      bot_app_id: 'app-smoke',
+      bot_secret_ref: 'env:UNUSED',
+    });
+    await server.start();
+
+    // No @-mention of our bot — only the peer bot being introduced is mentioned.
+    await bot.inject(
+      fakeInbound('chat-group-a', '/introduce', 'msg-introduce', {
+        mentions: [{ key: '@_user_9', id: { open_id: 'peer-bot-1' }, name: 'Peer' }],
+      }),
+    );
+
+    await sleep(60);
+    // Consumed before the gate: no Codex turn, no outbound, no reactions.
+    expect(fake.turnsHandled).toBe(0);
+    expect(bot.sentMessages).toEqual([]);
+    expect(bot.reactions).toEqual([]);
+    // The peer bot is now trusted for this chat (and known), but not the sender.
+    const entry = loadChatBots('flow').chats['chat-group-a'];
+    expect(entry?.trusted).toEqual(['peer-bot-1']);
+    expect(entry?.known).toEqual(['peer-bot-1']);
+  });
+
+  it('does NOT consume /introduce from a non-allowlisted sender (no trust, dropped by the gate)', async () => {
+    saveDispatcherAccess('flow', {
+      version: 1,
+      dm: { allow_users: [] },
+      group: {
+        allow_chats: ['chat-group-a'],
+        follow_users: ['sender-test'],
+        require_mention: true,
+      },
+      observed_chats: [],
+      warnings: [],
+      last_gate: null,
+    });
+    server = buildServer({ runtimeDir, fake, bot });
+    server.repos.dispatchers.create({
+      dispatcher_id: 'flow',
+      bot_app_id: 'app-smoke',
+      bot_secret_ref: 'env:UNUSED',
+    });
+    await server.start();
+
+    await bot.inject(
+      fakeInbound('chat-group-a', '/introduce', 'msg-introduce-stranger', {
+        senderId: 'stranger',
+        mentions: [{ key: '@_user_9', id: { open_id: 'peer-bot-2' }, name: 'Peer' }],
+      }),
+    );
+
+    await sleep(60);
+    // Not consumed as introduce; falls to the gate and is dropped (not allowlisted,
+    // and the bot was not mentioned). No trust written, no enqueue, no reactions.
+    expect(fake.turnsHandled).toBe(0);
+    expect(bot.reactions).toEqual([]);
+    const entry = loadChatBots('flow').chats['chat-group-a'];
+    expect(entry?.trusted ?? []).not.toContain('peer-bot-2');
   });
 
   it('records a trust-domain warning when one dispatcher receives multiple chats', async () => {


### PR DESCRIPTION
## Issue #62 — Phase 1 increment (NOT the full issue)

This is the **first PR of several** for issue #62. It lands the Phase 1
event-registry seam and the group `/introduce` hard contract. It deliberately
**does not** implement invite-code pairing or rich attachments yet — those are
named follow-ups below, not silent omissions. Do not close #62 on this PR.

Closes nothing; advances #62.

### Included in this PR

- **Phase 1 event-registry seam.** `FeishuBot.start` now takes a
  `FeishuInboundRoutes` object (`onMessage` + optional `onBotMemberAdded`)
  instead of a single handler. The bot builds the transport route table and
  registers `im.chat.member.bot.added_v1` when a handler is supplied, without
  growing branches in `Server` or the transport. Each route still awaits the
  full chain (gate → enqueue → reaction) before the SDK acks — the
  queue-before-ACK invariant is preserved. Normal message dispatch and the
  received/in-progress reaction flow are unchanged.
- **Group `/introduce` hard contract.** In a group, `/introduce` triggers **iff
  the sender is allowlisted**: no `@`-mention of our bot is required, but the
  chat must be in `group.allow_chats` **and** the sender in `group.follow_users`.
  "Any member of an allowlisted group" is deliberately **not** a path.
  `canRunIntroduce` is a dedicated sender-scoped predicate that never reuses a
  broad group-authorization predicate (it does not call `isGroupAuthorized`,
  which trusts a `follow-user` group without checking the sender). A bot sender
  is never on the human allowlist, so ambient self-introduction by an arbitrary
  bot does not trigger introduce.
- **Awareness vs trust separation.** New `chat-bots.json` per-dispatcher store
  tracks `known` (passively observed — awareness only) separately from `trusted`
  (introduced). The gate delivers a peer bot's group message only when its
  open_id is in the chat's trusted set; omitting `trustedBotIds` preserves prior
  drop-all-bots behavior, so existing gate tests are unaffected.
- **bot-added events** are recorded idempotently by event id and flag a baseline;
  no model notification.
- **`.agents/` updated** in the same PR (`domains/feishu-introduce.md`, the
  `chat-bots.json` state-file contract); `.agents/scripts/check.sh` passes.

### Deferred to follow-up PRs (tracked on #62) — with reasons

These are **user-prioritized** areas being split out for review hygiene, not
dropped:

- **Invite-code pairing + shared `Access` migration + `access.*` admin/CLI
  approve/deny.** Replacing the persisted access model is high-blast-radius: the
  legacy `access.json` shape is asserted directly by the `smoke`/`e2e`/`gate`
  tests, and the legacy→shared gate is **not** outcome-isomorphic (the legacy
  gate is conjunctive; the shared model picks one `groupPolicy`, so some
  permissive legacy states tighten to fail-closed). That migration deserves its
  own PR whose tests assert allow/drop equivalence for the configured cases and
  intentional tightening for the permissive ones.
- **Rich inbound attachments** (bounded authorized downloads + non-fetchable
  token references). The live SDK byte-fetch sits behind the transport boundary
  and cannot be exercised in CI; its own PR will land the injectable formatter +
  fake-tested caps + best-effort download together.
- **One-shot baseline discovery-context injection** and a **list-known-bots**
  MCP tool (the `chat-bots.json` store already keeps the durable bookkeeping
  these need).
- **`doc_comment`** handling.

### Tests

`packages/dreamux/tests/feishu-introduce.test.ts` (new) + a route-seam test in
`feishu-bot.test.ts`:

- `canRunIntroduce`: allowlisted sender in allowlisted chat → triggers;
  non-allowlisted sender (no `@`) → does not; allowlisted sender in a
  non-allowlisted chat → does not; empty allowlist → no one (not "any member");
  p2p → never.
- `detectIntroduce`: bare `/introduce`; `/introduce` after stripping a leading
  mention token (no `@` of our bot); mid-message and `/introducer` rejected;
  non-text/malformed rejected.
- Gate trust: a trusted bot delivers without a mention; an untrusted bot drops.
- `chat-bots.json`: observe records awareness not trust; introduce records
  trust; bot-added is idempotent and flags a baseline.
- Route seam: `onBotMemberAdded` registers the second route and is invoked.

### Verification gap (please read)

I could **not** run `tsc`/`vitest` in this worktree: it has no installed
dependencies and the monorepo install path
(`node common/scripts/install-run-rush.js update`) exceeded the available time
budget here, so the transport package's `dist` was never built for the host to
typecheck against. The change was reviewed by hand for type/seam correctness
against the real signatures, and `gitleaks` + the KB check pass. **CI (the rush
build/test gate) is the authoritative check** for this PR; please run it before
merge.
