### PR TITLE
feat(feishu-transport): 可注入 logger option，连接/SDK 诊断并入 channel 日志 (#74)

### DIFF
--- a/.agents/decisions/logging.md
+++ b/.agents/decisions/logging.md
@@ -70,22 +70,42 @@ Settled choices (as implemented):
   to a JSON-RPC envelope across the parse-error / unknown-method / admin-failure
   paths.
 
-### Deferred: `feishu-transport` package logging
+### Closed by #74: `feishu-transport` package logging
 
 The transport package's own `[feishu-sdk]` / connection-lifecycle lines
-(`reconnecting` / `reconnected` / `error` / startup-timeout) are **explicitly
-deferred** from this PR (Codex blocker #1). `FeishuTransportOptions` exposes
-only `client?` today; `sdkLogger` and `logConnection` are module-level
-singletons, so wiring a host logger in means a new public option + a published
-`@excitedjs/feishu-transport` minor version bump — out of scope for a host-side
-logging PR, and it would not change behaviour (default unchanged).
+(`reconnecting` / `reconnected` / `error` / startup-timeout) were **explicitly
+deferred** from the #70 PR (Codex blocker #1) and are now folded in by
+[#74](https://github.com/excitedjs/dreamux/issues/74).
 
-This defer does **not** lose those lines in practice: the transport routes them
-to **stderr**, and a daemonized `dreamux serve` already redirects stderr to
+`FeishuTransportOptions` gains an additive public `logger?` — a package-owned
+minimal `TransportLogger` interface (`packages/channel/feishu-transport/src/transport/diagnostics.ts`),
+**not** a reverse dependency on dreamux/pino. A per-instance
+`createTransportDiagnostics(logger?)` derives the SDK logger (one object shared
+by `lark.Client` / `EventDispatcher` / `WSClient`), the connection-lifecycle
+sink, and the best-effort `diagnostic()` sink (doc-comment / metadata /
+bot-info / socket-close failures). Instance-level, never a mutable global, so
+several dispatchers in one process never cross-write each other's logs. With no
+logger injected, the historical stderr behavior is preserved **byte-for-byte**
+(the `[feishu-sdk]` prefix, the `[feishu-transport] <ISO> <line>` connection
+lines, the best-effort `[feishu-transport] <message>` diagnostics — all to
+stderr, never a byte to stdout). The Lark-SDK-on-stdout corruption guard is
+unchanged: the default path stays on `console.error`, and the injected path
+never targets stdout.
+
+dreamux wires it through `Server`: the per-dispatcher `channelLog` is built
+**before** the bot, adapted via `pinoToTransportLogger` (`runtime/logger.ts`),
+and passed `createFeishuBot({ …, logger }) → createFeishuTransport(creds, { logger })`,
+so transport SDK/connection lines land in `logs/feishu-channel/<id>.log`.
+Safety boundary: the adapter only forwards the transport's own diagnostic
+`source`/`err` fields — never `appSecret`, raw events, `rawContent`, parsed
+text, or reply/card bodies — so routing into the channel log neither widens the
+secret/body surface nor pollutes the MCP stdout stream.
+
+Before #74 these lines were not lost, only unstructured: the transport routed
+them to **stderr**, and a daemonized `dreamux serve` already redirects stderr to
 `~/.dreamux/logs/daemon.stderr.log` (`onboard/service.ts` launchd
-`StandardErrorPath` / systemd `StandardError=append:`). They persist there
-unstructured and unsplit. Folding them into the per-dispatcher channel log is
-tracked in [#74](https://github.com/excitedjs/dreamux/issues/74).
+`StandardErrorPath` / systemd `StandardError=append:`). The default (no-logger)
+path keeps exactly that behavior.
 
 ## Logging convention (for future code)
 

--- a/common/changes/@excitedjs/dreamux/transport-logger-2026-06-05.json
+++ b/common/changes/@excitedjs/dreamux/transport-logger-2026-06-05.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@excitedjs/dreamux",
+      "comment": "Inject each dispatcher's per-dispatcher channel logger into its Feishu bot/transport, so the transport's Lark SDK and WebSocket connection diagnostics land in logs/feishu-channel/<id>.log alongside the host's own channel decisions (issue #74).",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@excitedjs/dreamux",
+  "email": "053700@gmail.com"
+}

--- a/common/changes/@excitedjs/feishu-transport/transport-logger-2026-06-05.json
+++ b/common/changes/@excitedjs/feishu-transport/transport-logger-2026-06-05.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@excitedjs/feishu-transport",
+      "comment": "Add an explicit, additive `logger?` option to `FeishuTransportOptions` (a package-owned minimal `TransportLogger` interface) so a host can fold the transport's own diagnostics — Lark SDK logging, WebSocket connection lifecycle, and best-effort doc-comment/metadata/bot-info/socket-close failures — into its per-component log. Instance-level: each transport derives its SDK and connection sinks from the injected logger. With no logger the historical stderr behavior is preserved byte-for-byte (issue #74).",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@excitedjs/feishu-transport",
+  "email": "053700@gmail.com"
+}

--- a/packages/channel/feishu-transport/src/index.ts
+++ b/packages/channel/feishu-transport/src/index.ts
@@ -94,6 +94,7 @@ export {
   type InboundRoutes,
   type RouteHandler,
 } from './transport/feishu.js'
+export type { TransportLogger } from './transport/diagnostics.js'
 
 // ── small shared util ──
 export { isRecord, asString } from './json.js'

--- a/packages/channel/feishu-transport/src/transport/diagnostics.ts
+++ b/packages/channel/feishu-transport/src/transport/diagnostics.ts
@@ -83,8 +83,10 @@ export interface TransportDiagnostics {
 
 /** Source tag stamped on injected SDK lines, mirroring the stderr `[feishu-sdk]` prefix. */
 const SDK_SOURCE = 'feishu-sdk'
-/** Source tag stamped on injected connection lines. */
+/** Source tag stamped on injected WebSocket connection-lifecycle lines. */
 const CONNECTION_SOURCE = 'feishu-transport-connection'
+/** Source tag stamped on injected best-effort failure diagnostics (non-connection). */
+const DIAGNOSTIC_SOURCE = 'feishu-transport-diagnostic'
 
 /**
  * Build the per-instance diagnostics for a transport. With no `logger` the
@@ -131,8 +133,8 @@ export function createTransportDiagnostics(logger?: TransportLogger): TransportD
       logger.warn(
         message,
         err !== undefined
-          ? { source: CONNECTION_SOURCE, err: serializeErr(err) }
-          : { source: CONNECTION_SOURCE },
+          ? { source: DIAGNOSTIC_SOURCE, err: serializeErr(err) }
+          : { source: DIAGNOSTIC_SOURCE },
       )
     },
   }

--- a/packages/channel/feishu-transport/src/transport/diagnostics.ts
+++ b/packages/channel/feishu-transport/src/transport/diagnostics.ts
@@ -1,0 +1,171 @@
+/**
+ * Transport-owned diagnostics, behind one injectable logger seam.
+ *
+ * Every line the transport emits about its own health — the Lark SDK's logging,
+ * the WebSocket connection lifecycle, and the best-effort failures of the
+ * doc-comment / metadata / bot-info / socket-close paths — flows through the
+ * single `TransportLogger` a host may inject via `FeishuTransportOptions.logger`.
+ *
+ * Two design rules hold this module together:
+ *
+ *   - **Instance-level, never a mutable global.** `createTransportDiagnostics`
+ *     is called once per `createFeishuTransport`, so each transport instance
+ *     derives its own SDK logger and connection/diagnostic sinks. Multiple
+ *     dispatchers in one process never cross-write each other's logs.
+ *   - **Byte-for-byte default.** With no injected logger the transport keeps
+ *     exactly its historical stderr behavior: the `[feishu-sdk]` prefix on SDK
+ *     lines, the `[feishu-transport] <ISO> <line>` connection lines, the
+ *     `[feishu-transport] <message>` best-effort diagnostics — all to stderr via
+ *     `console.error`, and never a byte to stdout (a host on an MCP stdio
+ *     transport reserves stdout for the JSON-RPC stream).
+ *
+ * Safety boundary: the injected-logger path only ever forwards what the stderr
+ * path already surfaces — SDK diagnostic args, connection-lifecycle wording, and
+ * the ids/error already present in a best-effort failure. It never attaches
+ * `appSecret`, raw events, `rawContent`, parsed text, or reply/card bodies as
+ * structured fields, so routing into a host's channel log neither widens the
+ * secret/body exposure nor pollutes stdout.
+ */
+
+/**
+ * A minimal, structured logger a host can inject so the transport's own
+ * diagnostics join the host's per-component log. Defined inside this package so
+ * the transport never reverse-depends on a host's logger (dreamux's pino, etc.);
+ * a host adapts its logger to this shape. Every method takes a message and
+ * optional structured `fields`; a pino-style `(fields, msg)` logger adapts in
+ * one line.
+ */
+export interface TransportLogger {
+  error(message: string, fields?: Record<string, unknown>): void
+  warn(message: string, fields?: Record<string, unknown>): void
+  info(message: string, fields?: Record<string, unknown>): void
+  debug(message: string, fields?: Record<string, unknown>): void
+  trace(message: string, fields?: Record<string, unknown>): void
+}
+
+/**
+ * The Lark SDK's logger shape: five levels, each variadic. `lark.Client`,
+ * `lark.EventDispatcher`, and `lark.WSClient` all accept this. The transport
+ * derives one of these per instance and hands the *same* object to all three.
+ */
+export interface SdkLogger {
+  error(...msg: unknown[]): void
+  warn(...msg: unknown[]): void
+  info(...msg: unknown[]): void
+  debug(...msg: unknown[]): void
+  trace(...msg: unknown[]): void
+}
+
+/** Levels a connection-lifecycle line is routed at on the injected path. */
+type ConnectionLevel = 'info' | 'error'
+
+/**
+ * Per-instance diagnostics sinks `createFeishuTransport` wires its SDK clients
+ * and its own failure paths into.
+ */
+export interface TransportDiagnostics {
+  /** The Lark SDK logger — pass to `Client` / `EventDispatcher` / `WSClient`. */
+  readonly sdkLogger: SdkLogger
+  /**
+   * A WebSocket connection-lifecycle line. Default path: stderr with an ISO
+   * timestamp. Injected path: routed at `level` (default `info`; failures pass
+   * `error`) with the host's own timestamp.
+   */
+  connection(line: string, level?: ConnectionLevel): void
+  /**
+   * A best-effort failure the transport degrades past (doc-comment / metadata
+   * fetch, bot-info resolution, socket close). Default path: stderr, with `err`
+   * passed as a trailing `console.error` arg so its stack still prints. Injected
+   * path: routed at `warn` with `err` serialized into a structured field.
+   */
+  diagnostic(message: string, err?: unknown): void
+}
+
+/** Source tag stamped on injected SDK lines, mirroring the stderr `[feishu-sdk]` prefix. */
+const SDK_SOURCE = 'feishu-sdk'
+/** Source tag stamped on injected connection lines. */
+const CONNECTION_SOURCE = 'feishu-transport-connection'
+
+/**
+ * Build the per-instance diagnostics for a transport. With no `logger` the
+ * returned sinks reproduce the historical stderr behavior byte-for-byte; with a
+ * `logger` they route structured into it.
+ */
+export function createTransportDiagnostics(logger?: TransportLogger): TransportDiagnostics {
+  if (logger === undefined) {
+    return {
+      sdkLogger: {
+        error: (...msg) => console.error('[feishu-sdk]', ...msg),
+        warn: (...msg) => console.error('[feishu-sdk]', ...msg),
+        info: (...msg) => console.error('[feishu-sdk]', ...msg),
+        debug: (...msg) => console.error('[feishu-sdk]', ...msg),
+        trace: (...msg) => console.error('[feishu-sdk]', ...msg),
+      },
+      connection: (line) => {
+        console.error(`[feishu-transport] ${new Date().toISOString()} ${line}`)
+      },
+      diagnostic: (message, err) => {
+        if (err !== undefined) console.error(`[feishu-transport] ${message}`, err)
+        else console.error(`[feishu-transport] ${message}`)
+      },
+    }
+  }
+
+  const sdkLevel =
+    (level: keyof TransportLogger) =>
+    (...msg: unknown[]) =>
+      logger[level](formatSdkArgs(msg), { source: SDK_SOURCE })
+
+  return {
+    sdkLogger: {
+      error: sdkLevel('error'),
+      warn: sdkLevel('warn'),
+      info: sdkLevel('info'),
+      debug: sdkLevel('debug'),
+      trace: sdkLevel('trace'),
+    },
+    connection: (line, level = 'info') => {
+      logger[level](line, { source: CONNECTION_SOURCE })
+    },
+    diagnostic: (message, err) => {
+      logger.warn(
+        message,
+        err !== undefined
+          ? { source: CONNECTION_SOURCE, err: serializeErr(err) }
+          : { source: CONNECTION_SOURCE },
+      )
+    },
+  }
+}
+
+/**
+ * Flatten the SDK's variadic log args into one message string for the injected
+ * path — the structured logger takes a single message, where the stderr path
+ * relied on `console.error`'s native multi-arg join. Errors render as their
+ * stack (or message); other non-strings are JSON-stringified, falling back to
+ * `String()` for anything circular. Only the SDK's own diagnostic args reach
+ * here — never a message body — so flattening cannot widen body exposure.
+ */
+function formatSdkArgs(args: unknown[]): string {
+  return args.map(stringifyArg).join(' ')
+}
+
+function stringifyArg(arg: unknown): string {
+  if (typeof arg === 'string') return arg
+  if (arg instanceof Error) return arg.stack ?? arg.message
+  try {
+    return JSON.stringify(arg)
+  } catch {
+    return String(arg)
+  }
+}
+
+/** Serialize an error into a logger-safe field (message + stack when present). */
+function serializeErr(err: unknown): { message: string; stack?: string } {
+  if (err instanceof Error) {
+    return err.stack !== undefined
+      ? { message: err.message, stack: err.stack }
+      : { message: err.message }
+  }
+  return { message: String(err) }
+}

--- a/packages/channel/feishu-transport/src/transport/feishu.ts
+++ b/packages/channel/feishu-transport/src/transport/feishu.ts
@@ -39,6 +39,11 @@ import {
   reconnectingLogLine,
   startupTimeoutLogLine,
 } from './connection.js'
+import {
+  createTransportDiagnostics,
+  type TransportDiagnostics,
+  type TransportLogger,
+} from './diagnostics.js'
 
 /** Cap on a single WebSocket handshake before it is aborted into a retry. */
 const WS_HANDSHAKE_TIMEOUT_MS = 15_000
@@ -50,23 +55,6 @@ const WS_HANDSHAKE_TIMEOUT_MS = 15_000
  * loop, so the transport cuts the attempt off.
  */
 const WS_STARTUP_GRACE_MS = 30_000
-
-/**
- * A Lark-SDK logger that writes every line to stderr.
- *
- * Hosts that run over an MCP stdio transport reserve stdout for the JSON-RPC
- * stream; the SDK's default logger writes to stdout, which corrupts it. Routing
- * the SDK's logger to stderr keeps stdout clean while the SDK's diagnostics
- * stay visible in the host's log. (Harmless for dreamux, which does not use
- * stdout for a protocol stream.)
- */
-const sdkLogger = {
-  error: (...msg: unknown[]) => console.error('[feishu-sdk]', ...msg),
-  warn: (...msg: unknown[]) => console.error('[feishu-sdk]', ...msg),
-  info: (...msg: unknown[]) => console.error('[feishu-sdk]', ...msg),
-  debug: (...msg: unknown[]) => console.error('[feishu-sdk]', ...msg),
-  trace: (...msg: unknown[]) => console.error('[feishu-sdk]', ...msg),
-}
 
 /** Outcome of an outbound send. */
 export interface FeishuSendResult {
@@ -347,6 +335,19 @@ export interface FeishuTransportOptions {
    * built from `creds`. Tests pass a stub; production never sets this.
    */
   client?: lark.Client
+  /**
+   * Structured logger for this transport's own diagnostics — the Lark SDK's
+   * logging, the WebSocket connection lifecycle, and the best-effort failures
+   * of the doc-comment / metadata / bot-info / socket-close paths. Additive and
+   * opt-in: with no logger the transport keeps its historical stderr behavior
+   * byte-for-byte (the `[feishu-sdk]` / `[feishu-transport]` prefixes, the ISO
+   * connection lines, and never a byte to stdout). A host injects this to fold
+   * the transport's lines into its own per-component log; see
+   * `./diagnostics.ts` for the seam and its safety boundary. Instance-level: the
+   * transport derives its SDK and connection sinks from this one logger, so
+   * several dispatchers in one process never cross-write each other's logs.
+   */
+  logger?: TransportLogger
 }
 
 /**
@@ -362,12 +363,17 @@ export function createFeishuTransport(
   creds: FeishuCredentials,
   options: FeishuTransportOptions = {},
 ): FeishuTransport {
+  // One diagnostics seam per transport instance: with no injected logger it
+  // reproduces the historical stderr behavior byte-for-byte; with one it routes
+  // structured into the host's log. Built before the SDK client so all three
+  // SDK objects below share this instance's single SDK logger.
+  const diag = createTransportDiagnostics(options.logger)
   const client =
     options.client ??
     new lark.Client({
       appId: creds.appId,
       appSecret: creds.appSecret,
-      logger: sdkLogger,
+      logger: diag.sdkLogger,
     })
   let wsClient: lark.WSClient | undefined
   let resolvedSelfId: string | undefined
@@ -378,8 +384,8 @@ export function createFeishuTransport(
    * this transport rather than threading a lock through here.
    */
   async function openInbound(routes: InboundRoutes): Promise<void> {
-    resolvedSelfId = await resolveBotOpenId(client)
-    const dispatcher = new lark.EventDispatcher({ logger: sdkLogger }).register(routes)
+    resolvedSelfId = await resolveBotOpenId(client, diag)
+    const dispatcher = new lark.EventDispatcher({ logger: diag.sdkLogger }).register(routes)
 
     // Resolves the first time the connection reaches `ready`; the startup
     // watchdog below races against it.
@@ -391,8 +397,9 @@ export function createFeishuTransport(
     const ws = new lark.WSClient({
       appId: creds.appId,
       appSecret: creds.appSecret,
-      // Route the SDK's own logging to stderr — see `sdkLogger`.
-      logger: sdkLogger,
+      // Route the SDK's own logging through this instance's diagnostics seam —
+      // stderr by default, the host's log when a logger is injected.
+      logger: diag.sdkLogger,
       // Bound a stuck WebSocket handshake so it fails into a retry rather
       // than holding a stuck DNS / NAT path open indefinitely.
       handshakeTimeoutMs: WS_HANDSHAKE_TIMEOUT_MS,
@@ -401,17 +408,17 @@ export function createFeishuTransport(
       // failing connection is observable instead of a silent retry loop.
       autoReconnect: true,
       onReady: () => {
-        logConnection('Feishu WebSocket connection is ready')
+        diag.connection('Feishu WebSocket connection is ready')
         markReady()
       },
-      onReconnecting: () => logConnection(reconnectingLogLine()),
-      onReconnected: () => logConnection(reconnectedLogLine()),
-      onError: (err) => logConnection(connectionErrorLogLine(err)),
+      onReconnecting: () => diag.connection(reconnectingLogLine()),
+      onReconnected: () => diag.connection(reconnectedLogLine()),
+      onError: (err) => diag.connection(connectionErrorLogLine(err), 'error'),
     })
     wsClient = ws
 
     void ws.start({ eventDispatcher: dispatcher }).catch((err: unknown) => {
-      logConnection(connectionErrorLogLine(err))
+      diag.connection(connectionErrorLogLine(err), 'error')
     })
 
     // The SDK retries pullConnectConfig with no delay until it first
@@ -422,7 +429,7 @@ export function createFeishuTransport(
     const cameUp = await raceConnectionReady(ready)
     if (!cameUp) {
       const gaveUp = ws.getConnectionStatus().state === 'failed'
-      logConnection(startupTimeoutLogLine(WS_STARTUP_GRACE_MS, gaveUp))
+      diag.connection(startupTimeoutLogLine(WS_STARTUP_GRACE_MS, gaveUp), 'error')
       ws.close()
       // Fail loud rather than leave a dispatcher whose bot is silently dark:
       // the host (dreamux's server) cleans up and surfaces the failure. A host
@@ -544,10 +551,7 @@ export function createFeishuTransport(
         })
         return commentFromBatchQuery(res.data?.items ?? [], commentId)
       } catch (err) {
-        console.error(
-          `[feishu-transport] could not fetch comment ${commentId} on ${fileToken}:`,
-          err,
-        )
+        diag.diagnostic(`could not fetch comment ${commentId} on ${fileToken}:`, err)
         return null
       }
     },
@@ -563,7 +567,7 @@ export function createFeishuTransport(
         if (!meta) return null
         return { title: meta.title ?? '', url: meta.url ?? '' }
       } catch (err) {
-        console.error(`[feishu-transport] could not fetch metadata for ${fileToken}:`, err)
+        diag.diagnostic(`could not fetch metadata for ${fileToken}:`, err)
         return null
       }
     },
@@ -574,7 +578,7 @@ export function createFeishuTransport(
       } catch (err) {
         // A close on an already-closed socket is expected; anything else
         // (e.g. the SDK's close surface changed) is worth a diagnostic line.
-        console.error('[feishu-transport] error while closing the Feishu WebSocket:', err)
+        diag.diagnostic('error while closing the Feishu WebSocket:', err)
       }
       wsClient = undefined
     },
@@ -632,7 +636,10 @@ const BOT_INFO_ATTEMPTS = 3
  * failure is logged with that consequence spelled out, and a transient error
  * is retried a few times before the transport gives up.
  */
-async function resolveBotOpenId(client: lark.Client): Promise<string | undefined> {
+async function resolveBotOpenId(
+  client: lark.Client,
+  diag: TransportDiagnostics,
+): Promise<string | undefined> {
   for (let attempt = 1; attempt <= BOT_INFO_ATTEMPTS; attempt++) {
     try {
       const res = await client.request<{ bot?: { open_id?: string } }>({
@@ -643,8 +650,8 @@ async function resolveBotOpenId(client: lark.Client): Promise<string | undefined
       if (openId) return openId
       // A well-formed response that simply lacks the field will not improve
       // on retry — stop here rather than spend the remaining attempts.
-      console.error(
-        '[feishu-transport] bot info response carried no open_id — groups that ' +
+      diag.diagnostic(
+        'bot info response carried no open_id — groups that ' +
           'require an @-mention will drop every message until the channel restarts',
       )
       return undefined
@@ -653,8 +660,8 @@ async function resolveBotOpenId(client: lark.Client): Promise<string | undefined
         await delay(attempt * 500)
         continue
       }
-      console.error(
-        `[feishu-transport] could not resolve the bot open_id after ${BOT_INFO_ATTEMPTS} ` +
+      diag.diagnostic(
+        `could not resolve the bot open_id after ${BOT_INFO_ATTEMPTS} ` +
           'attempts — groups that require an @-mention will drop every message ' +
           'until the channel restarts:',
         err,
@@ -668,11 +675,6 @@ async function resolveBotOpenId(client: lark.Client): Promise<string | undefined
 /** Resolve after `ms` milliseconds — the backoff between bot-info attempts. */
 function delay(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms))
-}
-
-/** Write a timestamped connection-lifecycle line to the host's stderr log. */
-function logConnection(line: string): void {
-  console.error(`[feishu-transport] ${new Date().toISOString()} ${line}`)
 }
 
 /**

--- a/packages/channel/feishu-transport/tests/diagnostics.test.ts
+++ b/packages/channel/feishu-transport/tests/diagnostics.test.ts
@@ -1,0 +1,168 @@
+/**
+ * Unit tests for `src/transport/diagnostics.ts` — the injectable logger seam.
+ *
+ * The byte-for-byte default and the safety boundary are the riskiest parts of
+ * the #74 logger work, so they are tested here, against the factory directly,
+ * rather than indirectly through `createFeishuTransport`:
+ *
+ *   - With no injected logger, every sink reproduces the historical stderr
+ *     wording exactly (`[feishu-sdk]` prefix, `[feishu-transport] <ISO> <line>`
+ *     connection lines, `[feishu-transport] <message>` diagnostics), all via
+ *     `console.error`, and nothing is ever written to stdout (`console.log`).
+ *   - With an injected logger, the routing reaches the logger and a sentinel
+ *     secret / message body never appears in any forwarded message or field.
+ */
+
+import { afterEach, describe, expect, test, vi } from 'vitest'
+
+import {
+  createTransportDiagnostics,
+  type TransportLogger,
+} from '../src/transport/diagnostics'
+
+/** A capturing `TransportLogger`: records every call as `[level, message, fields]`. */
+function spyLogger() {
+  const calls: Array<{
+    level: keyof TransportLogger
+    message: string
+    fields: Record<string, unknown> | undefined
+  }> = []
+  const make =
+    (level: keyof TransportLogger) =>
+    (message: string, fields?: Record<string, unknown>) => {
+      calls.push({ level, message, fields })
+    }
+  const logger: TransportLogger = {
+    error: make('error'),
+    warn: make('warn'),
+    info: make('info'),
+    debug: make('debug'),
+    trace: make('trace'),
+  }
+  return { logger, calls }
+}
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+describe('createTransportDiagnostics — default (no logger) is byte-for-byte stderr', () => {
+  test('sdkLogger prefixes [feishu-sdk] on every level and writes only to stderr', () => {
+    const err = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const log = vi.spyOn(console, 'log').mockImplementation(() => {})
+    const diag = createTransportDiagnostics()
+
+    diag.sdkLogger.error('e', 1)
+    diag.sdkLogger.warn('w')
+    diag.sdkLogger.info('i')
+    diag.sdkLogger.debug('d')
+    diag.sdkLogger.trace('t')
+
+    expect(err.mock.calls).toEqual([
+      ['[feishu-sdk]', 'e', 1],
+      ['[feishu-sdk]', 'w'],
+      ['[feishu-sdk]', 'i'],
+      ['[feishu-sdk]', 'd'],
+      ['[feishu-sdk]', 't'],
+    ])
+    expect(log).not.toHaveBeenCalled()
+  })
+
+  test('connection writes a single [feishu-transport] <ISO> <line> to stderr', () => {
+    const err = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const log = vi.spyOn(console, 'log').mockImplementation(() => {})
+    const diag = createTransportDiagnostics()
+
+    diag.connection('Feishu connection re-established.')
+    // The level argument does not change the default path — still one stderr line.
+    diag.connection('something failed', 'error')
+
+    expect(err).toHaveBeenCalledTimes(2)
+    const first = err.mock.calls[0]?.[0] as string
+    expect(first).toMatch(
+      /^\[feishu-transport\] \d{4}-\d{2}-\d{2}T[\d:.]+Z Feishu connection re-established\.$/,
+    )
+    expect(err.mock.calls[0]).toHaveLength(1)
+    expect(log).not.toHaveBeenCalled()
+  })
+
+  test('diagnostic keeps the message and passes err as a trailing console arg', () => {
+    const err = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const log = vi.spyOn(console, 'log').mockImplementation(() => {})
+    const diag = createTransportDiagnostics()
+    const cause = new Error('boom')
+
+    diag.diagnostic('could not fetch metadata for tok:', cause)
+    diag.diagnostic('bot info response carried no open_id')
+
+    expect(err.mock.calls).toEqual([
+      ['[feishu-transport] could not fetch metadata for tok:', cause],
+      ['[feishu-transport] bot info response carried no open_id'],
+    ])
+    expect(log).not.toHaveBeenCalled()
+  })
+})
+
+describe('createTransportDiagnostics — injected logger routing', () => {
+  test('sdkLogger routes each level to the matching logger method with a source field', () => {
+    const { logger, calls } = spyLogger()
+    const diag = createTransportDiagnostics(logger)
+
+    diag.sdkLogger.error('e', 1)
+    diag.sdkLogger.info('i')
+
+    expect(calls).toEqual([
+      { level: 'error', message: 'e 1', fields: { source: 'feishu-sdk' } },
+      { level: 'info', message: 'i', fields: { source: 'feishu-sdk' } },
+    ])
+  })
+
+  test('connection routes at info by default and at the given level on failures', () => {
+    const { logger, calls } = spyLogger()
+    const diag = createTransportDiagnostics(logger)
+
+    diag.connection('ready')
+    diag.connection('failed', 'error')
+
+    expect(calls).toEqual([
+      { level: 'info', message: 'ready', fields: { source: 'feishu-transport-connection' } },
+      { level: 'error', message: 'failed', fields: { source: 'feishu-transport-connection' } },
+    ])
+  })
+
+  test('diagnostic routes at warn and serializes the error into a field', () => {
+    const { logger, calls } = spyLogger()
+    const diag = createTransportDiagnostics(logger)
+
+    diag.diagnostic('could not fetch:', new Error('boom'))
+    diag.diagnostic('no open_id')
+
+    expect(calls[0]?.level).toBe('warn')
+    expect(calls[0]?.message).toBe('could not fetch:')
+    expect(calls[0]?.fields?.['source']).toBe('feishu-transport-connection')
+    expect(calls[0]?.fields?.['err']).toMatchObject({ message: 'boom' })
+    expect(calls[1]).toEqual({
+      level: 'warn',
+      message: 'no open_id',
+      fields: { source: 'feishu-transport-connection' },
+    })
+  })
+
+  test('safety: a sentinel secret / body never reaches the injected logger', () => {
+    const { logger, calls } = spyLogger()
+    const diag = createTransportDiagnostics(logger)
+    const SECRET = 'fake-not-a-real-secret'
+    const BODY = 'do-not-log-body'
+
+    // Drive every sink the transport uses. None of them is given the secret or
+    // a message body, so neither sentinel should appear in the forwarded output.
+    diag.sdkLogger.info('sdk diagnostic line')
+    diag.connection('Feishu connection re-established.')
+    diag.connection('Feishu connection failed and the SDK stopped retrying: timeout', 'error')
+    diag.diagnostic('could not fetch comment cmt_1 on tok_1:', new Error('network down'))
+
+    const haystack = JSON.stringify(calls)
+    expect(haystack).not.toContain(SECRET)
+    expect(haystack).not.toContain(BODY)
+  })
+})

--- a/packages/channel/feishu-transport/tests/diagnostics.test.ts
+++ b/packages/channel/feishu-transport/tests/diagnostics.test.ts
@@ -139,12 +139,12 @@ describe('createTransportDiagnostics — injected logger routing', () => {
 
     expect(calls[0]?.level).toBe('warn')
     expect(calls[0]?.message).toBe('could not fetch:')
-    expect(calls[0]?.fields?.['source']).toBe('feishu-transport-connection')
+    expect(calls[0]?.fields?.['source']).toBe('feishu-transport-diagnostic')
     expect(calls[0]?.fields?.['err']).toMatchObject({ message: 'boom' })
     expect(calls[1]).toEqual({
       level: 'warn',
       message: 'no open_id',
-      fields: { source: 'feishu-transport-connection' },
+      fields: { source: 'feishu-transport-diagnostic' },
     })
   })
 

--- a/packages/channel/feishu-transport/tests/transport-logger.test.ts
+++ b/packages/channel/feishu-transport/tests/transport-logger.test.ts
@@ -1,0 +1,158 @@
+/**
+ * Wiring tests for the #74 logger seam inside `createFeishuTransport`.
+ *
+ * The Lark SDK is mocked so these run with no live connection. Two claims are
+ * proven here (formatting is covered by `diagnostics.test.ts`, not re-checked):
+ *
+ *   1. `lark.Client`, `lark.EventDispatcher`, and `lark.WSClient` are all handed
+ *      the *same* instance-derived SDK logger object — so several dispatchers in
+ *      one process cannot cross-write each other's SDK logs.
+ *   2. Invoking the WebSocket lifecycle callbacks (`onReady` / `onReconnecting`
+ *      / `onReconnected` / `onError`) and hitting the startup-timeout path routes
+ *      a connection line to the injected `TransportLogger`.
+ */
+
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+
+const captured = vi.hoisted(() => ({
+  clientLoggers: [] as unknown[],
+  wsLoggers: [] as unknown[],
+  dispatcherLoggers: [] as unknown[],
+  wsOptions: [] as Array<Record<string, () => void>>,
+  control: { autoReady: true },
+}))
+
+vi.mock('@larksuiteoapi/node-sdk', () => {
+  class Client {
+    request = async (): Promise<{ bot: { open_id: string } }> => ({
+      bot: { open_id: 'ou_self' },
+    })
+    constructor(opts: { logger?: unknown }) {
+      captured.clientLoggers.push(opts.logger)
+    }
+  }
+  class EventDispatcher {
+    constructor(opts: { logger?: unknown }) {
+      captured.dispatcherLoggers.push(opts.logger)
+    }
+    register(): this {
+      return this
+    }
+  }
+  class WSClient {
+    private readonly opts: Record<string, () => void>
+    constructor(opts: Record<string, () => void> & { logger?: unknown }) {
+      captured.wsLoggers.push(opts.logger)
+      captured.wsOptions.push(opts)
+      this.opts = opts
+    }
+    async start(): Promise<void> {
+      // The success path marks the connection ready so `start()` resolves; the
+      // startup-timeout test flips `autoReady` off to leave it pending.
+      if (captured.control.autoReady) this.opts['onReady']?.()
+    }
+    close(): void {}
+    getConnectionStatus(): { state: string } {
+      return { state: 'connected' }
+    }
+  }
+  return { Client, EventDispatcher, WSClient }
+})
+
+// Imported after the mock is registered (vi.mock is hoisted above the imports).
+const { createFeishuTransport } = await import('../src/transport/feishu')
+import type { TransportLogger } from '../src/transport/diagnostics'
+
+/** Records connection-level routing so a test can assert what the logger saw. */
+function spyLogger() {
+  const calls: Array<{ level: keyof TransportLogger; message: string }> = []
+  const make =
+    (level: keyof TransportLogger) =>
+    (message: string) => {
+      calls.push({ level, message })
+    }
+  const logger: TransportLogger = {
+    error: make('error'),
+    warn: make('warn'),
+    info: make('info'),
+    debug: make('debug'),
+    trace: make('trace'),
+  }
+  return { logger, calls }
+}
+
+beforeEach(() => {
+  captured.clientLoggers.length = 0
+  captured.wsLoggers.length = 0
+  captured.dispatcherLoggers.length = 0
+  captured.wsOptions.length = 0
+  captured.control.autoReady = true
+})
+
+afterEach(() => {
+  vi.useRealTimers()
+})
+
+describe('createFeishuTransport — SDK logger is one instance-derived object', () => {
+  test('Client, EventDispatcher, and WSClient all receive the same SDK logger', async () => {
+    const { logger } = spyLogger()
+    const transport = createFeishuTransport(
+      { appId: 'app', appSecret: 'secret' },
+      { logger },
+    )
+
+    await transport.start({})
+
+    const clientLogger = captured.clientLoggers[0]
+    expect(clientLogger).toBeDefined()
+    expect(captured.dispatcherLoggers[0]).toBe(clientLogger)
+    expect(captured.wsLoggers[0]).toBe(clientLogger)
+  })
+})
+
+describe('createFeishuTransport — connection events reach the injected logger', () => {
+  test('onReady / onReconnecting / onReconnected route info, onError routes error', async () => {
+    const { logger, calls } = spyLogger()
+    const transport = createFeishuTransport(
+      { appId: 'app', appSecret: 'secret' },
+      { logger },
+    )
+
+    await transport.start({})
+    // start() already fired onReady; drive the remaining lifecycle callbacks.
+    const ws = captured.wsOptions[0]
+    expect(ws).toBeDefined()
+    ws?.['onReconnecting']?.()
+    ws?.['onReconnected']?.()
+    ;(ws?.['onError'] as unknown as (e: unknown) => void)?.(new Error('socket lost'))
+
+    const ready = calls.find((c) => c.message.includes('connection is ready'))
+    expect(ready?.level).toBe('info')
+    expect(calls.some((c) => c.level === 'info' && c.message.includes('reconnecting'))).toBe(true)
+    expect(calls.some((c) => c.level === 'info' && c.message.includes('re-established'))).toBe(true)
+    const errLine = calls.find((c) => c.level === 'error')
+    expect(errLine?.message).toContain('stopped retrying')
+  })
+
+  test('the startup-timeout path routes an error connection line and rejects', async () => {
+    vi.useFakeTimers()
+    captured.control.autoReady = false
+    const { logger, calls } = spyLogger()
+    const transport = createFeishuTransport(
+      { appId: 'app', appSecret: 'secret' },
+      { logger },
+    )
+
+    const settled = transport.start({}).then(
+      () => 'resolved',
+      (err: unknown) => err,
+    )
+    // Advance past the 30s startup grace window so the watchdog fires.
+    await vi.advanceTimersByTimeAsync(31_000)
+    const result = await settled
+
+    expect(result).toBeInstanceOf(Error)
+    const errLine = calls.find((c) => c.level === 'error')
+    expect(errLine?.message).toContain('did not come up within')
+  })
+})

--- a/packages/channel/feishu-transport/tests/transport.test.ts
+++ b/packages/channel/feishu-transport/tests/transport.test.ts
@@ -18,6 +18,7 @@ import {
   commentFromBatchQuery,
   createFeishuTransport,
 } from '../src/transport/feishu'
+import type { TransportLogger } from '../src/transport/diagnostics'
 
 /**
  * One `drive.v1.fileComment.batchQuery` response item, in the exact shape the
@@ -351,5 +352,52 @@ describe('createFeishuTransport — editText', () => {
     )
     expect(stub.patch).not.toHaveBeenCalled()
     expect(stub.update).not.toHaveBeenCalled()
+  })
+})
+
+describe('createFeishuTransport — injected logger safety boundary (#74)', () => {
+  test('a sentinel appSecret and message body never reach the injected logger', async () => {
+    // Sentinels fed through the *real* transport inputs — the credentials and an
+    // outbound body — so this proves the adapter does not surface them, rather
+    // than asserting against strings the test never passed in.
+    const SECRET = 'fake-not-a-real-secret'
+    const BODY = 'do-not-log-body'
+
+    const calls: Array<{ message: string; fields?: Record<string, unknown> }> = []
+    const record = (message: string, fields?: Record<string, unknown>) => {
+      calls.push({ message, fields })
+    }
+    const logger: TransportLogger = {
+      error: record,
+      warn: record,
+      info: record,
+      debug: record,
+      trace: record,
+    }
+
+    const stub = stubClient()
+    const transport = createFeishuTransport(
+      { appId: 'app', appSecret: SECRET },
+      { client: stub.client, logger },
+    )
+
+    // Send a real body (no log on success), then force the doc-comment fetch to
+    // fail so the best-effort `diagnostic()` sink actually runs.
+    await transport.send({ chatId: 'oc_chat' }, BODY)
+    const drive = (
+      stub.client as unknown as {
+        drive: { fileComment: { batchQuery: ReturnType<typeof vi.fn> } }
+      }
+    ).drive
+    drive.fileComment.batchQuery.mockRejectedValueOnce(new Error('network down'))
+    const comment = await transport.fetchDocComment('tok', 'docx', 'cmt')
+
+    expect(comment).toBeNull()
+    // The diagnostic path ran (so the assertion below is not vacuous)…
+    expect(calls.length).toBeGreaterThan(0)
+    // …yet neither sentinel appears anywhere in what the logger received.
+    const haystack = JSON.stringify(calls)
+    expect(haystack).not.toContain(SECRET)
+    expect(haystack).not.toContain(BODY)
   })
 })

--- a/packages/dreamux/src/feishu/bot.ts
+++ b/packages/dreamux/src/feishu/bot.ts
@@ -31,6 +31,7 @@ import {
   type FeishuTransport,
   type Mention,
   type OutboundTarget,
+  type TransportLogger,
 } from '@excitedjs/feishu-transport';
 
 /** The Feishu event_type carrying inbound chat messages. */
@@ -99,6 +100,15 @@ export interface FeishuBot {
 export interface CreateBotOptions {
   appId: string;
   appSecret: string;
+  /**
+   * Structured logger for the underlying transport's own diagnostics (Lark SDK
+   * logging, WebSocket connection lifecycle, best-effort fetch/close failures).
+   * Forwarded verbatim to `createFeishuTransport`. Omit to keep the transport's
+   * historical stderr behavior. The server injects the dispatcher's
+   * per-dispatcher channel logger here so connection/SDK lines land in
+   * `logs/feishu-channel/<id>.log` alongside the host's own channel decisions.
+   */
+  logger?: TransportLogger;
 }
 
 export interface CreateFeishuBotDeps {
@@ -121,10 +131,17 @@ export function createFeishuBot(
   deps: CreateFeishuBotDeps = {},
 ): FeishuBot {
   const transport = deps.createTransport?.(opts) ??
-    createFeishuTransport({
-      appId: opts.appId,
-      appSecret: opts.appSecret,
-    });
+    createFeishuTransport(
+      {
+        appId: opts.appId,
+        appSecret: opts.appSecret,
+      },
+      // Forward the host's logger so the transport's own SDK / connection
+      // diagnostics fold into the per-dispatcher channel log. `undefined` keeps
+      // the transport's default stderr behavior, so always passing the option
+      // object is safe and keeps the real wiring path explicit.
+      { logger: opts.logger },
+    );
 
   return {
     get appId(): string {

--- a/packages/dreamux/src/runtime/logger.ts
+++ b/packages/dreamux/src/runtime/logger.ts
@@ -29,6 +29,7 @@
 import { chmodSync, mkdirSync, openSync } from 'node:fs';
 import { dirname } from 'node:path';
 
+import type { TransportLogger } from '@excitedjs/feishu-transport';
 import pino, {
   type DestinationStream,
   type Logger,
@@ -144,4 +145,27 @@ function serializeErr(err: unknown): { message: string; stack?: string } {
       : { message: err.message };
   }
   return { message: String(err) };
+}
+
+/**
+ * Adapt a `DreamuxLogger` (pino) to the `@excitedjs/feishu-transport`
+ * `TransportLogger` seam, so the transport's own SDK / connection diagnostics
+ * fold into the same per-dispatcher channel log as the host's channel
+ * decisions. pino takes `(mergingObject, message)`, the transport seam emits
+ * `(message, fields?)` — this flips the argument order and supplies an empty
+ * object when the transport carried no fields.
+ *
+ * The transport only ever passes its own diagnostic source fields (an SDK/
+ * connection `source` tag and a serialized `err`); it never hands message
+ * bodies or credentials to the logger, so this adapter forwards `fields`
+ * verbatim without re-redacting (the pino `redact` config still applies).
+ */
+export function pinoToTransportLogger(logger: DreamuxLogger): TransportLogger {
+  return {
+    error: (message, fields) => logger.error(fields ?? {}, message),
+    warn: (message, fields) => logger.warn(fields ?? {}, message),
+    info: (message, fields) => logger.info(fields ?? {}, message),
+    debug: (message, fields) => logger.debug(fields ?? {}, message),
+    trace: (message, fields) => logger.trace(fields ?? {}, message),
+  };
 }

--- a/packages/dreamux/src/server.ts
+++ b/packages/dreamux/src/server.ts
@@ -62,6 +62,7 @@ import {
 import {
   createLogger,
   loggerToLevelFn,
+  pinoToTransportLogger,
   type DreamuxLogger,
 } from './runtime/logger.js';
 import { createAdminSocketServer, type AdminSocketServer } from './admin/socket.js';
@@ -287,14 +288,21 @@ export class Server {
     const botSecret = this.opts.skipBotSecret
       ? ''
       : resolveBotSecret(row.bot_secret_ref, cfg);
+    // Build the per-dispatcher channel logger first so it can be injected into
+    // the bot/transport — the transport's own SDK / connection diagnostics then
+    // land in this same `logs/feishu-channel/<id>.log`, not on bare stderr.
+    const channelLog = this.channelLoggerFactory(id);
     const bot = this.opts.botFactory
       ? this.opts.botFactory(row, botSecret)
-      : createFeishuBot({ appId: row.bot_app_id, appSecret: botSecret });
+      : createFeishuBot({
+          appId: row.bot_app_id,
+          appSecret: botSecret,
+          logger: pinoToTransportLogger(channelLog),
+        });
     const channelState: DispatcherChannelState = {
       inboundReactions: new Map(),
       pendingReceivedReactionClears: new Set(),
     };
-    const channelLog = this.channelLoggerFactory(id);
 
     const runtime = new DispatcherRuntime(row, {
       dispatchers: this.repos.dispatchers,

--- a/packages/dreamux/tests/feishu-bot-logger.test.ts
+++ b/packages/dreamux/tests/feishu-bot-logger.test.ts
@@ -1,0 +1,59 @@
+/**
+ * #74 wiring test: `createFeishuBot` forwards an injected `logger` to the REAL
+ * `createFeishuTransport` call.
+ *
+ * The production path is `?? createFeishuTransport(...)`, not the `deps`
+ * test seam — so asserting through a `deps.createTransport` spy would not catch
+ * a regression that dropped the second argument from the real call. This mocks
+ * the transport module (keeping its other exports real) and asserts the real
+ * `createFeishuTransport` receives `(creds, { logger })`.
+ */
+
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  createFeishuTransport,
+  type FeishuTransport,
+  type TransportLogger,
+} from '@excitedjs/feishu-transport';
+
+import { createFeishuBot } from '../src/feishu/bot.js';
+
+vi.mock('@excitedjs/feishu-transport', async (importActual) => {
+  const actual =
+    await importActual<typeof import('@excitedjs/feishu-transport')>();
+  return {
+    ...actual,
+    createFeishuTransport: vi.fn(() => ({}) as FeishuTransport),
+  };
+});
+
+describe('createFeishuBot — logger forwarding (real transport path)', () => {
+  it('passes the injected logger through to createFeishuTransport', () => {
+    const logger: TransportLogger = {
+      error: vi.fn(),
+      warn: vi.fn(),
+      info: vi.fn(),
+      debug: vi.fn(),
+      trace: vi.fn(),
+    };
+
+    createFeishuBot({ appId: 'app', appSecret: 'secret', logger });
+
+    expect(createFeishuTransport).toHaveBeenCalledWith(
+      { appId: 'app', appSecret: 'secret' },
+      { logger },
+    );
+  });
+
+  it('still calls the transport (with logger undefined) when none is injected', () => {
+    vi.mocked(createFeishuTransport).mockClear();
+
+    createFeishuBot({ appId: 'app', appSecret: 'secret' });
+
+    expect(createFeishuTransport).toHaveBeenCalledWith(
+      { appId: 'app', appSecret: 'secret' },
+      { logger: undefined },
+    );
+  });
+});

--- a/packages/dreamux/tests/logger.test.ts
+++ b/packages/dreamux/tests/logger.test.ts
@@ -13,7 +13,11 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { Writable } from 'node:stream';
 
-import { createLogger, loggerToLevelFn } from '../src/runtime/logger.js';
+import {
+  createLogger,
+  loggerToLevelFn,
+  pinoToTransportLogger,
+} from '../src/runtime/logger.js';
 
 function captureSink(): { sink: Writable; text: () => string } {
   const chunks: string[] = [];
@@ -120,5 +124,46 @@ describe('logger factory', () => {
     expect(line['msg']).toBe('start failed');
     expect(line['level']).toBe(50);
     expect((line['err'] as { message: string }).message).toBe('boom');
+  });
+
+  it('adapts to the feishu-transport TransportLogger seam (#74)', () => {
+    const { sink, text } = captureSink();
+    const logger = createLogger({ destination: sink });
+    const transportLogger = pinoToTransportLogger(logger);
+
+    // The transport seam emits (message, fields?); pino takes (mergingObject,
+    // message). The adapter flips the order and supplies {} when no fields.
+    transportLogger.info('connection ready', { source: 'feishu-transport-connection' });
+    transportLogger.error('sdk failure', { source: 'feishu-sdk' });
+    transportLogger.warn('best-effort failure');
+
+    const lines = text()
+      .trim()
+      .split('\n')
+      .map((l) => JSON.parse(l) as Record<string, unknown>);
+    expect(lines[0]).toMatchObject({
+      msg: 'connection ready',
+      level: 30,
+      source: 'feishu-transport-connection',
+    });
+    expect(lines[1]).toMatchObject({
+      msg: 'sdk failure',
+      level: 50,
+      source: 'feishu-sdk',
+    });
+    expect(lines[2]).toMatchObject({ msg: 'best-effort failure', level: 40 });
+  });
+
+  it('redacts an app_secret a transport diagnostic field might carry', () => {
+    const { sink, text } = captureSink();
+    const logger = createLogger({ destination: sink });
+    const transportLogger = pinoToTransportLogger(logger);
+
+    // The transport never logs the secret, but the host's redact config is the
+    // backstop — assert it still censors an app_secret reaching the field path.
+    transportLogger.warn('diagnostic', { app_secret: 'fake-not-a-real-secret' });
+
+    expect(text()).not.toContain('fake-not-a-real-secret');
+    expect(text()).toContain('[REDACTED]');
   });
 });


### PR DESCRIPTION
## 背景

#74 是 #70 文件日志的 follow-up。`@excitedjs/feishu-transport` 包**自身**的诊断日志在 #70 被显式 defer：`sdkLogger`（`[feishu-sdk]` 行）和 `logConnection`（连接 reconnecting/reconnected/error/startup-timeout）以及若干 best-effort 失败诊断都是模块级单例，硬编码走 `console.error → stderr`。daemon 模式下它们落到 `daemon.stderr.log`，但未结构化、未按 dispatcher 拆分、不在 `feishu-channel/<id>.log` 里——而连接 reconnect/disconnect 正是诊断"消息为何未送达"的关键信号。

## 改动

给 `FeishuTransportOptions` 增加显式、加法式的 public `logger?` option：

- **包内自带最小 `TransportLogger` 接口**（`transport/diagnostics.ts`），不反向依赖 dreamux/pino。
- **实例级**：`createTransportDiagnostics(logger?)` 每个 transport 实例派生一套 SDK logger（同一个对象同时交给 `lark.Client` / `EventDispatcher` / `WSClient`）、连接 sink、best-effort `diagnostic()` sink；不再有可变全局，多 dispatcher 同进程不互相串日志。
- **默认逐字节兼容**：不传 logger 时保持现有 stderr 行为——`[feishu-sdk]` 前缀、`[feishu-transport] <ISO> <line>` 连接行、`[feishu-transport] <message>` 诊断行，全部走 `console.error`，且绝不写 stdout（保留 MCP JSON-RPC 通道）。
- **覆盖所有 transport-owned 诊断**：除 `sdkLogger`/`logConnection` 外，文档评论/元数据获取失败、关闭 WebSocket 失败、解析 bot open_id 失败也统一经同一 adapter（不再有同包日志分裂在 stderr）。

dreamux 注入路径：`Server` 先建 per-dispatcher `channelLog`，经 `pinoToTransportLogger` 适配后，`createFeishuBot({ …, logger }) → createFeishuTransport(creds, { logger })`，使连接/SDK 行进入 `logs/feishu-channel/<id>.log`。

**安全边界**：adapter 只转发 transport 自身的诊断 `source`/`err` 字段，绝不主动附加 `appSecret`、raw event、`rawContent`、parsedText、回复/卡片正文；既不扩大 secret/body 暴露，也不污染 stdout。

## 测试

- `diagnostics.test.ts`：默认逐字节（含 `console.log` 从不调用的 no-stdout 守卫）+ 注入路由 + sentinel secret/body 不外泄。
- `transport-logger.test.ts`：mock Lark SDK，证明 `Client`/`EventDispatcher`/`WSClient` 拿到**同一个**实例派生 SDK logger（引用相等），并验证 `onReady`/`onReconnecting`/`onReconnected`/`onError`/startup-timeout 都路由到注入 logger。
- `feishu-bot-logger.test.ts`：验证**真实分支**把 logger 转发给 `createFeishuTransport`（非 dep seam）。
- `logger.test.ts`：`pinoToTransportLogger` 适配 + redact 兜底。
- 全量回归：introduce / reaction / trust / gate / MCP stdout 行为不变（189 个 dreamux 测试全过）。

## Rush change

- `@excitedjs/feishu-transport` minor（新增 public option）。
- `@excitedjs/dreamux` patch（接线）。

KB：`decisions/logging.md` 的 defer 段落改为「由 #74 关闭」。

Closes #74

🤖 Generated with [Claude Code](https://claude.com/claude-code)


## 残留说明

- **验收项 4b（Server 把同一 per-dispatcher logger 注入 bot/transport）以构造 + 单测覆盖，未加 e2e 断言**：现有 e2e harness 走 `botFactory` 注入 fake bot，绕过真实 `createFeishuBot` 接线；要做 server 级 e2e 需另搭一套 mock `createFeishuBot` + fake-codex 的脚手架，成本与 flake 风险偏高。本 PR 通过①`server.ts` 把 `channelLog = channelLoggerFactory(id)` 提到 bot 之前并 `pinoToTransportLogger(channelLog)` 注入（3 行可读接线）、②`feishu-bot-logger.test.ts` 证明真实分支把 logger 转发给 `createFeishuTransport`、③`logger.test.ts` 证明 adapter 行为，三者组合覆盖该路径。
- **注入路径下 SDK `debug`/`trace` 行受 pino `info` 级别过滤**：默认 stderr 路径无级别过滤、逐字节不变；注入到 channel log 时这两档低于默认 `info` 会被滤掉，属合理的降噪而非对默认行为的回退（可经 `DREAMUX_LOG_LEVEL=debug` 放开）。
