### PR TITLE
feat(daemon): daemon 命令组 + systemd linger 开机自启 + restart 完成提示 (#78)

### DIFF
--- a/.agents/decisions/global-bin-onboard-serve.md
+++ b/.agents/decisions/global-bin-onboard-serve.md
@@ -12,6 +12,14 @@ foreground `serve` decisions still stand.
 Dispatcher `tm` packaging and dispatcher-skill install location are superseded
 by [dispatcher-tm-packaging](dispatcher-tm-packaging.md).
 
+Two service-management decisions below are **reversed by
+[issue #78](https://github.com/excitedjs/dreamux/issues/78)**: there is now a
+public `dreamux daemon install|uninstall|start|stop|restart` command group, and
+`dreamux onboard` / `daemon install` now enable `loginctl enable-linger`
+(best-effort) so a `systemd --user` service starts at boot without an
+interactive login. See [the amendment](#amendment-issue-78-daemon-group--linger)
+at the end of this record.
+
 ## Context
 
 Issue #18 asks for a globally installed `dreamux` to expose one bin named
@@ -75,6 +83,8 @@ foreground `dreamux serve` supervised by a native user-level service manager.
 After `dreamux onboard` registers that service, operators use native
 `launchctl` or `systemctl --user` commands for ongoing service start, stop,
 status, and uninstall operations.
+*(Reversed by issue #78 — see the
+[amendment](#amendment-issue-78-daemon-group--linger).)*
 
 Dispatcher app-server processes do not set `CODEX_HOME`; they use Codex's
 global default home (`~/.codex`) for auth, config, and memory. The
@@ -92,9 +102,11 @@ auth, memory, and other user settings follow the operator's local Codex
 installation.
 
 Service registration is user-level only for issue #18:
-macOS LaunchAgent and Linux `systemd --user`. Root-scoped LaunchDaemons,
-root-scoped systemd services, and automatic `loginctl enable-linger` are out
-of scope.
+macOS LaunchAgent and Linux `systemd --user`. Root-scoped LaunchDaemons and
+root-scoped systemd services are out of scope. Automatic
+`loginctl enable-linger` was out of scope for issue #18 but is **now enabled
+(best-effort) by issue #78** — see the
+[amendment](#amendment-issue-78-daemon-group--linger).
 
 Use commodity packages for commodity infrastructure:
 
@@ -183,3 +195,36 @@ status.
   needs private, owner-writable control state under dreamux runtime state.
 - **Use Ink for onboarding:** rejected for now. `dreamux onboard` is a
   finite wizard, not a full-screen terminal application.
+
+## Amendment (issue #78): daemon group + linger
+
+[Issue #78](https://github.com/excitedjs/dreamux/issues/78) reverses two
+narrow decisions above. Everything else in this record stands.
+
+- **A public `dreamux daemon` command group exists**:
+  `daemon install|uninstall|start|stop|restart`. `start|stop|restart` are thin
+  cross-platform wrappers over the native manager
+  ([`/packages/dreamux/src/daemon/service-control.ts`](/packages/dreamux/src/daemon/service-control.ts));
+  `install`/`uninstall` reuse the onboard service slice
+  ([`/packages/dreamux/src/daemon/install.ts`](/packages/dreamux/src/daemon/install.ts)).
+  `daemon uninstall` removes only the service unit; top-level
+  `dreamux uninstall` still removes config/state/logs. Native `systemctl`/
+  `launchctl` remain valid; the group is a convenience and the home of the new
+  `restart` verb (which did not exist before).
+- **`loginctl enable-linger` is enabled best-effort** by both `onboard` and
+  `daemon install`, single-sourced in
+  [`/packages/dreamux/src/onboard/service.ts`](/packages/dreamux/src/onboard/service.ts)
+  (`enableSystemdLinger`). Failure (strict polkit / non-root) is non-fatal: it
+  surfaces a warning with the manual fix. `dreamux doctor` now reports a
+  `systemd linger` check.
+- **`daemon restart --notify-resumed --dispatcher <id>`** drops a one-shot
+  marker ([`/packages/dreamux/src/daemon/restart-intent.ts`](/packages/dreamux/src/daemon/restart-intent.ts),
+  path via `restartIntentPath()`) *before* triggering the restart — durable if
+  the caller is reaped during a self-update. The freshly started server loads
+  and deletes the marker once, and injects a `Restart completed.` turn into each
+  named dispatcher whose thread actually resumed. The injection happens after
+  the dispatcher slot is ready (so the resumed turn can reply through Feishu),
+  skips when a real inbound already woke the thread (there is no FIFO queue —
+  `TurnManager.injectNotice` detects an in-flight inbound), and never fails the
+  dispatcher start or the restart. Cold boots and crash auto-heals do not reach
+  the injection path with a live marker.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,9 +51,16 @@ two-paths consequence of `.agents/decisions/rush-pnpm-monorepo.md`).
 ## CLI surface
 
 The user-facing CLI is the single global bin `dreamux`. Current command tree:
-`onboard`, `serve`, `status`, `doctor`, `daemon install|uninstall|start|stop|status`,
-`dispatcher add|remove|list|status|start|stop`, and `config path|show`.
-`dreamux serve` is the foreground server entry point. Do not reintroduce
+`onboard`, `uninstall`, `serve`, `status`, `doctor`,
+`daemon install|uninstall|start|stop|restart`,
+`dispatcher add|remove|list|status|start|stop`, `feishu-mcp`, and
+`config path|show`. `dreamux serve` is the foreground server entry point. The
+`daemon` group wraps the native user-level service manager (Linux
+`systemctl --user`, macOS `launchctl`); `daemon uninstall` removes only the
+service unit, whereas top-level `dreamux uninstall` removes config/state/logs
+too. `daemon restart --notify-resumed --dispatcher <id>` drops a one-shot
+restart marker before restarting, so a resumed dispatcher gets a
+`Restart completed.` turn injected — see issue #78. Do not reintroduce
 global aliases such as `dreamux-server` or `server-ctl`; issue #18 explicitly
 removed the legacy global-bin transition period.
 

--- a/common/changes/@excitedjs/dreamux/feat-daemon-command-group_2026-06-04-20-03.json
+++ b/common/changes/@excitedjs/dreamux/feat-daemon-command-group_2026-06-04-20-03.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Add daemon command group (install/uninstall/start/stop/restart), enable systemd linger so the user service starts at boot, and inject a restart-completed notice into resumed dispatchers after daemon restart --notify-resumed",
+      "type": "minor",
+      "packageName": "@excitedjs/dreamux"
+    }
+  ],
+  "packageName": "@excitedjs/dreamux",
+  "email": "053700@gmail.com"
+}

--- a/packages/dreamux/src/cli/doctor.ts
+++ b/packages/dreamux/src/cli/doctor.ts
@@ -1,5 +1,5 @@
 import { existsSync, readFileSync } from 'node:fs';
-import { homedir } from 'node:os';
+import { homedir, userInfo } from 'node:os';
 
 import { parse as parsePlist, type PlistValue } from 'plist';
 
@@ -42,6 +42,8 @@ export interface DoctorOptions {
   homeDir?: string;
   uid?: number;
   nodeProbe?: ServiceNodeProbe;
+  /** Override the user checked for systemd lingering (tests). */
+  userName?: string;
 }
 
 export interface ServiceStatus {
@@ -116,6 +118,11 @@ export async function runDreamuxDoctor(
       ? `installed at ${service.unitPath}`
       : `not installed at ${service.unitPath}`,
   });
+  if (service.platform === 'systemd' && service.installed) {
+    checks.push(
+      await systemdLingerCheck(runner, options.userName ?? userInfo().username),
+    );
+  }
   await addManagedServiceLaunchChecks(
     checks,
     service,
@@ -323,6 +330,35 @@ async function systemdStatus(
     environment: unitFile.environment,
     execStart: unitFile.execStart,
   };
+}
+
+async function systemdLingerCheck(
+  runner: CommandRunner,
+  userName: string,
+): Promise<DoctorCheck> {
+  const fix =
+    'enable it with `loginctl enable-linger` (or rerun `dreamux daemon install`)';
+  try {
+    const raw = await runner.capture('loginctl', [
+      'show-user',
+      userName,
+      '--property=Linger',
+    ]);
+    const ok = /Linger=yes/.test(raw);
+    return {
+      name: 'systemd linger',
+      ok,
+      detail: ok
+        ? `enabled for ${userName}; the service starts at boot`
+        : `disabled for ${userName}; the service will not start at boot without an interactive login — ${fix}`,
+    };
+  } catch (err) {
+    return {
+      name: 'systemd linger',
+      ok: false,
+      detail: `could not determine lingering for ${userName} (${err instanceof Error ? err.message : String(err)}) — ${fix}`,
+    };
+  }
 }
 
 async function addManagedServiceLaunchChecks(

--- a/packages/dreamux/src/cli/dreamux.ts
+++ b/packages/dreamux/src/cli/dreamux.ts
@@ -30,6 +30,20 @@ import {
   type OnboardCliOptions,
 } from '../onboard/wizard.js';
 import type { OnboardRunResult } from '../onboard/types.js';
+import {
+  runDaemonInstall,
+  runDaemonUninstall,
+  type DaemonInstallResult,
+} from '../daemon/install.js';
+import {
+  controlUserService,
+  type DaemonVerb,
+} from '../daemon/service-control.js';
+import {
+  DEFAULT_RESTART_ANNOUNCE,
+  notifyResumedRestart,
+} from '../daemon/restart-intent.js';
+import { ExecaCommandRunner } from '../onboard/commands.js';
 import { printDoctorResult, runDreamuxDoctor } from './doctor.js';
 import { runFeishuMcp } from '../mcp/feishu-mcp.js';
 import { createLogger } from '../runtime/logger.js';
@@ -264,6 +278,7 @@ function printOnboardResult(result: OnboardRunResult): void {
     console.log(
       `dreamux onboard service: ${result.service.platform} ${result.service.unitPath}`,
     );
+    printServiceWarnings(result.service.lingerEnabled, result.service.warnings);
   }
 }
 
@@ -278,6 +293,148 @@ function printUninstallResult(result: UninstallRunResult): void {
   console.log(
     `dreamux uninstall service: ${result.service.platform} ${result.service.unitPath}`,
   );
+}
+
+function buildDaemonCommands(y: Argv): Argv {
+  return y
+    .command(
+      'install',
+      'Register (or re-register) the user-level service from config',
+      (yy) =>
+        yy
+          .option('start', {
+            type: 'boolean',
+            default: true,
+            describe: 'Start the service after registration',
+          })
+          .option('dry-run', {
+            type: 'boolean',
+            describe: 'Print the planned actions without writing or registering',
+          }),
+      async (argv) => {
+        const result = await runDaemonInstall({
+          startService: argv.start !== false,
+          dryRun: argv.dryRun === true,
+        });
+        printDaemonInstallResult(result);
+      },
+    )
+    .command(
+      'uninstall',
+      'Remove the user-level service unit only (keeps config, state, logs)',
+      (yy) =>
+        yy.option('dry-run', {
+          type: 'boolean',
+          describe: 'Print the planned removal without unregistering',
+        }),
+      async (argv) => {
+        const result = await runDaemonUninstall({ dryRun: argv.dryRun === true });
+        console.log(
+          `dreamux daemon uninstall: ${result.platform} unit ${result.removed ? 'removed' : 'absent'} at ${result.unitPath}`,
+        );
+      },
+    )
+    .command(
+      'start',
+      'Start the user-level service',
+      (yy) => yy,
+      async () => runDaemonControl('start'),
+    )
+    .command(
+      'stop',
+      'Stop the user-level service',
+      (yy) => yy,
+      async () => runDaemonControl('stop'),
+    )
+    .command(
+      'restart',
+      'Restart the user-level service',
+      (yy) =>
+        yy
+          .option('notify-resumed', {
+            type: 'boolean',
+            describe:
+              'After the restart, inject a one-shot notice into the named resumed dispatcher(s)',
+          })
+          .option('dispatcher', {
+            type: 'string',
+            array: true,
+            describe:
+              'Dispatcher id to notify (required with --notify-resumed; repeatable)',
+          })
+          .option('announce', {
+            type: 'string',
+            describe: `Notice text to inject (default: "${DEFAULT_RESTART_ANNOUNCE}")`,
+          }),
+      async (argv) => {
+        await handleDaemonRestart(argv);
+      },
+    )
+    .demandCommand(1, 'Choose a daemon command')
+    .strict();
+}
+
+async function runDaemonControl(verb: DaemonVerb): Promise<void> {
+  const result = await controlUserService(verb, {
+    runner: new ExecaCommandRunner(),
+  });
+  const issued = result.commands
+    .map((cmd) => `${cmd.command} ${cmd.args.join(' ')}`)
+    .join('; ');
+  console.log(
+    `dreamux daemon ${verb}: ${result.platform}${issued === '' ? ' (no-op)' : ` (${issued})`}`,
+  );
+}
+
+async function handleDaemonRestart(argv: unknown): Promise<void> {
+  const args = argv as {
+    notifyResumed?: boolean;
+    dispatcher?: string[];
+    announce?: string;
+  };
+  if (args.notifyResumed !== true) {
+    await runDaemonControl('restart');
+    return;
+  }
+
+  const targets = (args.dispatcher ?? []).map((id) => validateDispatcherId(id));
+  if (targets.length === 0) {
+    throw new Error('--notify-resumed requires at least one --dispatcher <id>');
+  }
+  console.log(
+    `dreamux daemon restart: will notify resumed dispatcher(s) ${targets.join(', ')}`,
+  );
+  // Marker first (durable across a self-update reap), restart second, and roll
+  // the marker back if the restart command fails while we are still alive.
+  await notifyResumedRestart({
+    targets,
+    ...(args.announce !== undefined ? { announce: args.announce } : {}),
+    now: Date.now(),
+    runControl: () => runDaemonControl('restart'),
+  });
+}
+
+function printDaemonInstallResult(result: DaemonInstallResult): void {
+  console.log('dreamux daemon install file ledger:');
+  for (const entry of result.files) {
+    console.log(`${entry.status}\t${entry.path}\t${entry.reason}`);
+  }
+  console.log(
+    `dreamux daemon install service: ${result.service.platform} ${result.service.unitPath}`,
+  );
+  printServiceWarnings(result.service.lingerEnabled, result.service.warnings);
+}
+
+function printServiceWarnings(
+  lingerEnabled: boolean | null,
+  warnings: string[],
+): void {
+  if (lingerEnabled === true) {
+    console.log('dreamux service: systemd lingering enabled (starts at boot)');
+  }
+  for (const warning of warnings) {
+    console.error(`warning: ${warning}`);
+  }
 }
 
 function buildConfigCommands(y: Argv): Argv {
@@ -368,6 +525,11 @@ async function main(): Promise<void> {
         }
         if (!result.ok) process.exitCode = 1;
       },
+    )
+    .command(
+      'daemon <command>',
+      'Manage the dreamux user-level service',
+      buildDaemonCommands,
     )
     .command(
       'dispatcher <command>',

--- a/packages/dreamux/src/daemon/install.ts
+++ b/packages/dreamux/src/daemon/install.ts
@@ -1,0 +1,128 @@
+/**
+ * `dreamux daemon install` / `daemon uninstall`.
+ *
+ * `install` re-registers the user-level service from the already-written
+ * dreamux config (it does not collect onboarding answers). It reuses the exact
+ * service slice onboard uses — `installUserService` — so linger handling and
+ * the unit contents stay single-sourced. `uninstall` removes only the service
+ * unit (never config / state / logs); that is the boundary against the
+ * top-level `dreamux uninstall`.
+ */
+
+import { ExecaCommandRunner } from '../onboard/commands.js';
+import {
+  installUserService,
+  removeUserService,
+  resolveServiceExecutable,
+  selectServiceNodeBin,
+  validateManagedServiceLaunch,
+  type ServiceInstallAnswers,
+  type ServiceInstallResult,
+  type ServiceNodeProbe,
+  type ServiceRemoveResult,
+} from '../onboard/service.js';
+import { TransparentFileLedger } from '../onboard/ledger.js';
+import type { CommandRunner, OnboardFileLedgerEntry } from '../onboard/types.js';
+import { globalConfigDir, loadConfig } from '../runtime/config.js';
+import { dreamuxBinPath } from '../runtime/package-bin.js';
+import { setRuntimeConfig, stateRoot } from '../runtime/paths.js';
+
+export interface DaemonInstallOptions {
+  startService?: boolean;
+  dryRun?: boolean;
+  runner?: CommandRunner;
+  platform?: NodeJS.Platform;
+  homeDir?: string;
+  uid?: number;
+  env?: NodeJS.ProcessEnv;
+  /** Stable-Node selection probe (tests). */
+  nodeProbe?: ServiceNodeProbe;
+}
+
+export interface DaemonInstallResult {
+  service: ServiceInstallResult;
+  files: OnboardFileLedgerEntry[];
+}
+
+export async function runDaemonInstall(
+  options: DaemonInstallOptions = {},
+): Promise<DaemonInstallResult> {
+  const runner = options.runner ?? new ExecaCommandRunner();
+  const env = options.env ?? process.env;
+  const dryRun = options.dryRun ?? false;
+  const startService = options.startService ?? true;
+
+  // Fail loudly when the operator has not run onboard yet — daemon install
+  // re-registers an existing setup, it does not create one.
+  const { config } = loadConfig({ configDir: globalConfigDir() });
+  setRuntimeConfig(config);
+
+  const codexBin = dryRun
+    ? config.codex.bin
+    : resolveServiceExecutable(config.codex.bin, env);
+  // Pin the managed service to a stable system Node (issue #83) rather than the
+  // current process Node — otherwise running `daemon install` from a
+  // version-manager Node would re-pin the service to that unstable Node.
+  const nodeBin = dryRun
+    ? process.execPath
+    : await selectServiceNodeBin({
+        platform: options.platform ?? process.platform,
+        currentNodeBin: process.execPath,
+        runner,
+        ...(options.nodeProbe !== undefined ? { probe: options.nodeProbe } : {}),
+      });
+  const answers: ServiceInstallAnswers = {
+    configDir: globalConfigDir(),
+    runtimeDir: stateRoot(),
+    codexBin,
+    dreamuxBin: dreamuxBinPath(env),
+    nodeBin,
+    startService,
+    dryRun,
+  };
+
+  if (!dryRun) {
+    const launch = await validateManagedServiceLaunch(answers, runner);
+    if (!launch.ok) {
+      throw new Error(
+        [
+          'dreamux managed service launch environment is not ready',
+          ...launch.errors.map((error) => `- ${error}`),
+          '- rerun dreamux onboard from the desired Node/Codex install',
+        ].join('\n'),
+      );
+    }
+  }
+
+  const ledger = new TransparentFileLedger();
+  const service = await installUserService({
+    answers,
+    ledger,
+    runner,
+    platform: options.platform,
+    homeDir: options.homeDir,
+    uid: options.uid,
+  });
+  return { service, files: ledger.entries() };
+}
+
+export interface DaemonUninstallOptions {
+  dryRun?: boolean;
+  runner?: CommandRunner;
+  platform?: NodeJS.Platform;
+  homeDir?: string;
+  uid?: number;
+}
+
+export async function runDaemonUninstall(
+  options: DaemonUninstallOptions = {},
+): Promise<ServiceRemoveResult> {
+  const runner = options.runner ?? new ExecaCommandRunner();
+  return removeUserService({
+    runner,
+    platform: options.platform,
+    homeDir: options.homeDir,
+    uid: options.uid,
+    dryRun: options.dryRun ?? false,
+  });
+}

--- a/packages/dreamux/src/daemon/restart-intent.ts
+++ b/packages/dreamux/src/daemon/restart-intent.ts
@@ -1,0 +1,214 @@
+/**
+ * Restart-notice marker — the one-shot signal that turns a plain service
+ * restart into "after you come back up, tell these resumed dispatchers the
+ * restart finished".
+ *
+ * Contract (issue #78):
+ *   - `dreamux daemon restart --notify-resumed --dispatcher <id>` writes the
+ *     marker to dreamux state *before* it asks the service manager to restart.
+ *     Writing first means the marker survives even when the calling CLI is a
+ *     child of the Codex process group that the restart reaps (the dispatcher
+ *     self-update case): the caller may be killed before `systemctl` returns,
+ *     so it must not depend on observing an exit code.
+ *   - The freshly started server loads the marker exactly once, deletes it
+ *     immediately (snapshot-in-memory semantics), then hands the announce text
+ *     to each named dispatcher as it comes up resumed. Deleting on load is what
+ *     stops a later cold boot / crash auto-heal from replaying the notice.
+ *   - A TTL bounds staleness: a marker older than its TTL is ignored (and the
+ *     file removed). The TTL is re-checked at claim time too, so a dispatcher
+ *     that only starts long after boot (e.g. via a later admin `dispatcher
+ *     start`) does not claim a stale notice.
+ */
+
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { dirname } from 'node:path';
+
+import { restartIntentPath } from '../runtime/paths.js';
+
+/** Default English notice injected into a resumed dispatcher after restart. */
+export const DEFAULT_RESTART_ANNOUNCE = 'Restart completed.';
+
+/**
+ * How long a restart marker stays valid. A `daemon restart` is a service
+ * restart (seconds), not a machine reboot, so ten minutes is comfortably
+ * longer than any healthy restart+resume while still bounding a stale marker
+ * left behind by a crash mid-restart.
+ */
+export const DEFAULT_RESTART_INTENT_TTL_MS = 10 * 60_000;
+
+export interface RestartIntentFile {
+  version: 1;
+  created_at_ms: number;
+  ttl_ms: number;
+  announce: string;
+  targets: string[];
+}
+
+export interface WriteRestartIntentOptions {
+  targets: string[];
+  announce?: string;
+  ttlMs?: number;
+  /** Wall clock at write time (callers pass Date.now()). */
+  now: number;
+  /** Override the marker path (tests). */
+  path?: string;
+}
+
+/**
+ * Persist the restart marker. Must be called *before* triggering the service
+ * manager restart so the marker is durable if the caller is killed.
+ */
+export function writeRestartIntent(options: WriteRestartIntentOptions): string {
+  const path = options.path ?? restartIntentPath();
+  const file: RestartIntentFile = {
+    version: 1,
+    created_at_ms: options.now,
+    ttl_ms: options.ttlMs ?? DEFAULT_RESTART_INTENT_TTL_MS,
+    announce:
+      options.announce !== undefined && options.announce.trim() !== ''
+        ? options.announce
+        : DEFAULT_RESTART_ANNOUNCE,
+    targets: dedupeNonEmpty(options.targets),
+  };
+  mkdirSync(dirname(path), { recursive: true });
+  writeFileSync(path, `${JSON.stringify(file, null, 2)}\n`, { mode: 0o600 });
+  return path;
+}
+
+/**
+ * Best-effort removal of the restart marker. Used to roll back a marker after
+ * the restart command itself fails synchronously while this process is still
+ * alive — leaving it would let the next ordinary `serve` start (within the TTL)
+ * falsely consume it and inject a notice for a restart that never happened. The
+ * self-update path where the caller is reaped before reaching here keeps the
+ * marker (durability), which is the intended behaviour (issue #78).
+ */
+export function clearRestartIntent(path: string = restartIntentPath()): void {
+  try {
+    rmSync(path, { force: true });
+  } catch {
+    /* best effort */
+  }
+}
+
+export interface NotifyResumedRestartOptions {
+  targets: string[];
+  announce?: string;
+  now: number;
+  /** Triggers the actual service-manager restart. */
+  runControl: () => Promise<void>;
+  path?: string;
+}
+
+/**
+ * Drop the restart marker, then trigger the restart. The marker is written
+ * first so it survives a self-update restart that reaps the caller. If the
+ * restart command instead fails synchronously (caller still alive), roll the
+ * marker back so a later ordinary `serve` start cannot falsely consume it
+ * within the TTL. See issue #78.
+ */
+export async function notifyResumedRestart(
+  options: NotifyResumedRestartOptions,
+): Promise<void> {
+  const path = writeRestartIntent({
+    targets: options.targets,
+    ...(options.announce !== undefined ? { announce: options.announce } : {}),
+    now: options.now,
+    ...(options.path !== undefined ? { path: options.path } : {}),
+  });
+  try {
+    await options.runControl();
+  } catch (err) {
+    clearRestartIntent(path);
+    throw err;
+  }
+}
+
+/**
+ * In-memory snapshot of the restart marker. Constructed once at server start;
+ * `claim` hands out the announce text per target exactly once.
+ */
+export class RestartIntentConsumer {
+  private readonly announce: string;
+  private readonly expiresAtMs: number;
+  private readonly remaining: Set<string>;
+
+  private constructor(
+    announce: string,
+    expiresAtMs: number,
+    remaining: Set<string>,
+  ) {
+    this.announce = announce;
+    this.expiresAtMs = expiresAtMs;
+    this.remaining = remaining;
+  }
+
+  /**
+   * Read the marker (if any), delete it from disk, and return a consumer. A
+   * missing / malformed / expired marker yields an empty consumer (and the
+   * stale file is removed). This is the only reader of the marker file.
+   */
+  static load(options: { now: number; path?: string } = { now: 0 }): RestartIntentConsumer {
+    const path = options.path ?? restartIntentPath();
+    const empty = new RestartIntentConsumer('', 0, new Set());
+    if (!existsSync(path)) return empty;
+    let parsed: RestartIntentFile | null = null;
+    try {
+      parsed = JSON.parse(readFileSync(path, 'utf8')) as RestartIntentFile;
+    } catch {
+      parsed = null;
+    }
+    // Single reader: drop the file regardless of validity so it never replays.
+    try {
+      rmSync(path, { force: true });
+    } catch {
+      /* best effort */
+    }
+    if (parsed === null || parsed.version !== 1) return empty;
+    const expiresAtMs = parsed.created_at_ms + parsed.ttl_ms;
+    if (options.now > expiresAtMs) return empty;
+    const announce =
+      typeof parsed.announce === 'string' && parsed.announce.trim() !== ''
+        ? parsed.announce
+        : DEFAULT_RESTART_ANNOUNCE;
+    return new RestartIntentConsumer(
+      announce,
+      expiresAtMs,
+      new Set(dedupeNonEmpty(parsed.targets ?? [])),
+    );
+  }
+
+  /**
+   * Claim the notice for one dispatcher. Returns the announce text the first
+   * time a still-valid target is seen, then null forever after (single
+   * consume). Re-checks the TTL so a late starter cannot claim a stale notice.
+   */
+  claim(dispatcherId: string, now: number): string | null {
+    if (!this.remaining.has(dispatcherId)) return null;
+    if (now > this.expiresAtMs) {
+      this.remaining.delete(dispatcherId);
+      return null;
+    }
+    this.remaining.delete(dispatcherId);
+    return this.announce;
+  }
+}
+
+function dedupeNonEmpty(values: string[]): string[] {
+  const out: string[] = [];
+  const seen = new Set<string>();
+  for (const value of values) {
+    if (typeof value !== 'string') continue;
+    const trimmed = value.trim();
+    if (trimmed === '' || seen.has(trimmed)) continue;
+    seen.add(trimmed);
+    out.push(trimmed);
+  }
+  return out;
+}

--- a/packages/dreamux/src/daemon/service-control.ts
+++ b/packages/dreamux/src/daemon/service-control.ts
@@ -1,0 +1,82 @@
+/**
+ * Service-manager lifecycle wrappers for the `dreamux daemon` command group.
+ *
+ * These talk to the native user-level service manager directly (Linux
+ * `systemctl --user`, macOS `launchctl`) — not the admin socket — so they work
+ * even when the server is down. Each verb maps to the platform's idiom:
+ *
+ *   verb     | systemd --user                       | launchd (gui/<uid>/<label>)
+ *   ---------|--------------------------------------|----------------------------
+ *   start    | start dreamux.service                | kickstart (bootstrap if unloaded)
+ *   stop     | stop dreamux.service                 | bootout (KeepAlive would relaunch a kill)
+ *   restart  | restart dreamux.service              | kickstart -k (bootstrap if unloaded)
+ *
+ * launchd's KeepAlive=true relaunches a plain `kill`, so a stop that *stays*
+ * stopped is a `bootout`; start/restart then re-bootstrap when needed.
+ */
+
+import { homedir } from 'node:os';
+
+import { LAUNCHD_LABEL, serviceUnitPath, SYSTEMD_UNIT } from '../onboard/service.js';
+import type { CommandRunner, ServicePlatform } from '../onboard/types.js';
+
+export type DaemonVerb = 'start' | 'stop' | 'restart';
+
+export interface ServiceControlOptions {
+  runner: CommandRunner;
+  platform?: NodeJS.Platform;
+  homeDir?: string;
+  uid?: number;
+  dryRun?: boolean;
+}
+
+export interface ServiceControlResult {
+  platform: ServicePlatform;
+  verb: DaemonVerb;
+  /** Commands actually issued (command + args), in order. */
+  commands: Array<{ command: string; args: string[] }>;
+}
+
+export async function controlUserService(
+  verb: DaemonVerb,
+  options: ServiceControlOptions,
+): Promise<ServiceControlResult> {
+  const homeDir = options.homeDir ?? homedir();
+  const unit = serviceUnitPath(options.platform, homeDir);
+  const dryRun = options.dryRun ?? false;
+  const commands: Array<{ command: string; args: string[] }> = [];
+
+  if (unit.platform === 'systemd') {
+    const args = ['--user', verb, SYSTEMD_UNIT];
+    await options.runner.run('systemctl', args, { dryRun });
+    commands.push({ command: 'systemctl', args });
+    return { platform: 'systemd', verb, commands };
+  }
+
+  const uid = options.uid ?? process.getuid?.();
+  if (uid === undefined) {
+    throw new Error('launchd user service control requires a numeric uid');
+  }
+  const target = `gui/${uid}/${LAUNCHD_LABEL}`;
+  const loaded = await options.runner.check('launchctl', ['print', target], { dryRun });
+
+  if (verb === 'stop') {
+    if (loaded) {
+      const args = ['bootout', target];
+      await options.runner.run('launchctl', args, { dryRun });
+      commands.push({ command: 'launchctl', args });
+    }
+    return { platform: 'launchd', verb, commands };
+  }
+
+  if (!loaded) {
+    const args = ['bootstrap', `gui/${uid}`, unit.path];
+    await options.runner.run('launchctl', args, { dryRun });
+    commands.push({ command: 'launchctl', args });
+    if (verb === 'start') return { platform: 'launchd', verb, commands };
+  }
+  const args = verb === 'restart' ? ['kickstart', '-k', target] : ['kickstart', target];
+  await options.runner.run('launchctl', args, { dryRun });
+  commands.push({ command: 'launchctl', args });
+  return { platform: 'launchd', verb, commands };
+}

--- a/packages/dreamux/src/dispatcher/runtime.ts
+++ b/packages/dreamux/src/dispatcher/runtime.ts
@@ -85,6 +85,13 @@ export class DispatcherRuntime {
   private client: CodexWsClient | null = null;
   private turnManager: TurnManager | null = null;
   private threadId: string | null = null;
+  /**
+   * Whether the most recent thread resolution resumed an existing Codex thread
+   * (true) rather than starting a fresh one or recovering from a failed resume.
+   * Consulted by the server right after the slot is ready to decide whether a
+   * `daemon restart` notice should be injected (issue #78).
+   */
+  private threadResumed = false;
   private status: DispatcherStatus = 'declared';
   private readonly log: NonNullable<DispatcherRuntimeDeps['log']>;
   private stopping = false;
@@ -114,6 +121,26 @@ export class DispatcherRuntime {
 
   getThreadId(): string | null {
     return this.threadId;
+  }
+
+  /** True when the live thread was resumed (not freshly started/recovered). */
+  wasThreadResumed(): boolean {
+    return this.threadResumed;
+  }
+
+  /**
+   * Inject a best-effort one-shot restart notice into the resumed thread. The
+   * server calls this only after the dispatcher slot is ready (so the resumed
+   * turn can reply through Feishu). Never throws — failures are logged.
+   */
+  async injectRestartNotice(text: string): Promise<void> {
+    if (this.turnManager === null) return;
+    const result = await this.turnManager.injectNotice(text);
+    if (result.status === 'submitted') {
+      this.log('info', 'restart notice injected into resumed thread');
+    } else if (result.status === 'skipped') {
+      this.log('info', 'restart notice skipped; a live inbound already arrived');
+    }
   }
 
   /**
@@ -226,6 +253,9 @@ export class DispatcherRuntime {
 
   private async resolveThread(): Promise<void> {
     if (this.client === null) throw new Error('client not initialized');
+    // Each resolution recomputes whether we resumed; a fresh start or a
+    // resume-failure recovery must not look like a resume to the notice gate.
+    this.threadResumed = false;
     const existing = this.threadId ?? this.row.thread_id;
     if (existing === null) {
       // Fresh thread.
@@ -243,6 +273,7 @@ export class DispatcherRuntime {
         threadId: existing,
       });
       this.threadId = existing;
+      this.threadResumed = true;
       this.log('info', `resumed thread ${this.threadId}`);
     } catch (err) {
       // Visible degradation (issue #2 Q11): start a fresh thread, record loss.

--- a/packages/dreamux/src/dispatcher/turn-manager.ts
+++ b/packages/dreamux/src/dispatcher/turn-manager.ts
@@ -29,6 +29,17 @@ export type InboundDeliveryResult =
   | { status: 'submitted'; turnId: string }
   | { status: 'failed'; error: Error };
 
+/**
+ * Result of a best-effort restart-notice injection. `skipped` means a real
+ * inbound had already been handed to Codex (it woke the thread on its own, so a
+ * synthetic notice would be redundant) — see issue #78.
+ */
+export type NoticeInjectionResult =
+  | { status: 'stopped' }
+  | { status: 'skipped' }
+  | { status: 'submitted'; turnId: string }
+  | { status: 'failed'; error: Error };
+
 export interface InboundDeliveryHooks {
   /**
    * Called after process-local dedupe accepts the message and before
@@ -57,6 +68,13 @@ export class TurnManager {
   private readonly seenMessageIds = new Set<string>();
   private readonly seenMessageIdOrder: string[] = [];
   private stopped = false;
+  /**
+   * Set once any real inbound has been accepted and handed to Codex. There is
+   * no FIFO queue here — inbound submission folds onto Codex's active turn — so
+   * this flag is what lets a best-effort restart-notice injection detect an
+   * in-flight inbound and skip rather than wake the thread twice (issue #78).
+   */
+  private inboundSubmitted = false;
   private readonly log: NonNullable<TurnManagerOptions['log']>;
   private readonly messageIdDedupeWindow: number;
 
@@ -84,6 +102,9 @@ export class TurnManager {
     if (!this.rememberMessageId(input.source_message_id)) {
       return { status: 'duplicate' };
     }
+    // Mark before any await so a concurrent restart-notice injection observes
+    // that a real inbound is in flight and skips itself.
+    this.inboundSubmitted = true;
 
     await this.notifyAccepted(input, hooks);
 
@@ -109,6 +130,43 @@ export class TurnManager {
         `turn/start submission failed for message ${input.source_message_id ?? '<none>'}: ${error.message}`,
         error,
       );
+      return { status: 'failed', error };
+    }
+  }
+
+  /**
+   * Best-effort one-shot notice injected after a `daemon restart --notify-
+   * resumed` resumes this dispatcher's thread. Skips if the manager is stopped,
+   * if a real inbound has already woken the thread, or if no thread is bound.
+   * A submission failure is reported, never thrown — it must not fail the
+   * dispatcher's start or the restart.
+   */
+  async injectNotice(text: string): Promise<NoticeInjectionResult> {
+    if (this.stopped) return { status: 'stopped' };
+    if (this.inboundSubmitted) return { status: 'skipped' };
+
+    const threadId = this.opts.getThreadId();
+    if (threadId === null) {
+      const error = new Error('restart notice injected without thread_id');
+      this.log('error', error.message);
+      return { status: 'failed', error };
+    }
+
+    // Mark before submitting so a racing real inbound is not double-counted and
+    // a second injection cannot fire.
+    this.inboundSubmitted = true;
+    try {
+      const res = await submitTurnStart(
+        this.opts.client,
+        threadId,
+        text,
+        this.opts.turnCwd ?? null,
+      );
+      this.log('info', `injected restart notice into thread ${threadId}`);
+      return { status: 'submitted', turnId: res.turn.id };
+    } catch (err) {
+      const error = err instanceof Error ? err : new Error(String(err));
+      this.log('warn', `restart notice injection failed: ${error.message}`, error);
       return { status: 'failed', error };
     }
   }

--- a/packages/dreamux/src/onboard/service.ts
+++ b/packages/dreamux/src/onboard/service.ts
@@ -1,4 +1,4 @@
-import { accessSync, constants } from 'node:fs';
+import { accessSync, constants, existsSync, rmSync } from 'node:fs';
 import { realpath } from 'node:fs/promises';
 import { homedir } from 'node:os';
 import { delimiter, dirname, isAbsolute, join, resolve } from 'node:path';
@@ -47,6 +47,15 @@ export interface ServiceInstallResult {
   unitPath: string;
   registered: boolean;
   started: boolean;
+  /**
+   * systemd `--user` only: whether `loginctl enable-linger` succeeded so the
+   * service starts at boot without an interactive login. null when not
+   * applicable (launchd, or a dry run). Failure is non-fatal and surfaced via
+   * `warnings`.
+   */
+  lingerEnabled: boolean | null;
+  /** Non-fatal operator-facing warnings (e.g. linger could not be enabled). */
+  warnings: string[];
 }
 
 export function serviceUnitPath(
@@ -105,10 +114,14 @@ export async function installUserService(
     },
   );
 
+  let lingerEnabled: boolean | null = null;
+  const warnings: string[] = [];
   if (unit.platform === 'launchd') {
     await registerLaunchd(unit.path, unitStatus, options);
   } else {
-    await registerSystemd(unit.path, options);
+    const systemd = await registerSystemd(unit.path, options);
+    lingerEnabled = systemd.lingerEnabled;
+    warnings.push(...systemd.warnings);
   }
 
   return {
@@ -116,6 +129,8 @@ export async function installUserService(
     unitPath: unit.path,
     registered: true,
     started: options.answers.startService,
+    lingerEnabled,
+    warnings,
   };
 }
 
@@ -527,7 +542,7 @@ async function registerLaunchd(
 async function registerSystemd(
   unitPath: string,
   options: ServiceInstallOptions,
-): Promise<void> {
+): Promise<{ lingerEnabled: boolean | null; warnings: string[] }> {
   await options.runner.run('systemctl', ['--user', 'daemon-reload'], {
     dryRun: options.answers.dryRun,
   });
@@ -538,6 +553,109 @@ async function registerSystemd(
     dryRun: options.answers.dryRun,
   });
   options.ledger.record(unitPath, 'unchanged', 'systemd user service registered');
+
+  // `systemctl --user enable` only schedules the service for an *active login
+  // session*. On a headless box with no graphical/SSH login the service never
+  // starts at boot. `loginctl enable-linger` is what makes a user service boot
+  // without a login — without it, "enabled" silently fails to autostart on
+  // reboot. Best-effort: a strict polkit / non-root setup may deny it, but that
+  // must not fail onboard / daemon install (issue #78).
+  const { lingerEnabled, warnings } = await enableSystemdLinger(options);
+  return { lingerEnabled, warnings };
+}
+
+/**
+ * Enable systemd user lingering for the calling user, best-effort. Returns the
+ * outcome plus any operator-facing warning. Skipped (null) on a dry run.
+ */
+export async function enableSystemdLinger(
+  options: Pick<ServiceInstallOptions, 'runner'> & {
+    answers: Pick<ServiceInstallAnswers, 'dryRun'>;
+  },
+): Promise<{ lingerEnabled: boolean | null; warnings: string[] }> {
+  if (options.answers.dryRun) return { lingerEnabled: null, warnings: [] };
+  const ok = await options.runner.check('loginctl', ['enable-linger']);
+  if (ok) return { lingerEnabled: true, warnings: [] };
+  return {
+    lingerEnabled: false,
+    warnings: [
+      'could not enable systemd lingering (loginctl enable-linger); the service ' +
+        'will not start at boot until you log in. Enable it manually with: ' +
+        'loginctl enable-linger',
+    ],
+  };
+}
+
+export interface ServiceRemoveOptions {
+  runner: CommandRunner;
+  platform?: NodeJS.Platform;
+  homeDir?: string;
+  uid?: number;
+  dryRun?: boolean;
+}
+
+export interface ServiceRemoveResult {
+  platform: ServicePlatform;
+  unitPath: string;
+  /** Whether the unit file existed and was removed. */
+  removed: boolean;
+}
+
+/**
+ * Unregister and remove the user-level service unit only. Shared by the
+ * top-level `dreamux uninstall` (which then also removes config/state/logs) and
+ * `dreamux daemon uninstall` (which removes *nothing else*). Best-effort on the
+ * service-manager calls — the unit-file removal is authoritative.
+ */
+export async function removeUserService(
+  options: ServiceRemoveOptions,
+): Promise<ServiceRemoveResult> {
+  const homeDir = options.homeDir ?? homedir();
+  const unit = serviceUnitPath(options.platform, homeDir);
+  const dryRun = options.dryRun ?? false;
+
+  if (unit.platform === 'launchd') {
+    const uid = options.uid ?? process.getuid?.();
+    if (uid === undefined) {
+      throw new Error('launchd user service uninstall requires a numeric uid');
+    }
+    const serviceTarget = `gui/${uid}/${LAUNCHD_LABEL}`;
+    const loaded = await options.runner.check('launchctl', ['print', serviceTarget], {
+      dryRun,
+    });
+    if (loaded) {
+      await runServiceBestEffort(options.runner, 'launchctl', ['bootout', serviceTarget], dryRun);
+    }
+  } else {
+    await runServiceBestEffort(
+      options.runner,
+      'systemctl',
+      ['--user', 'disable', '--now', SYSTEMD_UNIT],
+      dryRun,
+    );
+  }
+
+  const existed = existsSync(unit.path);
+  if (existed && !dryRun) rmSync(unit.path, { force: true });
+
+  if (unit.platform === 'systemd') {
+    await runServiceBestEffort(options.runner, 'systemctl', ['--user', 'daemon-reload'], dryRun);
+  }
+
+  return { platform: unit.platform, unitPath: unit.path, removed: existed };
+}
+
+async function runServiceBestEffort(
+  runner: CommandRunner,
+  command: string,
+  args: string[],
+  dryRun: boolean,
+): Promise<void> {
+  try {
+    await runner.run(command, args, { dryRun });
+  } catch {
+    /* The unit may already be absent or stopped; file removal is authoritative. */
+  }
 }
 
 function systemdEscapeArg(value: string): string {

--- a/packages/dreamux/src/onboard/types.ts
+++ b/packages/dreamux/src/onboard/types.ts
@@ -38,6 +38,8 @@ export interface OnboardRunResult {
         unitPath: string;
         registered: boolean;
         started: boolean;
+        lingerEnabled: boolean | null;
+        warnings: string[];
       }
     | null;
 }

--- a/packages/dreamux/src/onboard/uninstall.ts
+++ b/packages/dreamux/src/onboard/uninstall.ts
@@ -3,11 +3,7 @@ import { homedir } from 'node:os';
 import { basename, join, resolve, sep } from 'node:path';
 
 import { ExecaCommandRunner } from './commands.js';
-import {
-  LAUNCHD_LABEL,
-  serviceUnitPath,
-  SYSTEMD_UNIT,
-} from './service.js';
+import { removeUserService } from './service.js';
 import type { CommandRunner, ServicePlatform } from './types.js';
 import {
   assertNoLegacyTomlOnly,
@@ -58,7 +54,6 @@ export async function runUninstall(
   const configDir = normalizePath(options.configDir ?? globalConfigDir());
   const entries: UninstallEntry[] = [];
   const warnings: string[] = [];
-  const unit = serviceUnitPath(options.platform, options.homeDir ?? homedir());
   warnIfConfigIsNotReadable(configDir, warnings);
   const stateDir = normalizePath(stateRoot());
   const logDir = normalizePath(logsRoot());
@@ -68,18 +63,19 @@ export async function runUninstall(
   assertSafeOwnedDirectory(configDir, 'dreamux config directory');
   const workspaceSkillPaths = collectWorkspaceSkillPaths(configDir);
 
-  await unregisterService({
-    unitPath: unit.path,
-    platform: unit.platform,
+  // Service removal (unit-only) is shared with `dreamux daemon uninstall`.
+  const removal = await removeUserService({
     runner,
-    dryRun,
+    platform: options.platform,
+    homeDir: options.homeDir ?? homedir(),
     uid: options.uid,
+    dryRun,
   });
-  removePath(unit.path, entries, `${unit.platform} unit`, dryRun);
-
-  if (unit.platform === 'systemd') {
-    await runBestEffort(runner, 'systemctl', ['--user', 'daemon-reload'], dryRun);
-  }
+  entries.push({
+    path: removal.unitPath,
+    status: removal.removed ? 'removed' : 'missing',
+    reason: `${removal.platform} unit`,
+  });
 
   reportWorkspaceSkills(workspaceSkillPaths, entries);
   removeOwnedDirectory(stateDir, entries, 'dreamux state directory', dryRun);
@@ -90,8 +86,8 @@ export async function runUninstall(
     entries: entries.sort((a, b) => a.path.localeCompare(b.path)),
     warnings,
     service: {
-      platform: unit.platform,
-      unitPath: unit.path,
+      platform: removal.platform,
+      unitPath: removal.unitPath,
     },
   };
 }
@@ -136,56 +132,6 @@ function reportWorkspaceSkills(
       status: existsSync(path) ? 'skipped' : 'missing',
       reason: 'workspace-local dispatcher skill (not removed)',
     });
-  }
-}
-
-async function unregisterService(options: {
-  unitPath: string;
-  platform: ServicePlatform;
-  runner: CommandRunner;
-  dryRun: boolean;
-  uid?: number;
-}): Promise<void> {
-  if (options.platform === 'launchd') {
-    const uid = options.uid ?? process.getuid?.();
-    if (uid === undefined) {
-      throw new Error('launchd user service uninstall requires a numeric uid');
-    }
-    const serviceTarget = `gui/${uid}/${LAUNCHD_LABEL}`;
-    const loaded = await options.runner.check(
-      'launchctl',
-      ['print', serviceTarget],
-      { dryRun: options.dryRun },
-    );
-    if (loaded) {
-      await runBestEffort(
-        options.runner,
-        'launchctl',
-        ['bootout', serviceTarget],
-        options.dryRun,
-      );
-    }
-    return;
-  }
-
-  await runBestEffort(
-    options.runner,
-    'systemctl',
-    ['--user', 'disable', '--now', SYSTEMD_UNIT],
-    options.dryRun,
-  );
-}
-
-async function runBestEffort(
-  runner: CommandRunner,
-  command: string,
-  args: string[],
-  dryRun: boolean,
-): Promise<void> {
-  try {
-    await runner.run(command, args, { dryRun });
-  } catch {
-    /* The unit may already be absent or stopped; file deletion below is authoritative. */
   }
 }
 

--- a/packages/dreamux/src/runtime/paths.ts
+++ b/packages/dreamux/src/runtime/paths.ts
@@ -63,6 +63,16 @@ export function serverJsonPath(): string {
   return join(stateRoot(), 'server.json');
 }
 
+/**
+ * One-shot marker dropped by `dreamux daemon restart --notify-resumed` before
+ * it triggers the service-manager restart. The freshly started server reads it
+ * once, deletes it, and injects a "restart completed" notice into the named
+ * resumed dispatchers. Server-owned state; safe to delete.
+ */
+export function restartIntentPath(): string {
+  return join(stateRoot(), 'restart-intent.json');
+}
+
 export function logsRoot(): string {
   return join(dreamuxRoot(), 'logs');
 }

--- a/packages/dreamux/src/server.ts
+++ b/packages/dreamux/src/server.ts
@@ -66,6 +66,7 @@ import {
   type DreamuxLogger,
 } from './runtime/logger.js';
 import { createAdminSocketServer, type AdminSocketServer } from './admin/socket.js';
+import { RestartIntentConsumer } from './daemon/restart-intent.js';
 
 export const RECEIVED_REACTION_EMOJI = 'Get';
 export const IN_PROGRESS_REACTION_EMOJI = 'OnIt';
@@ -176,6 +177,11 @@ export class Server {
    */
   private readonly starting = new Map<string, Promise<void>>();
   private admin: AdminSocketServer | null = null;
+  /**
+   * One-shot restart-notice snapshot loaded at start(). Null until start();
+   * each resumed dispatcher claims its notice once as it comes up (issue #78).
+   */
+  private restartIntent: RestartIntentConsumer | null = null;
   private shuttingDown = false;
   private readonly opts: ServerOptions;
   private readonly log: DreamuxLogger;
@@ -220,6 +226,10 @@ export class Server {
 
   /** Bring up admin socket + all enabled dispatchers. */
   async start(): Promise<void> {
+    // Load (and delete) any restart marker before bringing dispatchers up, so
+    // the snapshot is in memory when each resumed dispatcher claims its notice.
+    this.restartIntent = RestartIntentConsumer.load({ now: Date.now() });
+
     this.admin = createAdminSocketServer(
       this,
       this.opts.adminSocketPath ?? adminSocketPath(),
@@ -504,6 +514,25 @@ export class Server {
       },
       'dispatcher ready',
     );
+
+    // Restart-notice injection happens here — after the slot is registered and
+    // the bot is listening — so the resumed turn can reply through Feishu. Only
+    // a thread that was actually resumed and is a named restart target gets a
+    // notice; cold boots and crash auto-heals never reach this path with a live
+    // marker. Best-effort: a failure must not fail the dispatcher (issue #78).
+    if (runtime.wasThreadResumed()) {
+      const notice = this.restartIntent?.claim(id, Date.now()) ?? null;
+      if (notice !== null) {
+        try {
+          await runtime.injectRestartNotice(notice);
+        } catch (err) {
+          channelLog.warn(
+            { dispatcher_id: id, err: errInfo(err) },
+            'restart notice injection errored',
+          );
+        }
+      }
+    }
   }
 
   /** Gracefully stop one dispatcher. Idempotent. */

--- a/packages/dreamux/tests/daemon.test.ts
+++ b/packages/dreamux/tests/daemon.test.ts
@@ -1,0 +1,270 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+
+import { controlUserService } from '../src/daemon/service-control.js';
+import { runDaemonInstall, runDaemonUninstall } from '../src/daemon/install.js';
+import type { ServiceNodeProbe } from '../src/onboard/service.js';
+import type { CommandRunner } from '../src/onboard/types.js';
+import { resetRuntimeConfig } from '../src/runtime/paths.js';
+
+interface Call {
+  command: string;
+  args: string[];
+}
+
+class FakeRunner implements CommandRunner {
+  launchdLoaded = false;
+  readonly calls: Call[] = [];
+
+  async run(command: string, args: string[], options: { dryRun?: boolean } = {}): Promise<void> {
+    if (options.dryRun) return;
+    this.calls.push({ command, args });
+  }
+
+  async check(command: string, args: string[]): Promise<boolean> {
+    if (command === 'launchctl' && args[0] === 'print') return this.launchdLoaded;
+    return false;
+  }
+
+  async capture(): Promise<string> {
+    return '';
+  }
+}
+
+const SYSTEMD_HOME = '/home/example';
+
+describe('daemon service control', () => {
+  it.each([
+    ['start', ['--user', 'start', 'dreamux.service']],
+    ['stop', ['--user', 'stop', 'dreamux.service']],
+    ['restart', ['--user', 'restart', 'dreamux.service']],
+  ] as const)('maps systemd %s to the right systemctl call', async (verb, args) => {
+    const runner = new FakeRunner();
+    const result = await controlUserService(verb, {
+      runner,
+      platform: 'linux',
+      homeDir: SYSTEMD_HOME,
+    });
+    expect(result.platform).toBe('systemd');
+    expect(runner.calls).toEqual([{ command: 'systemctl', args }]);
+  });
+
+  it('restarts a loaded launchd service with kickstart -k', async () => {
+    const runner = new FakeRunner();
+    runner.launchdLoaded = true;
+    await controlUserService('restart', {
+      runner,
+      platform: 'darwin',
+      homeDir: SYSTEMD_HOME,
+      uid: 501,
+    });
+    expect(runner.calls).toEqual([
+      { command: 'launchctl', args: ['kickstart', '-k', 'gui/501/dev.excited.dreamux'] },
+    ]);
+  });
+
+  it('stops a loaded launchd service with bootout', async () => {
+    const runner = new FakeRunner();
+    runner.launchdLoaded = true;
+    await controlUserService('stop', {
+      runner,
+      platform: 'darwin',
+      homeDir: SYSTEMD_HOME,
+      uid: 501,
+    });
+    expect(runner.calls).toEqual([
+      { command: 'launchctl', args: ['bootout', 'gui/501/dev.excited.dreamux'] },
+    ]);
+  });
+
+  it('bootstraps an unloaded launchd service on start', async () => {
+    const runner = new FakeRunner();
+    runner.launchdLoaded = false;
+    await controlUserService('start', {
+      runner,
+      platform: 'darwin',
+      homeDir: SYSTEMD_HOME,
+      uid: 501,
+    });
+    expect(runner.calls).toEqual([
+      {
+        command: 'launchctl',
+        args: [
+          'bootstrap',
+          'gui/501',
+          join(SYSTEMD_HOME, 'Library', 'LaunchAgents', 'dev.excited.dreamux.plist'),
+        ],
+      },
+    ]);
+  });
+});
+
+describe('daemon uninstall (service-only)', () => {
+  let home: string;
+
+  beforeEach(() => {
+    home = mkdtempSync(join(tmpdir(), 'dreamux-daemon-uninstall-'));
+  });
+
+  afterEach(() => {
+    rmSync(home, { recursive: true, force: true });
+  });
+
+  it('disables and removes an installed systemd unit', async () => {
+    const runner = new FakeRunner();
+    const unitDir = join(home, '.config', 'systemd', 'user');
+    mkdirSync(unitDir, { recursive: true });
+    writeFileSync(join(unitDir, 'dreamux.service'), '[Unit]\n');
+
+    const result = await runDaemonUninstall({ runner, platform: 'linux', homeDir: home });
+
+    expect(result).toMatchObject({ platform: 'systemd', removed: true });
+    expect(existsSync(join(unitDir, 'dreamux.service'))).toBe(false);
+    expect(runner.calls).toEqual([
+      { command: 'systemctl', args: ['--user', 'disable', '--now', 'dreamux.service'] },
+      { command: 'systemctl', args: ['--user', 'daemon-reload'] },
+    ]);
+  });
+
+  it('reports a missing unit without failing', async () => {
+    const runner = new FakeRunner();
+    const result = await runDaemonUninstall({ runner, platform: 'linux', homeDir: home });
+    expect(result).toMatchObject({ platform: 'systemd', removed: false });
+  });
+});
+
+// A runner that satisfies the managed-service launch checks and reports a
+// modern Node for every `--version` probe (both the current Node and the
+// stable candidate selectServiceNodeBin probes).
+class InstallRunner implements CommandRunner {
+  readonly calls: Call[] = [];
+  lingerEnableOk = true;
+
+  async run(command: string, args: string[], options: { dryRun?: boolean } = {}): Promise<void> {
+    if (options.dryRun) return;
+    this.calls.push({ command, args });
+  }
+
+  async check(command: string, args: string[]): Promise<boolean> {
+    if (args[0] === '--help') return true;
+    if (command === 'loginctl' && args[0] === 'enable-linger') return this.lingerEnableOk;
+    return false;
+  }
+
+  async capture(_command: string, args: string[]): Promise<string> {
+    if (args[0] === '--version') return 'v22.7.0';
+    throw new Error(`unexpected capture: ${args.join(' ')}`);
+  }
+}
+
+describe('daemon install (stable service Node, issue #83)', () => {
+  let root: string;
+  let oldHome: string | undefined;
+  let oldConfigDir: string | undefined;
+
+  beforeEach(() => {
+    root = mkdtempSync(join(tmpdir(), 'dreamux-daemon-install-'));
+    oldHome = process.env['HOME'];
+    oldConfigDir = process.env['DREAMUX_CONFIG_DIR'];
+    process.env['HOME'] = join(root, 'home');
+    process.env['DREAMUX_CONFIG_DIR'] = join(root, 'config');
+    writeInstallConfig(join(root, 'config'));
+  });
+
+  afterEach(() => {
+    restoreEnv('HOME', oldHome);
+    restoreEnv('DREAMUX_CONFIG_DIR', oldConfigDir);
+    resetRuntimeConfig();
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  function readUnitNodeBin(): string {
+    const unit = readFileSync(
+      join(root, 'home', '.config', 'systemd', 'user', 'dreamux.service'),
+      'utf8',
+    );
+    const line = unit
+      .split('\n')
+      .find((l) => l.startsWith('Environment=DREAMUX_NODE_BIN='));
+    return line?.slice('Environment=DREAMUX_NODE_BIN='.length) ?? '';
+  }
+
+  it('pins a stable system Node even when invoked from a version-manager Node', async () => {
+    const runner = new InstallRunner();
+    // The current Node would be a version-manager Node; /usr/local/bin/node is a
+    // stable system Node, so it must win and be persisted into the unit.
+    const stableNodeProbe: ServiceNodeProbe = {
+      realpath: async (path) => path,
+      isExecutable: (path) => path === '/usr/local/bin/node',
+    };
+
+    await runDaemonInstall({
+      runner,
+      platform: 'linux',
+      homeDir: join(root, 'home'),
+      nodeProbe: stableNodeProbe,
+    });
+
+    expect(readUnitNodeBin()).toBe('/usr/local/bin/node');
+    expect(readUnitNodeBin()).not.toBe(process.execPath);
+  });
+
+  it('falls back to the current Node when no stable system Node exists', async () => {
+    const runner = new InstallRunner();
+    const noSystemNodeProbe: ServiceNodeProbe = {
+      realpath: async (path) => path,
+      isExecutable: () => false,
+    };
+
+    await runDaemonInstall({
+      runner,
+      platform: 'linux',
+      homeDir: join(root, 'home'),
+      nodeProbe: noSystemNodeProbe,
+    });
+
+    expect(readUnitNodeBin()).toBe(process.execPath);
+  });
+});
+
+function writeInstallConfig(configDir: string): void {
+  mkdirSync(configDir, { recursive: true });
+  writeFileSync(
+    join(configDir, 'config.json'),
+    JSON.stringify({
+      // codex.bin must resolve to a runnable absolute path for the managed
+      // service launch check; the current Node binary is a convenient one.
+      codex: {
+        bin: process.execPath,
+        approval_policy: 'never',
+        sandbox_mode: 'workspace-write',
+        extra_args: [],
+        initialize_timeout_ms: 10000,
+      },
+      dispatchers: [
+        {
+          id: 'flow',
+          cwd: join(dirname(configDir), 'cwd'),
+          enabled: true,
+          feishu: { app_id: 'app-test', app_secret: 'secret-test' },
+          codex: { approval_policy: null, sandbox_mode: null, extra_args: [] },
+        },
+      ],
+    }),
+    { mode: 0o600 },
+  );
+}
+
+function restoreEnv(name: string, value: string | undefined): void {
+  if (value === undefined) delete process.env[name];
+  else process.env[name] = value;
+}

--- a/packages/dreamux/tests/doctor.test.ts
+++ b/packages/dreamux/tests/doctor.test.ts
@@ -25,6 +25,7 @@ class FakeRunner implements CommandRunner {
   systemdEnabled = false;
   systemdActive = false;
   launchdLoaded = false;
+  lingerEnabled = false;
   readonly nodeVersions = new Map<string, string>();
   readonly failedHelpCommands = new Set<string>();
   readonly calls: Array<{ command: string; args: string[] }> = [];
@@ -65,6 +66,9 @@ class FakeRunner implements CommandRunner {
     }
     if (command === 'launchctl' && args[0] === 'print' && this.launchdLoaded) {
       return 'state = running\npid = 1234\n';
+    }
+    if (command === 'loginctl' && args[0] === 'show-user') {
+      return `Linger=${this.lingerEnabled ? 'yes' : 'no'}`;
     }
     throw new Error(`unexpected capture: ${command} ${args.join(' ')}`);
   }
@@ -215,6 +219,7 @@ describe('dreamux doctor command', () => {
 
   it('warns (without failing) when the service Node is bound to a version manager', async () => {
     const runner = new FakeRunner();
+    runner.lingerEnabled = true; // not under test here; keep the linger check green
     writeConfig();
     writeDispatcherHome({ auth: true });
     const nvmNode = join(
@@ -266,6 +271,7 @@ describe('dreamux doctor command', () => {
 
   it('flags a system-looking shim that realpaths into a version manager', async () => {
     const runner = new FakeRunner();
+    runner.lingerEnabled = true; // not under test here; keep the linger check green
     writeConfig();
     writeDispatcherHome({ auth: true });
     const servicePath = join(root, 'home', '.config', 'systemd', 'user', 'dreamux.service');
@@ -403,6 +409,78 @@ describe('dreamux doctor command', () => {
       args: ['--help'],
     });
   });
+
+  it('flags disabled systemd lingering on an installed service', async () => {
+    const runner = new FakeRunner();
+    runner.lingerEnabled = false;
+    writeConfig();
+    writeDispatcherHome({ auth: true });
+    writeValidSystemdUnit();
+
+    const result = await runDreamuxDoctor({
+      runner,
+      platform: 'linux',
+      homeDir: join(root, 'home'),
+      userName: 'someone',
+      env: {},
+    });
+
+    const linger = result.checks.find((check) => check.name === 'systemd linger');
+    expect(linger).toMatchObject({ ok: false });
+    expect(linger?.detail).toContain('enable-linger');
+    expect(result.ok).toBe(false);
+  });
+
+  it('passes the linger check when lingering is enabled', async () => {
+    const runner = new FakeRunner();
+    runner.lingerEnabled = true;
+    writeConfig();
+    writeDispatcherHome({ auth: true });
+    writeValidSystemdUnit();
+
+    const result = await runDreamuxDoctor({
+      runner,
+      platform: 'linux',
+      homeDir: join(root, 'home'),
+      userName: 'someone',
+      env: {},
+    });
+
+    expect(result.checks.find((check) => check.name === 'systemd linger')).toMatchObject({
+      ok: true,
+    });
+  });
+
+  it('skips the linger check when no service is installed', async () => {
+    const runner = new FakeRunner();
+    writeConfig();
+    writeDispatcherHome({ auth: true });
+
+    const result = await runDreamuxDoctor({
+      runner,
+      platform: 'linux',
+      homeDir: join(root, 'home'),
+      env: {},
+    });
+
+    expect(result.checks.find((check) => check.name === 'systemd linger')).toBeUndefined();
+  });
+
+  function writeValidSystemdUnit(): void {
+    const servicePath = join(root, 'home', '.config', 'systemd', 'user', 'dreamux.service');
+    mkdirSync(dirname(servicePath), { recursive: true });
+    writeFileSync(
+      servicePath,
+      [
+        '[Service]',
+        `ExecStart=${process.env['DREAMUX_BIN']} serve`,
+        `Environment=DREAMUX_NODE_BIN=${process.execPath}`,
+        'Environment=CODEX_HOST_CODEX_BIN=codex',
+        'Environment=PATH=/usr/bin:/bin',
+        '',
+      ].join('\n'),
+    );
+  }
 
   function writeConfig(): void {
     const configPath = join(root, 'config', 'config.json');

--- a/packages/dreamux/tests/onboard.test.ts
+++ b/packages/dreamux/tests/onboard.test.ts
@@ -29,6 +29,7 @@ import {
 class FakeRunner implements CommandRunner {
   launchdLoaded = false;
   nodeVersion = 'v22.7.0';
+  lingerEnableOk = true;
   readonly failedHelpCommands = new Set<string>();
   readonly calls: Array<{
     command: string;
@@ -76,6 +77,9 @@ class FakeRunner implements CommandRunner {
     void options;
     if (args[0] === '--help') {
       return !this.failedHelpCommands.has(command);
+    }
+    if (command === 'loginctl' && args[0] === 'enable-linger') {
+      return this.lingerEnableOk;
     }
     return command === 'launchctl' &&
       args[0] === 'print' &&
@@ -164,6 +168,8 @@ describe('dreamux onboard', () => {
       platform: 'systemd',
       registered: true,
       started: true,
+      lingerEnabled: true,
+      warnings: [],
     });
     expect(runner.calls.map((call) => [call.command, call.args])).toEqual([
       ['systemctl', ['--user', 'daemon-reload']],
@@ -300,6 +306,38 @@ describe('dreamux onboard', () => {
     expect(serviceUnit).not.toContain(
       'Environment=DREAMUX_NODE_BIN=/usr/local/bin/node',
     );
+  });
+
+  it('degrades (does not fail) when systemd lingering cannot be enabled', async () => {
+    const runner = new FakeRunner();
+    runner.lingerEnableOk = false;
+    const answers = testAnswers({
+      configDir: join(root, 'config'),
+      runtimeDir: join(root, 'runtime'),
+      registerService: true,
+    });
+    writeGlobalCodexAuth(answers);
+
+    const result = await runOnboard({
+      answers,
+      runner,
+      platform: 'linux',
+      homeDir: join(root, 'home'),
+      env: { CODEX_ACCESS_TOKEN: 'interactive-token-test' },
+      nodeProbe: noSystemNodeProbe,
+    });
+
+    expect(result.service).toMatchObject({
+      platform: 'systemd',
+      registered: true,
+      lingerEnabled: false,
+    });
+    expect(result.service?.warnings.join(' ')).toContain('enable-linger');
+    // daemon-reload + enable still ran; linger failure is non-fatal.
+    expect(runner.calls.map((call) => [call.command, call.args])).toEqual([
+      ['systemctl', ['--user', 'daemon-reload']],
+      ['systemctl', ['--user', 'enable', '--now', 'dreamux.service']],
+    ]);
   });
 
   it('does not let an interactive shell token satisfy the managed service doctor', async () => {

--- a/packages/dreamux/tests/restart-intent.test.ts
+++ b/packages/dreamux/tests/restart-intent.test.ts
@@ -1,0 +1,117 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import {
+  DEFAULT_RESTART_ANNOUNCE,
+  DEFAULT_RESTART_INTENT_TTL_MS,
+  notifyResumedRestart,
+  RestartIntentConsumer,
+  writeRestartIntent,
+} from '../src/daemon/restart-intent.js';
+
+describe('restart intent marker', () => {
+  let dir: string;
+  let path: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'dreamux-restart-intent-'));
+    path = join(dir, 'restart-intent.json');
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('writes and reads a marker, then consumes per target exactly once', () => {
+    writeRestartIntent({
+      targets: ['flow', 'ops'],
+      announce: 'Restart completed.',
+      now: 1_000,
+      path,
+    });
+    expect(existsSync(path)).toBe(true);
+
+    const consumer = RestartIntentConsumer.load({ now: 2_000, path });
+    // Loading deletes the file (single reader).
+    expect(existsSync(path)).toBe(false);
+
+    expect(consumer.claim('flow', 2_000)).toBe('Restart completed.');
+    // Second claim for the same target returns null.
+    expect(consumer.claim('flow', 2_000)).toBeNull();
+    expect(consumer.claim('ops', 2_000)).toBe('Restart completed.');
+    // Untargeted dispatcher never claims.
+    expect(consumer.claim('other', 2_000)).toBeNull();
+  });
+
+  it('defaults the announce text and dedupes/trims targets', () => {
+    writeRestartIntent({
+      targets: ['flow', ' flow ', '', 'ops'],
+      now: 0,
+      path,
+    });
+    const file = JSON.parse(readFileSync(path, 'utf8')) as {
+      announce: string;
+      targets: string[];
+    };
+    expect(file.announce).toBe(DEFAULT_RESTART_ANNOUNCE);
+    expect(file.targets).toEqual(['flow', 'ops']);
+  });
+
+  it('ignores a marker past its TTL at load time', () => {
+    writeRestartIntent({ targets: ['flow'], now: 0, path });
+    const consumer = RestartIntentConsumer.load({
+      now: DEFAULT_RESTART_INTENT_TTL_MS + 1,
+      path,
+    });
+    expect(existsSync(path)).toBe(false);
+    expect(consumer.claim('flow', DEFAULT_RESTART_INTENT_TTL_MS + 1)).toBeNull();
+  });
+
+  it('re-checks the TTL at claim time for late starters', () => {
+    writeRestartIntent({ targets: ['flow'], ttlMs: 100, now: 0, path });
+    const consumer = RestartIntentConsumer.load({ now: 50, path });
+    // Within TTL at load, but claimed after expiry.
+    expect(consumer.claim('flow', 200)).toBeNull();
+  });
+
+  it('keeps the marker when the restart command succeeds', async () => {
+    let ran = false;
+    await notifyResumedRestart({
+      targets: ['flow'],
+      now: 0,
+      path,
+      runControl: async () => {
+        ran = true;
+      },
+    });
+    expect(ran).toBe(true);
+    // The server still needs to load+consume it after the restart.
+    expect(existsSync(path)).toBe(true);
+  });
+
+  it('rolls the marker back when the restart command fails synchronously', async () => {
+    await expect(
+      notifyResumedRestart({
+        targets: ['flow'],
+        now: 0,
+        path,
+        runControl: async () => {
+          throw new Error('systemctl --user restart failed');
+        },
+      }),
+    ).rejects.toThrow('systemctl --user restart failed');
+    // No stale marker → a later ordinary serve start cannot falsely consume it.
+    expect(existsSync(path)).toBe(false);
+  });
+
+  it('yields an empty consumer for a missing or malformed marker', () => {
+    expect(RestartIntentConsumer.load({ now: 0, path }).claim('flow', 0)).toBeNull();
+
+    writeFileSync(path, 'not json', { mode: 0o600 });
+    const consumer = RestartIntentConsumer.load({ now: 0, path });
+    expect(existsSync(path)).toBe(false);
+    expect(consumer.claim('flow', 0)).toBeNull();
+  });
+});

--- a/packages/dreamux/tests/smoke.test.ts
+++ b/packages/dreamux/tests/smoke.test.ts
@@ -49,7 +49,9 @@ import {
   dispatcherCodexHome,
   dispatcherWorkspaceSkillPath,
   dispatcherSocketPath,
+  restartIntentPath,
 } from '../src/runtime/paths.js';
+import { writeRestartIntent } from '../src/daemon/restart-intent.js';
 import { dreamuxBinPath } from '../src/runtime/package-bin.js';
 import { createLogger, type DreamuxLogger } from '../src/runtime/logger.js';
 import { startFakeCodex, type FakeCodex } from './fake-codex.js';
@@ -1565,6 +1567,48 @@ describe('dreamux MVP smoke', () => {
     // last_error is cleared when dispatcher reaches 'ready' again; the
     // durable evidence of degradation is last_lost_thread_id above.
     expect(d?.status).toBe('ready');
+  });
+
+  it('injects a restart notice into a resumed target after daemon restart --notify-resumed', async () => {
+    const config = configWithDispatcher();
+    server = buildServer({ runtimeDir, fake, bot, config });
+    server.repos.dispatchers.setThreadId('flow', 'thread_seed');
+    await server.start();
+    await server.shutdown();
+
+    // Marker written by `daemon restart --notify-resumed --dispatcher flow`.
+    writeRestartIntent({
+      targets: ['flow'],
+      announce: 'Restart completed.',
+      now: Date.now(),
+      path: restartIntentPath(),
+    });
+    expect(existsSync(restartIntentPath())).toBe(true);
+
+    server = buildServer({ runtimeDir, fake, bot, config });
+    await server.start();
+
+    await waitFor(() => codexInputs.includes('Restart completed.'));
+    // The thread was resumed (not freshly started) and the notice rode in.
+    expect(server.repos.dispatchers.get('flow')?.thread_id).toBe('thread_seed');
+    // The marker is one-shot: consumed on load and deleted from disk.
+    expect(existsSync(restartIntentPath())).toBe(false);
+  });
+
+  it('does not inject a restart notice without a marker (plain resume)', async () => {
+    const config = configWithDispatcher();
+    server = buildServer({ runtimeDir, fake, bot, config });
+    server.repos.dispatchers.setThreadId('flow', 'thread_seed');
+    await server.start();
+    await server.shutdown();
+    codexInputs = [];
+
+    server = buildServer({ runtimeDir, fake, bot, config });
+    await server.start();
+
+    await sleep(150);
+    expect(codexInputs).toEqual([]);
+    expect(server.repos.dispatchers.get('flow')?.thread_id).toBe('thread_seed');
   });
 
   it('approval fail-fast: server-request causes the turn to fail', async () => {

--- a/packages/dreamux/tests/turn-manager.test.ts
+++ b/packages/dreamux/tests/turn-manager.test.ts
@@ -67,6 +67,67 @@ describe('TurnManager inbound submission', () => {
   });
 });
 
+describe('TurnManager restart-notice injection', () => {
+  it('injects the notice as a turn when the thread is bound and idle', async () => {
+    const client = new FakeCodexClient();
+    const manager = new TurnManager({
+      dispatcherId: 'flow',
+      getThreadId: () => 'thread-1',
+      client: client as never,
+    });
+
+    await expect(manager.injectNotice('Restart completed.')).resolves.toEqual({
+      status: 'submitted',
+      turnId: 'turn-1',
+    });
+    expect(client.inputs).toEqual(['Restart completed.']);
+  });
+
+  it('skips when a real inbound has already woken the thread', async () => {
+    const client = new FakeCodexClient();
+    const manager = new TurnManager({
+      dispatcherId: 'flow',
+      getThreadId: () => 'thread-1',
+      client: client as never,
+    });
+
+    await manager.enqueue(input('msg-1', 'real work'));
+    await expect(manager.injectNotice('Restart completed.')).resolves.toEqual({
+      status: 'skipped',
+    });
+    expect(client.inputs).toEqual(['real work']);
+  });
+
+  it('fails (does not throw) when no thread is bound', async () => {
+    const client = new FakeCodexClient();
+    const manager = new TurnManager({
+      dispatcherId: 'flow',
+      getThreadId: () => null,
+      client: client as never,
+    });
+
+    const result = await manager.injectNotice('Restart completed.');
+    expect(result.status).toBe('failed');
+    expect(client.inputs).toEqual([]);
+  });
+
+  it('injects at most once', async () => {
+    const client = new FakeCodexClient();
+    const manager = new TurnManager({
+      dispatcherId: 'flow',
+      getThreadId: () => 'thread-1',
+      client: client as never,
+    });
+
+    await expect(manager.injectNotice('Restart completed.')).resolves
+      .toMatchObject({ status: 'submitted' });
+    await expect(manager.injectNotice('Restart completed.')).resolves.toEqual({
+      status: 'skipped',
+    });
+    expect(client.inputs).toEqual(['Restart completed.']);
+  });
+});
+
 function input(messageId: string, text: string) {
   return {
     source_chat_id: 'chat-a',


### PR DESCRIPTION
关联 #78。

## 问题

`systemd --user` 服务只有在用户有活动登录会话时才会被拉起。`onboard` 此前已执行 `daemon-reload` + `enable [--now]`,但**从未** `loginctl enable-linger`,因此在 headless 机器上重启后服务静默不自启。同时全仓没有 `restart` 能力,也没有 `daemon` 命令组(`.agents` 决策记录与 CLAUDE.md 里的 `daemon` 是过时幻影文档)。

## 改动

- **linger(单一真源)**:`onboard` 与 `daemon install` 共用 `onboard/service.ts` 的 `enableSystemdLinger`,best-effort 执行 `loginctl enable-linger`;失败非致命,打印手动修复指引。`dreamux doctor` 新增 `systemd linger` 检查。
- **daemon 命令组**:`install|uninstall|start|stop|restart`。`start/stop/restart` 跨平台封装 `systemctl --user` / `launchctl`(`daemon/service-control.ts`);`install`/`uninstall` 复用 onboard 的 service 切片(`daemon/install.ts`)。`daemon uninstall` 只删 service unit,**不碰** config/state/logs(与顶层 `dreamux uninstall` 的边界)。
- **restart 后注入英文成功提示**:`daemon restart --notify-resumed --dispatcher <id>` 在触发 restart **之前**写一次性 marker(`daemon/restart-intent.ts`,路径经 `paths.ts` 的 `restartIntentPath()`)——自更新场景下调用方可能被 reap 杀掉,故 marker 先落盘、不依赖退出码。新 `serve` 启动时一次性 load + 删盘(快照语义),仅向**真正 resume 成功**的目标注入 `Restart completed.`。

### 关键边界

- 注入点在 **dispatcher slot 注册之后**(`server.ts`,`slots.set` 之后),这样被唤醒的 turn 能正常经 Feishu 回话;开机冷启与 codex 崩溃自愈走 `restartCodexRuntime`,不经此路径,天然不注入。
- **TurnManager 没有 FIFO 队列**(按 Codex review 指出):注入不假设串行队列,而用 `inboundSubmitted` 标志检测 in-flight 真实入站,命中则跳过(`turn-manager.ts` 的 `injectNotice`)。
- marker 单次消费 + load 与 claim 两处校验 TTL(默认 10min),避免冷启/自愈/迟启动误触发。
- 新建 thread / resume 失败降级 → 不注入。

### 关于 stop-timeout(回应 review)

未给 unit 加 `TimeoutStopSec`/`KillMode`,经评估**无需改**:systemd 默认 `KillMode=control-group`,`restart` 会终止整个 cgroup(codex 子进程 `detached` 仅 setsid,仍在同 cgroup),且 systemd 等旧实例 stop 完成才拉起新实例,故新 serve `thread/resume` 时旧 codex 必已退出,不会抢占同一 thread;即便抢占,`resolveThread` 的 resume 失败分支会优雅降级且**不注入**,已被覆盖。

## 文档

- 撤销 `.agents/decisions/global-bin-onboard-serve.md` 的两条结论(无 daemon 命令组、linger out of scope),以 amendment 形式记录。
- 修正 CLAUDE.md「CLI surface」与真实命令树一致。
- `rush change`(minor)已附带。

## 测试

`node common/scripts/install-run-rush.js build` 通过;包内 `vitest run` 全量(**含 live codex**)**212 passed, 0 skipped**。

新增/扩展覆盖:
- `daemon.test.ts`:`controlUserService` 各 verb 在 systemd/launchd 的命令构造;`runDaemonUninstall` service-only 删除。
- `restart-intent.test.ts`:marker 读写、逐 target 单次消费、load/claim 双重 TTL、缺失/损坏降级。
- `turn-manager.test.ts`:`injectNotice` 注入/已有入站跳过/无 thread 失败/至多一次。
- `doctor.test.ts`:linger 启用/禁用/无服务跳过。
- `onboard.test.ts`:linger 成功断言 + 失败降级(daemon-reload/enable 仍执行)。
- `smoke.test.ts`:端到端——marker 命中 resumed dispatcher 注入 `Restart completed.`、无 marker 不注入。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
