### PR TITLE
fix(feishu): follow-user 群准入收敛到全局 allow_users 列表 (#79)

### DIFF
--- a/.agents/decisions/top-level-design.md
+++ b/.agents/decisions/top-level-design.md
@@ -174,17 +174,15 @@ time, admin socket path, and last error.
 child process status, and diagnostic timestamps. It must not contain Feishu
 credentials.
 
-`access.json` stores dispatcher-local access state. The MVP shape is:
+`access.json` stores dispatcher-local access state. The shape is:
 
 ```json
 {
-  "version": 1,
-  "dm": {
-    "allow_users": ["USER_ID"]
-  },
+  "version": 2,
+  "allow_users": ["USER_ID"],
   "group": {
+    "policy": "follow-user",
     "allow_chats": ["CHAT_ID"],
-    "follow_users": ["USER_ID"],
     "require_mention": true
   },
   "observed_chats": ["CHAT_ID"],
@@ -194,6 +192,27 @@ credentials.
   "last_gate": null
 }
 ```
+
+`allow_users` is a single global allowlist of sender open_ids, shared by direct
+messages and the group `follow-user` policy — the dreamux equivalent of the
+transport gate's top-level `allowFrom`. An empty list authorizes nobody. There
+is no separate per-group sender list.
+
+`group.policy` is one of `block`, `allowlist`, or `follow-user`:
+
+- `block` — every group message is dropped.
+- `allowlist` — the *group* is the unit of trust: a chat must be in
+  `allow_chats`, and any member there may speak (subject to `require_mention`).
+- `follow-user` — the *sender* is the unit of trust: the group needs no
+  authorization (`allow_chats` is ignored), a message is always mention-gated,
+  and the sender must be on the global `allow_users` list.
+
+The legacy v1 shape (`dm.allow_users` + a separate `group.follow_users`) is read
+and migrated forward by `readDispatcherAccess`: the two legacy sender lists are
+merged into `allow_users`, the policy is inferred (a non-empty `follow_users` →
+`follow-user`, else a non-empty `allow_chats` → `allowlist`, else the default
+`follow-user`), and the first save rewrites the file to the v2 shape. The legacy
+fields are never written back.
 
 It must not contain credentials, queued inbound messages, dedupe state, or a
 reaction ledger.
@@ -302,19 +321,30 @@ enter the Codex thread.
 
 ## Access Gate
 
-The access gate is dispatcher-local.
+The access gate is dispatcher-local. The runtime gate is `dreamuxFeishuGate`
+(`packages/dreamux/src/channel/feishu-gate.ts`); the transport `gate()` is the
+claudemux-ported reference and is not on the dreamux delivery path.
 
-For one-on-one chats, the sender must be allowed.
+For one-on-one chats, the sender must be on the global `allow_users` list.
 
-For group chats, the MVP follows the claudemux Feishu channel shape:
+For group chats, behavior follows `group.policy` (see the access.json shape
+above):
 
-- the chat must be allowed when a chat allowlist is configured;
-- the sender must be allowed when a follow-user allowlist is configured;
-- the bot must be mentioned for a group message to enter the dispatcher.
+- under `follow-user`, a message is delivered when the bot is @-mentioned and
+  the sender is on the global `allow_users` list — in *any* group, with no chat
+  allowlist required. This is the same list that authorizes direct messages.
+- under `allowlist`, the chat must be in `allow_chats`; any member there may
+  speak, gated by `require_mention`.
+- under `block`, every group message is dropped.
 
-When no group chat allowlist or follow-user allowlist is configured, group
-messages are still mention-gated. This keeps bootstrap usable while preventing
-ambient group chatter from entering the dispatcher.
+An empty `allow_users` authorizes nobody — consistent with direct messages.
+There is no "any member of a group" path: bootstrap is done by onboarding a
+sender onto `allow_users`, not by leaving the list empty.
+
+`/introduce` is a trust-changing command and is gated more tightly than
+delivery: regardless of policy it requires the chat to be named in `allow_chats`
+**and** the sender to be on the global `allow_users` list. Peer-bot trust is
+per-chat (`chat-bots.json`) and is never reached through `allow_users`.
 
 The gate adds a channel-owned received reaction only after a message is accepted
 and enqueued. If the message is rejected, no reaction is added.

--- a/.agents/domains/feishu-introduce.md
+++ b/.agents/domains/feishu-introduce.md
@@ -35,8 +35,9 @@ the allowlist**. No `@`-mention of our bot is required, and the group's
 
 The authorization is sender-scoped, not group-scoped. `canRunIntroduce`
 (`channel/introduce.ts`) requires the chat to be explicitly in
-`group.allow_chats` **and** the sender to be explicitly in `group.follow_users`.
-An empty `follow_users` authorizes nobody — "any member of an allowlisted group"
+`group.allow_chats` **and** the sender to be on the global `allow_users` list
+(the same list that gates direct messages and `follow-user` group delivery).
+An empty `allow_users` authorizes nobody — "any member of an allowlisted group"
 is deliberately **not** a path, and `canRunIntroduce` never reuses a broad
 group-authorization predicate that would trust the group without checking the
 sender's identity. A bot sender is never on the human allowlist, so ambient

--- a/common/changes/@excitedjs/dreamux/fix-follow-user-global-allowlist-2026-06-05.json
+++ b/common/changes/@excitedjs/dreamux/fix-follow-user-global-allowlist-2026-06-05.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@excitedjs/dreamux",
+      "comment": "Fix the follow-user group-access semantics: the dispatcher runtime gate (dreamuxFeishuGate) now gates group delivery on a single global allow-user list shared with direct messages, instead of a separate group.follow_users list, so a sender on the global allowlist who @-mentions the bot is delivered in any group (issue #79). The access.json shape is unified to v2: a top-level allow_users list plus an explicit group.policy (block | allowlist | follow-user); v1 files are migrated forward by readDispatcherAccess (legacy dm.allow_users and group.follow_users are merged and de-duplicated, the policy is inferred, and the first save rewrites the file). An empty allow_users now authorizes nobody, consistent with direct messages. /introduce sender authorization moves to the global allow_users list while still requiring the chat to be named in allow_chats.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@excitedjs/dreamux",
+  "email": "053700@gmail.com"
+}

--- a/packages/dreamux/src/channel/feishu-gate.ts
+++ b/packages/dreamux/src/channel/feishu-gate.ts
@@ -17,14 +17,40 @@ import { dispatcherAccessPath } from '../runtime/paths.js';
 export const TRUST_DOMAIN_WARNING =
   'dispatcher shares one Codex context across multiple Feishu chats';
 
