### PR TITLE
feat(feishu):trusted-bot 上下文、list_chat_bots 工具、先加后撤 reaction(#69)

### DIFF
--- a/.agents/decisions/top-level-design.md
+++ b/.agents/decisions/top-level-design.md
@@ -360,6 +360,9 @@ The MVP MCP tool surface is:
   topic-mode replies under the original topic.
 - `react`: add a model-owned reaction to a Feishu message. Parameters are
   `message_id` and `emoji`.
+- `list_chat_bots` (issue #69): read-only query of a group chat's known +
+  trusted peer bots (names + open_ids). Parameter is `chat_id`. Forwards an
+  `mcp.list_chat_bots` admin request to the serve-owned, store-backed reader.
 
 `edit_message` and model-owned `remove_reaction` are out of scope for the MVP.
 

--- a/.agents/domains/feishu-introduce.md
+++ b/.agents/domains/feishu-introduce.md
@@ -7,6 +7,9 @@
   `packages/dreamux/src/channel/introduce.ts`,
   `packages/dreamux/src/channel/chat-bots-store.ts`,
   `packages/dreamux/src/channel/feishu-gate.ts`,
+  `packages/dreamux/src/channel/feishu-message.ts`,
+  `packages/dreamux/src/mcp/feishu-mcp.ts`,
+  `packages/dreamux/src/admin/methods.ts`,
   `packages/dreamux/src/server.ts`,
   `packages/dreamux/src/runtime/paths.ts`
 
@@ -62,6 +65,31 @@ omitted, no bot sender is ever delivered — preserving prior behavior. Recordin
 a human open_id as "trusted" is harmless: the gate only bypasses for a bot
 *sender*, so a human entry never widens access.
 
+## One-shot trusted-bot context (issue #69)
+
+When `/introduce` newly trusts a bot — or the bot is added to a chat — the chat
+is flagged `needsBaseline` and its `baselineGeneration` is bumped
+(`chat-bots-store.ts`). On the next **delivered** group message,
+`formatFeishuMessageForCodex` appends a one-shot `<group_bots>` block listing the
+chat's **trusted** bots (name + open_id), so the model can map a peer bot's
+open_id to a name. Passive `known` bots are deliberately not pushed here; they
+are queried on demand via `list_chat_bots`.
+
+The clear is **commit-after-notify and generation-safe**: the deliver path
+snapshots the generation before enqueue and clears `needsBaseline` only after
+`enqueueInbound` returns `submitted`, and only via `clearBaselineIfCurrent`,
+which no-ops if a newer `/introduce` / bot-added bumped the generation
+mid-enqueue. `duplicate` / `stopped` / `failed` leave the context pending.
+
+## `list_chat_bots` query tool
+
+A model-facing Feishu MCP tool (`mcp/feishu-mcp.ts`) returns a chat's `known` and
+`trusted` peer bots as two separated arrays of `{ open_id, name? }`, for context
+recovery after compaction. It forwards an `mcp.list_chat_bots` request over the
+0600 admin socket to the read-only `Server.listChatBotsFromMcp`, which reads the
+`chat-bots-store` directly (no running slot required). Same transport shape as
+`reply` / `react`; no operator CLI surface.
+
 ## Deferred to follow-up PRs
 
 Not in this increment, tracked on issue #62:
@@ -69,5 +97,9 @@ Not in this increment, tracked on issue #62:
 - Invite-code pairing, the shared `Access` contract migration, and the
   operator approve/deny surface (`access.*` admin methods + CLI).
 - Rich inbound attachments (bounded authorized downloads, token references).
-- One-shot baseline discovery-context injection and a list-known-bots tool.
 - `doc_comment` handling.
+
+(The one-shot discovery-context injection and the list-known-bots tool landed in
+issue #69 — see the two sections above; the add-then-cancel reaction ordering it
+also carried is in
+[`/.agents/domains/non-blocking-dispatcher-inbound.md`](/.agents/domains/non-blocking-dispatcher-inbound.md).)

--- a/.agents/domains/non-blocking-dispatcher-inbound.md
+++ b/.agents/domains/non-blocking-dispatcher-inbound.md
@@ -125,10 +125,14 @@ inbound.
   `input.messageId` after the model reply is sent.
 - Replace the single `receivedReactions` map with a channel-owned inbound
   reaction ledger that stores the current reaction id and state per message id.
-  Feishu reactions are replaced by removing the previous channel-owned reaction
-  id and adding the new emoji.
+  A reaction is replaced **add-then-cancel** (issue #69): add the new emoji
+  first, store it, then remove the previous channel-owned reaction id, so the
+  message never shows a zero-reaction window during `[received] → [in progress]`.
+  A failed or empty add keeps the previous reaction and ledger entry.
 - Keep `pendingReceivedReactionClears`: an MCP reply can still clear before an
-  async add/replace reaction call finishes.
+  async add/replace reaction call finishes. With add-then-cancel, a late clear
+  removes the just-added reaction and does not store it; the previous reaction is
+  already taken by `clearInboundReaction`, which read the ledger before any store.
 
 `packages/dreamux/src/channel/feishu-message.ts`
 
@@ -144,7 +148,8 @@ The channel-owned reaction has three visible states:
   `[received]`. "Immediately" means before Codex submission, not before
   access/dedupe.
 - Codex accepts `turn/start`: replace with `[in progress]` immediately at
-  submission acceptance, not at model consumption.
+  submission acceptance, not at model consumption. The replacement is
+  add-then-cancel (add `[in progress]`, then remove `[received]`).
 - The model replies through MCP `reply` for that `message_id`: remove the
   channel-owned reaction.
 

--- a/.agents/proposals/feishu-bot-trust-context.md
+++ b/.agents/proposals/feishu-bot-trust-context.md
@@ -1,0 +1,110 @@
+# Feishu trusted-bot context + list-chat-bots query + add-then-cancel reactions
+
+- **Status:** Implemented (issue #69 review accepted; the settled behavior now
+  lives in the domain/decision docs linked under Disposition — this proposal is
+  kept as the design-rationale + open-question record)
+- **Date:** 2026-06-05
+- **Affects:** `/packages/dreamux/src/channel/chat-bots-store.ts`,
+  `/packages/dreamux/src/channel/feishu-message.ts`,
+  `/packages/dreamux/src/mcp/feishu-mcp.ts`,
+  `/packages/dreamux/src/admin/methods.ts`,
+  `/packages/dreamux/src/server.ts`
+- **Source:** https://github.com/excitedjs/dreamux/issues/69
+  (focused follow-up to the closed epic
+  [#62](https://github.com/excitedjs/dreamux/issues/62), first increment #68;
+  design review on the issue is accepted with the constraints below)
+
+## Context
+
+#68 shipped the typed event-route seam, the `/introduce` hard contract, and the
+`known` / `trusted` peer-bot store (see
+[`domains/feishu-introduce.md`](../domains/feishu-introduce.md)). Two Phase 4
+items from #62 were deferred — one-shot discovery context and a list-known-bots
+capability — and a separate channel-behavior tweak (reaction ordering) is folded
+into the same focused change.
+
+The first introduce requirement is **already satisfied by #68, with regression
+coverage**: an allowlisted human's `/introduce` trusts the mentioned bots
+immediately (no prior bot-to-bot trust needed) and records their `open_id` plus
+best-effort display name; `tests/feishu-introduce.test.ts` and
+`tests/smoke.test.ts` already cover the auth predicate, the trust store, and the
+no-`@` consume-without-enqueue path. PR1 does **not** re-test that baseline — its
+new tests target the pending-context behavior below.
+
+## Behavior under review
+
+### Trusted-bot context on the next message (one-shot, generation-safe)
+
+After an `/introduce` adds newly trusted bots, the model's dispatcher context
+should carry the group's trusted bot identities (display name + `open_id`) once,
+so it can tell which bot/open_id sent a message or is otherwise known in the
+group.
+
+- Reuse the existing `needsBaseline` pending-context flag in
+  `chat-bots-store.ts` (today only set by `im.chat.member.bot.added_v1`); set it
+  when introduce adds a newly trusted bot.
+- Render a small escaped `<group_bots>` block in `formatFeishuMessageForCodex`
+  on the next delivered group message, escaped consistently with the existing
+  `<feishu_message>` envelope. **Inject `trusted` only** — `known` is passive
+  awareness, not trust, and is noisy; it is returned by `list_chat_bots` instead.
+- **Conditional / generation-safe clear (critical):** `TurnManager.enqueue()`
+  calls `onAccepted` before `turn/start`, so the pending flag may be cleared
+  **only** after `enqueueInbound()` returns `status: 'submitted'`. Never clear on
+  `duplicate`, `stopped`, or `failed` (the #62 commit-after-notify pattern).
+  Guard against lost updates: if another `/introduce` or bot-added event changes
+  the pending context while the first message is being enqueued, a late clear
+  must not erase the newer context — use a generation / snapshot compare, not a
+  blind boolean reset.
+
+### `list_chat_bots` query tool
+
+A model-facing Feishu MCP tool that returns the current group chat's `known` and
+`trusted` bots (names + open_ids, as two clearly separated arrays), for context
+recovery after compaction. It follows the existing `reply` / `react` shape: a
+tool in `feishu-mcp.ts` forwarding an `mcp.list_chat_bots` request over the 0600
+admin socket to a read-only `Server` method backed by the chat-bots store. No
+new trust boundary, and no separate operator CLI/admin command in PR1.
+
+### Reaction ordering: add-then-cancel
+
+The inbound reaction lifecycle currently cancels the previous reaction and then
+adds the new one (`setInboundReaction`, `Get` → `OnIt`). The agreed order is:
+
+1. check pending clear;
+2. capture the previous reaction;
+3. **add** the new reaction;
+4. if a pending clear appeared, remove the just-added reaction and do not store
+   it, then return;
+5. otherwise store the new reaction;
+6. **then cancel** the previous reaction.
+
+Race / failure constraints: a reply arriving while the previous reaction is
+being canceled must still let `replyFromMcp` remove the newly stored reaction
+(the reply-wins guarantee); if the new add fails or returns no reaction id, keep
+the previous reaction/ledger entry rather than deleting it. New tests beyond the
+existing "reply wins the initial add" race: a replacement-race test around the
+`[received] → [in progress]` transition, and a test proving add happens before
+cancel.
+
+### Feishu API assumption (to confirm in review)
+
+Add-then-cancel assumes Feishu lets the same bot/app add the new emoji while its
+previous reaction is still present on the same message. The repo fake/transport
+tests only prove request shape, not live platform semantics. If the assumption
+is false, a different no-zero-window strategy is needed.
+
+## Open questions
+
+Resolved on the issue review: one-shot cadence (yes), trusted-only proactive
+injection (yes), `list_chat_bots` as a model tool backed by the admin method
+(yes, not a new operator CLI), and add-then-cancel acceptable only with the
+stronger race tests above. The remaining live question is the Feishu reaction-API
+assumption.
+
+## Disposition
+
+When the review converges and PR1 lands, promote the settled parts into the
+relevant settled docs — `domains/feishu-introduce.md` (trust context / listing),
+`decisions/top-level-design.md` (MCP tool surface), and
+`domains/non-blocking-dispatcher-inbound.md` (reaction replacement ordering) —
+and retire this proposal.

--- a/.agents/root.md
+++ b/.agents/root.md
@@ -64,6 +64,11 @@ Background and older issue context:
   reconciliation, access surface, message-format, CLI/diagnostic robustness);
   groups the deferred epic follow-ups + the #58 ultracode findings into the next
   workstream.
+- [`proposals/feishu-bot-trust-context.md`](proposals/feishu-bot-trust-context.md)
+  — issue #69 follow-up to #62: trusted-bot next-message context, a
+  `list_chat_bots` query tool, and add-then-cancel reaction ordering
+  (implemented; settled behavior in `domains/feishu-introduce.md` +
+  `domains/non-blocking-dispatcher-inbound.md`).
 - [`domains/non-blocking-dispatcher-inbound.md`](domains/non-blocking-dispatcher-inbound.md)
   — final issue #63 runtime model for accepted Feishu inbound: every accepted
   deduped message submits `turn/start`, and reactions move through the

--- a/common/changes/@excitedjs/dreamux/feat-dx69-trusted-bot-context_2026-06-05-00-00.json
+++ b/common/changes/@excitedjs/dreamux/feat-dx69-trusted-bot-context_2026-06-05-00-00.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@excitedjs/dreamux",
+      "comment": "Inject a one-shot <group_bots> context of a group's trusted bots on the first delivered message after /introduce (commit-after-notify, generation-safe clear); add a model-facing list_chat_bots MCP tool (backed by a read-only mcp.list_chat_bots admin method) returning a chat's known + trusted bots; and change the inbound reaction lifecycle to add-then-cancel so the message never shows a zero-reaction window during the received -> in-progress transition.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@excitedjs/dreamux"
+}

--- a/packages/dreamux/src/admin/methods.ts
+++ b/packages/dreamux/src/admin/methods.ts
@@ -113,6 +113,16 @@ export const adminMethods: Record<string, AdminHandler> = {
       throw new AdminError('REACTION_FAILED', parseMessage(err));
     }
   },
+
+  // Read-only: lists a chat's known + trusted peer bots (issue #69). Reads the
+  // per-dispatcher chat-bots store, so it does not require a running slot — only
+  // a declared dispatcher.
+  'mcp.list_chat_bots': (server, params) => {
+    const id = mustDispatcherId(params);
+    mustExistingDispatcher(server, id);
+    const chatId = mustString(params, 'chat_id');
+    return server.listChatBotsFromMcp({ dispatcherId: id, chatId });
+  },
 };
 
 function mustString(

--- a/packages/dreamux/src/channel/chat-bots-store.ts
+++ b/packages/dreamux/src/channel/chat-bots-store.ts
@@ -44,8 +44,19 @@ export interface ChatBotsEntry {
   trusted: string[];
   /** Best-effort open_id → display name map for known/trusted bots. */
   names: Record<string, string>;
-  /** Set when the bot is added to this chat; consumed by a later baseline inject. */
+  /**
+   * Set when this chat has pending discovery context to inject once (a bot was
+   * added, or an `/introduce` newly trusted a bot). Consumed by the next
+   * delivered group message; see `pendingBaseline` / `clearBaselineIfCurrent`.
+   */
   needsBaseline: boolean;
+  /**
+   * Monotonic counter bumped every time `needsBaseline` is (re)set. The deliver
+   * path snapshots it before enqueue and only clears the flag if it is still
+   * current, so a newer `/introduce` / bot-added event arriving mid-enqueue is
+   * not clobbered by a stale clear (issue #69, generation-safe one-shot clear).
+   */
+  baselineGeneration: number;
   /** Recent bot-added event ids, for idempotent member-event handling. */
   seenEventIds: string[];
 }
@@ -60,12 +71,49 @@ export interface PeerBot {
   name?: string;
 }
 
+/** The pending one-shot discovery context for one chat (issue #69). */
+export interface PendingBaseline {
+  /** Whether this chat has discovery context waiting to be injected. */
+  needsBaseline: boolean;
+  /** Snapshot of the entry's generation, for a generation-safe clear. */
+  generation: number;
+  /** The chat's trusted peer bots (open_id + best-effort name). */
+  trusted: PeerBot[];
+}
+
+/** Known and trusted peer bots for one chat, for the `list_chat_bots` tool. */
+export interface ChatBotsListing {
+  known: PeerBot[];
+  trusted: PeerBot[];
+}
+
 export function defaultChatBotsState(): ChatBotsState {
   return { version: 1, chats: {} };
 }
 
 function emptyEntry(): ChatBotsEntry {
-  return { known: [], trusted: [], names: {}, needsBaseline: false, seenEventIds: [] };
+  return {
+    known: [],
+    trusted: [],
+    names: {},
+    needsBaseline: false,
+    baselineGeneration: 0,
+    seenEventIds: [],
+  };
+}
+
+/** Flag a chat as having pending discovery context, bumping its generation. */
+function markBaseline(entry: ChatBotsEntry): void {
+  entry.needsBaseline = true;
+  entry.baselineGeneration += 1;
+}
+
+/** Build PeerBot records (open_id + best-effort name) for a set of open_ids. */
+function peerBotsFrom(entry: ChatBotsEntry, openIds: string[]): PeerBot[] {
+  return openIds.map((openId) => {
+    const name = entry.names[openId];
+    return name !== undefined && name !== '' ? { openId, name } : { openId };
+  });
 }
 
 /**
@@ -144,8 +192,65 @@ export function trustIntroducedBots(
       changed = true;
     }
   }
+  // A newly trusted bot is pending discovery context for the next message
+  // (issue #69). Re-introducing already-trusted bots changes nothing, so it
+  // does not re-arm the one-shot.
+  if (added.length > 0) markBaseline(entry);
   if (changed) saveChatBots(dispatcherId, state);
   return added;
+}
+
+/**
+ * The chat's pending one-shot discovery context, snapshotted for a
+ * generation-safe clear (issue #69). The deliver path reads this before
+ * enqueue, injects the trusted bots when `needsBaseline`, and clears via
+ * `clearBaselineIfCurrent` only after a successful submission.
+ */
+export function pendingBaseline(
+  dispatcherId: string,
+  chatId: string,
+): PendingBaseline {
+  const entry = loadChatBots(dispatcherId).chats[chatId];
+  if (entry === undefined) {
+    return { needsBaseline: false, generation: 0, trusted: [] };
+  }
+  return {
+    needsBaseline: entry.needsBaseline,
+    generation: entry.baselineGeneration,
+    trusted: peerBotsFrom(entry, entry.trusted),
+  };
+}
+
+/**
+ * Clear the pending-context flag only if the chat's generation still matches
+ * the snapshot taken before enqueue. A newer `/introduce` / bot-added event
+ * that arrived mid-enqueue bumps the generation, so this no-ops rather than
+ * dropping the newer pending context (issue #69).
+ */
+export function clearBaselineIfCurrent(
+  dispatcherId: string,
+  chatId: string,
+  generation: number,
+): void {
+  const state = loadChatBots(dispatcherId);
+  const entry = state.chats[chatId];
+  if (entry === undefined || !entry.needsBaseline) return;
+  if (entry.baselineGeneration !== generation) return;
+  entry.needsBaseline = false;
+  saveChatBots(dispatcherId, state);
+}
+
+/** Known and trusted peer bots for one chat (the `list_chat_bots` tool). */
+export function listChatBots(
+  dispatcherId: string,
+  chatId: string,
+): ChatBotsListing {
+  const entry = loadChatBots(dispatcherId).chats[chatId];
+  if (entry === undefined) return { known: [], trusted: [] };
+  return {
+    known: peerBotsFrom(entry, entry.known),
+    trusted: peerBotsFrom(entry, entry.trusted),
+  };
 }
 
 /** The trust set the gate consults for one chat. */
@@ -170,7 +275,7 @@ export function recordBotAdded(
     entry.seenEventIds.push(eventId);
     while (entry.seenEventIds.length > MAX_SEEN_EVENT_IDS) entry.seenEventIds.shift();
   }
-  entry.needsBaseline = true;
+  markBaseline(entry);
   saveChatBots(dispatcherId, state);
   return true;
 }
@@ -204,6 +309,11 @@ function normalizeEntry(raw: unknown): ChatBotsEntry {
   entry.trusted = stringArray(obj['trusted']);
   entry.seenEventIds = stringArray(obj['seenEventIds']);
   entry.needsBaseline = obj['needsBaseline'] === true;
+  entry.baselineGeneration =
+    typeof obj['baselineGeneration'] === 'number' &&
+    Number.isFinite(obj['baselineGeneration'])
+      ? obj['baselineGeneration']
+      : 0;
   const names = obj['names'];
   if (names !== null && typeof names === 'object' && !Array.isArray(names)) {
     for (const [k, v] of Object.entries(names as Record<string, unknown>)) {

--- a/packages/dreamux/src/channel/feishu-message.ts
+++ b/packages/dreamux/src/channel/feishu-message.ts
@@ -1,11 +1,25 @@
 import type { Mention } from '@excitedjs/feishu-transport';
 
 import type { FeishuInboundEvent } from '../feishu/bot.js';
+import type { PeerBot } from './chat-bots-store.js';
 
 export const FEISHU_SKILL_FALLBACK_NOTE =
   'Parser note: message text may be incomplete. Use the Feishu skill with the chat_id and message_id above to fetch the original message when needed.';
 
-export function formatFeishuMessageForCodex(event: FeishuInboundEvent): string {
+export interface FormatFeishuMessageOptions {
+  /**
+   * Trusted peer bots to surface once, as a `<group_bots>` block (issue #69).
+   * Injected only on the first delivered group message after an `/introduce`
+   * (or bot-added) so the model can map a bot open_id to a name. Trusted only —
+   * passive `known` bots are queried via `list_chat_bots`, not pushed here.
+   */
+  trustedBots?: PeerBot[];
+}
+
+export function formatFeishuMessageForCodex(
+  event: FeishuInboundEvent,
+  options: FormatFeishuMessageOptions = {},
+): string {
   const attrs: Array<[string, string]> = [
     ['chat_id', event.chatId],
     ['chat_type', event.chatType],
@@ -18,6 +32,7 @@ export function formatFeishuMessageForCodex(event: FeishuInboundEvent): string {
   const fallback = shouldAddFallbackNote(event)
     ? `\n\n${FEISHU_SKILL_FALLBACK_NOTE}`
     : '';
+  const groupBots = renderGroupBots(options.trustedBots ?? []);
 
   const attrLines = attrs.map(
     ([key, value]) => `  ${key}="${escapeXmlAttribute(value)}"`,
@@ -27,8 +42,25 @@ export function formatFeishuMessageForCodex(event: FeishuInboundEvent): string {
   return [
     '<feishu_message',
     ...attrLines,
-    `${body}${fallback}`,
+    `${body}${fallback}${groupBots}`,
     '</feishu_message>',
+  ].join('\n');
+}
+
+/**
+ * Render the one-shot trusted-bot discovery block. Empty string when there are
+ * no trusted bots, so the common path is byte-for-byte unchanged.
+ */
+function renderGroupBots(trustedBots: PeerBot[]): string {
+  if (trustedBots.length === 0) return '';
+  const lines = trustedBots.map((bot) => {
+    const name = bot.name ?? '';
+    return `  <bot name="${escapeXmlAttribute(name)}" open_id="${escapeXmlAttribute(bot.openId)}" />`;
+  });
+  return [
+    '\n\n<group_bots note="trusted bots in this group; a bot speaks without @-mentioning us">',
+    ...lines,
+    '</group_bots>',
   ].join('\n');
 }
 

--- a/packages/dreamux/src/feishu/bot.ts
+++ b/packages/dreamux/src/feishu/bot.ts
@@ -287,6 +287,11 @@ export interface FakeFeishuBot extends FeishuBot {
     messageId: string;
     reactionId: string;
   }>;
+  /** Combined add/remove timeline, in call order (tests assert ordering). */
+  readonly reactionOps: Array<
+    | { op: 'add'; messageId: string; emoji: string; reactionId: string }
+    | { op: 'remove'; messageId: string; reactionId: string }
+  >;
   inject(event: FeishuInboundEvent): Promise<void>;
   injectBotMemberAdded(event: FeishuBotMemberAddedEvent): Promise<void>;
   setSendError(err: Error | null): void;
@@ -317,6 +322,7 @@ export function createFakeFeishuBot(appId: string = 'fake-bot'): FakeFeishuBot {
     messageId: string;
     reactionId: string;
   }> = [];
+  const reactionOps: FakeFeishuBot['reactionOps'] = [];
 
   return {
     appId,
@@ -340,6 +346,7 @@ export function createFakeFeishuBot(appId: string = 'fake-bot'): FakeFeishuBot {
       }
       const reactionId = `reaction-fake-${nextReactionId++}`;
       reactions.push({ messageId, emoji, reactionId });
+      reactionOps.push({ op: 'add', messageId, emoji, reactionId });
       return reactionId;
     },
     async removeReaction(messageId: string, reactionId: string): Promise<void> {
@@ -347,6 +354,7 @@ export function createFakeFeishuBot(appId: string = 'fake-bot'): FakeFeishuBot {
         throw removeReactionError;
       }
       removedReactions.push({ messageId, reactionId });
+      reactionOps.push({ op: 'remove', messageId, reactionId });
     },
     async close(): Promise<void> {
       routes = null;
@@ -359,6 +367,9 @@ export function createFakeFeishuBot(appId: string = 'fake-bot'): FakeFeishuBot {
     },
     get removedReactions() {
       return removedReactions;
+    },
+    get reactionOps() {
+      return reactionOps;
     },
     async inject(event: FeishuInboundEvent): Promise<void> {
       if (routes === null) throw new Error('fake bot not started');

--- a/packages/dreamux/src/mcp/feishu-mcp.ts
+++ b/packages/dreamux/src/mcp/feishu-mcp.ts
@@ -181,6 +181,22 @@ function feishuTools(): Array<Record<string, unknown>> {
         required: ['message_id', 'emoji'],
       },
     },
+    {
+      name: 'list_chat_bots',
+      description:
+        'List the peer bots known and trusted in a Feishu group chat (names + open_ids). Use to recover bot identities after a context compaction.',
+      inputSchema: {
+        type: 'object',
+        additionalProperties: false,
+        properties: {
+          chat_id: {
+            type: 'string',
+            description: 'Feishu chat id from the inbound feishu_message block.',
+          },
+        },
+        required: ['chat_id'],
+      },
+    },
   ];
 }
 
@@ -210,6 +226,17 @@ async function callTool(
         },
         ctx.socketPath,
         'react',
+      );
+    }
+    if (call.name === 'list_chat_bots') {
+      return forwardToolCall(
+        'mcp.list_chat_bots',
+        {
+          dispatcher_id: ctx.dispatcherId,
+          ...listChatBotsArgs(call.arguments),
+        },
+        ctx.socketPath,
+        'list_chat_bots',
       );
     }
     return toolError(`unknown Feishu tool '${String(call.name)}'`);
@@ -281,6 +308,13 @@ function reactArgs(value: unknown): Record<string, unknown> {
   return {
     message_id: requireString(obj, 'message_id'),
     emoji: requireString(obj, 'emoji'),
+  };
+}
+
+function listChatBotsArgs(value: unknown): Record<string, unknown> {
+  const obj = asRecord(value, 'list_chat_bots arguments');
+  return {
+    chat_id: requireString(obj, 'chat_id'),
   };
 }
 

--- a/packages/dreamux/src/server.ts
+++ b/packages/dreamux/src/server.ts
@@ -34,11 +34,15 @@ import {
   introducedPeers,
 } from './channel/introduce.js';
 import {
+  clearBaselineIfCurrent,
+  listChatBots,
   observeKnownBot,
+  pendingBaseline,
   recordBotAdded,
   trustIntroducedBots,
   trustedBotIds,
 } from './channel/chat-bots-store.js';
+import type { PeerBot } from './channel/chat-bots-store.js';
 import { formatFeishuMessageForCodex } from './channel/feishu-message.js';
 import { parseCodexArgs, codexArgsToCli } from './runtime/codex-args.js';
 import { feishuMcpCodexArgs } from './codex/mcp-config.js';
@@ -125,6 +129,22 @@ export interface ServerMcpReactInput {
   dispatcherId: string;
   messageId: string;
   emoji: string;
+}
+
+export interface ServerMcpListChatBotsInput {
+  dispatcherId: string;
+  chatId: string;
+}
+
+export interface WireChatBot {
+  open_id: string;
+  name?: string;
+}
+
+export interface ServerMcpListChatBotsResult {
+  chat_id: string;
+  known: WireChatBot[];
+  trusted: WireChatBot[];
 }
 
 export class Server {
@@ -321,11 +341,23 @@ export class Server {
             );
             return;
           }
+          // Issue #69: a group with pending discovery context gets a one-shot
+          // `<group_bots>` block of its trusted bots on this delivery. We
+          // snapshot the generation before enqueue so a concurrent
+          // `/introduce` / bot-added that re-arms the flag mid-enqueue is not
+          // clobbered by the clear below.
+          const baseline =
+            event.chatType === 'group' ? pendingBaseline(id, event.chatId) : null;
+          const injectBots =
+            baseline !== null && baseline.needsBaseline && baseline.trusted.length > 0;
           const input: InboundTurnInput = {
             source_chat_id: event.chatId,
             source_message_id: event.messageId,
             sender_id: event.senderId,
-            parsed_text: formatFeishuMessageForCodex(event),
+            parsed_text: formatFeishuMessageForCodex(
+              event,
+              injectBots ? { trustedBots: baseline.trusted } : {},
+            ),
           };
           const delivery = await runtime.enqueueInbound(input, {
             onAccepted: async (acceptedInput) => {
@@ -340,6 +372,12 @@ export class Server {
             },
           });
           if (delivery.status === 'submitted') {
+            // Commit-after-notify: only clear the one-shot once the turn is
+            // actually submitted, and only if the generation is still current.
+            // `duplicate` / `stopped` / `failed` leave the context pending.
+            if (injectBots) {
+              clearBaselineIfCurrent(id, event.chatId, baseline.generation);
+            }
             await setInboundReaction(
               id,
               bot,
@@ -427,6 +465,22 @@ export class Server {
     return { reaction_id: reactionId };
   }
 
+  /**
+   * Read-only query of one chat's known + trusted peer bots (issue #69). Backs
+   * the model-facing `list_chat_bots` MCP tool. Reads the per-dispatcher
+   * chat-bots store directly, so it does not require a running dispatcher slot.
+   */
+  listChatBotsFromMcp(
+    input: ServerMcpListChatBotsInput,
+  ): ServerMcpListChatBotsResult {
+    const listing = listChatBots(input.dispatcherId, input.chatId);
+    return {
+      chat_id: input.chatId,
+      known: listing.known.map(toWireChatBot),
+      trusted: listing.trusted.map(toWireChatBot),
+    };
+  }
+
   private mustRunningSlot(id: string): DispatcherSlot {
     const slot = this.slots.get(id);
     if (slot === undefined) {
@@ -470,6 +524,13 @@ export class Server {
   }
 }
 
+function toWireChatBot(bot: PeerBot): WireChatBot {
+  return {
+    open_id: bot.openId,
+    ...(bot.name !== undefined && bot.name !== '' ? { name: bot.name } : {}),
+  };
+}
+
 async function setInboundReaction(
   dispatcherId: string,
   bot: FeishuBot,
@@ -483,6 +544,50 @@ async function setInboundReaction(
   if (channelState.pendingReceivedReactionClears.has(messageId)) return;
 
   const previous = channelState.inboundReactions.get(messageId);
+
+  // Add-then-cancel (issue #69): add the new reaction FIRST so the message
+  // never shows zero reactions during the received -> in_progress transition,
+  // then cancel the previous one. A failed/empty add keeps the previous
+  // reaction and ledger entry rather than leaving the message bare.
+  let reactionId: string;
+  try {
+    reactionId = await bot.addReaction(messageId, emoji);
+  } catch (err) {
+    console.error(
+      `[server] failed to add the ${state} reaction for dispatcher '${dispatcherId}':`,
+      err,
+    );
+    return;
+  }
+  if (reactionId === '') {
+    console.error(
+      `[server] Feishu returned no reaction_id for the ${state} reaction in dispatcher '${dispatcherId}'`,
+    );
+    return;
+  }
+
+  // A reply may have cleared this message while the add was in flight. Remove
+  // the just-added reaction and do not store it; the previous reaction was
+  // already taken by clearInboundReaction, which read the ledger before any
+  // store here. This preserves the reply-wins-the-race guarantee.
+  if (channelState.pendingReceivedReactionClears.has(messageId)) {
+    try {
+      await bot.removeReaction(messageId, reactionId);
+    } catch (err) {
+      console.error(
+        `[server] failed to clear the late ${state} reaction for dispatcher '${dispatcherId}' message '${messageId}':`,
+        err,
+      );
+    }
+    return;
+  }
+
+  channelState.inboundReactions.set(messageId, {
+    chatId: input.source_chat_id,
+    reactionId,
+    state,
+  });
+
   if (previous !== undefined) {
     try {
       await bot.removeReaction(messageId, previous.reactionId);
@@ -492,39 +597,6 @@ async function setInboundReaction(
         err,
       );
     }
-    channelState.inboundReactions.delete(messageId);
-  }
-  if (channelState.pendingReceivedReactionClears.has(messageId)) return;
-
-  try {
-    const reactionId = await bot.addReaction(messageId, emoji);
-    if (reactionId === '') {
-      console.error(
-        `[server] Feishu returned no reaction_id for the ${state} reaction in dispatcher '${dispatcherId}'`,
-      );
-      return;
-    }
-    if (channelState.pendingReceivedReactionClears.has(messageId)) {
-      try {
-        await bot.removeReaction(messageId, reactionId);
-      } catch (err) {
-        console.error(
-          `[server] failed to clear the late ${state} reaction for dispatcher '${dispatcherId}' message '${messageId}':`,
-          err,
-        );
-      }
-      return;
-    }
-    channelState.inboundReactions.set(messageId, {
-      chatId: input.source_chat_id,
-      reactionId,
-      state,
-    });
-  } catch (err) {
-    console.error(
-      `[server] failed to add the ${state} reaction for dispatcher '${dispatcherId}':`,
-      err,
-    );
   }
 }
 

--- a/packages/dreamux/tests/feishu-introduce.test.ts
+++ b/packages/dreamux/tests/feishu-introduce.test.ts
@@ -22,8 +22,11 @@ import {
   introducedPeers,
 } from '../src/channel/introduce.js';
 import {
+  clearBaselineIfCurrent,
+  listChatBots,
   loadChatBots,
   observeKnownBot,
+  pendingBaseline,
   recordBotAdded,
   trustIntroducedBots,
   trustedBotIds,
@@ -192,5 +195,87 @@ describe('chat-bots store — awareness vs trust are separate', () => {
     expect(recordBotAdded('d1', 'chat-a', 'evt-1')).toBe(true);
     expect(recordBotAdded('d1', 'chat-a', 'evt-1')).toBe(false);
     expect(loadChatBots('d1').chats['chat-a']?.needsBaseline).toBe(true);
+  });
+});
+
+describe('chat-bots store — one-shot pending context (issue #69)', () => {
+  let root: string;
+  let previousHome: string | undefined;
+
+  beforeEach(() => {
+    root = mkdtempSync(join(tmpdir(), 'dreamux-chatbots-pending-'));
+    previousHome = process.env['HOME'];
+    process.env['HOME'] = join(root, 'home');
+    resetRuntimeConfig();
+  });
+
+  afterEach(() => {
+    if (previousHome === undefined) delete process.env['HOME'];
+    else process.env['HOME'] = previousHome;
+    resetRuntimeConfig();
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  it('arms a generation-stamped pending baseline carrying the trusted bots', () => {
+    trustIntroducedBots('d1', 'chat-a', [{ openId: 'peer-a', name: 'Peer A' }]);
+    const pending = pendingBaseline('d1', 'chat-a');
+    expect(pending.needsBaseline).toBe(true);
+    expect(pending.generation).toBe(1);
+    expect(pending.trusted).toEqual([{ openId: 'peer-a', name: 'Peer A' }]);
+  });
+
+  it('only trusted (not passively known) bots ride the pending baseline', () => {
+    observeKnownBot('d1', 'chat-a', { openId: 'known-only', name: 'Known' });
+    trustIntroducedBots('d1', 'chat-a', [{ openId: 'peer-a', name: 'Peer A' }]);
+    expect(pendingBaseline('d1', 'chat-a').trusted).toEqual([
+      { openId: 'peer-a', name: 'Peer A' },
+    ]);
+  });
+
+  it('re-introducing an already-trusted bot does not re-arm the one-shot', () => {
+    trustIntroducedBots('d1', 'chat-a', [{ openId: 'peer-a' }]);
+    clearBaselineIfCurrent('d1', 'chat-a', pendingBaseline('d1', 'chat-a').generation);
+    expect(pendingBaseline('d1', 'chat-a').needsBaseline).toBe(false);
+    const added = trustIntroducedBots('d1', 'chat-a', [{ openId: 'peer-a' }]);
+    expect(added).toEqual([]);
+    expect(pendingBaseline('d1', 'chat-a').needsBaseline).toBe(false);
+  });
+
+  it('clears the flag when the generation still matches the snapshot', () => {
+    trustIntroducedBots('d1', 'chat-a', [{ openId: 'peer-a' }]);
+    const snapshot = pendingBaseline('d1', 'chat-a');
+    clearBaselineIfCurrent('d1', 'chat-a', snapshot.generation);
+    expect(pendingBaseline('d1', 'chat-a').needsBaseline).toBe(false);
+  });
+
+  it('does NOT clear when a newer event bumped the generation mid-enqueue', () => {
+    trustIntroducedBots('d1', 'chat-a', [{ openId: 'peer-a' }]);
+    const stale = pendingBaseline('d1', 'chat-a'); // generation 1
+    // A second /introduce arrives before the stale clear runs.
+    trustIntroducedBots('d1', 'chat-a', [{ openId: 'peer-b' }]); // generation 2
+    clearBaselineIfCurrent('d1', 'chat-a', stale.generation);
+    const after = pendingBaseline('d1', 'chat-a');
+    expect(after.needsBaseline).toBe(true);
+    expect(after.trusted).toEqual([{ openId: 'peer-a' }, { openId: 'peer-b' }]);
+  });
+
+  it('listChatBots returns known and trusted separately, with names', () => {
+    observeKnownBot('d1', 'chat-a', { openId: 'known-a', name: 'Known A' });
+    trustIntroducedBots('d1', 'chat-a', [{ openId: 'peer-a', name: 'Peer A' }]);
+    const listing = listChatBots('d1', 'chat-a');
+    expect(listing.known).toEqual([
+      { openId: 'known-a', name: 'Known A' },
+      { openId: 'peer-a', name: 'Peer A' },
+    ]);
+    expect(listing.trusted).toEqual([{ openId: 'peer-a', name: 'Peer A' }]);
+  });
+
+  it('returns empty listings/baseline for an unknown chat', () => {
+    expect(listChatBots('d1', 'nope')).toEqual({ known: [], trusted: [] });
+    expect(pendingBaseline('d1', 'nope')).toEqual({
+      needsBaseline: false,
+      generation: 0,
+      trusted: [],
+    });
   });
 });

--- a/packages/dreamux/tests/feishu-mcp.test.ts
+++ b/packages/dreamux/tests/feishu-mcp.test.ts
@@ -118,7 +118,11 @@ describe('feishu-mcp stdio shim', () => {
 
     writeJson(input, { jsonrpc: '2.0', id: 2, method: 'tools/list', params: {} });
     const tools = await reader.next() as { result: { tools: Array<{ name: string }> } };
-    expect(tools.result.tools.map((tool) => tool.name)).toEqual(['reply', 'react']);
+    expect(tools.result.tools.map((tool) => tool.name)).toEqual([
+      'reply',
+      'react',
+      'list_chat_bots',
+    ]);
 
     input.end();
     await run;
@@ -213,6 +217,61 @@ describe('feishu-mcp stdio shim', () => {
             text: 'hello',
             mention_user_ids: ['sender-a'],
           },
+        },
+      ]);
+
+      input.end();
+      await run;
+    } finally {
+      await admin.close();
+    }
+  });
+
+  it('forwards list_chat_bots tool calls to the dispatcher-scoped admin method', async () => {
+    const admin = await startFakeAdminServer((request) => ({
+      id: request.id,
+      ok: true,
+      result: {
+        chat_id: 'chat-a',
+        known: [{ open_id: 'ou-known' }],
+        trusted: [{ open_id: 'ou-peer', name: 'Peer' }],
+      },
+    }));
+    try {
+      const input = new PassThrough();
+      const output = new PassThrough();
+      const reader = new JsonLineReader(output);
+      const run = runFeishuMcp({
+        dispatcherId: 'dispatcher-a',
+        adminSocketPath: admin.socketPath,
+        input,
+        output,
+        log: () => {},
+      });
+
+      writeJson(input, {
+        jsonrpc: '2.0',
+        id: 1,
+        method: 'tools/call',
+        params: { name: 'list_chat_bots', arguments: { chat_id: 'chat-a' } },
+      });
+      const response = await reader.next();
+      expect(response).toMatchObject({
+        jsonrpc: '2.0',
+        id: 1,
+        result: {
+          structuredContent: {
+            chat_id: 'chat-a',
+            known: [{ open_id: 'ou-known' }],
+            trusted: [{ open_id: 'ou-peer', name: 'Peer' }],
+          },
+        },
+      });
+      expect(admin.requests).toEqual([
+        {
+          id: expect.any(String) as string,
+          method: 'mcp.list_chat_bots',
+          params: { dispatcher_id: 'dispatcher-a', chat_id: 'chat-a' },
         },
       ]);
 

--- a/packages/dreamux/tests/feishu-message.test.ts
+++ b/packages/dreamux/tests/feishu-message.test.ts
@@ -30,6 +30,28 @@ describe('formatFeishuMessageForCodex', () => {
     expect(block).toContain('  sender_name="Ada &amp; Bob"');
   });
 
+  it('omits the group_bots block when no trusted bots are supplied', () => {
+    expect(formatFeishuMessageForCodex(event(), {})).not.toContain('<group_bots');
+    expect(formatFeishuMessageForCodex(event(), { trustedBots: [] })).not.toContain(
+      '<group_bots',
+    );
+  });
+
+  it('renders a one-shot group_bots block of trusted bots with escaped values', () => {
+    const block = formatFeishuMessageForCodex(event(), {
+      trustedBots: [
+        { openId: 'ou-peer-a', name: 'Peer & "A"' },
+        { openId: 'ou-peer-b' },
+      ],
+    });
+    expect(block).toContain(
+      '<group_bots note="trusted bots in this group; a bot speaks without @-mentioning us">',
+    );
+    expect(block).toContain('  <bot name="Peer &amp; &quot;A&quot;" open_id="ou-peer-a" />');
+    expect(block).toContain('  <bot name="" open_id="ou-peer-b" />');
+    expect(block.endsWith('</group_bots>\n</feishu_message>')).toBe(true);
+  });
+
   it('adds a Feishu skill fallback note when text content cannot be parsed', () => {
     const block = formatFeishuMessageForCodex(
       event({

--- a/packages/dreamux/tests/smoke.test.ts
+++ b/packages/dreamux/tests/smoke.test.ts
@@ -539,6 +539,110 @@ describe('dreamux MVP smoke', () => {
     ]);
   });
 
+  it('adds the in-progress reaction before cancelling the received one (add-then-cancel)', async () => {
+    server = buildServer({ runtimeDir, fake, bot });
+    server.repos.dispatchers.create({
+      dispatcher_id: 'flow',
+      bot_app_id: 'app-smoke',
+      bot_secret_ref: 'env:UNUSED',
+    });
+    await server.start();
+
+    await bot.inject(fakeInbound('chat-group-a', 'hi', 'msg-order'));
+
+    await waitFor(
+      () => bot.reactions.length === 2 && bot.removedReactions.length === 1,
+    );
+    // The received->in_progress transition must add the new reaction before it
+    // removes the previous one, so the message never shows zero reactions.
+    const addInProgress = bot.reactionOps.findIndex(
+      (op) => op.op === 'add' && op.emoji === IN_PROGRESS_REACTION_EMOJI,
+    );
+    const removeReceived = bot.reactionOps.findIndex(
+      (op) => op.op === 'remove' && op.reactionId === 'reaction-fake-1',
+    );
+    expect(addInProgress).toBeGreaterThanOrEqual(0);
+    expect(removeReceived).toBeGreaterThan(addInProgress);
+  });
+
+  it('reply wins the received->in_progress replacement race without leaving a dangling reaction', async () => {
+    await fake.close();
+    codexInputs = [];
+    fake = await startFakeCodex({
+      turnDelayMs: 2000,
+      replyFor: captureAndEchoCodexInput(codexInputs),
+    });
+
+    let releaseInProgress!: () => void;
+    let markInProgressStarted!: () => void;
+    const inProgressStarted = new Promise<void>((resolve) => {
+      markInProgressStarted = resolve;
+    });
+    const inProgressBlocked = new Promise<void>((resolve) => {
+      releaseInProgress = resolve;
+    });
+    const originalAddReaction = bot.addReaction.bind(bot);
+    bot.addReaction = async (messageId, emoji) => {
+      if (emoji === IN_PROGRESS_REACTION_EMOJI) {
+        markInProgressStarted();
+        await inProgressBlocked;
+      }
+      return originalAddReaction(messageId, emoji);
+    };
+
+    server = buildServer({ runtimeDir, fake, bot });
+    server.repos.dispatchers.create({
+      dispatcher_id: 'flow',
+      bot_app_id: 'app-smoke',
+      bot_secret_ref: 'env:UNUSED',
+    });
+    await server.start();
+
+    const injected = bot.inject(
+      fakeInbound('chat-group-a', 'fast reply', 'msg-replace-race'),
+    );
+    // The received reaction is added; the in-progress add is now blocked.
+    await inProgressStarted;
+    await waitFor(() => bot.reactions.length === 1);
+
+    await sendAdminRequest(
+      'mcp.reply',
+      {
+        dispatcher_id: 'flow',
+        chat_id: 'chat-group-a',
+        message_id: 'msg-replace-race',
+        text: 'manual reply mid-transition',
+      },
+      { socketPath: join(runtimeDir, 'admin.sock') },
+    );
+    // The reply removed the received reaction (the only one in the ledger).
+    expect(bot.removedReactions).toEqual([
+      { messageId: 'msg-replace-race', reactionId: 'reaction-fake-1' },
+    ]);
+
+    // Now the in-progress add lands; it must be removed (late pending clear),
+    // not stored and left dangling.
+    releaseInProgress();
+    await injected;
+    await waitFor(() => bot.removedReactions.length === 2);
+    expect(bot.removedReactions).toEqual([
+      { messageId: 'msg-replace-race', reactionId: 'reaction-fake-1' },
+      { messageId: 'msg-replace-race', reactionId: 'reaction-fake-2' },
+    ]);
+    expect(bot.reactions).toEqual([
+      {
+        messageId: 'msg-replace-race',
+        emoji: RECEIVED_REACTION_EMOJI,
+        reactionId: 'reaction-fake-1',
+      },
+      {
+        messageId: 'msg-replace-race',
+        emoji: IN_PROGRESS_REACTION_EMOJI,
+        reactionId: 'reaction-fake-2',
+      },
+    ]);
+  });
+
   it('mcp.react adds a model-owned reaction without clearing received reactions', async () => {
     server = buildServer({ runtimeDir, fake, bot });
     server.repos.dispatchers.create({
@@ -742,6 +846,106 @@ describe('dreamux MVP smoke', () => {
     const entry = loadChatBots('flow').chats['chat-group-a'];
     expect(entry?.trusted).toEqual(['peer-bot-1']);
     expect(entry?.known).toEqual(['peer-bot-1']);
+  });
+
+  it('injects a one-shot group_bots context on the next group message after /introduce', async () => {
+    saveDispatcherAccess('flow', {
+      version: 1,
+      dm: { allow_users: [] },
+      group: {
+        allow_chats: ['chat-group-a'],
+        follow_users: ['sender-test'],
+        require_mention: true,
+      },
+      observed_chats: [],
+      warnings: [],
+      last_gate: null,
+    });
+    server = buildServer({ runtimeDir, fake, bot });
+    server.repos.dispatchers.create({
+      dispatcher_id: 'flow',
+      bot_app_id: 'app-smoke',
+      bot_secret_ref: 'env:UNUSED',
+    });
+    await server.start();
+
+    // /introduce trusts the peer bot and arms the one-shot context.
+    await bot.inject(
+      fakeInbound('chat-group-a', '/introduce', 'msg-intro', {
+        mentions: [{ key: '@_user_9', id: { open_id: 'peer-bot-1' }, name: 'Peer Bot' }],
+      }),
+    );
+    await sleep(40);
+    expect(fake.turnsHandled).toBe(0);
+
+    // Next delivered group message carries the trusted bots once.
+    await bot.inject(fakeInbound('chat-group-a', 'hello again', 'msg-after-1'));
+    await waitFor(() => codexInputs.length === 1);
+    expect(codexInputs[0]).toContain('<group_bots');
+    expect(codexInputs[0]).toContain('open_id="peer-bot-1"');
+    expect(codexInputs[0]).toContain('name="Peer Bot"');
+
+    // The message after that does NOT — it was a one-shot, cleared after submit.
+    await bot.inject(fakeInbound('chat-group-a', 'and again', 'msg-after-2'));
+    await waitFor(() => codexInputs.length === 2);
+    expect(codexInputs[1]).not.toContain('<group_bots');
+    expect(loadChatBots('flow').chats['chat-group-a']?.needsBaseline).toBe(false);
+  });
+
+  it('mcp.list_chat_bots returns the chat known + trusted bots with names', async () => {
+    saveDispatcherAccess('flow', {
+      version: 1,
+      dm: { allow_users: [] },
+      group: {
+        allow_chats: ['chat-group-a'],
+        follow_users: ['sender-test'],
+        require_mention: true,
+      },
+      observed_chats: [],
+      warnings: [],
+      last_gate: null,
+    });
+    server = buildServer({ runtimeDir, fake, bot });
+    server.repos.dispatchers.create({
+      dispatcher_id: 'flow',
+      bot_app_id: 'app-smoke',
+      bot_secret_ref: 'env:UNUSED',
+    });
+    await server.start();
+
+    // Trust one bot via /introduce, and passively observe another bot sender.
+    await bot.inject(
+      fakeInbound('chat-group-a', '/introduce', 'msg-intro-list', {
+        mentions: [{ key: '@_user_9', id: { open_id: 'peer-bot-1' }, name: 'Peer Bot' }],
+      }),
+    );
+    await bot.inject(
+      fakeInbound('chat-group-a', 'ambient bot chatter', 'msg-bot-obs', {
+        senderId: 'known-bot-2',
+        senderType: 'bot',
+        senderName: 'Ambient Bot',
+      }),
+    );
+    await sleep(40);
+
+    const result = (await sendAdminRequest(
+      'mcp.list_chat_bots',
+      { dispatcher_id: 'flow', chat_id: 'chat-group-a' },
+      { socketPath: join(runtimeDir, 'admin.sock') },
+    )) as {
+      chat_id: string;
+      known: Array<{ open_id: string; name?: string }>;
+      trusted: Array<{ open_id: string; name?: string }>;
+    };
+
+    expect(result.chat_id).toBe('chat-group-a');
+    expect(result.trusted).toEqual([{ open_id: 'peer-bot-1', name: 'Peer Bot' }]);
+    expect(result.known).toEqual(
+      expect.arrayContaining([
+        { open_id: 'peer-bot-1', name: 'Peer Bot' },
+        { open_id: 'known-bot-2', name: 'Ambient Bot' },
+      ]),
+    );
   });
 
   it('does NOT consume /introduce from a non-allowlisted sender (no trust, dropped by the gate)', async () => {


### PR DESCRIPTION
关联并关闭 #69(#62 的聚焦后续,phase 1 见 #68)。实现按 Codex 在 #69 的 review 收敛后的方案。

## 改动内容

1. **trusted-bot 一次性上下文(one-shot)** — `/introduce` 新增 trusted bot(或 bot 被加入群)时,该群被打上带 generation 的 pending baseline 标志。下一条**被投递**的群消息经 `formatFeishuMessageForCodex` 追加一个 `<group_bots>` 块,列出该群 trusted bot 的 `name` + `open_id`,让模型能把 bot open_id 映射到名字。**只注入 trusted**;被动 `known` 不进主动上下文。
2. **commit-after-notify + generation-safe 清除** — 仅在 `enqueueInbound` 返回 `submitted` 后才清 pending 标志,且经 `clearBaselineIfCurrent` 比对 generation:若入队期间又有 `/introduce` / bot-added 把 generation bump 了,则 no-op,不擦掉更新的 pending。`duplicate` / `stopped` / `failed` 一律保留。
3. **`list_chat_bots` 工具** — model 可见的 Feishu MCP 工具,经 0600 admin socket 转发 `mcp.list_chat_bots` 到只读的 `Server.listChatBotsFromMcp`,直接读 `chat-bots-store`(不要求 running slot)。返回 `known` 与 `trusted` 两个分开的 `{ open_id, name? }` 数组,用于 compaction 后恢复 bot 身份。与 `reply`/`react` 同构,不新增 operator CLI 面。
4. **reaction 先加后撤(add-then-cancel)** — `setInboundReaction` 改为先加新 reaction 并入账、再撤旧的,使消息在 `[received] → [in progress]` 过渡中不出现零 reaction 窗口。迟到的 pending-clear 会移除刚加的 reaction;add 失败/空 id 时保留旧 reaction 与账目。

## #68 既有行为(本 PR 不重复)

allowlist 真人 `/introduce` 立即信任被 @ 的 bot 并记录 open_id/名字的行为已在 #68 落地,且已有回归测试(`feishu-introduce.test.ts` / `smoke.test.ts`)。本 PR 的新测试只针对 pending context 等新行为。

## 测试

- store:pending baseline 的 generation 标记、generation-safe 清除(含 mid-enqueue bump 不被擦)、known/trusted 分离 listing。
- `formatFeishuMessageForCodex`:`<group_bots>` 渲染与转义、无 trusted 时不渲染。
- `list_chat_bots` MCP 转发到 `mcp.list_chat_bots`。
- server-path:`/introduce` 后下一条群消息携带一次性 `<group_bots>`、再下一条不再携带(one-shot 已清);`mcp.list_chat_bots` 返回 known+trusted。
- reaction:证明 add 先于 cancel 的顺序测试;`[received] → [in progress]` 过渡期间 reply 抢入的 replacement-race(reply-wins 且新 reaction 不悬挂)。fake bot 新增 `reactionOps` 时间线。

命令:`rush build`、`vitest run`(168 passed / 1 skipped = live-codex)、`rush change --verify`、KB `check.sh`(19 files OK)。

## 残留风险

- **Feishu reaction API 语义假设未经线上验证**:add-then-cancel 假设 Feishu 允许同一 bot/app 在旧 reaction 仍存在时给同一条消息加新 emoji。仓库 fake/transport 测试只验证请求形态,不验证线上语义。若该假设不成立,需改用别的 "无零窗口" 策略(已在 #69 列为前提)。
- bot-added(无 `/introduce`)设置的 `needsBaseline` 在本 PR 不消费(主动上下文只注 trusted),保持 pending,无害,留待后续 known-baseline 工作。

## KB

settled 文档已更新:`domains/feishu-introduce.md`、`decisions/top-level-design.md`、`domains/non-blocking-dispatcher-inbound.md`;新增 `proposals/feishu-bot-trust-context.md` 作为设计记录。

Closes #69
