### PR TITLE
feat(channel): 为未授权的群 /introduce 增加 channel 诊断日志 (#77)

### DIFF
--- a/.agents/domains/feishu-introduce.md
+++ b/.agents/domains/feishu-introduce.md
@@ -49,6 +49,23 @@ introduced are the message's other mentions; they are recorded as **trusted**
 for that chat and the `/introduce` message is consumed (never delivered to Codex
 as a turn).
 
+## Unauthorized-introduce diagnostic (issue #77)
+
+A `/introduce` whose sender is not authorized is **not** consumed: it falls
+through to `dreamuxFeishuGate` and is dropped like any other group message —
+most misleadingly as `bot not mentioned`, because the introduce path waives the
+mention requirement that the gate still enforces. To keep this one-glance
+diagnosable, `introduceDenyReason` (`channel/introduce.ts`) is the discriminated
+source of truth — `canRunIntroduce` is its boolean projection — returning a
+stable, grep-able code: `non_group`, `empty_sender_id`, `chat_not_allowlisted`,
+`sender_not_followed`. When `detectIntroduce` matches but the reason is
+non-null, `server.ts` emits one channel log `introduce detected but not
+authorized` carrying only `chat_id`/`sender_id`/`message_id`/`reason` (never the
+message body, mentioned peer open_ids, or mention names), then continues into
+the **unchanged** gate. This is observability only: gate decisions, trust
+writes, baseline arming, and authorized-introduce consume behavior are
+unchanged.
+
 ## Awareness vs trust
 
 `chat-bots.json` tracks two sets per chat that must never be conflated:

--- a/common/changes/@excitedjs/dreamux/introduce-unauthorized-diagnostic-2026-06-05.json
+++ b/common/changes/@excitedjs/dreamux/introduce-unauthorized-diagnostic-2026-06-05.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@excitedjs/dreamux",
+      "comment": "Log a distinct channel diagnostic ('introduce detected but not authorized') with a stable reason code (non_group / empty_sender_id / chat_not_allowlisted / sender_not_followed) when a group /introduce is detected but the sender is not authorized, instead of letting it surface as an ordinary gate drop (e.g. 'bot not mentioned'). Gate, trust, and /introduce semantics are unchanged (issue #77).",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@excitedjs/dreamux",
+  "email": "053700@gmail.com"
+}