+/**
+ * Group-access mode — which trust model gates group messages.
+ *
+ *  - `block`       — every group message is dropped.
+ *  - `allowlist`   — the *group* is the unit of trust: a chat must be in
+ *                    `group.allow_chats`, and any member there may speak
+ *                    (subject to `group.require_mention`).
+ *  - `follow-user` — the *sender* is the unit of trust: the group needs no
+ *                    authorization (`allow_chats` is ignored), a message is
+ *                    always mention-gated, and the sender's open_id must be on
+ *                    the top-level `allow_users` list — the same list that
+ *                    authorizes direct messages.
+ */
+export type GroupPolicy = 'block' | 'allowlist' | 'follow-user';
+
 export interface DispatcherAccessState {
-  version: 1;
-  dm: {
-    allow_users: string[];
-  };
+  /**
+   * Schema version. `1` was the legacy two-list shape (`dm.allow_users` +
+   * `group.follow_users`); `2` unifies them into the top-level `allow_users`
+   * and adds the explicit `group.policy`. `readDispatcherAccess` migrates a v1
+   * file forward by field presence; the marker just records that the rewrite
+   * happened.
+   */
+  version: 2;
+  /**
+   * The single global allowlist of sender open_ids, shared by direct messages
+   * and the group `follow-user` policy (the dreamux equivalent of the transport
+   * gate's top-level `allowFrom`). An empty list authorizes nobody.
+   */
+  allow_users: string[];
   group: {
+    policy: GroupPolicy;
+    /** Authorized chat_ids — consulted only under the `allowlist` policy. */
     allow_chats: string[];
-    follow_users: string[];
     require_mention: boolean;
   };
   observed_chats: string[];
@@ -74,13 +100,11 @@ export type DreamuxFeishuGateResult =
 
 export function defaultDispatcherAccessState(): DispatcherAccessState {
   return {
-    version: 1,
-    dm: {
-      allow_users: [],
-    },
+    version: 2,
+    allow_users: [],
     group: {
+      policy: 'follow-user',
       allow_chats: [],
-      follow_users: [],
       require_mention: true,
     },
     observed_chats: [],
@@ -133,7 +157,7 @@ export function dreamuxFeishuGate(
 
   if (input.chatType === 'p2p') {
     if (senderIsBot) return drop(`bot sender type: ${input.senderType}`);
-    if (!access.dm.allow_users.includes(input.senderId)) {
+    if (!access.allow_users.includes(input.senderId)) {
       return drop('direct sender not allowed');
     }
     return deliver(access, input, now);
@@ -143,25 +167,48 @@ export function dreamuxFeishuGate(
     return drop(`unsupported chat type: ${input.chatType}`);
   }
 
-  if (access.group.allow_chats.length > 0 &&
-    !access.group.allow_chats.includes(input.chatId)) {
+  const policy = access.group.policy;
+  if (policy === 'block') {
+    return drop('group messages are blocked (group policy: block)');
+  }
+
+  // Under `allowlist` the group is the unit of trust: the chat must be named.
+  // Under `follow-user` the chat allowlist is intentionally ignored — the group
+  // needs no authorization, only the sender does.
+  if (policy === 'allowlist' && !access.group.allow_chats.includes(input.chatId)) {
     return drop('group chat not allowed');
   }
 
   if (senderIsBot) {
     // A peer bot speaks only if it was introduced (trusted) for this chat by an
     // allowlisted `/introduce`. Trusted bots bypass the mention gate because a
-    // bot cannot @-mention us; untrusted bots are dropped as before.
+    // bot cannot @-mention us; untrusted bots are dropped as before. This is
+    // per-chat trust (`trustedBotIds` is scoped to this chat by the caller) and
+    // is never reached through the human `allow_users` list.
     if (input.trustedBotIds?.has(input.senderId) ?? false) {
       return deliver(access, input, now);
     }
     return drop(`bot sender type: ${input.senderType}`);
   }
 
-  if (access.group.follow_users.length > 0 &&
-    !access.group.follow_users.includes(input.senderId)) {
-    return drop('sender not allowed by follow-user gate');
+  if (policy === 'follow-user') {
+    // A deliberate @-mention is always required — without it the bot would
+    // react to every message in the group. The flag `group.require_mention`
+    // governs only the `allowlist` policy.
+    if (input.botOpenId === undefined) {
+      return drop('group message requires a bot mention but bot open_id is unknown');
+    }
+    if (!isBotMentioned(input.mentions, input.botOpenId)) {
+      return drop('bot not mentioned');
+    }
+    if (!access.allow_users.includes(input.senderId)) {
+      return drop('sender not on allowlist');
+    }
+    return deliver(access, input, now);
   }
+
+  // policy === 'allowlist': the chat is already authorized above; any member
+  // may speak, subject to the configurable mention gate.
   if (access.group.require_mention) {
     if (input.botOpenId === undefined) {
       return drop('group message requires a bot mention but bot open_id is unknown');
@@ -235,24 +282,45 @@ function readDispatcherAccess(
   const group = isRecord(raw['group']) ? raw['group'] : {};
   const lastGate = raw['last_gate'];
 
+  // v2 unifies three possible sources of allowed senders into one list:
+  //   - top-level `allow_users` (v2),
+  //   - legacy `dm.allow_users` (v1 direct allowlist),
+  //   - legacy `group.follow_users` (v1 group sender allowlist).
+  // They are merged and de-duplicated; the legacy fields are read but never
+  // written back, so the first save collapses the file to the v2 shape. The
+  // union means DM access becomes `dm.allow_users ∪ group.follow_users` — for
+  // the common case (the two were equal, or dm ⊇ follow) DM is unchanged.
+  const topAllow = readStringArray(raw, 'allow_users', [], path);
+  const legacyDmAllow = readStringArray(dm, 'allow_users', [], path);
+  const legacyFollow = readStringArray(group, 'follow_users', [], path);
+  const allowUsers = [...new Set([...topAllow, ...legacyDmAllow, ...legacyFollow])];
+  const allowChats = readStringArray(
+    group,
+    'allow_chats',
+    defaults.group.allow_chats,
+    path,
+  );
+
+  // Group policy: an explicit value always wins. Otherwise infer from the
+  // legacy shape — a non-empty `follow_users` is the strongest signal the
+  // operator wanted sender-scoped gating, so preserve it as `follow-user`
+  // (never silently relax it to chat-only `allowlist`); then a non-empty
+  // `allow_chats` means chat-scoped gating; else the secure default.
+  const explicitPolicy = readGroupPolicy(group['policy'], path);
+  const policy: GroupPolicy =
+    explicitPolicy ??
+    (legacyFollow.length > 0
+      ? 'follow-user'
+      : allowChats.length > 0
+        ? 'allowlist'
+        : defaults.group.policy);
+
   return {
-    version: 1,
-    dm: {
-      allow_users: readStringArray(dm, 'allow_users', defaults.dm.allow_users, path),
-    },
+    version: 2,
+    allow_users: allowUsers,
     group: {
-      allow_chats: readStringArray(
-        group,
-        'allow_chats',
-        defaults.group.allow_chats,
-        path,
-      ),
-      follow_users: readStringArray(
-        group,
-        'follow_users',
-        defaults.group.follow_users,
-        path,
-      ),
+      policy,
+      allow_chats: allowChats,
       require_mention: readBoolean(
         group,
         'require_mention',
@@ -271,6 +339,19 @@ function readDispatcherAccess(
       ? null
       : readGateDiagnostic(lastGate, path),
   };
+}
+
+function readGroupPolicy(
+  value: unknown,
+  path: string,
+): GroupPolicy | undefined {
+  if (value === undefined) return undefined;
+  if (value !== 'block' && value !== 'allowlist' && value !== 'follow-user') {
+    throw new Error(
+      `dispatcher access error in ${path}: group.policy must be block, allowlist, or follow-user`,
+    );
+  }
+  return value;
 }
 
 function readGateDiagnostic(raw: unknown, path: string): GateDiagnostic {

--- a/packages/dreamux/src/channel/introduce.ts
+++ b/packages/dreamux/src/channel/introduce.ts
@@ -51,7 +51,8 @@ export type IntroduceDenyReason =
  * contract; `canRunIntroduce` is the boolean projection of it.
  *
  * Sender-scoped, not group-scoped: the chat must be explicitly allowlisted AND
- * the sender must be on the per-chat sender allowlist. Empty allowlists do not
+ * the sender must be on the global `allow_users` list (the same list that gates
+ * direct messages and `follow-user` group delivery). Empty allowlists do not
  * authorize anyone — there is no "any member of an allowlisted group" path.
  */
 export function introduceDenyReason(
@@ -60,14 +61,18 @@ export function introduceDenyReason(
 ): IntroduceDenyReason | null {
   if (input.chatType !== 'group') return 'non_group';
   if (input.senderId === '') return 'empty_sender_id';
-  // The chat must be explicitly allowlisted. An empty allow_chats means "every
-  // chat" for normal delivery, but for a trust-changing command we require the
-  // chat to be named, so introduce never fires in an incidental group.
+  // The chat must be explicitly allowlisted. Under the `follow-user` policy an
+  // empty `allow_chats` means "every chat" for normal delivery, but a
+  // trust-changing command always requires the chat to be named, so introduce
+  // never fires in an incidental group regardless of the group policy.
   if (!access.group.allow_chats.includes(input.chatId)) return 'chat_not_allowlisted';
-  // The sender must be explicitly allowlisted. An empty follow_users authorizes
-  // nobody for introduce — this is the line that makes the rule sender-scoped
-  // rather than "any member of an allowlisted group".
-  if (!access.group.follow_users.includes(input.senderId)) return 'sender_not_followed';
+  // The sender must be on the global allow-user list — the same list that gates
+  // direct messages and `follow-user` group delivery. An empty list authorizes
+  // nobody, keeping the rule sender-scoped rather than "any member of an
+  // allowlisted group". The `sender_not_followed` code name predates the
+  // single-list unification (issue #79) but still reads correctly: the sender
+  // is not a followed/allow-listed user.
+  if (!access.allow_users.includes(input.senderId)) return 'sender_not_followed';
   return null;
 }
 

--- a/packages/dreamux/tests/codex-live.test.ts
+++ b/packages/dreamux/tests/codex-live.test.ts
@@ -45,6 +45,7 @@ import {
   type FakeFeishuBot,
   type FeishuInboundEvent,
 } from '../src/feishu/bot.js';
+import { saveDispatcherAccess } from '../src/channel/feishu-gate.js';
 import { BUILT_IN_DEFAULTS, type DreamuxConfig } from '../src/runtime/config.js';
 import type {
   ServerNotification,
@@ -442,6 +443,17 @@ describe('codex live integration', () => {
 
       process.env['HOME'] = runtimeHome;
       process.env['CODEX_HOME'] = previousCodexHome ?? join(operatorHome, '.codex');
+      // Onboard the live sender onto the global allow-user list so the folded
+      // group messages are delivered (empty `allow_users` authorizes nobody
+      // under the follow-user gate).
+      saveDispatcherAccess('live', {
+        version: 2,
+        allow_users: ['sender-live'],
+        group: { policy: 'follow-user', allow_chats: [], require_mention: true },
+        observed_chats: [],
+        warnings: [],
+        last_gate: null,
+      });
 
       try {
         server = new Server({

--- a/packages/dreamux/tests/e2e.test.ts
+++ b/packages/dreamux/tests/e2e.test.ts
@@ -15,7 +15,10 @@ import {
   Server,
 } from '../src/server.js';
 import { sendAdminRequest } from '../src/admin/client.js';
-import { loadDispatcherAccess } from '../src/channel/feishu-gate.js';
+import {
+  loadDispatcherAccess,
+  saveDispatcherAccess,
+} from '../src/channel/feishu-gate.js';
 import { CodexWsClient } from '../src/codex/rpc.js';
 import {
   CodexProcess,
@@ -240,6 +243,17 @@ describe('dreamux cross-module e2e', () => {
     previousHome = process.env['HOME'];
     process.env['HOME'] = join(runtimeDir, 'home');
     writeReadyDispatcherWorkspace('flow');
+    // Onboard the canonical sender onto the global allow-user list so a
+    // mentioned group message is delivered (empty `allow_users` authorizes
+    // nobody under the follow-user gate).
+    saveDispatcherAccess('flow', {
+      version: 2,
+      allow_users: ['sender-test'],
+      group: { policy: 'follow-user', allow_chats: [], require_mention: true },
+      observed_chats: [],
+      warnings: [],
+      last_gate: null,
+    });
     codexInputs = [];
     fake = await startFakeCodex({
       replyFor: captureCodexInputs(codexInputs),

--- a/packages/dreamux/tests/feishu-gate.test.ts
+++ b/packages/dreamux/tests/feishu-gate.test.ts
@@ -1,13 +1,15 @@
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import {
   existsSync,
+  mkdirSync,
   mkdtempSync,
   readFileSync,
   rmSync,
   statSync,
+  writeFileSync,
 } from 'node:fs';
-import { homedir, tmpdir } from 'node:os';
-import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
 
 import {
   TRUST_DOMAIN_WARNING,
@@ -20,10 +22,8 @@ import {
 import { dispatcherAccessPath, resetRuntimeConfig } from '../src/runtime/paths.js';
 
 describe('dreamuxFeishuGate', () => {
-  it('delivers direct messages only from allowed senders', () => {
-    const access = state({
-      dm: { allow_users: ['sender-allowed'] },
-    });
+  it('delivers direct messages only from senders on the global allow-user list', () => {
+    const access = state({ allow_users: ['sender-allowed'] });
 
     expect(gate({ chatType: 'p2p', senderId: 'sender-allowed' }, access))
       .toMatchObject({ action: 'deliver' });
@@ -35,7 +35,7 @@ describe('dreamuxFeishuGate', () => {
   });
 
   it('drops self-sent, bot-sender, and missing-sender messages', () => {
-    const access = state();
+    const access = state({ allow_users: ['sender-allowed'] });
 
     expect(gate({ senderId: '' }, access)).toMatchObject({
       action: 'drop',
@@ -52,56 +52,151 @@ describe('dreamuxFeishuGate', () => {
       });
   });
 
-  it('requires a bot mention before group delivery', () => {
-    const access = state();
-
-    expect(gate({}, access)).toMatchObject({ action: 'deliver' });
-    expect(gate({ mentions: [] }, access)).toMatchObject({
-      action: 'drop',
-      reason: 'bot not mentioned',
+  describe('follow-user policy — the global allow-user list gates every group', () => {
+    const access = state({
+      allow_users: ['sender-allowed'],
+      group: { policy: 'follow-user', allow_chats: [], require_mention: true },
     });
-    expect(gate({ botOpenId: undefined }, access)).toMatchObject({
-      action: 'drop',
-      reason: 'group message requires a bot mention but bot open_id is unknown',
+
+    it('delivers a global allow-user who @-mentions the bot in any group', () => {
+      expect(gate({ chatId: 'chat-group-a' }, access)).toMatchObject({
+        action: 'deliver',
+      });
+      // A different group the operator never configured — still delivered.
+      expect(gate({ chatId: 'chat-group-z' }, access)).toMatchObject({
+        action: 'deliver',
+      });
+    });
+
+    it('ignores a configured chat allowlist under follow-user', () => {
+      // allow_chats names only chat-group-a, but follow-user does not gate on
+      // the chat: an allow-user is delivered in an unlisted chat all the same.
+      const scoped = state({
+        allow_users: ['sender-allowed'],
+        group: {
+          policy: 'follow-user',
+          allow_chats: ['chat-group-a'],
+          require_mention: true,
+        },
+      });
+      expect(gate({ chatId: 'chat-group-z' }, scoped)).toMatchObject({
+        action: 'deliver',
+      });
+    });
+
+    it('drops a sender who is not on the global allow-user list', () => {
+      expect(gate({ senderId: 'sender-other' }, access)).toMatchObject({
+        action: 'drop',
+        reason: 'sender not on allowlist',
+      });
+    });
+
+    it('always requires an @-mention, regardless of require_mention', () => {
+      expect(gate({ mentions: [] }, access)).toMatchObject({
+        action: 'drop',
+        reason: 'bot not mentioned',
+      });
+      const noMentionFlag = state({
+        allow_users: ['sender-allowed'],
+        group: {
+          policy: 'follow-user',
+          allow_chats: [],
+          require_mention: false,
+        },
+      });
+      expect(gate({ mentions: [] }, noMentionFlag)).toMatchObject({
+        action: 'drop',
+        reason: 'bot not mentioned',
+      });
+    });
+
+    it('drops when the bot open_id is unknown', () => {
+      expect(gate({ botOpenId: undefined }, access)).toMatchObject({
+        action: 'drop',
+        reason: 'group message requires a bot mention but bot open_id is unknown',
+      });
     });
   });
 
-  it('enforces configured group chat allowlists', () => {
+  describe('allowlist policy — the chat is the unit of trust', () => {
     const access = state({
-      group: {
-        ...defaultDispatcherAccessState().group,
-        allow_chats: ['chat-group-a'],
-      },
+      // No global allow-user: allowlist mode trusts the group, not the sender.
+      group: { policy: 'allowlist', allow_chats: ['chat-group-a'], require_mention: true },
     });
 
-    expect(gate({ chatId: 'chat-group-a' }, access)).toMatchObject({
-      action: 'deliver',
+    it('delivers any member of an authorized chat once the bot is mentioned', () => {
+      expect(gate({ chatId: 'chat-group-a', senderId: 'anyone' }, access))
+        .toMatchObject({ action: 'deliver' });
     });
-    expect(gate({ chatId: 'chat-group-b' }, access)).toMatchObject({
-      action: 'drop',
-      reason: 'group chat not allowed',
+
+    it('drops a chat that is not on the allowlist', () => {
+      expect(gate({ chatId: 'chat-group-b' }, access)).toMatchObject({
+        action: 'drop',
+        reason: 'group chat not allowed',
+      });
+    });
+
+    it('honors require_mention in allowlist mode', () => {
+      expect(gate({ chatId: 'chat-group-a', mentions: [] }, access))
+        .toMatchObject({ action: 'drop', reason: 'bot not mentioned' });
+
+      const open = state({
+        group: { policy: 'allowlist', allow_chats: ['chat-group-a'], require_mention: false },
+      });
+      expect(gate({ chatId: 'chat-group-a', mentions: [] }, open))
+        .toMatchObject({ action: 'deliver' });
     });
   });
 
-  it('enforces follow-user allowlists across groups', () => {
-    const access = state({
-      group: {
-        ...defaultDispatcherAccessState().group,
-        follow_users: ['sender-allowed'],
-      },
+  describe('block policy', () => {
+    it('drops every group message', () => {
+      const access = state({
+        allow_users: ['sender-allowed'],
+        group: { policy: 'block', allow_chats: [], require_mention: true },
+      });
+      expect(gate({}, access)).toMatchObject({
+        action: 'drop',
+        reason: 'group messages are blocked (group policy: block)',
+      });
+    });
+  });
+
+  describe('peer-bot trust is per-chat and never reached through allow_users', () => {
+    const botBase = { senderId: 'peer-bot', senderType: 'bot' };
+
+    it('drops an un-introduced bot sender', () => {
+      const access = state({ group: { policy: 'allowlist', allow_chats: ['chat-group-a'], require_mention: true } });
+      expect(gate(botBase, access)).toMatchObject({ action: 'drop' });
     });
 
-    expect(gate({ senderId: 'sender-allowed' }, access)).toMatchObject({
-      action: 'deliver',
+    it('delivers an introduced (trusted) bot sender without a mention, under follow-user', () => {
+      const access = state({
+        allow_users: ['sender-allowed'],
+        group: { policy: 'follow-user', allow_chats: [], require_mention: true },
+      });
+      expect(
+        gate({ ...botBase, mentions: [], trustedBotIds: new Set(['peer-bot']) }, access),
+      ).toMatchObject({ action: 'deliver' });
     });
-    expect(gate({ senderId: 'sender-other' }, access)).toMatchObject({
-      action: 'drop',
-      reason: 'sender not allowed by follow-user gate',
+  });
+
+  it('shares one global list across direct and follow-user group delivery', () => {
+    const access = state({
+      allow_users: ['shared-user'],
+      group: { policy: 'follow-user', allow_chats: [], require_mention: true },
     });
+    expect(gate({ chatType: 'p2p', senderId: 'shared-user' }, access))
+      .toMatchObject({ action: 'deliver' });
+    expect(gate({ chatType: 'group', senderId: 'shared-user' }, access))
+      .toMatchObject({ action: 'deliver' });
   });
 
   it('records a trust-domain warning when one dispatcher observes multiple chats', () => {
-    const first = gate({ chatId: 'chat-group-a' }, state());
+    const access = state({
+      allow_users: ['sender-allowed'],
+      group: { policy: 'follow-user', allow_chats: [], require_mention: true },
+    });
+    const first = gate({ chatId: 'chat-group-a' }, access);
     expect(first.action).toBe('deliver');
     if (first.action !== 'deliver') throw new Error('unreachable');
     expect(first.warning).toBeNull();
@@ -117,7 +212,6 @@ describe('dreamuxFeishuGate', () => {
       'chat-group-b',
     ]);
   });
-
 });
 
 describe('dispatcher access state files', () => {
@@ -138,11 +232,17 @@ describe('dispatcher access state files', () => {
     rmSync(root, { recursive: true, force: true });
   });
 
-  it('defaults missing access.json and writes owner-only access state', () => {
-    expect(loadDispatcherAccess('flow')).toEqual(defaultDispatcherAccessState());
+  it('defaults a missing access.json to the secure follow-user shape', () => {
+    const loaded = loadDispatcherAccess('flow');
+    expect(loaded).toEqual(defaultDispatcherAccessState());
+    expect(loaded.version).toBe(2);
+    expect(loaded.allow_users).toEqual([]);
+    expect(loaded.group.policy).toBe('follow-user');
+  });
 
+  it('writes owner-only v2 state and round-trips', () => {
     const access = state({
-      dm: { allow_users: ['sender-allowed'] },
+      allow_users: ['sender-allowed'],
       observed_chats: ['chat-group-a'],
     });
     saveDispatcherAccess('flow', access);
@@ -150,26 +250,123 @@ describe('dispatcher access state files', () => {
     const path = dispatcherAccessPath('flow');
     expect(existsSync(path)).toBe(true);
     expect(statSync(path).mode & 0o777).toBe(0o600);
-    expect(JSON.parse(readFileSync(path, 'utf8'))).toMatchObject({
-      dm: { allow_users: ['sender-allowed'] },
-      observed_chats: ['chat-group-a'],
+    const onDisk = JSON.parse(readFileSync(path, 'utf8'));
+    expect(onDisk).toMatchObject({
+      version: 2,
+      allow_users: ['sender-allowed'],
+      group: { policy: 'follow-user' },
     });
+    // The legacy fields must not be written back.
+    expect(onDisk.dm).toBeUndefined();
+    expect(onDisk.group.follow_users).toBeUndefined();
     expect(loadDispatcherAccess('flow')).toEqual(access);
   });
+
+  describe('v1 → v2 migration', () => {
+    it('lifts legacy dm.allow_users into the global list (follow-user)', () => {
+      writeRawAccess('flow', {
+        version: 1,
+        dm: { allow_users: ['user-a'] },
+        group: { allow_chats: [], follow_users: [], require_mention: true },
+      });
+      const access = loadDispatcherAccess('flow');
+      expect(access.version).toBe(2);
+      expect(access.allow_users).toEqual(['user-a']);
+      expect(access.group.policy).toBe('follow-user');
+    });
+
+    it('preserves a legacy follow_users restriction as follow-user, not allowlist', () => {
+      // Both lists set: the sender restriction must NOT be silently relaxed to
+      // chat-only allowlist gating (that would let any chat member talk).
+      writeRawAccess('flow', {
+        version: 1,
+        dm: { allow_users: [] },
+        group: {
+          allow_chats: ['chat-group-a'],
+          follow_users: ['user-a'],
+          require_mention: true,
+        },
+      });
+      const access = loadDispatcherAccess('flow');
+      expect(access.allow_users).toEqual(['user-a']);
+      expect(access.group.policy).toBe('follow-user');
+      expect(access.group.allow_chats).toEqual(['chat-group-a']);
+    });
+
+    it('infers allowlist when only a chat allowlist is configured', () => {
+      writeRawAccess('flow', {
+        version: 1,
+        dm: { allow_users: [] },
+        group: {
+          allow_chats: ['chat-group-a'],
+          follow_users: [],
+          require_mention: true,
+        },
+      });
+      expect(loadDispatcherAccess('flow').group.policy).toBe('allowlist');
+    });
+
+    it('merges and de-duplicates dm.allow_users and group.follow_users', () => {
+      writeRawAccess('flow', {
+        version: 1,
+        dm: { allow_users: ['user-a', 'user-b'] },
+        group: {
+          allow_chats: [],
+          follow_users: ['user-b', 'user-c'],
+          require_mention: true,
+        },
+      });
+      expect(loadDispatcherAccess('flow').allow_users).toEqual([
+        'user-a',
+        'user-b',
+        'user-c',
+      ]);
+    });
+
+    it('honors an explicit group.policy over inference', () => {
+      writeRawAccess('flow', {
+        version: 2,
+        allow_users: ['user-a'],
+        group: {
+          policy: 'allowlist',
+          allow_chats: ['chat-group-a'],
+          require_mention: true,
+        },
+      });
+      expect(loadDispatcherAccess('flow').group.policy).toBe('allowlist');
+    });
+
+    it('rejects an invalid group.policy', () => {
+      writeRawAccess('flow', {
+        version: 2,
+        allow_users: [],
+        group: { policy: 'nonsense', allow_chats: [], require_mention: true },
+      });
+      expect(() => loadDispatcherAccess('flow')).toThrow(/group\.policy/);
+    });
+  });
 });
+
+function writeRawAccess(id: string, raw: unknown): void {
+  const path = dispatcherAccessPath(id);
+  mkdirSync(dirname(path), { recursive: true });
+  writeFileSync(path, JSON.stringify(raw), 'utf8');
+}
 
 function state(
   overrides: Partial<DispatcherAccessState> = {},
 ): DispatcherAccessState {
+  const base = defaultDispatcherAccessState();
   return {
-    ...defaultDispatcherAccessState(),
+    ...base,
     ...overrides,
+    group: { ...base.group, ...(overrides.group ?? {}) },
   };
 }
 
 function gate(
   overrides: Partial<Parameters<typeof dreamuxFeishuGate>[0]> = {},
-  access = state(),
+  access = state({ allow_users: ['sender-allowed'] }),
 ) {
   return dreamuxFeishuGate(
     {

--- a/packages/dreamux/tests/feishu-introduce.test.ts
+++ b/packages/dreamux/tests/feishu-introduce.test.ts
@@ -35,9 +35,13 @@ import {
 import { resetRuntimeConfig } from '../src/runtime/paths.js';
 import type { Mention } from '@excitedjs/feishu-transport';
 
-function state(group: Partial<DispatcherAccessState['group']> = {}): DispatcherAccessState {
+function state(overrides: Partial<DispatcherAccessState> = {}): DispatcherAccessState {
   const base = defaultDispatcherAccessState();
-  return { ...base, group: { ...base.group, ...group } };
+  return {
+    ...base,
+    ...overrides,
+    group: { ...base.group, ...(overrides.group ?? {}) },
+  };
 }
 
 function textContent(text: string): string {
@@ -46,35 +50,35 @@ function textContent(text: string): string {
 
 describe('canRunIntroduce — sender-scoped, not group-scoped', () => {
   it('authorizes an allowlisted sender in an allowlisted chat', () => {
-    const access = state({ allow_chats: ['chat-a'], follow_users: ['user-a'] });
+    const access = state({ allow_users: ['user-a'], group: { allow_chats: ['chat-a'] } });
     expect(
       canRunIntroduce(access, { chatType: 'group', chatId: 'chat-a', senderId: 'user-a' }),
     ).toBe(true);
   });
 
   it('rejects a non-allowlisted sender even in an allowlisted chat', () => {
-    const access = state({ allow_chats: ['chat-a'], follow_users: ['user-a'] });
+    const access = state({ allow_users: ['user-a'], group: { allow_chats: ['chat-a'] } });
     expect(
       canRunIntroduce(access, { chatType: 'group', chatId: 'chat-a', senderId: 'user-x' }),
     ).toBe(false);
   });
 
   it('rejects an allowlisted sender in a chat that is not allowlisted', () => {
-    const access = state({ allow_chats: ['chat-a'], follow_users: ['user-a'] });
+    const access = state({ allow_users: ['user-a'], group: { allow_chats: ['chat-a'] } });
     expect(
       canRunIntroduce(access, { chatType: 'group', chatId: 'chat-other', senderId: 'user-a' }),
     ).toBe(false);
   });
 
   it('does NOT treat "any member of an allowlisted group" as authorized (empty allowlist)', () => {
-    const access = state({ allow_chats: ['chat-a'], follow_users: [] });
+    const access = state({ allow_users: [], group: { allow_chats: ['chat-a'] } });
     expect(
       canRunIntroduce(access, { chatType: 'group', chatId: 'chat-a', senderId: 'anyone' }),
     ).toBe(false);
   });
 
   it('never fires for direct messages', () => {
-    const access = state({ allow_chats: ['chat-a'], follow_users: ['user-a'] });
+    const access = state({ allow_users: ['user-a'], group: { allow_chats: ['chat-a'] } });
     expect(
       canRunIntroduce(access, { chatType: 'p2p', chatId: 'chat-a', senderId: 'user-a' }),
     ).toBe(false);
@@ -86,49 +90,49 @@ describe('introduceDenyReason — stable diagnostic codes (issue #77)', () => {
   // rejection point and is logged verbatim, so an operator can tell an
   // introduce blocked by the allowlist apart from an ordinary gate drop.
   it('returns null (authorized) for an allowlisted sender in an allowlisted chat', () => {
-    const access = state({ allow_chats: ['chat-a'], follow_users: ['user-a'] });
+    const access = state({ allow_users: ['user-a'], group: { allow_chats: ['chat-a'] } });
     expect(
       introduceDenyReason(access, { chatType: 'group', chatId: 'chat-a', senderId: 'user-a' }),
     ).toBeNull();
   });
 
   it('reports non_group for a direct message', () => {
-    const access = state({ allow_chats: ['chat-a'], follow_users: ['user-a'] });
+    const access = state({ allow_users: ['user-a'], group: { allow_chats: ['chat-a'] } });
     expect(
       introduceDenyReason(access, { chatType: 'p2p', chatId: 'chat-a', senderId: 'user-a' }),
     ).toBe('non_group');
   });
 
   it('reports empty_sender_id when the sender id is missing', () => {
-    const access = state({ allow_chats: ['chat-a'], follow_users: ['user-a'] });
+    const access = state({ allow_users: ['user-a'], group: { allow_chats: ['chat-a'] } });
     expect(
       introduceDenyReason(access, { chatType: 'group', chatId: 'chat-a', senderId: '' }),
     ).toBe('empty_sender_id');
   });
 
   it('reports chat_not_allowlisted when the chat is not explicitly allowlisted', () => {
-    const access = state({ allow_chats: ['chat-a'], follow_users: ['user-a'] });
+    const access = state({ allow_users: ['user-a'], group: { allow_chats: ['chat-a'] } });
     expect(
       introduceDenyReason(access, { chatType: 'group', chatId: 'chat-other', senderId: 'user-a' }),
     ).toBe('chat_not_allowlisted');
   });
 
-  it('reports sender_not_followed when follow_users is empty (the misleading case)', () => {
-    const access = state({ allow_chats: ['chat-a'], follow_users: [] });
+  it('reports sender_not_followed when allow_users is empty (the misleading case)', () => {
+    const access = state({ allow_users: [], group: { allow_chats: ['chat-a'] } });
     expect(
       introduceDenyReason(access, { chatType: 'group', chatId: 'chat-a', senderId: 'anyone' }),
     ).toBe('sender_not_followed');
   });
 
-  it('reports sender_not_followed when follow_users is non-empty but excludes the sender', () => {
-    const access = state({ allow_chats: ['chat-a'], follow_users: ['user-a'] });
+  it('reports sender_not_followed when allow_users is non-empty but excludes the sender', () => {
+    const access = state({ allow_users: ['user-a'], group: { allow_chats: ['chat-a'] } });
     expect(
       introduceDenyReason(access, { chatType: 'group', chatId: 'chat-a', senderId: 'user-x' }),
     ).toBe('sender_not_followed');
   });
 
   it('stays consistent with canRunIntroduce across every branch', () => {
-    const access = state({ allow_chats: ['chat-a'], follow_users: ['user-a'] });
+    const access = state({ allow_users: ['user-a'], group: { allow_chats: ['chat-a'] } });
     const inputs = [
       { chatType: 'group', chatId: 'chat-a', senderId: 'user-a' },
       { chatType: 'p2p', chatId: 'chat-a', senderId: 'user-a' },
@@ -206,12 +210,12 @@ describe('gate trust — only introduced bots may speak in a group', () => {
   };
 
   it('drops a bot sender that has not been introduced', () => {
-    const access = state({ allow_chats: ['chat-a'] });
+    const access = state({ group: { policy: 'allowlist', allow_chats: ['chat-a'] } });
     expect(dreamuxFeishuGate(base, access)).toMatchObject({ action: 'drop' });
   });
 
   it('delivers a bot sender that was introduced (trusted), without a mention', () => {
-    const access = state({ allow_chats: ['chat-a'] });
+    const access = state({ group: { policy: 'allowlist', allow_chats: ['chat-a'] } });
     expect(
       dreamuxFeishuGate({ ...base, trustedBotIds: new Set(['peer-bot']) }, access),
     ).toMatchObject({ action: 'deliver' });

--- a/packages/dreamux/tests/smoke.test.ts
+++ b/packages/dreamux/tests/smoke.test.ts
@@ -279,6 +279,19 @@ describe('dreamux MVP smoke', () => {
       replyFor: captureAndEchoCodexInput(codexInputs),
     });
     bot = createFakeFeishuBot('app-smoke');
+    // Suite baseline: the canonical sender is onboarded onto the global
+    // allow-user list, so a mentioned group message from it is delivered.
+    // Empty `allow_users` now authorizes nobody (the follow-user fix), so
+    // tests that exercise delivery need this seed; tests that assert a drop
+    // override it or rely on a different gate reason (no mention, bot sender).
+    saveDispatcherAccess('flow', {
+      version: 2,
+      allow_users: ['sender-test'],
+      group: { policy: 'follow-user', allow_chats: [], require_mention: true },
+      observed_chats: [],
+      warnings: [],
+      last_gate: null,
+    });
   });
 
   afterEach(async () => {
@@ -798,13 +811,11 @@ describe('dreamux MVP smoke', () => {
 
   it('reads access gate configuration from access.json and allows configured DMs', async () => {
     saveDispatcherAccess('flow', {
-      version: 1,
-      dm: {
-        allow_users: ['sender-dm'],
-      },
+      version: 2,
+      allow_users: ['sender-dm'],
       group: {
+        policy: 'allowlist',
         allow_chats: ['chat-group-a'],
-        follow_users: ['sender-dm'],
         require_mention: true,
       },
       observed_chats: [],
@@ -827,9 +838,9 @@ describe('dreamux MVP smoke', () => {
 
     await waitFor(() => fake.turnsHandled === 1);
     const access = loadDispatcherAccess('flow');
-    expect(access.dm.allow_users).toEqual(['sender-dm']);
+    expect(access.allow_users).toEqual(['sender-dm']);
+    expect(access.group.policy).toEqual('allowlist');
     expect(access.group.allow_chats).toEqual(['chat-group-a']);
-    expect(access.group.follow_users).toEqual(['sender-dm']);
     expect(access.observed_chats).toEqual(['chat-dm']);
     expect(bot.reactions.map((reaction) => reaction.messageId)).toEqual([
       'msg-dm',
@@ -843,11 +854,11 @@ describe('dreamux MVP smoke', () => {
 
   it('consumes a no-@ /introduce from an allowlisted sender and records trust without enqueue or reactions', async () => {
     saveDispatcherAccess('flow', {
-      version: 1,
-      dm: { allow_users: [] },
+      version: 2,
+      allow_users: ['sender-test'],
       group: {
+        policy: 'allowlist',
         allow_chats: ['chat-group-a'],
-        follow_users: ['sender-test'],
         require_mention: true,
       },
       observed_chats: [],
@@ -882,11 +893,11 @@ describe('dreamux MVP smoke', () => {
 
   it('injects a one-shot group_bots context on the next group message after /introduce', async () => {
     saveDispatcherAccess('flow', {
-      version: 1,
-      dm: { allow_users: [] },
+      version: 2,
+      allow_users: ['sender-test'],
       group: {
+        policy: 'allowlist',
         allow_chats: ['chat-group-a'],
-        follow_users: ['sender-test'],
         require_mention: true,
       },
       observed_chats: [],
@@ -926,11 +937,11 @@ describe('dreamux MVP smoke', () => {
 
   it('mcp.list_chat_bots returns the chat known + trusted bots with names', async () => {
     saveDispatcherAccess('flow', {
-      version: 1,
-      dm: { allow_users: [] },
+      version: 2,
+      allow_users: ['sender-test'],
       group: {
+        policy: 'allowlist',
         allow_chats: ['chat-group-a'],
-        follow_users: ['sender-test'],
         require_mention: true,
       },
       observed_chats: [],
@@ -982,11 +993,11 @@ describe('dreamux MVP smoke', () => {
 
   it('does NOT consume /introduce from a non-allowlisted sender (no trust, dropped by the gate)', async () => {
     saveDispatcherAccess('flow', {
-      version: 1,
-      dm: { allow_users: [] },
+      version: 2,
+      allow_users: ['sender-test'],
       group: {
+        policy: 'allowlist',
         allow_chats: ['chat-group-a'],
-        follow_users: ['sender-test'],
         require_mention: true,
       },
       observed_chats: [],
@@ -1033,13 +1044,14 @@ describe('dreamux MVP smoke', () => {
       message_id: 'msg-introduce-stranger',
       reason: 'sender_not_followed',
     });
-    // The original gate behavior is unchanged: with a non-empty follow_users the
-    // sender still drops on the follow-user gate afterwards.
+    // The unauthorized introduce still falls through to the gate, which drops it
+    // — here as `bot not mentioned`, since the stranger mentioned only the peer
+    // bot. The issue #77 diagnostic above is what names the real cause.
     expect(
       lines.some(
         (l) =>
           l['msg'] === 'feishu inbound dropped' &&
-          l['reason'] === 'sender not allowed by follow-user gate',
+          l['reason'] === 'bot not mentioned',
       ),
     ).toBe(true);
     // No-leak: the diagnostic carries only ids/reason — never the message body,
@@ -1050,16 +1062,17 @@ describe('dreamux MVP smoke', () => {
     expect(text).not.toContain('Peer');
   });
 
-  it('diagnoses an unauthorized /introduce when follow_users is empty (would surface as bot-not-mentioned)', async () => {
-    // The misleading case from issue #77: with follow_users empty the follow-user
-    // gate is skipped, so the eventual drop reason is the require_mention
-    // `bot not mentioned` — which looks like the user simply forgot to @ the bot.
+  it('diagnoses an unauthorized /introduce when allow_users is empty (would surface as bot-not-mentioned)', async () => {
+    // The misleading case from issue #77: with allow_users empty the sender is
+    // unauthorized, and because the gate is mention-first the eventual drop
+    // reason is `bot not mentioned` — which looks like the user simply forgot to
+    // @ the bot, hiding the real cause that the issue #77 diagnostic names.
     saveDispatcherAccess('flow', {
-      version: 1,
-      dm: { allow_users: [] },
+      version: 2,
+      allow_users: [],
       group: {
+        policy: 'follow-user',
         allow_chats: ['chat-group-a'],
-        follow_users: [],
         require_mention: true,
       },
       observed_chats: [],
@@ -1109,11 +1122,11 @@ describe('dreamux MVP smoke', () => {
 
   it('diagnoses an unauthorized /introduce when the chat is not allowlisted', async () => {
     saveDispatcherAccess('flow', {
-      version: 1,
-      dm: { allow_users: [] },
+      version: 2,
+      allow_users: ['sender-test'],
       group: {
+        policy: 'allowlist',
         allow_chats: ['chat-group-other'],
-        follow_users: ['sender-test'],
         require_mention: true,
       },
       observed_chats: [],
@@ -1157,11 +1170,11 @@ describe('dreamux MVP smoke', () => {
 
   it('diagnoses an unauthorized /introduce sent as a direct message (non_group)', async () => {
     saveDispatcherAccess('flow', {
-      version: 1,
-      dm: { allow_users: ['sender-test'] },
+      version: 2,
+      allow_users: ['sender-test'],
       group: {
+        policy: 'follow-user',
         allow_chats: ['chat-group-a'],
-        follow_users: ['sender-test'],
         require_mention: true,
       },
       observed_chats: [],
@@ -1205,11 +1218,11 @@ describe('dreamux MVP smoke', () => {
 
   it('an authorized /introduce is consumed without emitting the unauthorized diagnostic', async () => {
     saveDispatcherAccess('flow', {
-      version: 1,
-      dm: { allow_users: [] },
+      version: 2,
+      allow_users: ['sender-test'],
       group: {
+        policy: 'allowlist',
         allow_chats: ['chat-group-a'],
-        follow_users: ['sender-test'],
         require_mention: true,
       },
       observed_chats: [],


### PR DESCRIPTION
## 背景

修复 #79：follow-user 群消息准入语义实现错误。

dispatcher 运行时 gate（`dreamuxFeishuGate`，`packages/dreamux/src/channel/feishu-gate.ts`）此前把群准入门禁挂在一个**独立的** `group.follow_users` 列表上，而 DM 用的是 `dm.allow_users`。后果是：已在全局 allowlist 里的人，在群里 @ bot 仍被丢弃，除非再单独把他加进 `group.follow_users`。这与 follow-user 的本意（「跟随全局 user allowlist」）相反，也偏离了它自称镜像的 claudemux transport gate——后者 DM 与群 follow-user 共用同一份顶层 `allowFrom`。

## 改动

**统一 access.json 为 v2 形状**

- 顶层单一 `allow_users`：DM 与群 follow-user 共用（等价 transport 的 `allowFrom`）。空列表 = 无人，与 DM 一致。
- 显式 `group.policy`：`block` | `allowlist` | `follow-user`。
  - `follow-user`：忽略 chat allowlist；**始终**要求 @bot；sender 必须 ∈ 全局 `allow_users`，在**任意**群均可投递。
  - `allowlist`：群为信任单元——chat 必须 ∈ `allow_chats`，授权群内任意成员可发（受 `require_mention` 约束）。
  - `block`：丢弃所有群消息。

**v1 → v2 迁移**（`readDispatcherAccess`，按字段存在性）

- `allow_users` = dedup(顶层 `allow_users` ∪ 旧 `dm.allow_users` ∪ 旧 `group.follow_users`)。
- policy 推断：显式值优先；否则旧 `follow_users` 非空 → `follow-user`（**绝不**静默放宽为 chat-only 的 allowlist，以免丢失已配置的 sender 限制）；否则旧 `allow_chats` 非空 → `allowlist`；否则默认 `follow-user`。
- 旧字段可读但不再回写，首次 save 收敛为 v2。
- 注意：统一后 DM 准入名单变为 `dm.allow_users ∪ group.follow_users` 的并集；对常见场景（两份相等，或 dm ⊇ follow）DM 行为不变。

**`/introduce`**

- sender 校验改读全局 `allow_users`；仍要求 chat ∈ `allow_chats`（trust 写入即便在 follow-user 模式也需具名群）。
- peer-bot trust 保持 per-chat（`chat-bots.json`），永不经由 `allow_users`。

**KB**

- 同步更新 `.agents/decisions/top-level-design.md`（access.json 形状 + Access Gate 两节）与 `.agents/domains/feishu-introduce.md`。

## 行为变更

空 `allow_users` 在 follow-user 模式 = 无人可发群消息（与 DM「空 = 无人」一致，安全默认）。覆盖了旧 KB 中「空列表 = mention-gated 任意人」的 bootstrap 描述——bootstrap 改为把 sender onboard 进 `allow_users`。

## 测试

- `tests/feishu-gate.test.ts`：重写为行为化用例——全局 allow-user 在任意群 @bot 投递、不在列表丢弃、未 @bot 丢弃；allowlist 模式（chat 门禁 + `require_mention`）；block 模式；peer-bot per-chat trust；DM 与群共用同一份列表;并新增 v1→v2 迁移单测（dm-only / follow_users-only / 两者+去重 / allow_chats-only / 显式 policy / 非法 policy）。
- `tests/feishu-introduce.test.ts`、`tests/smoke.test.ts`、`tests/e2e.test.ts`、`tests/codex-live.test.ts`：适配新形状，并按需 onboard 测试 sender。
- 全量：`rush build` 通过；`@excitedjs/dreamux` 205/205 通过（含 6 个真实 codex live 用例）；`rush test` 三包全绿。

Closes #79

🤖 Generated with [Claude Code](https://claude.com/claude-code)
