### PR TITLE
feat(logging): host 全链路持久化文件日志 (#70)

### DIFF
--- a/.agents/decisions/README.md
+++ b/.agents/decisions/README.md
@@ -9,7 +9,7 @@ topic slugs remain reviewable and merge-friendly.
 | Theme | Records |
 |---|---|
 | Repository shape | [rush-pnpm-monorepo](rush-pnpm-monorepo.md), [install-model](install-model.md) |
-| Runtime architecture | [top-level-design](top-level-design.md), [global-config-dir](global-config-dir.md) |
+| Runtime architecture | [top-level-design](top-level-design.md), [global-config-dir](global-config-dir.md), [logging](logging.md) |
 | Public surface | [cli-and-package-naming](cli-and-package-naming.md), [dispatcher-tm-boundary](dispatcher-tm-boundary.md), [dispatcher-tm-packaging](dispatcher-tm-packaging.md), [global-bin-onboard-serve](global-bin-onboard-serve.md), [global-config-dir](global-config-dir.md) |
 | Release and safeguards | [npm-release-oidc](npm-release-oidc.md), [anti-leak-guardrail](anti-leak-guardrail.md) |
 
@@ -22,6 +22,7 @@ topic slugs remain reviewable and merge-friendly.
 - [global-bin-onboard-serve](global-bin-onboard-serve.md)
 - [global-config-dir](global-config-dir.md)
 - [install-model](install-model.md)
+- [logging](logging.md)
 - [npm-release-oidc](npm-release-oidc.md)
 - [rush-pnpm-monorepo](rush-pnpm-monorepo.md)
 - [top-level-design](top-level-design.md)

--- a/.agents/decisions/logging.md
+++ b/.agents/decisions/logging.md
@@ -125,9 +125,15 @@ settle the design in comments, then implement — rather than landing a PR first
   "SUCCESS WITH WARNINGS" from the JSON lines on stderr — same class of stderr
   output the old `console.error` calls produced, not a failure.
 - Tests gate the security defaults: redacted `app_secret`, message body absent
-  from the persisted log, `0o600` files (incl. tightening a wider pre-existing
-  file), per-dispatcher capture isolation, level threshold, and the
-  `feishu-mcp` stdout JSON-RPC contract across error paths.
+  from the persisted log (inbound drop/submit **and** outbound reply/react),
+  `0o600` files (incl. tightening a wider pre-existing file), per-dispatcher
+  capture isolation, level threshold, and the `feishu-mcp` stdout JSON-RPC
+  contract across error paths.
+- Outbound `reply`/`react` log both success (ids: `message_ids` / `reaction_id`,
+  `emoji`) and failure (error summary) to the per-dispatcher channel log, never
+  the reply `text`. The admin layer turning a failure into an `OUTBOUND_FAILED`
+  / `REACTION_FAILED` response does **not** replace the persistent log
+  (PR #75 review).
 
 ## Alternatives considered
 

--- a/.agents/decisions/logging.md
+++ b/.agents/decisions/logging.md
@@ -1,0 +1,137 @@
+# Persistent file logging
+
+- **Status:** In progress (implemented, pending PR merge)
+- **Date:** 2026-06-05
+- **Affects:** server runtime, Feishu channel, access gate, inbound/outbound,
+  `/introduce`, `feishu-mcp` stdio shim, dispatcher lifecycle, logs layout
+- **PR / Issue:** [#70](https://github.com/excitedjs/dreamux/issues/70)
+  (Codex reviewed the proposal; verdicts and merge bar are in the issue
+  comments)
+
+## Context
+
+Only the Codex app-server child's stdout/stderr persists to disk
+(`codex/supervisor.ts` → `logs/codex-app-server/<id>.log`). Everything dreamux
+itself decides — gate deliver/drop, trust-domain warnings, `/introduce`,
+inbound submit, outbound `reply`/`react`, reaction-ledger errors, dispatcher
+restart — is `console.error` only (48 call sites) and is lost when `serve` runs
+as a daemon. `top-level-design.md` already reserves `logs/dreamux-server.log`
+and `logs/feishu-channel/<id>.log`, and `paths.ts` exposes `serverLogPath()` /
+`feishuChannelLogDir()`, but nothing writes them. Dropped messages and failed
+introduces are therefore undiagnosable after the fact.
+
+This was scoped as a **standalone PR**, deliberately separate from the Feishu
+`/introduce` / bot-trust / reaction work, per the issue-first workflow below.
+
+## Decision
+
+Use **`pino`** as the host logger, built through a new factory
+`src/runtime/logger.ts`, writing structured JSON to the
+already-reserved files under `~/.dreamux/logs/`.
+
+Settled choices (as implemented):
+
+- **`pino.destination()` + `pino.multistream`**, never the worker-thread
+  `pino.transport` — robust for the short-lived `feishu-mcp` stdio shim and for
+  vitest.
+- **`sync: true` everywhere.** The shim and tests need synchronous writes; the
+  server avoids a flush-on-shutdown lifecycle. No line is lost on exit.
+- **One pino instance per file.** A `child()` shares the parent stream, so the
+  global `server` log (`logs/dreamux-server.log`) and each per-dispatcher
+  channel log (`logs/feishu-channel/<id>.log`) are **separate instances**, built
+  by an injected `channelLoggerFactory`. `child()` would only bind fields within
+  one file.
+- **Dual output, structured on both streams (v1).** When a file is configured,
+  the logger writes JSON to BOTH the file and stderr via `multistream`, so a
+  foreground `serve` stays visible. No `pino-pretty` and no stderr-reparsing
+  stream in v1 (the fragile path) — structured-on-stderr is a deliberate UX
+  choice (Codex open-question #2).
+- **The `console.*` migration is NOT blanket** (Codex #2 / #5). Only
+  long-running/diagnostic surfaces moved to the logger: `serve` (`cli/server.ts`)
+  and the whole `server.ts` `[server]` diagnostic set, plus the dispatcher
+  runtime/turn-manager `log` seam and the `feishu-mcp` diagnostic seam. CLI
+  result output (`doctor`, `config show/path`, `server-ctl`, help/onboard/
+  uninstall ledgers) stays on `console`/stdout — that is a CLI contract.
+- **Level via `DREAMUX_LOG_LEVEL`, default `info`** (Codex #3); the factory also
+  takes an explicit `level` option for tests. Not a `config.json` field
+  (state/logs do not follow `DREAMUX_CONFIG_DIR`).
+- **Files are `0o600`** — the factory does `mkdir` + `openSync(path,'a',0o600)`
+  + `chmodSync(path,0o600)` (tightening a pre-existing wider file), then hands
+  the fd to pino, matching `supervisor.ts`.
+- **Secrets via pino `redact`** (`app_secret`, `*.app_secret`, `*.secret`,
+  censored to `[REDACTED]`) — declarative and tested.
+- **Message bodies are never passed to the logger.** Callers log ids only
+  (`chat_id`/`message_id`/`sender_id`/reason), never `parsed_text` /
+  `rawContent` / reply `text`. There is no body-verbose flag in v1; absence is
+  the default and is asserted by a body-substring test (Codex #5).
+- **The `feishu-mcp` shim never writes to stdout** (stdout is the JSON-RPC
+  transport); its diagnostics go to `logs/feishu-mcp/<id>.log` + stderr through
+  the existing injectable `log` seam. A regression test locks every stdout line
+  to a JSON-RPC envelope across the parse-error / unknown-method / admin-failure
+  paths.
+
+### Deferred: `feishu-transport` package logging
+
+The transport package's own `[feishu-sdk]` / connection-lifecycle lines
+(`reconnecting` / `reconnected` / `error` / startup-timeout) are **explicitly
+deferred** from this PR (Codex blocker #1). `FeishuTransportOptions` exposes
+only `client?` today; `sdkLogger` and `logConnection` are module-level
+singletons, so wiring a host logger in means a new public option + a published
+`@excitedjs/feishu-transport` minor version bump — out of scope for a host-side
+logging PR, and it would not change behaviour (default unchanged).
+
+This defer does **not** lose those lines in practice: the transport routes them
+to **stderr**, and a daemonized `dreamux serve` already redirects stderr to
+`~/.dreamux/logs/daemon.stderr.log` (`onboard/service.ts` launchd
+`StandardErrorPath` / systemd `StandardError=append:`). They persist there
+unstructured and unsplit. Folding them into the per-dispatcher channel log is
+tracked in [#74](https://github.com/excitedjs/dreamux/issues/74).
+
+## Logging convention (for future code)
+
+- Path builders stay in `runtime/paths.ts`; **construction** lives in
+  `runtime/logger.ts`. Do not build a logger by raw-stringing a log path.
+- Log enough to reconstruct a message's fate — `dispatcher_id`, `chat_id`,
+  `message_id`, `sender_id`, decision, reason — but **never the message body**.
+  Pass ids, not the event/object that carries `parsed_text` / `rawContent` /
+  reply `text`.
+- Two distinct sensitive-data surfaces: **runtime logs on local disk** may carry
+  IDs (needed for diagnosis; not a commit); **committed text** (code, KB, test
+  fixtures) is the public-repo red line — placeholder IDs only, never a real
+  `ou_`/`oc_`/`cli_`.
+- The logger factory takes an **explicit destination** so tests inject a tmp
+  path. `paths.ts` `dreamuxRoot()` hardcodes `homedir()` and does **not** honor
+  `DREAMUX_CONFIG_DIR` (only `config.ts` does, for the config file) — tests must
+  inject, not rely on the env var.
+
+## Issue-first workflow
+
+Logging was planned **issue-first**: a GitHub issue (#70) carrying
+requirements, technical proposal, rollout scope, test plan, and open design
+questions was opened and reviewed **before** any code or PR. Open design
+questions are tracked as issue comments for Codex review. New cross-cutting
+infrastructure work in this repo should follow the same shape — open the issue,
+settle the design in comments, then implement — rather than landing a PR first.
+
+## Consequences
+
+- New runtime dependency `pino` on `@excitedjs/dreamux` (a real runtime dep, not
+  a dev tool — distinct from the PR #6 `tsx` red line).
+- **No rotation in the first PR** — `dreamux-server.log` and per-dispatcher
+  files grow unbounded until truncated. A rotation/retention decision is
+  deferred.
+- **Test-time stderr noise.** Tests that construct a `Server` without injecting
+  a logger get a stderr-only default at `info`, so `rush test` reports
+  "SUCCESS WITH WARNINGS" from the JSON lines on stderr — same class of stderr
+  output the old `console.error` calls produced, not a failure.
+- Tests gate the security defaults: redacted `app_secret`, message body absent
+  from the persisted log, `0o600` files (incl. tightening a wider pre-existing
+  file), per-dispatcher capture isolation, level threshold, and the
+  `feishu-mcp` stdout JSON-RPC contract across error paths.
+
+## Alternatives considered
+
+- **`winston`** — heavier, larger surface; rejected for a CLI/server host.
+- **`debug`** — no structured output, no file sink; insufficient.
+- **`pino.transport` worker** — fragile for short-lived shim/test processes;
+  rejected in favor of `pino.destination()`.

--- a/.agents/decisions/top-level-design.md
+++ b/.agents/decisions/top-level-design.md
@@ -148,11 +148,24 @@ State and logs are server-owned. They are not operator-editable config.
       codex.sock
   logs/
     dreamux-server.log
+    daemon.stdout.log          when run as a daemon (onboard service redirect)
+    daemon.stderr.log
     feishu-channel/
       dispatcher-a.log
+    feishu-mcp/
+      dispatcher-a.log         feishu-mcp stdio shim diagnostics (issue #70)
     codex-app-server/
-      dispatcher-a.log
+      dispatcher-a.log         Codex app-server child stdout
+      dispatcher-a.stderr.log  Codex app-server child stderr
 ```
+
+Host logging (issue #70): `dreamux serve`, the Feishu channel (gate
+deliver/drop, inbound submit, outbound, `/introduce`), and dispatcher lifecycle
+write structured `pino` JSON to these files (and mirror to stderr so a
+foreground `serve` stays visible). Path builders live in `src/runtime/paths.ts`;
+logger construction lives in `src/runtime/logger.ts`. Message bodies are never
+logged; `app_secret` is redacted. See
+[the logging decision](logging.md).
 
 `server.json` stores process-level status only: pid, status, version, started
 time, admin socket path, and last error.

--- a/common/changes/@excitedjs/dreamux/file-logging-2026-06-05.json
+++ b/common/changes/@excitedjs/dreamux/file-logging-2026-06-05.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@excitedjs/dreamux",
+      "comment": "Add persistent structured file logging (pino) across server, Feishu channel, gate/drop/inbound/outbound/introduce, dispatcher runtime, and the feishu-mcp stdio shim; logs persist under ~/.dreamux/logs (issue #70).",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@excitedjs/dreamux",
+  "email": "053700@gmail.com"
+}

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -59,6 +59,9 @@ importers:
       execa:
         specifier: ^9.6.1
         version: 9.6.1
+      pino:
+        specifier: ^9.5.0
+        version: 9.14.0
       plist:
         specifier: ^5.0.0
         version: 5.0.0
@@ -246,6 +249,9 @@ packages:
 
   '@larksuiteoapi/node-sdk@1.66.0':
     resolution: {integrity: sha512-ueKbbdvmVGVie3KvKbvHZqvDC/gg3M0rRDeyQanQWK+i2bQgiiTpIfpqVWvxuTgprV31yqV7HPMjN6KegWSCfA==}
+
+  '@pinojs/redact@0.4.0':
+    resolution: {integrity: sha512-k2ENnmBugE/rzQfEcdWHcCY+/FM3VLzH9cYEsbdsoqrvzAKRhUZeRNhAZvB8OitQJ1TBed3yqWtdjzS6wJKBwg==}
 
   '@protobufjs/aspromise@1.1.2':
     resolution: {integrity: sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==}
@@ -474,6 +480,10 @@ packages:
 
   asynckit@0.4.0:
     resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
+
+  atomic-sleep@1.0.0:
+    resolution: {integrity: sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ==}
+    engines: {node: '>=8.0.0'}
 
   axios@1.13.6:
     resolution: {integrity: sha512-ChTCHMouEe2kn713WHbQGcuYrr6fXTBiu460OTwWrWob16g1bXn4vtz07Ope7ewMozJAnEquLk5lWQWtBig9DQ==}
@@ -720,6 +730,10 @@ packages:
     resolution: {integrity: sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==}
     engines: {node: '>= 0.4'}
 
+  on-exit-leak-free@2.1.2:
+    resolution: {integrity: sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA==}
+    engines: {node: '>=14.0.0'}
+
   parse-ms@4.0.0:
     resolution: {integrity: sha512-TXfryirbmq34y8QBwgqCVLi+8oA3oWx2eAnSn62ITyEhEYaWRlVZ2DvMM9eZbMs/RfxPu/PK/aBLyGj4IrqMHw==}
     engines: {node: '>=18'}
@@ -742,6 +756,16 @@ packages:
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
 
+  pino-abstract-transport@2.0.0:
+    resolution: {integrity: sha512-F63x5tizV6WCh4R6RHyi2Ml+M70DNRXt/+HANowMflpgGFMAym/VKm6G7ZOQRjqN7XbGxK1Lg9t6ZrtzOaivMw==}
+
+  pino-std-serializers@7.1.0:
+    resolution: {integrity: sha512-BndPH67/JxGExRgiX1dX0w1FvZck5Wa4aal9198SrRhZjH3GxKQUKIBnYJTdj2HDN3UQAS06HlfcSbQj2OHmaw==}
+
+  pino@9.14.0:
+    resolution: {integrity: sha512-8OEwKp5juEvb/MjpIc4hjqfgCNysrS94RIOMXYvpYCdm/jglrKEiAYmiumbmGhCvs+IcInsphYDFwqrjr7398w==}
+    hasBin: true
+
   plist@5.0.0:
     resolution: {integrity: sha512-20N+g1DvMm/DFRbsvER7tT4wDryq0WunK7VMkDaiJcKNapAnUMkTsAnacFYf8n420F4Hf6/hefgmJRkMb1M0fg==}
     engines: {node: '>=18'}
@@ -754,6 +778,9 @@ packages:
     resolution: {integrity: sha512-gjVS5hOP+M3wMm5nmNOucbIrqudzs9v/57bWRHQWLYklXqoXKrVfYW2W9+glfGsqtPgpiz5WwyEEB+ksXIx3gQ==}
     engines: {node: '>=18'}
 
+  process-warning@5.0.0:
+    resolution: {integrity: sha512-a39t9ApHNx2L4+HBnQKqxxHNs1r7KF+Intd8Q/g1bUh6q0WIp9voPXJ/x0j+ZL45KF1pJd9+q2jLIRMfvEshkA==}
+
   protobufjs@7.6.1:
     resolution: {integrity: sha512-4K0myLaWL5EteuSAro91EGFgcfVgxb64Jx+7oDAY6GOkXD4M69yuSEljNcInGVCA5sOPxmZ/EqDLj2x0Q0+Ygg==}
     engines: {node: '>=12.0.0'}
@@ -765,6 +792,13 @@ packages:
     resolution: {integrity: sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==}
     engines: {node: '>=0.6'}
 
+  quick-format-unescaped@4.0.4:
+    resolution: {integrity: sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==}
+
+  real-require@0.2.0:
+    resolution: {integrity: sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg==}
+    engines: {node: '>= 12.13.0'}
+
   require-directory@2.1.1:
     resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
     engines: {node: '>=0.10.0'}
@@ -773,6 +807,10 @@ packages:
     resolution: {integrity: sha512-WHeFSbZYsPu3+bLoNRUuAO+wavNlocOPf3wSHTP7hcFKVnJeWsYlCDbr3mTS14FCizf9ccIxXA8sGL8zKeQN3g==}
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
+
+  safe-stable-stringify@2.5.0:
+    resolution: {integrity: sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA==}
+    engines: {node: '>=10'}
 
   shebang-command@2.0.0:
     resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
@@ -812,9 +850,16 @@ packages:
     resolution: {integrity: sha512-dWUG8F5sIIARXih1DTaQAX4SsiTXhInKf1buxdY9DIg4ZYPZK5nGM1VRIYmEbDbsHt7USo99xSLFu5Q1IqTmsg==}
     engines: {node: '>= 18'}
 
+  sonic-boom@4.2.1:
+    resolution: {integrity: sha512-w6AxtubXa2wTXAUsZMMWERrsIRAdrK0Sc+FUytWvYAhBJLyuI4llrMIC1DtlNSdI99EI86KZum2MMq3EAZlF9Q==}
+
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
+
+  split2@4.2.0:
+    resolution: {integrity: sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==}
+    engines: {node: '>= 10.x'}
 
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
@@ -833,6 +878,9 @@ packages:
   strip-final-newline@4.0.0:
     resolution: {integrity: sha512-aulFJcD6YK8V1G7iRB5tigAP4TsHBZZrOV8pjV++zdUwmeV8uzbY7yn6h9MswN62adStNZFuCIx4haBnRuMDaw==}
     engines: {node: '>=18'}
+
+  thread-stream@3.2.0:
+    resolution: {integrity: sha512-zLBvqpwr4Esa0kRjcrzGU6zL25lePWaCLMx0RQFrmteozIfeNdaMLpG5U7PeHzvlFkAWaRKA9/KVW4F60iB+qw==}
 
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
@@ -1072,6 +1120,8 @@ snapshots:
       - debug
       - utf-8-validate
 
+  '@pinojs/redact@0.4.0': {}
+
   '@protobufjs/aspromise@1.1.2': {}
 
   '@protobufjs/base64@1.1.2': {}
@@ -1242,6 +1292,8 @@ snapshots:
   assertion-error@2.0.1: {}
 
   asynckit@0.4.0: {}
+
+  atomic-sleep@1.0.0: {}
 
   axios@1.13.6:
     dependencies:
@@ -1490,6 +1542,8 @@ snapshots:
 
   object-inspect@1.13.4: {}
 
+  on-exit-leak-free@2.1.2: {}
+
   parse-ms@4.0.0: {}
 
   path-key@3.1.1: {}
@@ -1501,6 +1555,26 @@ snapshots:
   pathval@2.0.1: {}
 
   picocolors@1.1.1: {}
+
+  pino-abstract-transport@2.0.0:
+    dependencies:
+      split2: 4.2.0
+
+  pino-std-serializers@7.1.0: {}
+
+  pino@9.14.0:
+    dependencies:
+      '@pinojs/redact': 0.4.0
+      atomic-sleep: 1.0.0
+      on-exit-leak-free: 2.1.2
+      pino-abstract-transport: 2.0.0
+      pino-std-serializers: 7.1.0
+      process-warning: 5.0.0
+      quick-format-unescaped: 4.0.4
+      real-require: 0.2.0
+      safe-stable-stringify: 2.5.0
+      sonic-boom: 4.2.1
+      thread-stream: 3.2.0
 
   plist@5.0.0:
     dependencies:
@@ -1516,6 +1590,8 @@ snapshots:
   pretty-ms@9.3.0:
     dependencies:
       parse-ms: 4.0.0
+
+  process-warning@5.0.0: {}
 
   protobufjs@7.6.1:
     dependencies:
@@ -1537,6 +1613,10 @@ snapshots:
   qs@6.15.2:
     dependencies:
       side-channel: 1.1.0
+
+  quick-format-unescaped@4.0.4: {}
+
+  real-require@0.2.0: {}
 
   require-directory@2.1.1: {}
 
@@ -1570,6 +1650,8 @@ snapshots:
       '@rollup/rollup-win32-x64-gnu': 4.60.4
       '@rollup/rollup-win32-x64-msvc': 4.60.4
       fsevents: 2.3.3
+
+  safe-stable-stringify@2.5.0: {}
 
   shebang-command@2.0.0:
     dependencies:
@@ -1613,7 +1695,13 @@ snapshots:
 
   smol-toml@1.6.1: {}
 
+  sonic-boom@4.2.1:
+    dependencies:
+      atomic-sleep: 1.0.0
+
   source-map-js@1.2.1: {}
+
+  split2@4.2.0: {}
 
   stackback@0.0.2: {}
 
@@ -1630,6 +1718,10 @@ snapshots:
       ansi-regex: 5.0.1
 
   strip-final-newline@4.0.0: {}
+
+  thread-stream@3.2.0:
+    dependencies:
+      real-require: 0.2.0
 
   tinybench@2.9.0: {}
 

--- a/packages/dreamux/package.json
+++ b/packages/dreamux/package.json
@@ -40,6 +40,7 @@
     "yargs": "^17.7.2",
     "@clack/prompts": "^1.5.0",
     "execa": "^9.6.1",
+    "pino": "^9.5.0",
     "plist": "^5.0.0"
   },
   "devDependencies": {

--- a/packages/dreamux/src/cli/dreamux.ts
+++ b/packages/dreamux/src/cli/dreamux.ts
@@ -32,6 +32,8 @@ import {
 import type { OnboardRunResult } from '../onboard/types.js';
 import { printDoctorResult, runDreamuxDoctor } from './doctor.js';
 import { runFeishuMcp } from '../mcp/feishu-mcp.js';
+import { createLogger } from '../runtime/logger.js';
+import { feishuMcpLogPath } from '../runtime/paths.js';
 
 const HERE = dirname(fileURLToPath(import.meta.url));
 const SERVER_ENTRY = join(HERE, 'server.js');
@@ -377,9 +379,17 @@ async function main(): Promise<void> {
       'Run the dispatcher-scoped Feishu MCP stdio shim',
       buildFeishuMcpCommand,
       async (argv) => {
+        const dispatcherId = validateDispatcherId(argv.dispatcher);
+        // stdout is the JSON-RPC transport — the shim's diagnostics persist to
+        // logs/feishu-mcp/<id>.log and stderr, never stdout.
+        const log = createLogger({
+          name: `feishu-mcp/${dispatcherId}`,
+          filePath: feishuMcpLogPath(dispatcherId),
+        });
         await runFeishuMcp({
-          dispatcherId: validateDispatcherId(argv.dispatcher),
+          dispatcherId,
           adminSocketPath: argv.adminSocket,
+          log: (message) => log.info(message),
         });
       },
     )

--- a/packages/dreamux/src/cli/server.ts
+++ b/packages/dreamux/src/cli/server.ts
@@ -19,11 +19,15 @@ import { mkdirSync } from 'node:fs';
 
 import { Server } from '../server.js';
 import { loadConfig } from '../runtime/config.js';
+import { createLogger } from '../runtime/logger.js';
 import {
   adminSocketPath,
   codexAppServerLogDir,
   feishuChannelLogDir,
+  feishuChannelLogPath,
+  feishuMcpLogDir,
   logsRoot,
+  serverLogPath,
   stateRoot,
 } from '../runtime/paths.js';
 
@@ -36,19 +40,30 @@ async function main(): Promise<void> {
   // Load ~/.dreamux/config.json before anything else starts. Missing or invalid
   // config is a setup error; `dreamux serve` must not silently create defaults.
   const { config, configFile } = loadConfig();
-  console.error(`[server] loaded global config from ${configFile}`);
 
   mkdirSync(stateRoot(), { recursive: true });
   mkdirSync(logsRoot(), { recursive: true });
   mkdirSync(codexAppServerLogDir(), { recursive: true });
   mkdirSync(feishuChannelLogDir(), { recursive: true });
+  mkdirSync(feishuMcpLogDir(), { recursive: true });
 
-  const server = new Server({ config });
+  // The CLI is the only constructor of file-backed loggers; everything else
+  // (tests) gets stderr-only defaults. Both stream to stderr too, so a
+  // foreground `serve` stays visible.
+  const logger = createLogger({ name: 'server', filePath: serverLogPath() });
+  logger.info({ config_file: configFile }, 'loaded global config');
+
+  const server = new Server({
+    config,
+    logger,
+    channelLoggerFactory: (id) =>
+      createLogger({ name: `channel/${id}`, filePath: feishuChannelLogPath(id) }),
+  });
   await server.start();
-  console.error(`[server] up; admin socket: ${adminSocketPath()}`);
+  logger.info({ admin_socket: adminSocketPath() }, 'server up');
 
   const shutdown = async (signal: string): Promise<void> => {
-    console.error(`[server] received ${signal}`);
+    logger.info({ signal }, 'received signal');
     await server.shutdown();
     process.exit(0);
   };

--- a/packages/dreamux/src/runtime/logger.ts
+++ b/packages/dreamux/src/runtime/logger.ts
@@ -1,0 +1,147 @@
+/**
+ * Persistent structured logging for the dreamux host (issue #70).
+ *
+ * One small factory builds every logger; `paths.ts` owns *where* logs go, this
+ * module owns *how* they are constructed. The host had no durable log of its
+ * own decisions — gate deliver/drop, `/introduce`, inbound/outbound, dispatcher
+ * lifecycle — only `console.error` that a daemonized `serve` could not surface
+ * in a structured, per-component file. This factory closes that gap.
+ *
+ * Design (settled in the issue #70 decision record):
+ *   - `pino` with `pino.multistream`, never the worker-thread transport: robust
+ *     for the short-lived `feishu-mcp` stdio shim and for vitest.
+ *   - Dual output. When `filePath` is given we write JSON to BOTH the file and
+ *     stderr, so a foreground `serve` never goes dark. Format is structured on
+ *     both streams (a deliberate v1 UX choice — no `pino-pretty`, no fragile
+ *     reparsing stream).
+ *   - `sync: true` everywhere. The shim and tests need synchronous writes; the
+ *     server avoids a flush-on-shutdown lifecycle. No log line is lost on exit.
+ *   - Files are opened `0o600` (mkdir + open + chmod), matching the Codex
+ *     supervisor and the `0600` posture of `config.json` / state files.
+ *   - Credentials are removed declaratively via pino `redact`. Message *bodies*
+ *     are NOT redacted — they are simply never passed to the logger (callers
+ *     log ids, never `parsed_text` / `rawContent` / reply text).
+ *   - The factory takes an explicit destination. `paths.ts` `dreamuxRoot()`
+ *     hardcodes `homedir()` and does not honor `DREAMUX_CONFIG_DIR`, so tests
+ *     inject a tmp `filePath`; they must not expect an env var to move logs.
+ */
+
+import { chmodSync, mkdirSync, openSync } from 'node:fs';
+import { dirname } from 'node:path';
+
+import pino, {
+  type DestinationStream,
+  type Logger,
+  type LoggerOptions,
+} from 'pino';
+
+export type DreamuxLogger = Logger;
+
+export interface CreateLoggerOptions {
+  /**
+   * Component name stamped on every line (`server`, `channel/<id>`,
+   * `feishu-mcp/<id>`). Surfaces in the structured output and the stderr line.
+   */
+  name?: string;
+  /**
+   * Absolute path of the log file. When omitted the logger writes to stderr
+   * only — the safe default for tests and any `Server` constructed without an
+   * injected file-backed logger (it opens zero files).
+   */
+  filePath?: string;
+  /**
+   * Also mirror to stderr so a foreground `serve` stays visible. Defaults to
+   * `true`. Always `false`-irrelevant when `filePath` is unset (stderr is then
+   * the only stream).
+   */
+  stderr?: boolean;
+  /** Minimum level. Defaults to `DREAMUX_LOG_LEVEL`, then `info`. */
+  level?: pino.Level;
+  /**
+   * Test seam: an explicit destination stream that replaces both the file and
+   * stderr. When set, `filePath`/`stderr` are ignored. Lets a test capture
+   * output in-memory without touching the filesystem.
+   */
+  destination?: DestinationStream;
+}
+
+/**
+ * Paths whose values are redacted from every log line. Covers the Feishu
+ * `app_secret` wherever it might be nested (config snapshot, dispatcher row,
+ * credentials object) plus a generic `*.secret` catch.
+ */
+const REDACT_PATHS = [
+  'app_secret',
+  '*.app_secret',
+  'appSecret',
+  '*.appSecret',
+  'secret',
+  '*.secret',
+  'feishu.app_secret',
+  '*.feishu.app_secret',
+] as const;
+
+function resolveLevel(level?: pino.Level): pino.Level {
+  if (level !== undefined) return level;
+  const fromEnv = process.env['DREAMUX_LOG_LEVEL'];
+  if (fromEnv !== undefined && fromEnv !== '') return fromEnv as pino.Level;
+  return 'info';
+}
+
+/**
+ * Open a log file at `path` with owner-only permissions. Creates the parent
+ * directory, appends, and chmods to `0o600` so a pre-existing wider-permission
+ * file is tightened rather than trusted.
+ */
+function openLogFileStream(path: string): DestinationStream {
+  mkdirSync(dirname(path), { recursive: true });
+  const fd = openSync(path, 'a', 0o600);
+  chmodSync(path, 0o600);
+  return pino.destination({ fd, sync: true });
+}
+
+export function createLogger(opts: CreateLoggerOptions = {}): DreamuxLogger {
+  const level = resolveLevel(opts.level);
+  const base: LoggerOptions = {
+    level,
+    base: opts.name !== undefined ? { name: opts.name } : {},
+    redact: { paths: [...REDACT_PATHS], censor: '[REDACTED]' },
+  };
+
+  if (opts.destination !== undefined) {
+    return pino(base, opts.destination);
+  }
+
+  const streams: pino.StreamEntry[] = [];
+  if (opts.filePath !== undefined) {
+    streams.push({ level, stream: openLogFileStream(opts.filePath) });
+  }
+  if (opts.filePath === undefined || opts.stderr !== false) {
+    streams.push({ level, stream: pino.destination({ fd: 2, sync: true }) });
+  }
+
+  return pino(base, pino.multistream(streams, { dedupe: false }));
+}
+
+/**
+ * Adapt a `DreamuxLogger` to the `(level, msg, err?)` seam that
+ * `DispatcherRuntime` and `TurnManager` already accept, so dispatcher lifecycle
+ * lands in the per-dispatcher channel log without changing their call sites.
+ */
+export function loggerToLevelFn(
+  logger: DreamuxLogger,
+): (level: 'info' | 'warn' | 'error', msg: string, err?: unknown) => void {
+  return (level, msg, err) => {
+    if (err !== undefined) logger[level]({ err: serializeErr(err) }, msg);
+    else logger[level](msg);
+  };
+}
+
+function serializeErr(err: unknown): { message: string; stack?: string } {
+  if (err instanceof Error) {
+    return err.stack !== undefined
+      ? { message: err.message, stack: err.stack }
+      : { message: err.message };
+  }
+  return { message: String(err) };
+}

--- a/packages/dreamux/src/runtime/paths.ts
+++ b/packages/dreamux/src/runtime/paths.ts
@@ -141,6 +141,23 @@ export function feishuChannelLogDir(): string {
   return join(logsRoot(), 'feishu-channel');
 }
 
+/** Per-dispatcher channel log: gate decisions, inbound, outbound, introduce. */
+export function feishuChannelLogPath(id: string): string {
+  return join(feishuChannelLogDir(), `${dispatcherPathSegment(id)}.log`);
+}
+
+export function feishuMcpLogDir(): string {
+  return join(logsRoot(), 'feishu-mcp');
+}
+
+/**
+ * Per-dispatcher Feishu MCP stdio shim log. The shim's stdout is the JSON-RPC
+ * transport, so its diagnostics persist here (and to stderr) — never stdout.
+ */
+export function feishuMcpLogPath(id: string): string {
+  return join(feishuMcpLogDir(), `${dispatcherPathSegment(id)}.log`);
+}
+
 export function dispatcherCodexAppServerLogPath(id: string): string {
   return join(codexAppServerLogDir(), `${dispatcherPathSegment(id)}.log`);
 }

--- a/packages/dreamux/src/server.ts
+++ b/packages/dreamux/src/server.ts
@@ -55,6 +55,11 @@ import {
   dispatcherCodexCwd,
   setRuntimeConfig,
 } from './runtime/paths.js';
+import {
+  createLogger,
+  loggerToLevelFn,
+  type DreamuxLogger,
+} from './runtime/logger.js';
 import { createAdminSocketServer, type AdminSocketServer } from './admin/socket.js';
 
 export const RECEIVED_REACTION_EMOJI = 'Get';
@@ -87,6 +92,18 @@ export interface ServerOptions {
   codexRestartBackoffBaseMs?: number;
   /** Codex child/WS restart backoff cap override (tests). */
   codexRestartBackoffMaxMs?: number;
+  /**
+   * Server-level logger (admin socket, dispatcher supervision, shutdown). When
+   * omitted, a stderr-only logger is used — the CLI entry point injects a
+   * file-backed one so tests stay filesystem-free.
+   */
+  logger?: DreamuxLogger;
+  /**
+   * Per-dispatcher channel logger factory (gate, inbound, outbound, introduce,
+   * dispatcher lifecycle). Defaults to a stderr-only logger per dispatcher; the
+   * CLI injects a factory that writes `logs/feishu-channel/<id>.log`.
+   */
+  channelLoggerFactory?: (dispatcherId: string) => DreamuxLogger;
 }
 
 export interface Repos {
@@ -98,6 +115,7 @@ interface DispatcherSlot {
   runtime: DispatcherRuntime;
   bot: FeishuBot;
   channelState: DispatcherChannelState;
+  log: DreamuxLogger;
 }
 
 interface DispatcherChannelState {
@@ -139,6 +157,8 @@ export class Server {
   private admin: AdminSocketServer | null = null;
   private shuttingDown = false;
   private readonly opts: ServerOptions;
+  private readonly log: DreamuxLogger;
+  private readonly channelLoggerFactory: (dispatcherId: string) => DreamuxLogger;
 
   constructor(opts: ServerOptions = {}) {
     this.opts = opts;
@@ -146,6 +166,12 @@ export class Server {
     // happens. paths.runtimeRoot / adminSocketPath / etc. consult this
     // snapshot for non-env defaults (env vars still win).
     setRuntimeConfig(opts.config ?? BUILT_IN_DEFAULTS);
+    // Default loggers are stderr-only (zero files opened) so tests that
+    // construct a Server without injecting a logger never touch ~/.dreamux.
+    this.log = opts.logger ?? createLogger({ name: 'server' });
+    this.channelLoggerFactory =
+      opts.channelLoggerFactory ??
+      ((id) => createLogger({ name: `channel/${id}` }));
     this.repos = {
       dispatchers: new DispatcherStore(opts.config ?? BUILT_IN_DEFAULTS),
     };
@@ -178,16 +204,19 @@ export class Server {
       this.opts.adminSocketPath ?? adminSocketPath(),
     );
     await this.admin.start();
-    console.error(`[server] admin socket listening at ${this.admin.socketPath}`);
+    this.log.info(
+      { admin_socket: this.admin.socketPath },
+      'admin socket listening',
+    );
 
     const rows = this.repos.dispatchers.listEnabled();
     for (const row of rows) {
       try {
         await this.startDispatcher(row.dispatcher_id);
       } catch (err) {
-        console.error(
-          `[server] dispatcher '${row.dispatcher_id}' failed to start:`,
-          err,
+        this.log.error(
+          { dispatcher_id: row.dispatcher_id, err: errInfo(err) },
+          'dispatcher failed to start',
         );
         // server keeps running; admin can inspect & retry via dispatcher.start
       }
@@ -245,6 +274,7 @@ export class Server {
       inboundReactions: new Map(),
       pendingReceivedReactionClears: new Set(),
     };
+    const channelLog = this.channelLoggerFactory(id);
 
     const runtime = new DispatcherRuntime(row, {
       dispatchers: this.repos.dispatchers,
@@ -257,6 +287,7 @@ export class Server {
       extraEnv: dispatcherConfig?.codex.extra_env ?? {},
       restartBackoffBaseMs: this.opts.codexRestartBackoffBaseMs,
       restartBackoffMaxMs: this.opts.codexRestartBackoffMaxMs,
+      log: loggerToLevelFn(channelLog),
     });
 
     try {
@@ -295,6 +326,14 @@ export class Server {
           ) {
             const peers = introducedPeers(event.mentions, bot.botOpenId);
             if (peers.length > 0) trustIntroducedBots(id, event.chatId, peers);
+            channelLog.info(
+              {
+                chat_id: event.chatId,
+                sender_id: event.senderId,
+                trusted_peers: peers.length,
+              },
+              'introduce consumed',
+            );
             return;
           }
 
@@ -311,13 +350,21 @@ export class Server {
           }, access);
           saveDispatcherAccess(id, gate.access);
           if (gate.warning !== null) {
-            console.error(
-              `[server] trust-domain warning for dispatcher '${id}': ${gate.warning}`,
+            channelLog.warn(
+              { chat_id: event.chatId, warning: gate.warning },
+              'trust-domain warning',
             );
           }
           if (gate.action === 'drop') {
-            console.error(
-              `[server] dropped feishu inbound for dispatcher '${id}': ${gate.reason}`,
+            channelLog.info(
+              {
+                chat_id: event.chatId,
+                chat_type: event.chatType,
+                sender_id: event.senderId,
+                message_id: event.messageId,
+                reason: gate.reason,
+              },
+              'feishu inbound dropped',
             );
             return;
           }
@@ -333,6 +380,7 @@ export class Server {
                 id,
                 bot,
                 channelState,
+                channelLog,
                 acceptedInput,
                 RECEIVED_REACTION_EMOJI,
                 'received',
@@ -340,17 +388,31 @@ export class Server {
             },
           });
           if (delivery.status === 'submitted') {
+            channelLog.info(
+              {
+                chat_id: event.chatId,
+                sender_id: event.senderId,
+                message_id: event.messageId,
+              },
+              'feishu inbound submitted',
+            );
             await setInboundReaction(
               id,
               bot,
               channelState,
+              channelLog,
               input,
               IN_PROGRESS_REACTION_EMOJI,
               'in_progress',
             );
           } else if (delivery.status === 'failed') {
-            console.error(
-              `[server] failed to submit Feishu inbound for dispatcher '${id}': ${delivery.error.message}`,
+            channelLog.error(
+              {
+                chat_id: event.chatId,
+                message_id: event.messageId,
+                err: errInfo(delivery.error),
+              },
+              'failed to submit feishu inbound',
             );
           }
         },
@@ -371,9 +433,14 @@ export class Server {
       throw err;
     }
 
-    this.slots.set(id, { row, runtime, bot, channelState });
-    console.error(
-      `[server] dispatcher '${id}' is ready (bot=${row.bot_app_id} cwd=${row.codex_cwd ?? dispatcherCodexCwd(id)})`,
+    this.slots.set(id, { row, runtime, bot, channelState, log: channelLog });
+    this.log.info(
+      {
+        dispatcher_id: id,
+        bot_app_id: row.bot_app_id,
+        cwd: row.codex_cwd ?? dispatcherCodexCwd(id),
+      },
+      'dispatcher ready',
     );
   }
 
@@ -384,12 +451,15 @@ export class Server {
     try {
       await slot.bot.close();
     } catch (err) {
-      console.error(`[server] error closing bot for '${id}':`, err);
+      slot.log.error({ dispatcher_id: id, err: errInfo(err) }, 'error closing bot');
     }
     try {
       await slot.runtime.stop();
     } catch (err) {
-      console.error(`[server] error stopping dispatcher '${id}':`, err);
+      slot.log.error(
+        { dispatcher_id: id, err: errInfo(err) },
+        'error stopping dispatcher',
+      );
     }
     this.slots.delete(id);
   }
@@ -415,6 +485,7 @@ export class Server {
         input.dispatcherId,
         slot.bot,
         slot.channelState,
+        slot.log,
         input.messageId,
       );
     }
@@ -459,7 +530,7 @@ export class Server {
   async shutdown(): Promise<void> {
     if (this.shuttingDown) return;
     this.shuttingDown = true;
-    console.error('[server] shutting down...');
+    this.log.info('shutting down');
     for (const id of Array.from(this.slots.keys())) {
       await this.stopDispatcher(id);
     }
@@ -474,6 +545,7 @@ async function setInboundReaction(
   dispatcherId: string,
   bot: FeishuBot,
   channelState: DispatcherChannelState,
+  log: DreamuxLogger,
   input: InboundTurnInput,
   emoji: string,
   state: InboundReactionState,
@@ -487,9 +559,9 @@ async function setInboundReaction(
     try {
       await bot.removeReaction(messageId, previous.reactionId);
     } catch (err) {
-      console.error(
-        `[server] failed to replace the ${previous.state} reaction for dispatcher '${dispatcherId}' message '${messageId}':`,
-        err,
+      log.warn(
+        { dispatcher_id: dispatcherId, message_id: messageId, err: errInfo(err) },
+        `failed to replace the ${previous.state} reaction`,
       );
     }
     channelState.inboundReactions.delete(messageId);
@@ -499,8 +571,9 @@ async function setInboundReaction(
   try {
     const reactionId = await bot.addReaction(messageId, emoji);
     if (reactionId === '') {
-      console.error(
-        `[server] Feishu returned no reaction_id for the ${state} reaction in dispatcher '${dispatcherId}'`,
+      log.warn(
+        { dispatcher_id: dispatcherId, message_id: messageId },
+        `Feishu returned no reaction_id for the ${state} reaction`,
       );
       return;
     }
@@ -508,9 +581,9 @@ async function setInboundReaction(
       try {
         await bot.removeReaction(messageId, reactionId);
       } catch (err) {
-        console.error(
-          `[server] failed to clear the late ${state} reaction for dispatcher '${dispatcherId}' message '${messageId}':`,
-          err,
+        log.warn(
+          { dispatcher_id: dispatcherId, message_id: messageId, err: errInfo(err) },
+          `failed to clear the late ${state} reaction`,
         );
       }
       return;
@@ -521,9 +594,9 @@ async function setInboundReaction(
       state,
     });
   } catch (err) {
-    console.error(
-      `[server] failed to add the ${state} reaction for dispatcher '${dispatcherId}':`,
-      err,
+    log.warn(
+      { dispatcher_id: dispatcherId, message_id: messageId, err: errInfo(err) },
+      `failed to add the ${state} reaction`,
     );
   }
 }
@@ -532,6 +605,7 @@ async function clearInboundReaction(
   dispatcherId: string,
   bot: FeishuBot,
   channelState: DispatcherChannelState,
+  log: DreamuxLogger,
   messageId: string,
 ): Promise<void> {
   rememberPendingReceivedReactionClear(channelState, messageId);
@@ -543,11 +617,21 @@ async function clearInboundReaction(
     await bot.removeReaction(messageId, reaction.reactionId);
     channelState.inboundReactions.delete(messageId);
   } catch (err) {
-    console.error(
-      `[server] failed to clear the ${reaction.state} reaction for dispatcher '${dispatcherId}' message '${messageId}':`,
-      err,
+    log.warn(
+      { dispatcher_id: dispatcherId, message_id: messageId, err: errInfo(err) },
+      `failed to clear the ${reaction.state} reaction`,
     );
   }
+}
+
+/** Compact, redaction-friendly error shape for structured log fields. */
+function errInfo(err: unknown): { message: string; stack?: string } {
+  if (err instanceof Error) {
+    return err.stack !== undefined
+      ? { message: err.message, stack: err.stack }
+      : { message: err.message };
+  }
+  return { message: String(err) };
 }
 
 function rememberPendingReceivedReactionClear(

--- a/packages/dreamux/src/server.ts
+++ b/packages/dreamux/src/server.ts
@@ -470,15 +470,40 @@ export class Server {
 
   async replyFromMcp(input: ServerMcpReplyInput): Promise<{ message_ids: string[] }> {
     const slot = this.mustRunningSlot(input.dispatcherId);
-    const result = await slot.bot.send(
-      channelOutboundToFeishuTarget({
-        conversationId: input.chatId,
-        ...(input.messageId !== undefined ? { replyTo: input.messageId } : {}),
-        ...(input.mentionUserIds !== undefined
-          ? { mentionUsers: input.mentionUserIds }
-          : {}),
-      }),
-      input.text,
+    let result: { messageIds: string[] };
+    try {
+      result = await slot.bot.send(
+        channelOutboundToFeishuTarget({
+          conversationId: input.chatId,
+          ...(input.messageId !== undefined ? { replyTo: input.messageId } : {}),
+          ...(input.mentionUserIds !== undefined
+            ? { mentionUsers: input.mentionUserIds }
+            : {}),
+        }),
+        input.text,
+      );
+    } catch (err) {
+      // Persist the outbound failure so a daemon can later tell whether a model
+      // reply ever left the host. The message body (`input.text`) is omitted.
+      slot.log.error(
+        {
+          dispatcher_id: input.dispatcherId,
+          chat_id: input.chatId,
+          message_id: input.messageId,
+          err: errInfo(err),
+        },
+        'feishu reply failed',
+      );
+      throw err;
+    }
+    slot.log.info(
+      {
+        dispatcher_id: input.dispatcherId,
+        chat_id: input.chatId,
+        message_id: input.messageId,
+        message_ids: result.messageIds,
+      },
+      'feishu reply sent',
     );
     if (input.messageId !== undefined) {
       await clearInboundReaction(
@@ -494,7 +519,30 @@ export class Server {
 
   async reactFromMcp(input: ServerMcpReactInput): Promise<{ reaction_id: string }> {
     const slot = this.mustRunningSlot(input.dispatcherId);
-    const reactionId = await slot.bot.addReaction(input.messageId, input.emoji);
+    let reactionId: string;
+    try {
+      reactionId = await slot.bot.addReaction(input.messageId, input.emoji);
+    } catch (err) {
+      slot.log.error(
+        {
+          dispatcher_id: input.dispatcherId,
+          message_id: input.messageId,
+          emoji: input.emoji,
+          err: errInfo(err),
+        },
+        'feishu react failed',
+      );
+      throw err;
+    }
+    slot.log.info(
+      {
+        dispatcher_id: input.dispatcherId,
+        message_id: input.messageId,
+        emoji: input.emoji,
+        reaction_id: reactionId,
+      },
+      'feishu react sent',
+    );
     return { reaction_id: reactionId };
   }
 

--- a/packages/dreamux/tests/feishu-mcp.test.ts
+++ b/packages/dreamux/tests/feishu-mcp.test.ts
@@ -315,4 +315,77 @@ describe('feishu-mcp stdio shim', () => {
       await admin.close();
     }
   });
+
+  // Issue #70: stdout is the JSON-RPC transport. Diagnostics must go to the
+  // `log` seam (file/stderr), never stdout — even on parse errors, unknown
+  // methods, and admin-forwarding failures. A regression here corrupts the
+  // Codex<->shim protocol stream.
+  it('never writes non-protocol output to stdout, even on error paths', async () => {
+    const input = new PassThrough();
+    const output = new PassThrough();
+    const rawLines: string[] = [];
+    output.setEncoding('utf8');
+    let pending = '';
+    output.on('data', (chunk: string) => {
+      pending += chunk;
+      let idx: number;
+      while ((idx = pending.indexOf('\n')) !== -1) {
+        const line = pending.slice(0, idx);
+        pending = pending.slice(idx + 1);
+        if (line.trim() !== '') rawLines.push(line);
+      }
+    });
+    const logMessages: string[] = [];
+    const run = runFeishuMcp({
+      dispatcherId: 'dispatcher-a',
+      // A socket that does not exist forces the admin-forwarding path to throw,
+      // which exercises the `log` diagnostic seam.
+      adminSocketPath: '/tmp/dreamux-nonexistent-70.sock',
+      input,
+      output,
+      log: (message) => logMessages.push(message),
+    });
+
+    // Malformed JSON line — parse error path.
+    input.write('this is not json\n');
+    // Unknown method.
+    writeJson(input, { jsonrpc: '2.0', id: 1, method: 'no/such/method', params: {} });
+    // A tools/call that forwards to the (missing) admin socket and throws.
+    writeJson(input, {
+      jsonrpc: '2.0',
+      id: 2,
+      method: 'tools/call',
+      params: {
+        name: 'reply',
+        arguments: { chat_id: 'chat-a', text: 'hello' },
+      },
+    });
+
+    input.end();
+    await run;
+    // Give the output stream a tick to flush any trailing line.
+    await new Promise((resolve) => setImmediate(resolve));
+
+    // Every line on stdout is a well-formed JSON-RPC envelope — including the
+    // parse-error, unknown-method, and admin-failure paths.
+    expect(rawLines.length).toBe(3);
+    const parsed = rawLines.map(
+      (line) => JSON.parse(line) as Record<string, unknown>,
+    );
+    for (const envelope of parsed) {
+      expect(envelope['jsonrpc']).toBe('2.0');
+    }
+    // Parse error (id null) and unknown-method (id 1) are JSON-RPC errors; the
+    // admin-forwarding failure (id 2) is returned as an in-band MCP tool error,
+    // never a raw diagnostic on stdout.
+    expect(parsed[0]).toMatchObject({ id: null, error: { code: -32700 } });
+    expect(parsed[1]).toMatchObject({ id: 1, error: { code: -32601 } });
+    expect(parsed[2]).toMatchObject({ id: 2, result: { isError: true } });
+
+    // Whatever the shim sent to its `log` seam must never appear on stdout.
+    const stdout = rawLines.join('\n');
+    for (const message of logMessages) {
+      expect(stdout).not.toContain(message);
+    }
+  });
 });

--- a/packages/dreamux/tests/logger.test.ts
+++ b/packages/dreamux/tests/logger.test.ts
@@ -1,0 +1,124 @@
+/**
+ * Unit tests for the issue #70 logger factory.
+ *
+ * The factory takes an explicit destination so these tests never touch
+ * ~/.dreamux: filesystem assertions use a mkdtemp path, behavioural assertions
+ * use an in-memory capture stream. (paths.ts hardcodes homedir() and does not
+ * honor DREAMUX_CONFIG_DIR, so injection — not an env var — is the seam.)
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { mkdtempSync, readFileSync, rmSync, statSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { Writable } from 'node:stream';
+
+import { createLogger, loggerToLevelFn } from '../src/runtime/logger.js';
+
+function captureSink(): { sink: Writable; text: () => string } {
+  const chunks: string[] = [];
+  const sink = new Writable({
+    write(chunk, _enc, cb) {
+      chunks.push(chunk.toString());
+      cb();
+    },
+  });
+  return { sink, text: () => chunks.join('') };
+}
+
+describe('logger factory', () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'dreamux-logger-'));
+  });
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('creates the log dir and a 0600 file at an injected path', () => {
+    const filePath = join(dir, 'nested', 'server.log');
+    const logger = createLogger({ name: 'server', filePath, stderr: false });
+    logger.info('hello');
+
+    const mode = statSync(filePath).mode & 0o777;
+    expect(mode).toBe(0o600);
+    const contents = readFileSync(filePath, 'utf8');
+    expect(contents).toContain('"msg":"hello"');
+    expect(contents).toContain('"name":"server"');
+  });
+
+  it('tightens a pre-existing wider-permission file to 0600', () => {
+    const filePath = join(dir, 'pre.log');
+    writeFileSync(filePath, '', { mode: 0o644 });
+    const logger = createLogger({ filePath, stderr: false });
+    logger.info('x');
+    expect(statSync(filePath).mode & 0o777).toBe(0o600);
+  });
+
+  it('redacts credential fields by default', () => {
+    const { sink, text } = captureSink();
+    const logger = createLogger({ destination: sink });
+    logger.info({ app_secret: 'top-secret-value', feishu: { app_secret: 'nested' } }, 'cfg');
+    const out = text();
+    expect(out).not.toContain('top-secret-value');
+    expect(out).not.toContain('nested');
+    expect(out).toContain('[REDACTED]');
+  });
+
+  it('does not log fields the caller never passes (message bodies)', () => {
+    const { sink, text } = captureSink();
+    const logger = createLogger({ destination: sink });
+    // The server logs ids only; a body would only appear if a caller passed it.
+    logger.info({ chat_id: 'chat-a', message_id: 'm1', reason: 'bot not mentioned' }, 'drop');
+    const out = text();
+    expect(out).toContain('chat-a');
+    expect(out).not.toContain('the actual message body text');
+  });
+
+  it('honors an explicit level and drops lines below it', () => {
+    const { sink, text } = captureSink();
+    const logger = createLogger({ destination: sink, level: 'warn' });
+    logger.info('below threshold');
+    logger.warn('at threshold');
+    const out = text();
+    expect(out).not.toContain('below threshold');
+    expect(out).toContain('at threshold');
+  });
+
+  it('reads DREAMUX_LOG_LEVEL when no explicit level is set', () => {
+    const prev = process.env['DREAMUX_LOG_LEVEL'];
+    process.env['DREAMUX_LOG_LEVEL'] = 'error';
+    try {
+      const { sink, text } = captureSink();
+      const logger = createLogger({ destination: sink });
+      logger.warn('warn dropped');
+      logger.error('error kept');
+      expect(text()).not.toContain('warn dropped');
+      expect(text()).toContain('error kept');
+    } finally {
+      if (prev === undefined) delete process.env['DREAMUX_LOG_LEVEL'];
+      else process.env['DREAMUX_LOG_LEVEL'] = prev;
+    }
+  });
+
+  it('writes to both the file and stderr when filePath is set (foreground stays visible)', () => {
+    const filePath = join(dir, 'dual.log');
+    // We cannot easily capture fd 2 here; assert the file half of the dual
+    // stream. The stderr half is exercised by foreground `serve` in practice.
+    const logger = createLogger({ name: 'server', filePath });
+    logger.info('dual-output line');
+    expect(readFileSync(filePath, 'utf8')).toContain('dual-output line');
+  });
+
+  it('adapts to the (level, msg, err) seam used by dispatcher runtime', () => {
+    const { sink, text } = captureSink();
+    const logger = createLogger({ destination: sink });
+    const fn = loggerToLevelFn(logger);
+    fn('error', 'start failed', new Error('boom'));
+    const line = JSON.parse(text().trim()) as Record<string, unknown>;
+    expect(line['msg']).toBe('start failed');
+    expect(line['level']).toBe(50);
+    expect((line['err'] as { message: string }).message).toBe('boom');
+  });
+});

--- a/packages/dreamux/tests/runtime-paths.test.ts
+++ b/packages/dreamux/tests/runtime-paths.test.ts
@@ -11,6 +11,10 @@ import {
   dispatcherCodexAppServerErrorLogPath,
   dispatcherCodexAppServerLogPath,
   dispatcherDir,
+  feishuChannelLogDir,
+  feishuChannelLogPath,
+  feishuMcpLogDir,
+  feishuMcpLogPath,
   dispatcherSocketPath,
   dispatcherStatusPath,
   dispatcherWorkspaceCodexSkillsDir,
@@ -84,6 +88,14 @@ describe('runtime paths', () => {
     );
     expect(dispatcherCodexAppServerErrorLogPath('dispatcher-a')).toBe(
       join(logsRoot(), 'codex-app-server', 'dispatcher-a.stderr.log'),
+    );
+    expect(feishuChannelLogDir()).toBe(join(logsRoot(), 'feishu-channel'));
+    expect(feishuChannelLogPath('dispatcher-a')).toBe(
+      join(logsRoot(), 'feishu-channel', 'dispatcher-a.log'),
+    );
+    expect(feishuMcpLogDir()).toBe(join(logsRoot(), 'feishu-mcp'));
+    expect(feishuMcpLogPath('dispatcher-a')).toBe(
+      join(logsRoot(), 'feishu-mcp', 'dispatcher-a.log'),
     );
   });
 

--- a/packages/dreamux/tests/smoke.test.ts
+++ b/packages/dreamux/tests/smoke.test.ts
@@ -51,7 +51,35 @@ import {
   dispatcherSocketPath,
 } from '../src/runtime/paths.js';
 import { dreamuxBinPath } from '../src/runtime/package-bin.js';
+import { createLogger, type DreamuxLogger } from '../src/runtime/logger.js';
 import { startFakeCodex, type FakeCodex } from './fake-codex.js';
+import { Writable } from 'node:stream';
+
+/** Collect every JSON log line written to an injected logger destination. */
+function captureLogger(name: string): {
+  logger: DreamuxLogger;
+  lines: () => Array<Record<string, unknown>>;
+  text: () => string;
+} {
+  const chunks: string[] = [];
+  const sink = new Writable({
+    write(chunk, _enc, cb) {
+      chunks.push(chunk.toString());
+      cb();
+    },
+  });
+  const logger = createLogger({ name, destination: sink });
+  const text = (): string => chunks.join('');
+  return {
+    logger,
+    text,
+    lines: () =>
+      text()
+        .split('\n')
+        .filter((line) => line.trim() !== '')
+        .map((line) => JSON.parse(line) as Record<string, unknown>),
+  };
+}
 
 class NoopCodexProcess extends CodexProcess {
   constructor(opts: CodexProcessOptions) {
@@ -80,11 +108,15 @@ function buildServer(opts: {
   codexClientFactory?: () => CodexWsClient;
   codexRestartBackoffBaseMs?: number;
   codexRestartBackoffMaxMs?: number;
+  channelLoggerFactory?: (dispatcherId: string) => DreamuxLogger;
 }): Server {
   return new Server({
     config: opts.config ?? BUILT_IN_DEFAULTS,
     adminSocketPath: join(opts.runtimeDir, 'admin.sock'),
     skipBotSecret: opts.skipBotSecret ?? true,
+    ...(opts.channelLoggerFactory !== undefined
+      ? { channelLoggerFactory: opts.channelLoggerFactory }
+      : {}),
     botFactory: (_row, secret) => {
       opts.capturedBotSecrets?.push(secret);
       return opts.bot;
@@ -804,6 +836,74 @@ describe('dreamux MVP smoke', () => {
     ]);
     await waitFor(() => fake.turnsHandled === 2);
     expect(bot.sentMessages).toEqual([]);
+  });
+
+  // Issue #70: a dropped inbound must be diagnosable (reason + ids) without
+  // leaking the message body into the persistent log.
+  it('logs gate drops with ids and reason but never the message body', async () => {
+    const capture = captureLogger('channel/flow');
+    const SECRET_BODY = 'PLEASE-DO-NOT-LOG-THIS-BODY';
+    server = buildServer({
+      runtimeDir,
+      fake,
+      bot,
+      channelLoggerFactory: () => capture.logger,
+    });
+    server.repos.dispatchers.create({
+      dispatcher_id: 'flow',
+      bot_app_id: 'app-smoke',
+      bot_secret_ref: 'env:UNUSED',
+    });
+    await server.start();
+
+    // A group message with no @-mention of our bot is dropped by the gate.
+    await bot.inject(
+      fakeInbound('chat-group-a', SECRET_BODY, 'msg-dropped', { mentions: [] }),
+    );
+    await sleep(60);
+
+    expect(fake.turnsHandled).toBe(0);
+    const dropLine = capture
+      .lines()
+      .find((line) => line['msg'] === 'feishu inbound dropped');
+    expect(dropLine).toBeDefined();
+    expect(dropLine).toMatchObject({
+      chat_id: 'chat-group-a',
+      message_id: 'msg-dropped',
+      reason: 'bot not mentioned',
+    });
+    // The body text must not appear anywhere in the persisted log.
+    expect(capture.text()).not.toContain(SECRET_BODY);
+  });
+
+  // Issue #70: a delivered inbound is logged (submitted) — still ids only.
+  it('logs accepted inbound as submitted without the message body', async () => {
+    const capture = captureLogger('channel/flow');
+    const SECRET_BODY = 'ACCEPTED-BODY-MUST-NOT-LEAK';
+    server = buildServer({
+      runtimeDir,
+      fake,
+      bot,
+      channelLoggerFactory: () => capture.logger,
+    });
+    server.repos.dispatchers.create({
+      dispatcher_id: 'flow',
+      bot_app_id: 'app-smoke',
+      bot_secret_ref: 'env:UNUSED',
+    });
+    await server.start();
+
+    await bot.inject(fakeInbound('chat-group-a', SECRET_BODY, 'msg-accepted'));
+    await waitFor(() => fake.turnsHandled === 1);
+
+    const submitted = capture
+      .lines()
+      .find((line) => line['msg'] === 'feishu inbound submitted');
+    expect(submitted).toMatchObject({
+      chat_id: 'chat-group-a',
+      message_id: 'msg-accepted',
+    });
+    expect(capture.text()).not.toContain(SECRET_BODY);
   });
 
   it('submits each pending inbound with turn/start while Codex folds active-turn input', async () => {

--- a/packages/dreamux/tests/smoke.test.ts
+++ b/packages/dreamux/tests/smoke.test.ts
@@ -906,6 +906,137 @@ describe('dreamux MVP smoke', () => {
     expect(capture.text()).not.toContain(SECRET_BODY);
   });
 
+  // Issue #70 (PR #75 review): outbound reply/react must be diagnosable —
+  // success and failure — without leaking the reply body. The admin layer
+  // turning a failure into a response does not replace a persistent log.
+  it('logs a successful outbound reply with ids but never the reply text', async () => {
+    const capture = captureLogger('channel/flow');
+    const REPLY_BODY = 'REPLY-BODY-MUST-NOT-LEAK';
+    server = buildServer({
+      runtimeDir,
+      fake,
+      bot,
+      channelLoggerFactory: () => capture.logger,
+    });
+    server.repos.dispatchers.create({
+      dispatcher_id: 'flow',
+      bot_app_id: 'app-smoke',
+      bot_secret_ref: 'env:UNUSED',
+    });
+    await server.start();
+
+    const result = await server.replyFromMcp({
+      dispatcherId: 'flow',
+      chatId: 'chat-group-a',
+      messageId: 'msg-reply',
+      text: REPLY_BODY,
+    });
+    expect(result.message_ids).toEqual(['message-fake-1']);
+
+    const sent = capture
+      .lines()
+      .find((line) => line['msg'] === 'feishu reply sent');
+    expect(sent).toMatchObject({
+      dispatcher_id: 'flow',
+      chat_id: 'chat-group-a',
+      message_id: 'msg-reply',
+      message_ids: ['message-fake-1'],
+    });
+    expect(capture.text()).not.toContain(REPLY_BODY);
+  });
+
+  it('logs a failed outbound reply with the error summary and rethrows (no body)', async () => {
+    const capture = captureLogger('channel/flow');
+    const REPLY_BODY = 'FAILED-REPLY-BODY-MUST-NOT-LEAK';
+    bot.setSendError(new Error('feishu send boom'));
+    server = buildServer({
+      runtimeDir,
+      fake,
+      bot,
+      channelLoggerFactory: () => capture.logger,
+    });
+    server.repos.dispatchers.create({
+      dispatcher_id: 'flow',
+      bot_app_id: 'app-smoke',
+      bot_secret_ref: 'env:UNUSED',
+    });
+    await server.start();
+
+    await expect(
+      server.replyFromMcp({
+        dispatcherId: 'flow',
+        chatId: 'chat-group-a',
+        messageId: 'msg-reply-fail',
+        text: REPLY_BODY,
+      }),
+    ).rejects.toThrow('feishu send boom');
+
+    const failed = capture
+      .lines()
+      .find((line) => line['msg'] === 'feishu reply failed');
+    expect(failed).toMatchObject({
+      dispatcher_id: 'flow',
+      chat_id: 'chat-group-a',
+      message_id: 'msg-reply-fail',
+    });
+    expect((failed?.['err'] as { message: string }).message).toBe(
+      'feishu send boom',
+    );
+    expect(capture.text()).not.toContain(REPLY_BODY);
+  });
+
+  it('logs outbound react success and failure with ids and emoji', async () => {
+    const capture = captureLogger('channel/flow');
+    server = buildServer({
+      runtimeDir,
+      fake,
+      bot,
+      channelLoggerFactory: () => capture.logger,
+    });
+    server.repos.dispatchers.create({
+      dispatcher_id: 'flow',
+      bot_app_id: 'app-smoke',
+      bot_secret_ref: 'env:UNUSED',
+    });
+    await server.start();
+
+    const ok = await server.reactFromMcp({
+      dispatcherId: 'flow',
+      messageId: 'msg-react',
+      emoji: 'THUMBSUP',
+    });
+    expect(ok.reaction_id).toBe('reaction-fake-1');
+    const sent = capture
+      .lines()
+      .find((line) => line['msg'] === 'feishu react sent');
+    expect(sent).toMatchObject({
+      dispatcher_id: 'flow',
+      message_id: 'msg-react',
+      emoji: 'THUMBSUP',
+      reaction_id: 'reaction-fake-1',
+    });
+
+    bot.setReactionError(new Error('feishu react boom'));
+    await expect(
+      server.reactFromMcp({
+        dispatcherId: 'flow',
+        messageId: 'msg-react-fail',
+        emoji: 'EYES',
+      }),
+    ).rejects.toThrow('feishu react boom');
+    const failed = capture
+      .lines()
+      .find((line) => line['msg'] === 'feishu react failed');
+    expect(failed).toMatchObject({
+      dispatcher_id: 'flow',
+      message_id: 'msg-react-fail',
+      emoji: 'EYES',
+    });
+    expect((failed?.['err'] as { message: string }).message).toBe(
+      'feishu react boom',
+    );
+  });
+
   it('submits each pending inbound with turn/start while Codex folds active-turn input', async () => {
     // Restart fake with a slow active turn so later submissions fold into it.
     await fake.close();


### PR DESCRIPTION
关联 #70。Codex 已 review 方案并给出 merge bar（见 #70 评论），本 PR 按其 verdict 实现。

## 目标

此前 host 唯一落盘的日志只有 Codex app-server 子进程的 stdout/stderr；dreamux 自身的每个决策（gate deliver/drop、`/introduce`、inbound 提交、outbound `reply`/`react`、dispatcher 生命周期）都只有 `console.error`，daemon 模式下无法事后排查。本 PR 引入轻量结构化文件日志，让这些事件落到 `~/.dreamux/logs/` 下。

**范围仅日志**，不夹带任何 introduce / bot-trust / reaction 行为改动（那是 #69 的范畴）。

## 实现要点

- **logger 选型 `pino`**：`pino.destination()` + `pino.multistream`，`sync:true`，不用 worker transport。
- **新模块 `src/runtime/logger.ts`**：工厂接收**可注入的 destination**（测试注入 tmp 路径，不依赖 env）；文件以 `mkdir + open(0o600) + chmod` 打开。
- **路径统一在 `paths.ts`**：新增 `feishuChannelLogPath(id)`、`feishuMcpLogDir()`、`feishuMcpLogPath(id)`。
- **每文件一个独立实例**：全局 `server` 日志 + 每 dispatcher 的 `channelLoggerFactory`；不用 `.child()` 跨文件。
- **双输出**：配了文件时，JSON 同时写文件和 stderr → 前台 `serve` 不变哑（v1 刻意结构化输出，不引入 pino-pretty / 不做脆弱的 stderr 重解析）。
- **`console.*` 非整体替换**：只迁移长驻/诊断面（`serve`、`server.ts`、dispatcher runtime/turn-manager 的 `log` seam、`feishu-mcp` 诊断 seam）；CLI 正常输出（doctor/config/server-ctl/onboard）继续走 stdout。
- **敏感默认值**：凭据用 pino `redact`（`app_secret` 等 → `[REDACTED]`）；消息体**永不传给 logger**（只记 id）。
- **`feishu-mcp` shim 绝不写 stdout**（stdout 是 JSON-RPC 通道），诊断走 `logs/feishu-mcp/<id>.log` + stderr。
- **级别**：`DREAMUX_LOG_LEVEL`（默认 `info`）+ 工厂显式 option。
- **测试安全**：未注入 logger 的默认实例只写 stder（零文件），CLI 是唯一构造文件 logger 的地方。

## merge bar 对照

| 要求 | 落实 |
|---|---|
| 路径在 `paths.ts` 统一 | ✅ `feishuChannelLogPath` / `feishuMcpLogDir` / `feishuMcpLogPath` |
| logger 工厂可注入 tmp destination | ✅ `createLogger({ destination })` / `{ filePath }` |
| `serve` 前台仍可见 | ✅ multistream 文件+stderr |
| `feishu-mcp` stdout 合约有测试 | ✅ 跨 parse-error / unknown-method / admin-failure 断言每行都是 JSON-RPC |
| 敏感默认值有回归测试 | ✅ redact + body-absence（logger 级与 server drop/submit 级） |
| transport 包：新增 option 或明确 defer | ✅ **明确 defer** → #74 |

## transport 包为何 defer

`@excitedjs/feishu-transport` 的 `[feishu-sdk]` / 连接事件是模块级单例、硬编码 `console.error`；接入需新增 public option + 该包 minor 版本 bump，超出"host 侧日志"范围且不改变行为。这些行已走 stderr，daemon 模式下经 `onboard/service.ts` 的重定向落到 `logs/daemon.stderr.log`，**不丢**，只是未结构化。归入 channel 日志的工作在 **#74** 跟踪。

## 测试

- `tests/logger.test.ts`：路径+`0600` 创建、收紧既有宽权限文件、redact、body-absence、级别阈值、`DREAMUX_LOG_LEVEL`、`(level,msg,err)` 适配。
- `tests/smoke.test.ts`：server 级 gate drop / inbound submitted 的 body-absence + id/reason 断言（注入 capture logger）。
- `tests/feishu-mcp.test.ts`：stdout JSON-RPC 合约。
- `tests/runtime-paths.test.ts`：新路径断言。

本地：`rush build` 通过；`rush test` 全绿（165 passed / 1 live-codex skipped，dreamux 因测试期 logger 往 stderr 写 JSON 行显示 "SUCCESS WITH WARNINGS"，与旧 `console.error` 同类，非失败）；`rush change --verify` 通过；`.agents/scripts/check.sh` 通过；gitleaks pre-commit 通过。

## 风险 / 注意

- **无日志轮转**：`dreamux-server.log` 与各 dispatcher 文件无界增长，需手动截断（后续决策）。
- **测试期 stderr 噪声**：默认 stderr-only logger 在 `info` 级产生 JSON 行，使 `rush test` 报 warnings（非回归）。
- transport 连接事件暂未结构化（见 #74）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
