### PR TITLE
feat(onboard): 服务 Node 优先选稳定系统 Node + doctor 版本管理器漂移告警

### DIFF
--- a/.agents/decisions/global-bin-onboard-serve.md
+++ b/.agents/decisions/global-bin-onboard-serve.md
@@ -48,11 +48,27 @@ systemd keep it alive.
 
 The generated service environment must be self-sufficient. It must not rely on
 interactive shell startup files such as `.zshrc` to make Node or Codex
-available. During onboarding, dreamux captures the Node executable that is
-running onboarding, validates that it satisfies the package's supported Node
-range, resolves the Codex executable to a runnable path for managed service use,
-seeds `HOME` for clean user-service probes, and renders those values into the
-user service environment.
+available. During onboarding, dreamux selects a service Node, validates that it
+satisfies the package's supported Node range, resolves the Codex executable to a
+runnable path for managed service use, seeds `HOME` for clean user-service
+probes, and renders those values into the user service environment.
+
+The service Node is not the onboarding Node frozen unconditionally. Onboarding
+prefers a stable system Node from a platform-aware candidate list (macOS covers
+Homebrew under `/opt/homebrew` and `/usr/local`; Linux covers `/usr/local/bin`,
+`/usr/bin`, `/bin`), accepting the first candidate that exists, is not bound to
+a version manager, and satisfies `MIN_SERVICE_NODE_VERSION`. It falls back to
+the onboarding Node (`process.execPath`) only when no stable candidate
+qualifies. The candidate's own path — a stable symlink, never its `realpath` —
+is what gets persisted, which keeps the volatile Homebrew Cellar path out of the
+service; when the fallback Node is itself a Cellar path, onboarding best-effort
+remaps it to the matching Homebrew `opt/...` symlink and otherwise persists it
+unchanged. The fallback reproduces the original fragility when onboarding runs
+under a version-manager Node, which is exactly what the `dreamux doctor`
+stability advisory exists to surface. Selection and that advisory share one
+async, injectable version-manager predicate (resolving symlinks before
+matching nvm/fnm/asdf/volta markers, including the macOS fnm default under
+`~/Library/Application Support/fnm/`) so they cannot drift apart.
 
 There is no public `dreamux daemon ...` command tree. The daemon form is
 foreground `dreamux serve` supervised by a native user-level service manager.
@@ -129,8 +145,14 @@ status.
   systemd execute the same global bin the operator invoked.
 - The `dreamux` launcher honors `DREAMUX_NODE_BIN` when present, falling back to
   `node` for ordinary interactive and npm-bin use. Service generation sets
-  `DREAMUX_NODE_BIN` and a minimal `PATH` so nvm-installed Node works without
+  `DREAMUX_NODE_BIN` (to the selected stable Node, see above) and a minimal
+  `PATH` whose first entry is that Node's directory, so the service runs without
   sourcing shell rc files.
+- `dreamux doctor` emits a non-fatal `warn`-severity advisory when the installed
+  service `DREAMUX_NODE_BIN` resolves into a version manager. The advisory keeps
+  the check `ok: true` so it never flips the doctor exit code — a version
+  manager-bound but currently-runnable service stays green with a visible
+  warning that points the operator to rerun `dreamux onboard`.
 - Codex's global default home is intentionally reused, so login state, memory,
   and local Codex configuration follow the operator's machine. dreamux must not
   delete that home during uninstall.

--- a/common/changes/@excitedjs/dreamux/service-node-selection-drift_2026-06-05-04-07.json
+++ b/common/changes/@excitedjs/dreamux/service-node-selection-drift_2026-06-05-04-07.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Prefer a stable platform-aware system Node for the managed service (Homebrew on macOS, system paths on Linux) with fallback to the current Node, and add a non-fatal dreamux doctor advisory when the service Node is bound to a version manager.",
+      "type": "minor",
+      "packageName": "@excitedjs/dreamux"
+    }
+  ],
+  "packageName": "@excitedjs/dreamux",
+  "email": "15624809+YourWildDad@users.noreply.github.com"
+}

--- a/packages/dreamux/src/cli/doctor.ts
+++ b/packages/dreamux/src/cli/doctor.ts
@@ -24,9 +24,12 @@ import {
 } from '../runtime/paths.js';
 import { ExecaCommandRunner } from '../onboard/commands.js';
 import {
+  defaultServiceNodeProbe,
+  detectServiceNodeVersionManager,
   LAUNCHD_LABEL,
   MIN_SERVICE_NODE_VERSION,
   nodeVersionSatisfies,
+  type ServiceNodeProbe,
   serviceUnitPath,
   SYSTEMD_UNIT,
 } from '../onboard/service.js';