--- a/packages/dreamux/src/channel/introduce.ts
+++ b/packages/dreamux/src/channel/introduce.ts
@@ -34,28 +34,53 @@ export interface IntroduceAuthInput {
 }
 
 /**
- * True when `senderId` may run `/introduce` in this chat.
+ * Stable, machine-grep-able reason an `/introduce` was not authorized. Each
+ * value maps one-to-one to a rejection point in `introduceDenyReason`; they are
+ * logged verbatim so an operator can tell "introduce blocked by allowlist" apart
+ * from an ordinary gate drop (issue #77). They carry no message content.
+ */
+export type IntroduceDenyReason =
+  | 'non_group'
+  | 'empty_sender_id'
+  | 'chat_not_allowlisted'
+  | 'sender_not_followed';
+
+/**
+ * The reason `senderId` may NOT run `/introduce` in this chat, or `null` when it
+ * is authorized. This is the single source of truth for the issue #62 hard
+ * contract; `canRunIntroduce` is the boolean projection of it.
  *
- * Sender-scoped, not group-scoped (the issue #62 hard contract): the chat must
- * be explicitly allowlisted AND the sender must be on the per-chat sender
- * allowlist. Empty allowlists do not authorize anyone — there is no "any member
- * of an allowlisted group" path.
+ * Sender-scoped, not group-scoped: the chat must be explicitly allowlisted AND
+ * the sender must be on the per-chat sender allowlist. Empty allowlists do not
+ * authorize anyone — there is no "any member of an allowlisted group" path.
+ */
+export function introduceDenyReason(
+  access: DispatcherAccessState,
+  input: IntroduceAuthInput,
+): IntroduceDenyReason | null {
+  if (input.chatType !== 'group') return 'non_group';
+  if (input.senderId === '') return 'empty_sender_id';
+  // The chat must be explicitly allowlisted. An empty allow_chats means "every
+  // chat" for normal delivery, but for a trust-changing command we require the
+  // chat to be named, so introduce never fires in an incidental group.
+  if (!access.group.allow_chats.includes(input.chatId)) return 'chat_not_allowlisted';
+  // The sender must be explicitly allowlisted. An empty follow_users authorizes
+  // nobody for introduce — this is the line that makes the rule sender-scoped
+  // rather than "any member of an allowlisted group".
+  if (!access.group.follow_users.includes(input.senderId)) return 'sender_not_followed';
+  return null;
+}
+
+/**
+ * True when `senderId` may run `/introduce` in this chat. Boolean projection of
+ * `introduceDenyReason`; kept as a named predicate so callers on the consume
+ * path read clearly and stay byte-identical to the pre-issue-#77 behavior.
  */
 export function canRunIntroduce(
   access: DispatcherAccessState,
   input: IntroduceAuthInput,
 ): boolean {
-  if (input.chatType !== 'group') return false;
-  if (input.senderId === '') return false;
-  // The chat must be explicitly allowlisted. An empty allow_chats means "every
-  // chat" for normal delivery, but for a trust-changing command we require the
-  // chat to be named, so introduce never fires in an incidental group.
-  if (!access.group.allow_chats.includes(input.chatId)) return false;
-  // The sender must be explicitly allowlisted. An empty follow_users authorizes
-  // nobody for introduce — this is the line that makes the rule sender-scoped
-  // rather than "any member of an allowlisted group".
-  if (!access.group.follow_users.includes(input.senderId)) return false;
-  return true;
+  return introduceDenyReason(access, input) === null;
 }
 
 /**

--- a/packages/dreamux/src/server.ts
+++ b/packages/dreamux/src/server.ts
@@ -29,8 +29,8 @@ import {
   saveDispatcherAccess,
 } from './channel/feishu-gate.js';
 import {
-  canRunIntroduce,
   detectIntroduce,
+  introduceDenyReason,
   introducedPeers,
 } from './channel/introduce.js';
 import {
@@ -344,25 +344,41 @@ export class Server {
               ...(event.senderName !== '' ? { name: event.senderName } : {}),
             });
           }
-          if (
-            detectIntroduce(event.messageType, event.rawContent, event.mentions) &&
-            canRunIntroduce(access, {
+          if (detectIntroduce(event.messageType, event.rawContent, event.mentions)) {
+            const denyReason = introduceDenyReason(access, {
               chatType: event.chatType,
               chatId: event.chatId,
               senderId: event.senderId,
-            })
-          ) {
-            const peers = introducedPeers(event.mentions, bot.botOpenId);
-            if (peers.length > 0) trustIntroducedBots(id, event.chatId, peers);
+            });
+            if (denyReason === null) {
+              const peers = introducedPeers(event.mentions, bot.botOpenId);
+              if (peers.length > 0) trustIntroducedBots(id, event.chatId, peers);
+              channelLog.info(
+                {
+                  chat_id: event.chatId,
+                  sender_id: event.senderId,
+                  trusted_peers: peers.length,
+                },
+                'introduce consumed',
+              );
+              return;
+            }
+            // Issue #77: a `/introduce` that the sender is not authorized to run
+            // would otherwise fall through and surface as an ordinary gate drop
+            // (e.g. `bot not mentioned`, because the introduce path deliberately
+            // waives the mention requirement that the gate enforces), hiding the
+            // real cause. Emit one diagnostic with the stable deny reason, then
+            // let the normal gate run unchanged — trust is not written and no
+            // baseline is armed on this path.
             channelLog.info(
               {
                 chat_id: event.chatId,
                 sender_id: event.senderId,
-                trusted_peers: peers.length,
+                message_id: event.messageId,
+                reason: denyReason,
               },
-              'introduce consumed',
+              'introduce detected but not authorized',
             );
-            return;
           }
 
           const gate = dreamuxFeishuGate({

--- a/packages/dreamux/tests/feishu-introduce.test.ts
+++ b/packages/dreamux/tests/feishu-introduce.test.ts
@@ -19,6 +19,7 @@ import {
 import {
   canRunIntroduce,
   detectIntroduce,
+  introduceDenyReason,
   introducedPeers,
 } from '../src/channel/introduce.js';
 import {
@@ -77,6 +78,67 @@ describe('canRunIntroduce — sender-scoped, not group-scoped', () => {
     expect(
       canRunIntroduce(access, { chatType: 'p2p', chatId: 'chat-a', senderId: 'user-a' }),
     ).toBe(false);
+  });
+});
+
+describe('introduceDenyReason — stable diagnostic codes (issue #77)', () => {
+  // canRunIntroduce is the boolean projection; every reason code maps 1:1 to a
+  // rejection point and is logged verbatim, so an operator can tell an
+  // introduce blocked by the allowlist apart from an ordinary gate drop.
+  it('returns null (authorized) for an allowlisted sender in an allowlisted chat', () => {
+    const access = state({ allow_chats: ['chat-a'], follow_users: ['user-a'] });
+    expect(
+      introduceDenyReason(access, { chatType: 'group', chatId: 'chat-a', senderId: 'user-a' }),
+    ).toBeNull();
+  });
+
+  it('reports non_group for a direct message', () => {
+    const access = state({ allow_chats: ['chat-a'], follow_users: ['user-a'] });
+    expect(
+      introduceDenyReason(access, { chatType: 'p2p', chatId: 'chat-a', senderId: 'user-a' }),
+    ).toBe('non_group');
+  });
+
+  it('reports empty_sender_id when the sender id is missing', () => {
+    const access = state({ allow_chats: ['chat-a'], follow_users: ['user-a'] });
+    expect(
+      introduceDenyReason(access, { chatType: 'group', chatId: 'chat-a', senderId: '' }),
+    ).toBe('empty_sender_id');
+  });
+
+  it('reports chat_not_allowlisted when the chat is not explicitly allowlisted', () => {
+    const access = state({ allow_chats: ['chat-a'], follow_users: ['user-a'] });
+    expect(
+      introduceDenyReason(access, { chatType: 'group', chatId: 'chat-other', senderId: 'user-a' }),
+    ).toBe('chat_not_allowlisted');
+  });
+
+  it('reports sender_not_followed when follow_users is empty (the misleading case)', () => {
+    const access = state({ allow_chats: ['chat-a'], follow_users: [] });
+    expect(
+      introduceDenyReason(access, { chatType: 'group', chatId: 'chat-a', senderId: 'anyone' }),
+    ).toBe('sender_not_followed');
+  });
+
+  it('reports sender_not_followed when follow_users is non-empty but excludes the sender', () => {
+    const access = state({ allow_chats: ['chat-a'], follow_users: ['user-a'] });
+    expect(
+      introduceDenyReason(access, { chatType: 'group', chatId: 'chat-a', senderId: 'user-x' }),
+    ).toBe('sender_not_followed');
+  });
+
+  it('stays consistent with canRunIntroduce across every branch', () => {
+    const access = state({ allow_chats: ['chat-a'], follow_users: ['user-a'] });
+    const inputs = [
+      { chatType: 'group', chatId: 'chat-a', senderId: 'user-a' },
+      { chatType: 'p2p', chatId: 'chat-a', senderId: 'user-a' },
+      { chatType: 'group', chatId: 'chat-a', senderId: '' },
+      { chatType: 'group', chatId: 'chat-other', senderId: 'user-a' },
+      { chatType: 'group', chatId: 'chat-a', senderId: 'user-x' },
+    ];
+    for (const input of inputs) {
+      expect(canRunIntroduce(access, input)).toBe(introduceDenyReason(access, input) === null);
+    }
   });
 });
 

--- a/packages/dreamux/tests/smoke.test.ts
+++ b/packages/dreamux/tests/smoke.test.ts
@@ -993,7 +993,13 @@ describe('dreamux MVP smoke', () => {
       warnings: [],
       last_gate: null,
     });
-    server = buildServer({ runtimeDir, fake, bot });
+    const channel = captureLogger('channel');
+    server = buildServer({
+      runtimeDir,
+      fake,
+      bot,
+      channelLoggerFactory: () => channel.logger,
+    });
     server.repos.dispatchers.create({
       dispatcher_id: 'flow',
       bot_app_id: 'app-smoke',
@@ -1015,6 +1021,229 @@ describe('dreamux MVP smoke', () => {
     expect(bot.reactions).toEqual([]);
     const entry = loadChatBots('flow').chats['chat-group-a'];
     expect(entry?.trusted ?? []).not.toContain('peer-bot-2');
+
+    // Issue #77: the unauthorized introduce is diagnosed before the gate runs,
+    // with the stable reason — not silently surfaced as the gate's eventual
+    // `bot not mentioned` drop.
+    const lines = channel.lines();
+    const diag = lines.find((l) => l['msg'] === 'introduce detected but not authorized');
+    expect(diag).toMatchObject({
+      chat_id: 'chat-group-a',
+      sender_id: 'stranger',
+      message_id: 'msg-introduce-stranger',
+      reason: 'sender_not_followed',
+    });
+    // The original gate behavior is unchanged: with a non-empty follow_users the
+    // sender still drops on the follow-user gate afterwards.
+    expect(
+      lines.some(
+        (l) =>
+          l['msg'] === 'feishu inbound dropped' &&
+          l['reason'] === 'sender not allowed by follow-user gate',
+      ),
+    ).toBe(true);
+    // No-leak: the diagnostic carries only ids/reason — never the message body,
+    // the mentioned peer's open_id, or the mention display name.
+    const text = channel.text();
+    expect(text).not.toContain('/introduce');
+    expect(text).not.toContain('peer-bot-2');
+    expect(text).not.toContain('Peer');
+  });
+
+  it('diagnoses an unauthorized /introduce when follow_users is empty (would surface as bot-not-mentioned)', async () => {
+    // The misleading case from issue #77: with follow_users empty the follow-user
+    // gate is skipped, so the eventual drop reason is the require_mention
+    // `bot not mentioned` — which looks like the user simply forgot to @ the bot.
+    saveDispatcherAccess('flow', {
+      version: 1,
+      dm: { allow_users: [] },
+      group: {
+        allow_chats: ['chat-group-a'],
+        follow_users: [],
+        require_mention: true,
+      },
+      observed_chats: [],
+      warnings: [],
+      last_gate: null,
+    });
+    const channel = captureLogger('channel');
+    server = buildServer({
+      runtimeDir,
+      fake,
+      bot,
+      channelLoggerFactory: () => channel.logger,
+    });
+    server.repos.dispatchers.create({
+      dispatcher_id: 'flow',
+      bot_app_id: 'app-smoke',
+      bot_secret_ref: 'env:UNUSED',
+    });
+    await server.start();
+
+    await bot.inject(
+      fakeInbound('chat-group-a', '/introduce', 'msg-introduce-empty-follow', {
+        senderId: 'sender-test',
+        mentions: [{ key: '@_user_9', id: { open_id: 'peer-bot-3' }, name: 'Peer' }],
+      }),
+    );
+
+    await sleep(60);
+    expect(fake.turnsHandled).toBe(0);
+    expect(bot.reactions).toEqual([]);
+    expect(loadChatBots('flow').chats['chat-group-a']?.trusted ?? []).not.toContain('peer-bot-3');
+
+    const lines = channel.lines();
+    expect(lines.find((l) => l['msg'] === 'introduce detected but not authorized')).toMatchObject({
+      chat_id: 'chat-group-a',
+      sender_id: 'sender-test',
+      message_id: 'msg-introduce-empty-follow',
+      reason: 'sender_not_followed',
+    });
+    // Same gate drop as before the diagnostic existed.
+    expect(
+      lines.some(
+        (l) => l['msg'] === 'feishu inbound dropped' && l['reason'] === 'bot not mentioned',
+      ),
+    ).toBe(true);
+  });
+
+  it('diagnoses an unauthorized /introduce when the chat is not allowlisted', async () => {
+    saveDispatcherAccess('flow', {
+      version: 1,
+      dm: { allow_users: [] },
+      group: {
+        allow_chats: ['chat-group-other'],
+        follow_users: ['sender-test'],
+        require_mention: true,
+      },
+      observed_chats: [],
+      warnings: [],
+      last_gate: null,
+    });
+    const channel = captureLogger('channel');
+    server = buildServer({
+      runtimeDir,
+      fake,
+      bot,
+      channelLoggerFactory: () => channel.logger,
+    });
+    server.repos.dispatchers.create({
+      dispatcher_id: 'flow',
+      bot_app_id: 'app-smoke',
+      bot_secret_ref: 'env:UNUSED',
+    });
+    await server.start();
+
+    await bot.inject(
+      fakeInbound('chat-group-a', '/introduce', 'msg-introduce-other-chat', {
+        senderId: 'sender-test',
+        mentions: [{ key: '@_user_9', id: { open_id: 'peer-bot-4' }, name: 'Peer' }],
+      }),
+    );
+
+    await sleep(60);
+    expect(fake.turnsHandled).toBe(0);
+    expect(loadChatBots('flow').chats['chat-group-a']?.trusted ?? []).not.toContain('peer-bot-4');
+
+    expect(
+      channel.lines().find((l) => l['msg'] === 'introduce detected but not authorized'),
+    ).toMatchObject({
+      chat_id: 'chat-group-a',
+      sender_id: 'sender-test',
+      message_id: 'msg-introduce-other-chat',
+      reason: 'chat_not_allowlisted',
+    });
+  });
+
+  it('diagnoses an unauthorized /introduce sent as a direct message (non_group)', async () => {
+    saveDispatcherAccess('flow', {
+      version: 1,
+      dm: { allow_users: ['sender-test'] },
+      group: {
+        allow_chats: ['chat-group-a'],
+        follow_users: ['sender-test'],
+        require_mention: true,
+      },
+      observed_chats: [],
+      warnings: [],
+      last_gate: null,
+    });
+    const channel = captureLogger('channel');
+    server = buildServer({
+      runtimeDir,
+      fake,
+      bot,
+      channelLoggerFactory: () => channel.logger,
+    });
+    server.repos.dispatchers.create({
+      dispatcher_id: 'flow',
+      bot_app_id: 'app-smoke',
+      bot_secret_ref: 'env:UNUSED',
+    });
+    await server.start();
+
+    await bot.inject(
+      fakeInbound('chat-dm', '/introduce', 'msg-introduce-dm', {
+        chatType: 'p2p',
+        senderId: 'sender-test',
+        mentions: [],
+      }),
+    );
+
+    await waitFor(() => fake.turnsHandled === 1);
+    // Diagnosed as non_group, then delivered normally as an ordinary DM — the
+    // introduce trust path never fires outside a group.
+    expect(
+      channel.lines().find((l) => l['msg'] === 'introduce detected but not authorized'),
+    ).toMatchObject({
+      chat_id: 'chat-dm',
+      sender_id: 'sender-test',
+      message_id: 'msg-introduce-dm',
+      reason: 'non_group',
+    });
+  });
+
+  it('an authorized /introduce is consumed without emitting the unauthorized diagnostic', async () => {
+    saveDispatcherAccess('flow', {
+      version: 1,
+      dm: { allow_users: [] },
+      group: {
+        allow_chats: ['chat-group-a'],
+        follow_users: ['sender-test'],
+        require_mention: true,
+      },
+      observed_chats: [],
+      warnings: [],
+      last_gate: null,
+    });
+    const channel = captureLogger('channel');
+    server = buildServer({
+      runtimeDir,
+      fake,
+      bot,
+      channelLoggerFactory: () => channel.logger,
+    });
+    server.repos.dispatchers.create({
+      dispatcher_id: 'flow',
+      bot_app_id: 'app-smoke',
+      bot_secret_ref: 'env:UNUSED',
+    });
+    await server.start();
+
+    await bot.inject(
+      fakeInbound('chat-group-a', '/introduce', 'msg-introduce-ok', {
+        senderId: 'sender-test',
+        mentions: [{ key: '@_user_9', id: { open_id: 'peer-bot-5' }, name: 'Peer Bot' }],
+      }),
+    );
+
+    await sleep(60);
+    // Consumed: trust written, no enqueue, and crucially no unauthorized diagnostic.
+    expect(fake.turnsHandled).toBe(0);
+    expect(loadChatBots('flow').chats['chat-group-a']?.trusted).toEqual(['peer-bot-5']);
+    const lines = channel.lines();
+    expect(lines.some((l) => l['msg'] === 'introduce consumed')).toBe(true);
+    expect(lines.some((l) => l['msg'] === 'introduce detected but not authorized')).toBe(false);
   });
 
   it('records a trust-domain warning when one dispatcher receives multiple chats', async () => {


### PR DESCRIPTION
## 背景

群里一条 `/introduce`,当发送者无权运行(issue #62 硬约定:chat 须显式在 `allow_chats`、sender 须显式在 `follow_users`)时,此前不会被消费,而是直接落到投递 gate,表现成普通 drop。最具误导性的情形是 reason 浮现成 `bot not mentioned`——因为 introduce 路径故意豁免了 gate 仍在强制的 @ 要求。排查者会误判为"用户没 @ bot",而真实原因是 introduce 被 allowlist / `follow_users` 配置拦截,在日志里完全不可见。

运行态把配置修好后功能本就是通的。本 PR 只补可观测性,不改任何 gate / trust / `/introduce` 语义。

## 改动

- 新增 `introduceDenyReason()`(`packages/dreamux/src/channel/introduce.ts`):作为 issue #62 硬约定的判别式唯一事实来源,返回稳定、可机器检索的 reason code:`non_group` / `empty_sender_id` / `chat_not_allowlisted` / `sender_not_followed`。`canRunIntroduce()` 改为它的 boolean 投影,语义等价、调用点行为不变。
- `packages/dreamux/src/server.ts`:当 `detectIntroduce()` 命中但 `introduceDenyReason()` 非 null 时,打一条 channel 日志 `introduce detected but not authorized`,**随后继续走原 gate(不 early-return)**。授权路径仍照旧 `introduce consumed` 并 `return`。
- 日志字段最小化:仅 `chat_id` / `sender_id` / `message_id` / `reason`;绝不记录消息正文、被 @ 的 peer open_id、mention 显示名、allowlist 内容或任何 secret。
- 更新 `.agents/domains/feishu-introduce.md` 记录该诊断与 reason code。

## 不变量(逐字节不变)

gate 的 drop/deliver 决策、trust 写入、baseline arming、已授权 `/introduce` 的 consume 行为均未改动——这是纯可观测性增强。

## 测试

- **单元**(`tests/feishu-introduce.test.ts`):`introduceDenyReason` 覆盖每个 reason code(含 `non_group`、`empty_sender_id` 边界、`sender_not_followed` 空/非空两形态),并断言与 `canRunIntroduce` 跨所有分支一致。
- **集成**(`tests/smoke.test.ts`):用捕获的 channel logger 跑完整 server,覆盖 `sender_not_followed`(`follow_users` 为空与非空)、`chat_not_allowlisted`、`non_group`,以及一条已授权 consume 回归。每条断言:诊断日志被打出且 reason 正确、无 Codex enqueue、无 trust 写入、原 gate drop reason 不变;外加 no-leak 断言(日志文本不含 `/introduce` 正文、peer open_id、mention 名)。
- 全量 `vitest run`:197 passed / 1 skipped,`rush build`(含 tsc 类型检查)通过。

Closes #77