@@ -38,6 +41,7 @@ export interface DoctorOptions {
   platform?: NodeJS.Platform;
   homeDir?: string;
   uid?: number;
+  nodeProbe?: ServiceNodeProbe;
 }
 
 export interface ServiceStatus {
@@ -57,6 +61,10 @@ export interface DoctorCheck {
   name: string;
   ok: boolean;
   detail: string;
+  // Advisory severity for an `ok: true` check that still warrants attention
+  // (e.g. a version-manager-bound Node that runs today but is fragile). A
+  // `warn` never flips `result.ok` or the CLI exit code; it stays visible.
+  severity?: 'warn';
 }
 
 export interface DispatcherDoctorReport {
@@ -108,7 +116,12 @@ export async function runDreamuxDoctor(
       ? `installed at ${service.unitPath}`
       : `not installed at ${service.unitPath}`,
   });
-  await addManagedServiceLaunchChecks(checks, service, runner);
+  await addManagedServiceLaunchChecks(
+    checks,
+    service,
+    runner,
+    options.nodeProbe ?? defaultServiceNodeProbe,
+  );
 
   const dispatchers = readDispatchers(config, options.env ?? process.env, service);
   if (dispatchers.length === 0) {
@@ -140,7 +153,12 @@ export function printDoctorResult(result: DreamuxDoctorResult): void {
   console.log(`config: ${result.configFile}`);
   console.log(`state: ${result.stateDir}`);
   for (const check of result.checks) {
-    console.log(`${check.ok ? 'ok' : 'fail'}\t${check.name}\t${check.detail}`);
+    const label = check.ok
+      ? check.severity === 'warn'
+        ? 'warn'
+        : 'ok'
+      : 'fail';
+    console.log(`${label}\t${check.name}\t${check.detail}`);
   }
   for (const dispatcher of result.dispatchers) {
     printDispatcherDoctor(dispatcher);
@@ -311,6 +329,7 @@ async function addManagedServiceLaunchChecks(
   checks: DoctorCheck[],
   service: ServiceStatus,
   runner: CommandRunner,
+  probe: ServiceNodeProbe,
 ): Promise<void> {
   if (!service.installed) return;
   const env = service.environment;
@@ -334,6 +353,19 @@ async function addManagedServiceLaunchChecks(
   const serviceEnv = env as Record<string, string>;
   const nodeBin = serviceEnv['DREAMUX_NODE_BIN'];
   checks.push(await checkNodeLaunch(nodeBin, serviceEnv, runner));
+
+  // Drift advisory: the service Node runs today but is bound to a version
+  // manager, so a version switch/cleanup will break it. Surface it visibly
+  // without failing — reuses the same predicate selection uses.
+  const manager = await detectServiceNodeVersionManager(nodeBin, probe);
+  if (manager !== null) {
+    checks.push({
+      name: 'managed service Node stability',
+      ok: true,
+      severity: 'warn',
+      detail: `${nodeBin} resolves into ${manager}-managed Node; a version switch or cleanup will break the managed service. Rerun dreamux onboard to repin to a stable Node.`,
+    });
+  }
 
   const dreamuxBin = service.execStart?.[0];
   checks.push(

--- a/packages/dreamux/src/onboard/run.ts
+++ b/packages/dreamux/src/onboard/run.ts
@@ -36,6 +36,8 @@ import {
   installUserService,
   managedServiceEnvironment,
   resolveServiceExecutable,
+  selectServiceNodeBin,
+  type ServiceNodeProbe,
   validateManagedServiceLaunch,
 } from './service.js';
 import type {
@@ -55,6 +57,7 @@ export interface RunOnboardOptions {
   homeDir?: string;
   uid?: number;
   env?: NodeJS.ProcessEnv;
+  nodeProbe?: ServiceNodeProbe;
 }
 
 export async function runOnboard(
@@ -70,11 +73,19 @@ export async function runOnboard(
   const serviceCodexBin = answers.registerService && !answers.dryRun
     ? resolveServiceExecutable(dreamuxConfig.codex.bin, env)
     : dreamuxConfig.codex.bin;
+  const serviceNodeBin = answers.registerService && !answers.dryRun
+    ? await selectServiceNodeBin({
+        platform: options.platform ?? process.platform,
+        currentNodeBin: process.execPath,
+        runner,
+        probe: options.nodeProbe,
+      })
+    : process.execPath;
   const effectiveAnswers = {
     ...answers,
     runtimeDir: stateRoot(),
     codexBin: serviceCodexBin,
-    nodeBin: process.execPath,
+    nodeBin: serviceNodeBin,
   };
   setRuntimeConfig(dreamuxConfig);
 

--- a/packages/dreamux/src/onboard/service.ts
+++ b/packages/dreamux/src/onboard/service.ts
@@ -1,4 +1,5 @@
 import { accessSync, constants } from 'node:fs';
+import { realpath } from 'node:fs/promises';
 import { homedir } from 'node:os';
 import { delimiter, dirname, isAbsolute, join, resolve } from 'node:path';
 
@@ -249,6 +250,195 @@ export function nodeVersionSatisfies(raw: string): boolean {
   if (!Number.isInteger(major) || !Number.isInteger(minor)) return false;
   if (major > 22) return true;
   return major === 22 && minor >= 7;
+}
+
+/**
+ * Filesystem probes the service-Node selection and the doctor drift check both
+ * depend on. Injectable so tests can model symlinks, candidate existence, and
+ * version-manager layouts without touching the real filesystem.
+ */
+export interface ServiceNodeProbe {
+  realpath: (path: string) => Promise<string>;
+  isExecutable: (path: string) => boolean;
+}
+
+export const defaultServiceNodeProbe: ServiceNodeProbe = {
+  realpath: (path) => realpath(path),
+  isExecutable: (path) => isExecutable(path),
+};
+
+// Markers matched (case-insensitively) against a Node binary's resolved path.
+// Each marker keeps a leading `/.<name>/` or explicit segment anchor so a user
+// directory such as `/home/volta/` never matches the `/.volta/` marker. macOS
+// fnm installs under `~/Library/Application Support/fnm/`; dreamux supports
+// launchd, so that path must be covered.
+const VERSION_MANAGER_MARKERS: Array<{ manager: string; markers: string[] }> = [
+  { manager: 'nvm', markers: ['/.nvm/versions/node/'] },
+  {
+    manager: 'fnm',
+    markers: [
+      '/.fnm/',
+      'fnm_multishells',
+      '/.local/share/fnm/',
+      '/library/application support/fnm/',
+    ],
+  },
+  { manager: 'asdf', markers: ['/.asdf/installs/nodejs/', '/.asdf/shims/'] },
+  { manager: 'volta', markers: ['/.volta/'] },
+];
+
+/** Pure marker match on a single path; returns the manager name or null. */
+export function versionManagerOfPath(path: string): string | null {
+  const needle = path.toLowerCase();
+  for (const entry of VERSION_MANAGER_MARKERS) {
+    if (entry.markers.some((marker) => needle.includes(marker))) {
+      return entry.manager;
+    }
+  }
+  return null;
+}
+
+/**
+ * The single async/injectable predicate selection and doctor share. Resolves
+ * symlinks first so a `/usr/local/bin/node` shim pointing into nvm/fnm/asdf is
+ * caught; falls back to the raw path when realpath fails (e.g. broken link).
+ */
+export async function detectServiceNodeVersionManager(
+  nodeBin: string,
+  probe: ServiceNodeProbe = defaultServiceNodeProbe,
+): Promise<string | null> {
+  const raw = versionManagerOfPath(nodeBin);
+  if (raw !== null) return raw;
+  let resolved: string;
+  try {
+    resolved = await probe.realpath(nodeBin);
+  } catch {
+    return null;
+  }
+  return versionManagerOfPath(resolved);
+}
+
+/**
+ * Platform-aware stable Node candidates, decoupled from SERVICE_PATH_DEFAULTS
+ * (which only renders the service PATH). macOS covers Homebrew (Apple Silicon
+ * and Intel prefixes); Linux covers the standard system locations.
+ */
+export function stableNodeCandidates(platform: NodeJS.Platform): string[] {
+  if (platform === 'darwin') {
+    return [
+      '/opt/homebrew/bin/node',
+      '/opt/homebrew/opt/node/bin/node',
+      '/opt/homebrew/opt/node@24/bin/node',
+      '/opt/homebrew/opt/node@22/bin/node',
+      '/usr/local/bin/node',
+      '/usr/local/opt/node/bin/node',
+      '/usr/local/opt/node@24/bin/node',
+      '/usr/local/opt/node@22/bin/node',
+      '/usr/bin/node',
+    ];
+  }
+  return ['/usr/local/bin/node', '/usr/bin/node', '/bin/node'];
+}
+
+export interface SelectServiceNodeOptions {
+  platform: NodeJS.Platform;
+  currentNodeBin: string;
+  runner: CommandRunner;
+  probe?: ServiceNodeProbe;
+}
+
+/**
+ * Choose the Node binary persisted into the managed-service environment.
+ * Prefers a stable system Node (exists, not version-manager-bound, satisfies
+ * MIN_SERVICE_NODE_VERSION); falls back to the current Node otherwise. The
+ * fallback reproduces the original fragility when onboarding itself runs under
+ * a version-manager Node — that case is the doctor drift advisory's job to
+ * surface, not this function's.
+ */
+export async function selectServiceNodeBin(
+  options: SelectServiceNodeOptions,
+): Promise<string> {
+  const probe = options.probe ?? defaultServiceNodeProbe;
+  for (const candidate of stableNodeCandidates(options.platform)) {
+    if (!probe.isExecutable(candidate)) continue;
+    if ((await detectServiceNodeVersionManager(candidate, probe)) !== null) {
+      continue;
+    }
+    let version: string;
+    try {
+      version = await options.runner.capture(candidate, ['--version']);
+    } catch {
+      continue;
+    }
+    if (!nodeVersionSatisfies(version)) continue;
+    // Persist the candidate path itself (a stable symlink), never its realpath,
+    // so a Homebrew symlink keeps the volatile Cellar path out of the service.
+    return candidate;
+  }
+  return stabilizeHomebrewCellarNode(
+    options.currentNodeBin,
+    options.platform,
+    probe,
+  );
+}
+
+const HOMEBREW_PREFIXES = ['/opt/homebrew', '/usr/local'];
+
+interface HomebrewCellarMatch {
+  prefix: string;
+  major: string | null;
+}
+
+function matchHomebrewCellar(path: string): HomebrewCellarMatch | null {
+  for (const prefix of HOMEBREW_PREFIXES) {
+    const cellar = `${prefix}/Cellar/node`;
+    if (!path.startsWith(`${cellar}/`) && !path.startsWith(`${cellar}@`)) {
+      continue;
+    }
+    const major = path.slice(cellar.length).match(/^@(\d+)\//);
+    return { prefix, major: major === null ? null : major[1] };
+  }
+  return null;
+}
+
+/**
+ * Homebrew Cellar (`<prefix>/Cellar/node[@major]/<version>/bin/node`) is NOT a
+ * version manager, but it is a version-pinned path unfit for a persistent
+ * service. When the fallback Node is a Cellar path, best-effort remap it to the
+ * matching stable Homebrew symlink. The realpath-equality guard disambiguates
+ * `node` vs `node@<major>`; no match returns the input unchanged and never
+ * throws, so a stabilization miss cannot fail onboarding. darwin-only.
+ */
+export async function stabilizeHomebrewCellarNode(
+  nodeBin: string,
+  platform: NodeJS.Platform,
+  probe: ServiceNodeProbe = defaultServiceNodeProbe,
+): Promise<string> {
+  if (platform !== 'darwin') return nodeBin;
+  let resolved: string;
+  try {
+    resolved = await probe.realpath(nodeBin);
+  } catch {
+    resolved = nodeBin;
+  }
+  const cellar = matchHomebrewCellar(nodeBin) ?? matchHomebrewCellar(resolved);
+  if (cellar === null) return nodeBin;
+
+  const links: string[] = [];
+  if (cellar.major !== null) {
+    links.push(`${cellar.prefix}/opt/node@${cellar.major}/bin/node`);
+  }
+  links.push(`${cellar.prefix}/opt/node/bin/node`, `${cellar.prefix}/bin/node`);
+
+  for (const link of links) {
+    if (!probe.isExecutable(link)) continue;
+    try {
+      if ((await probe.realpath(link)) === resolved) return link;
+    } catch {
+      // ignore and try the next candidate symlink
+    }
+  }
+  return nodeBin;
 }
 
 function managedServicePath(answers: ServiceInstallAnswers): string {

--- a/packages/dreamux/tests/doctor.test.ts
+++ b/packages/dreamux/tests/doctor.test.ts
@@ -12,6 +12,7 @@ import { build as buildPlist } from 'plist';
 
 import { runDreamuxDoctor } from '../src/cli/doctor.js';
 import type { CommandRunner } from '../src/onboard/types.js';
+import type { ServiceNodeProbe } from '../src/onboard/service.js';
 import {
   dispatcherCodexCwd,
   dispatcherCodexHome,
@@ -210,6 +211,137 @@ describe('dreamux doctor command', () => {
     expect(result.service.environment?.['CODEX_HOST_CODEX_BIN']).toBe(
       '/service/codex\\x20literal',
     );
+  });
+
+  it('warns (without failing) when the service Node is bound to a version manager', async () => {
+    const runner = new FakeRunner();
+    writeConfig();
+    writeDispatcherHome({ auth: true });
+    const nvmNode = join(
+      root,
+      'home',
+      '.nvm',
+      'versions',
+      'node',
+      'v22.7.0',
+      'bin',
+      'node',
+    );
+    const servicePath = join(root, 'home', '.config', 'systemd', 'user', 'dreamux.service');
+    mkdirSync(dirname(servicePath), { recursive: true });
+    writeFileSync(
+      servicePath,
+      [
+        '[Service]',
+        'ExecStart=/service/dreamux serve',
+        `Environment=DREAMUX_NODE_BIN=${nvmNode}`,
+        'Environment=CODEX_HOST_CODEX_BIN=/service/codex',
+        'Environment=PATH=/service/bin:/usr/bin:/bin',
+        '',
+      ].join('\n'),
+    );
+    runner.nodeVersions.set(nvmNode, 'v22.7.0');
+
+    const result = await runDreamuxDoctor({
+      runner,
+      platform: 'linux',
+      homeDir: join(root, 'home'),
+      env: {},
+    });
+
+    // The Node runs today, so the binary check stays green and result.ok holds.
+    expect(result.ok).toBe(true);
+    expect(
+      result.checks.find((check) => check.name === 'managed service Node binary'),
+    ).toMatchObject({ ok: true });
+    const advisory = result.checks.find(
+      (check) => check.name === 'managed service Node stability',
+    );
+    expect(advisory).toMatchObject({
+      ok: true,
+      severity: 'warn',
+      detail: expect.stringContaining('nvm'),
+    });
+  });
+
+  it('flags a system-looking shim that realpaths into a version manager', async () => {
+    const runner = new FakeRunner();
+    writeConfig();
+    writeDispatcherHome({ auth: true });
+    const servicePath = join(root, 'home', '.config', 'systemd', 'user', 'dreamux.service');
+    mkdirSync(dirname(servicePath), { recursive: true });
+    writeFileSync(
+      servicePath,
+      [
+        '[Service]',
+        'ExecStart=/service/dreamux serve',
+        'Environment=DREAMUX_NODE_BIN=/usr/local/bin/node',
+        'Environment=CODEX_HOST_CODEX_BIN=/service/codex',
+        'Environment=PATH=/service/bin:/usr/bin:/bin',
+        '',
+      ].join('\n'),
+    );
+    runner.nodeVersions.set('/usr/local/bin/node', 'v22.7.0');
+    const shimProbe: ServiceNodeProbe = {
+      isExecutable: () => true,
+      realpath: async (path) =>
+        path === '/usr/local/bin/node'
+          ? '/Users/u/Library/Application Support/fnm/node-versions/v22/installation/bin/node'
+          : path,
+    };
+
+    const result = await runDreamuxDoctor({
+      runner,
+      platform: 'linux',
+      homeDir: join(root, 'home'),
+      env: {},
+      nodeProbe: shimProbe,
+    });
+
+    expect(result.ok).toBe(true);
+    expect(
+      result.checks.find(
+        (check) => check.name === 'managed service Node stability',
+      ),
+    ).toMatchObject({ ok: true, severity: 'warn', detail: expect.stringContaining('fnm') });
+  });
+
+  it('does not warn when the service Node is a stable system path', async () => {
+    const runner = new FakeRunner();
+    writeConfig();
+    writeDispatcherHome({ auth: true });
+    const servicePath = join(root, 'home', '.config', 'systemd', 'user', 'dreamux.service');
+    mkdirSync(dirname(servicePath), { recursive: true });
+    writeFileSync(
+      servicePath,
+      [
+        '[Service]',
+        'ExecStart=/service/dreamux serve',
+        'Environment=DREAMUX_NODE_BIN=/usr/local/bin/node',
+        'Environment=CODEX_HOST_CODEX_BIN=/service/codex',
+        'Environment=PATH=/service/bin:/usr/bin:/bin',
+        '',
+      ].join('\n'),
+    );
+    runner.nodeVersions.set('/usr/local/bin/node', 'v22.7.0');
+    const stableProbe: ServiceNodeProbe = {
+      isExecutable: () => true,
+      realpath: async (path) => path,
+    };
+
+    const result = await runDreamuxDoctor({
+      runner,
+      platform: 'linux',
+      homeDir: join(root, 'home'),
+      env: {},
+      nodeProbe: stableProbe,
+    });
+
+    expect(
+      result.checks.find(
+        (check) => check.name === 'managed service Node stability',
+      ),
+    ).toBeUndefined();
   });
 
   it('checks the installed launchd plist environment instead of failing unconditionally', async () => {

--- a/packages/dreamux/tests/onboard.test.ts
+++ b/packages/dreamux/tests/onboard.test.ts
@@ -18,6 +18,7 @@ import {
   type OnboardCliOptions,
 } from '../src/onboard/wizard.js';
 import type { CommandRunner, OnboardAnswers } from '../src/onboard/types.js';
+import type { ServiceNodeProbe } from '../src/onboard/service.js';
 import {
   dispatcherCodexHome,
   dispatcherWorkspaceSkillPath,
@@ -96,6 +97,14 @@ class FakeRunner implements CommandRunner {
   }
 }
 
+// No stable system Node exists: every candidate is skipped, so onboarding
+// falls back to the current Node (process.execPath). Keeps the assertions on
+// DREAMUX_NODE_BIN hermetic regardless of what the test host has installed.
+const noSystemNodeProbe: ServiceNodeProbe = {
+  realpath: async (path) => path,
+  isExecutable: () => false,
+};
+
 function writeGlobalCodexAuth(answers: OnboardAnswers): void {
   const authPath = join(dispatcherCodexHome(answers.dispatcherId), 'auth.json');
   mkdirSync(dirname(authPath), { recursive: true });
@@ -147,6 +156,7 @@ describe('dreamux onboard', () => {
       platform: 'linux',
       homeDir: join(root, 'home'),
       env: { CODEX_ACCESS_TOKEN: 'interactive-token-test' },
+      nodeProbe: noSystemNodeProbe,
     });
 
     expect(result.doctor.ok).toBe(true);
@@ -218,6 +228,80 @@ describe('dreamux onboard', () => {
     );
   });
 
+  it('pins the service to a stable system Node and leads PATH with its directory', async () => {
+    const runner = new FakeRunner();
+    const answers = testAnswers({
+      configDir: join(root, 'config'),
+      runtimeDir: join(root, 'runtime'),
+      dreamuxBin: '/usr/local/bin/dreamux',
+    });
+    writeGlobalCodexAuth(answers);
+    // /usr/local/bin/node exists, is not version-manager-bound, satisfies the
+    // minimum version, so it wins over process.execPath.
+    const stableNodeProbe: ServiceNodeProbe = {
+      realpath: async (path) => path,
+      isExecutable: (path) => path === '/usr/local/bin/node',
+    };
+
+    await runOnboard({
+      answers,
+      runner,
+      platform: 'linux',
+      homeDir: join(root, 'home'),
+      env: { CODEX_ACCESS_TOKEN: 'interactive-token-test' },
+      nodeProbe: stableNodeProbe,
+    });
+
+    const serviceUnit = readFileSync(
+      join(root, 'home', '.config', 'systemd', 'user', 'dreamux.service'),
+      'utf8',
+    );
+    expect(serviceUnit).toContain('Environment=DREAMUX_NODE_BIN=/usr/local/bin/node');
+    expect(serviceUnit).toContain('Environment=PATH=/usr/local/bin');
+    expect(serviceUnit).not.toContain(
+      `Environment=DREAMUX_NODE_BIN=${process.execPath}`,
+    );
+  });
+
+  it('excludes a version-manager-bound candidate and falls back to the current Node', async () => {
+    const runner = new FakeRunner();
+    const answers = testAnswers({
+      configDir: join(root, 'config'),
+      runtimeDir: join(root, 'runtime'),
+      dreamuxBin: '/usr/local/bin/dreamux',
+    });
+    writeGlobalCodexAuth(answers);
+    // /usr/local/bin/node is executable but realpaths into an nvm install, so
+    // it must be skipped and onboarding falls back to process.execPath.
+    const vmShimProbe: ServiceNodeProbe = {
+      realpath: async (path) =>
+        path === '/usr/local/bin/node'
+          ? `${join(root, 'home')}/.nvm/versions/node/v22.7.0/bin/node`
+          : path,
+      isExecutable: (path) => path === '/usr/local/bin/node',
+    };
+
+    await runOnboard({
+      answers,
+      runner,
+      platform: 'linux',
+      homeDir: join(root, 'home'),
+      env: { CODEX_ACCESS_TOKEN: 'interactive-token-test' },
+      nodeProbe: vmShimProbe,
+    });
+
+    const serviceUnit = readFileSync(
+      join(root, 'home', '.config', 'systemd', 'user', 'dreamux.service'),
+      'utf8',
+    );
+    expect(serviceUnit).toContain(
+      `Environment=DREAMUX_NODE_BIN=${process.execPath}`,
+    );
+    expect(serviceUnit).not.toContain(
+      'Environment=DREAMUX_NODE_BIN=/usr/local/bin/node',
+    );
+  });
+
   it('does not let an interactive shell token satisfy the managed service doctor', async () => {
     const runner = new FakeRunner();
     const answers = testAnswers({
@@ -281,6 +365,7 @@ describe('dreamux onboard', () => {
       homeDir: join(root, 'home'),
       uid: 501,
       env: {},
+      nodeProbe: noSystemNodeProbe,
     });
     await runOnboard({
       answers,
@@ -289,6 +374,7 @@ describe('dreamux onboard', () => {
       homeDir: join(root, 'home'),
       uid: 501,
       env: {},
+      nodeProbe: noSystemNodeProbe,
     });
 
     expect(countCalls(runner, 'codex', ['plugin'])).toBe(0);

--- a/packages/dreamux/tests/service-node.test.ts
+++ b/packages/dreamux/tests/service-node.test.ts
@@ -1,0 +1,242 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  detectServiceNodeVersionManager,
+  selectServiceNodeBin,
+  stabilizeHomebrewCellarNode,
+  stableNodeCandidates,
+  versionManagerOfPath,
+  type ServiceNodeProbe,
+} from '../src/onboard/service.js';
+import type { CommandRunner } from '../src/onboard/types.js';
+
+class FakeRunner implements CommandRunner {
+  // node bin path -> version string the probe should report
+  readonly versions = new Map<string, string>();
+  readonly captured: string[] = [];
+
+  async run(): Promise<void> {}
+  async check(): Promise<boolean> {
+    return true;
+  }
+  async capture(command: string, args: string[]): Promise<string> {
+    if (args[0] === '--version') {
+      this.captured.push(command);
+      const version = this.versions.get(command);
+      if (version === undefined) {
+        throw new Error(`no fake node at ${command}`);
+      }
+      return version;
+    }
+    throw new Error(`unexpected capture: ${command} ${args.join(' ')}`);
+  }
+}
+
+/** A probe whose executable set and symlink map are explicit. */
+function probeFrom(options: {
+  executables: string[];
+  links?: Record<string, string>;
+}): ServiceNodeProbe {
+  const executables = new Set(options.executables);
+  const links = options.links ?? {};
+  return {
+    isExecutable: (path) => executables.has(path),
+    realpath: async (path) => {
+      if (path in links) return links[path];
+      if (executables.has(path)) return path;
+      throw new Error(`ENOENT: ${path}`);
+    },
+  };
+}
+
+describe('versionManagerOfPath', () => {
+  it.each([
+    ['/home/u/.nvm/versions/node/v22.7.0/bin/node', 'nvm'],
+    ['/home/u/.fnm/node-versions/v22/installation/bin/node', 'fnm'],
+    ['/home/u/.local/state/fnm_multishells/12345_1/bin/node', 'fnm'],
+    ['/home/u/.local/share/fnm/node-versions/v22/installation/bin/node', 'fnm'],
+    ['/Users/u/Library/Application Support/fnm/node-versions/v22/bin/node', 'fnm'],
+    ['/home/u/.asdf/installs/nodejs/22.7.0/bin/node', 'asdf'],
+    ['/home/u/.asdf/shims/node', 'asdf'],
+    ['/home/u/.volta/tools/image/node/22.7.0/bin/node', 'volta'],
+  ])('flags %s as %s', (path, manager) => {
+    expect(versionManagerOfPath(path)).toBe(manager);
+  });
+
+  it('does not match a user directory literally named volta', () => {
+    expect(versionManagerOfPath('/home/volta/bin/node')).toBeNull();
+  });
+
+  it('returns null for system paths', () => {
+    expect(versionManagerOfPath('/usr/local/bin/node')).toBeNull();
+    expect(versionManagerOfPath('/opt/homebrew/bin/node')).toBeNull();
+  });
+});
+
+describe('detectServiceNodeVersionManager', () => {
+  it('catches a system-looking shim that realpaths into a version manager', async () => {
+    const probe = probeFrom({
+      executables: ['/usr/local/bin/node'],
+      links: {
+        '/usr/local/bin/node': '/home/u/.nvm/versions/node/v22.7.0/bin/node',
+      },
+    });
+    expect(
+      await detectServiceNodeVersionManager('/usr/local/bin/node', probe),
+    ).toBe('nvm');
+  });
+
+  it('returns null when neither the raw nor resolved path is managed', async () => {
+    const probe = probeFrom({ executables: ['/usr/bin/node'] });
+    expect(
+      await detectServiceNodeVersionManager('/usr/bin/node', probe),
+    ).toBeNull();
+  });
+
+  it('falls back to the raw path when realpath fails', async () => {
+    const probe = probeFrom({ executables: [] });
+    expect(
+      await detectServiceNodeVersionManager(
+        '/home/u/.volta/tools/image/node/22.7.0/bin/node',
+        probe,
+      ),
+    ).toBe('volta');
+  });
+});
+
+describe('stableNodeCandidates', () => {
+  it('covers Homebrew on macOS', () => {
+    const list = stableNodeCandidates('darwin');
+    expect(list).toContain('/opt/homebrew/bin/node');
+    expect(list).toContain('/opt/homebrew/opt/node@22/bin/node');
+    expect(list).toContain('/usr/local/opt/node/bin/node');
+    expect(list).toContain('/usr/bin/node');
+  });
+
+  it('uses system locations on Linux', () => {
+    expect(stableNodeCandidates('linux')).toEqual([
+      '/usr/local/bin/node',
+      '/usr/bin/node',
+      '/bin/node',
+    ]);
+  });
+});
+
+describe('selectServiceNodeBin', () => {
+  it('picks the first executable, non-managed, version-satisfying candidate', async () => {
+    const runner = new FakeRunner();
+    runner.versions.set('/usr/local/bin/node', 'v22.9.0');
+    const probe = probeFrom({ executables: ['/usr/local/bin/node'] });
+
+    const selected = await selectServiceNodeBin({
+      platform: 'linux',
+      currentNodeBin: '/home/u/.nvm/versions/node/v18.0.0/bin/node',
+      runner,
+      probe,
+    });
+    // Persists the candidate path itself, never its realpath.
+    expect(selected).toBe('/usr/local/bin/node');
+  });
+
+  it('skips a candidate that is too old and tries the next', async () => {
+    const runner = new FakeRunner();
+    runner.versions.set('/usr/local/bin/node', 'v18.20.0');
+    runner.versions.set('/usr/bin/node', 'v22.7.0');
+    const probe = probeFrom({
+      executables: ['/usr/local/bin/node', '/usr/bin/node'],
+    });
+
+    const selected = await selectServiceNodeBin({
+      platform: 'linux',
+      currentNodeBin: '/usr/bin/node',
+      runner,
+      probe,
+    });
+    expect(selected).toBe('/usr/bin/node');
+  });
+
+  it('skips a version-manager-bound candidate without probing its version', async () => {
+    const runner = new FakeRunner();
+    const probe = probeFrom({
+      executables: ['/usr/local/bin/node'],
+      links: {
+        '/usr/local/bin/node': '/home/u/.fnm/node-versions/v22/installation/bin/node',
+      },
+    });
+
+    const selected = await selectServiceNodeBin({
+      platform: 'linux',
+      currentNodeBin: '/some/current/node',
+      runner,
+      probe,
+    });
+    expect(selected).toBe('/some/current/node');
+    expect(runner.captured).not.toContain('/usr/local/bin/node');
+  });
+
+  it('falls back to the current Node when no stable candidate exists', async () => {
+    const runner = new FakeRunner();
+    const probe = probeFrom({ executables: [] });
+
+    const selected = await selectServiceNodeBin({
+      platform: 'linux',
+      currentNodeBin: '/home/u/.nvm/versions/node/v22.7.0/bin/node',
+      runner,
+      probe,
+    });
+    // Fallback reproduces the fragility; the doctor advisory is the safety net.
+    expect(selected).toBe('/home/u/.nvm/versions/node/v22.7.0/bin/node');
+  });
+});
+
+describe('stabilizeHomebrewCellarNode', () => {
+  it('remaps a Cellar path to the @major Homebrew symlink that points back to it', async () => {
+    const cellar = '/opt/homebrew/Cellar/node@22/22.7.0/bin/node';
+    const probe = probeFrom({
+      executables: ['/opt/homebrew/opt/node@22/bin/node', cellar],
+      links: { '/opt/homebrew/opt/node@22/bin/node': cellar },
+    });
+
+    expect(await stabilizeHomebrewCellarNode(cellar, 'darwin', probe)).toBe(
+      '/opt/homebrew/opt/node@22/bin/node',
+    );
+  });
+
+  it('remaps an unversioned Cellar node to opt/node/bin/node', async () => {
+    const cellar = '/usr/local/Cellar/node/24.1.0/bin/node';
+    const probe = probeFrom({
+      executables: ['/usr/local/opt/node/bin/node', cellar],
+      links: { '/usr/local/opt/node/bin/node': cellar },
+    });
+
+    expect(await stabilizeHomebrewCellarNode(cellar, 'darwin', probe)).toBe(
+      '/usr/local/opt/node/bin/node',
+    );
+  });
+
+  it('keeps the input when no stable symlink resolves back to it', async () => {
+    const cellar = '/opt/homebrew/Cellar/node/24.1.0/bin/node';
+    const probe = probeFrom({ executables: [cellar] });
+
+    expect(await stabilizeHomebrewCellarNode(cellar, 'darwin', probe)).toBe(
+      cellar,
+    );
+  });
+
+  it('is a no-op on non-darwin platforms', async () => {
+    const cellar = '/opt/homebrew/Cellar/node/24.1.0/bin/node';
+    const probe = probeFrom({ executables: [cellar] });
+
+    expect(await stabilizeHomebrewCellarNode(cellar, 'linux', probe)).toBe(
+      cellar,
+    );
+  });
+
+  it('leaves a non-Cellar path untouched', async () => {
+    const probe = probeFrom({ executables: ['/opt/homebrew/bin/node'] });
+
+    expect(
+      await stabilizeHomebrewCellarNode('/opt/homebrew/bin/node', 'darwin', probe),
+    ).toBe('/opt/homebrew/bin/node');
+  });
+});


### PR DESCRIPTION
## 背景

承接 #81。PR #61 让被托管服务环境自给自足（`DREAMUX_NODE_BIN` / 绝对 `CODEX_HOST_CODEX_BIN` / 最小 `PATH`），但 service Node 仍是无条件冻结 `process.execPath`。当 onboarding 跑在 nvm/fnm/asdf/volta 的 Node 下时，服务被钉死在易变的版本管理器路径上，版本切换/清理后会静默挂掉，且 doctor 此前不会预警。

经过 Codex 两轮方案 review（platform-aware 候选、macOS fnm marker、Homebrew Cellar 边界），本 PR 实现修复。

## 改动

- **platform-aware service Node 选择**（`src/onboard/service.ts` `selectServiceNodeBin` + `run.ts`）：优先从候选清单选稳定系统 Node（macOS 覆盖 `/opt/homebrew`、`/usr/local` 下 Homebrew；Linux 为 `/usr/local/bin`、`/usr/bin`、`/bin`），取第一个**存在 + 非版本管理器 + 满足 `MIN_SERVICE_NODE_VERSION`** 的候选；都不满足才 fallback 到 `process.execPath`。
- **持久化稳定符号链接而非 realpath**：候选落盘的是其自身路径（如 `/opt/homebrew/bin/node`），Homebrew Cellar 天然被规避；fallback 的 Node 若本身就是 Cellar 路径，best-effort 映射回 `opt/...` 稳定 symlink（映射不到按原样、不让 onboarding 失败）。
- **doctor 漂移 advisory**（`src/cli/doctor.ts`）：安装的 `DREAMUX_NODE_BIN` 解析后落在版本管理器时，给出 `warn` 级别、`ok: true` 的可见告警，指引重跑 `dreamux onboard`；**不**用 `ok: false` 表达，**不**翻转退出码。
- **共享谓词**：selection 与 doctor 复用同一个 async / 依赖可注入的版本管理器判定（先 `realpath` 再匹配 nvm/fnm/asdf/volta marker，含 macOS fnm 默认目录 `~/Library/Application Support/fnm/`），避免两处漂移。
- PR #61 的 launcher / env 合约不回退。
- 同步 KB 决策记录 `.agents/decisions/global-bin-onboard-serve.md` 与 rush change。

## 测试

- 新增 `tests/service-node.test.ts`：谓词（含 macOS fnm、`/home/volta` 误报防护）、platform 候选、selection（选中/过老跳过/排除版本管理器/fallback）、Cellar 稳定化（@major / 无版本 / 映射不到保持原值 / 非 darwin no-op）。
- `tests/onboard.test.ts`：新增稳定系统 Node 被选中且 `PATH` 首项为其目录、版本管理器候选被排除并 fallback；既有 execPath 断言用例注入 probe 保持 hermetic。
- `tests/doctor.test.ts`：版本管理器绑定告警（不失败）、`/usr/local/bin/node` realpath 到 fnm 被识破、稳定路径不告警。

### 验证

- `node common/scripts/install-run-rush.js update`
- `./node_modules/.bin/tsc -p tsconfig.json --noEmit`（packages/dreamux，干净）
- `node common/scripts/install-run-rush.js build --to @excitedjs/dreamux`
- `node common/scripts/install-run-rush.js test`（通过；dreamux 目标 warning 仅因测试日志写 stderr）
- `.agents/scripts/check.sh`（KB OK）
- `node common/scripts/install-run-rush.js change --verify --no-fetch`
- pre-commit `gitleaks protect --staged`（no leaks）

Closes #81
