### PR TITLE
refactor: 清除同步阻塞 IO 并加 ESLint 硬门禁 (#85)

### DIFF
--- a/.agents/components/repo-structure.md
+++ b/.agents/components/repo-structure.md
@@ -1,6 +1,6 @@
 # Component: repo structure
 
-Rush + pnpm monorepo since issue #4. Three packages today, all wired
+Rush + pnpm monorepo since issue #4. Four packages today, all wired
 through pnpm `workspace:*` and installed via the rush path only (see
 [the install-model decision](../decisions/install-model.md)):
 
@@ -9,6 +9,7 @@ through pnpm `workspace:*` and installed via the rush path only (see
 | `@excitedjs/dreamux` | `/packages/dreamux/` | the host server |
 | `@excitedjs/feishu-transport` | `/packages/channel/feishu-transport/` | platform-I/O core; **sole** importer of `@larksuiteoapi/node-sdk` |
 | `@excitedjs/feishu-channel` | `/packages/channel/feishu-channel/` | per-host channel layer (placeholder today) |
+| `@excitedjs/eslint-config` | `/packages/eslint-config/` | private (unpublished) shared ESLint flat config; single source of the synchronous-blocking-IO ban (see [the no-sync-io decision](../decisions/no-sync-io-lint-gate.md)) |
 
 The channel refactor (#4) extracted the Feishu platform I/O out of the
 dreamux host into `@excitedjs/feishu-transport`, so the host and the
@@ -53,10 +54,17 @@ verbatim through the move):
 ## Installation — the rush path only
 
 ```bash
-node common/scripts/install-run-rush.js update   # then build / test
+node common/scripts/install-run-rush.js update   # then build / lint / test
 node common/scripts/install-run-rush.js build
+node common/scripts/install-run-rush.js lint
 node common/scripts/install-run-rush.js test
 ```
+
+`rush lint` is a Rush bulk command that runs each package's `eslint .` against
+the shared `@excitedjs/eslint-config`. It enforces the synchronous-blocking-IO
+ban (`src/**` is a hard error; `tests/**` is audited) — see
+[the no-sync-io decision](../decisions/no-sync-io-lint-gate.md). CI runs it in
+the `rush` job; the pre-commit hook lints staged `.ts` as a local pre-flight.
 
 The per-package `cd packages/dreamux && npm install` path is **retired**:
 `@excitedjs/dreamux` now depends on `@excitedjs/feishu-transport` via the

--- a/.agents/decisions/README.md
+++ b/.agents/decisions/README.md
@@ -11,7 +11,7 @@ topic slugs remain reviewable and merge-friendly.
 | Repository shape | [rush-pnpm-monorepo](rush-pnpm-monorepo.md), [install-model](install-model.md) |
 | Runtime architecture | [top-level-design](top-level-design.md), [global-config-dir](global-config-dir.md), [logging](logging.md) |
 | Public surface | [cli-and-package-naming](cli-and-package-naming.md), [dispatcher-tm-boundary](dispatcher-tm-boundary.md), [dispatcher-tm-packaging](dispatcher-tm-packaging.md), [global-bin-onboard-serve](global-bin-onboard-serve.md), [global-config-dir](global-config-dir.md) |
-| Release and safeguards | [npm-release-oidc](npm-release-oidc.md), [anti-leak-guardrail](anti-leak-guardrail.md) |
+| Release and safeguards | [npm-release-oidc](npm-release-oidc.md), [anti-leak-guardrail](anti-leak-guardrail.md), [no-sync-io-lint-gate](no-sync-io-lint-gate.md) |
 
 ## Alphabetical Index
 
@@ -23,6 +23,7 @@ topic slugs remain reviewable and merge-friendly.
 - [global-config-dir](global-config-dir.md)
 - [install-model](install-model.md)
 - [logging](logging.md)
+- [no-sync-io-lint-gate](no-sync-io-lint-gate.md)
 - [npm-release-oidc](npm-release-oidc.md)
 - [rush-pnpm-monorepo](rush-pnpm-monorepo.md)
 - [top-level-design](top-level-design.md)

--- a/.agents/decisions/no-sync-io-lint-gate.md
+++ b/.agents/decisions/no-sync-io-lint-gate.md
@@ -1,0 +1,73 @@
+# No synchronous blocking IO in package source
+
+- **Status:** Accepted
+- **Date:** 2026-06-05
+- **Affects:** all `/packages/*/src/`, the new `@excitedjs/eslint-config`
+  package, CI, the pre-commit hook
+- **PR / Issue:** [#85](https://github.com/excitedjs/dreamux/issues/85)
+
+## Context
+
+dreamux is one long-running Node process hosting N dispatchers on a single
+event loop. Any `fs.*Sync` / `child_process.*Sync` call in runtime or CLI code
+blocks that loop: while one dispatcher reads a status file synchronously, every
+other dispatcher's inbound, outbound, and Codex traffic stalls. The codebase
+had accumulated synchronous IO across config, onboarding, channel state, the
+admin socket, the Codex supervisor, and the daemon/CLI paths. We wanted both a
+one-time cleanup and a permanent guard so new sync IO cannot regress in.
+
+## Decision
+
+Ban synchronous blocking IO in package source and enforce it with ESLint.
+
+- All `/packages/*/src/**/*.ts` is converted to the async APIs
+  (`node:fs/promises`, async `child_process`). The async ripple is threaded
+  through every caller (e.g. `DispatcherStore` mutators, `Server.start()`'s
+  `await store.hydrate()`, `resolveServiceExecutable`, the doctor/onboard
+  chains).
+- The rule set lives in a single private workspace package,
+  [`@excitedjs/eslint-config`](/packages/eslint-config/), re-exported by a thin
+  per-package `eslint.config.js`. Primary rule: `eslint-plugin-n`'s `n/no-sync`
+  (suffix `Sync` matcher). Backstops: `no-restricted-imports` (alias imports of
+  `*Sync` from `node:fs`/`node:child_process`) and a narrow
+  `no-restricted-syntax` (destructure rebind). Disable comments must carry a
+  reason (`@eslint-community/eslint-comments/require-description`) and unused
+  disables are an error (`reportUnusedDisableDirectives`).
+- Scope by glob: `src/**` is a hard `error`; `tests/**` turns `n/no-sync`
+  **off** (sync `fs` fixtures are allowed) but still bans synchronous
+  `child_process` to discourage new usage.
+- `eslint-plugin-n` is pinned to exactly `17.18.0` — the last release before
+  `n/no-sync` began requiring TypeScript type information (17.19.0+), which
+  would force `parserOptions.project` and break the pure-syntactic config.
+
+## Consequences
+
+- **Enforcement:** `rush lint` (a Rush bulk command) runs `eslint .` per
+  package; the CI `rush` job runs it after typecheck; the committed
+  `common/git-hooks/pre-commit` lints staged `.ts` against each package's flat
+  config (warn-and-pass when eslint isn't installed — CI is the real gate).
+  `/packages/dreamux/tests/no-sync-io-gate.test.ts` is an executable contract
+  for the rule behaviour (src errors, tests exempt, child_process still banned,
+  reason-less disable rejected).
+- **`createLogger` stays synchronous.** The `Server` constructor builds loggers
+  synchronously, so `runtime/logger.ts` lets `pino.destination({ mkdir, mode,
+  sync: true })` own the file open (a config flag, not a `*Sync` call, so it is
+  outside the gate). It keeps `sync: true` deliberately — an async destination
+  would force a `flushSync()` in a `process.on('exit')` handler, re-adding sync
+  IO in the one truly sync-only context. The pre-existing-wider-file 0600
+  tighten is preserved as a fire-and-forget async `chmod`.
+- **Two audited test exemptions** for synchronous `child_process`:
+  `bin-launcher.test.ts` (`spawnSync`) and `codex-live.test.ts` (`execSync`),
+  each with a reasoned `eslint-disable`.
+- **Foot-gun:** the config is intentionally pure-syntactic (no
+  `parserOptions.project`), so `no-floating-promises` is **not** available — a
+  newly-`async` function called as a bare statement compiles and lints clean but
+  floats at runtime. The cleanup audited every converted write helper's callers
+  by hand; future async conversions must do the same.
+
+## Alternatives considered
+
+- **Warning → error staged rollout.** Rejected: the codebase was zeroed in the
+  same PR, so the rule ships as `error` immediately with no warning phase.
+- **Per-package inline ESLint config.** Rejected in favour of one shared
+  `@excitedjs/eslint-config` so the rule set has a single source of truth.

--- a/.agents/root.md
+++ b/.agents/root.md
@@ -36,10 +36,12 @@ Background and older issue context:
 │   │   ├── src/                   admin, cli, codex, dispatcher, feishu, runtime, legacy db
 │   │   ├── tests/                 vitest (smoke + live-codex + bin-launcher + onboard)
 │   │   └── db/migrations/         legacy SQLite migrations targeted for removal
-│   └── channel/
-│       ├── feishu-transport/      @excitedjs/feishu-transport — platform-I/O core
-│       │                          (sole @larksuiteoapi/node-sdk importer)
-│       └── feishu-channel/        @excitedjs/feishu-channel — channel layer (placeholder)
+│   ├── channel/
+│   │   ├── feishu-transport/      @excitedjs/feishu-transport — platform-I/O core
+│   │   │                          (sole @larksuiteoapi/node-sdk importer)
+│   │   └── feishu-channel/        @excitedjs/feishu-channel — channel layer (placeholder)
+│   └── eslint-config/             @excitedjs/eslint-config — shared lint config
+│                                  (private; no-sync-IO gate, issue #85)
 ├── bin/                           thin redirectors → packages/dreamux/bin/
 ├── .agents/                       this knowledge base
 ├── .github/workflows/             CI

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,8 +8,9 @@
 #     (generic, committed) plus an optional private domain denylist supplied via
 #     the AUTHOR_EMAIL_DENYLIST_REGEX repo variable (kept out of this file).
 #   - shellcheck — lint committed shell entry points and hooks.
-#   - rush — bootstrap, build, typecheck, and test the whole workspace via the
-#     monorepo path (the single supported install path — see decision 0006).
+#   - rush — bootstrap, build, typecheck, lint, and test the whole workspace via
+#     the monorepo path (the single supported install path — see decision 0006).
+#     The lint step enforces the issue #85 synchronous-blocking-IO ban.
 #     This replaces the old per-package `npm ci` job, which cannot resolve the
 #     `workspace:*` dependency that landed with the channel refactor (#4).
 #   - kb — validate the .agents/ knowledge base (link / orphan check)
@@ -153,7 +154,7 @@ jobs:
         run: ./.agents/scripts/check.sh
 
   rush:
-    name: rush — bootstrap / build / typecheck / test (${{ matrix.os }})
+    name: rush — bootstrap / build / typecheck / lint / test (${{ matrix.os }})
     strategy:
       fail-fast: false
       matrix:
@@ -174,6 +175,11 @@ jobs:
         run: node common/scripts/install-run-rush.js build
       - name: rush typecheck
         run: node common/scripts/install-run-rush.js typecheck
+      # Enforce the issue #85 synchronous-blocking-IO ban (n/no-sync + import /
+      # syntax backstops, shared via @excitedjs/eslint-config). src/** is a hard
+      # error on any *Sync IO; tests/** is audited via reasoned disables.
+      - name: rush lint
+        run: node common/scripts/install-run-rush.js lint
       - name: install codex for live compatibility test
         run: |
           npm install --global @openai/codex@latest

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,10 +17,12 @@ fix it in the same PR.
 
 `excitedjs/dreamux` is a **Rush + pnpm monorepo** since issue #4.
 
-- `/packages/<name>/` holds publishable packages. Today: `@excitedjs/dreamux`
+- `/packages/<name>/` holds packages. Publishable today: `@excitedjs/dreamux`
   (the host), `@excitedjs/feishu-transport` (the platform-I/O core, sole owner
   of the `@larksuiteoapi/node-sdk` import), and `@excitedjs/feishu-channel`
   (per-host channel layer, a placeholder today) — see the channel refactor (#4).
+  Private (unpublished): `@excitedjs/eslint-config`, the shared ESLint flat
+  config that is the single source of the synchronous-blocking-IO ban (#85).
 - `/rush.json`, `/common/config/rush/`, `/common/scripts/install-run-rush.js`
   are the rush + pnpm scaffolding.
 - `/bin/dreamux` is a source-checkout convenience shim that forwards to
@@ -116,6 +118,17 @@ explicitly supersedes the top-level design.
   byte-identical with the claudemux repo** — do not edit them in only one repo;
   if gitleaks false-positives, stop and ask rather than adding a local
   allowlist, and sync any config change across both repos.
+- **No synchronous blocking IO in package source. (#85.)** dreamux is one
+  event loop hosting N dispatchers; a `*Sync` fs/`child_process` call stalls
+  every dispatcher. `n/no-sync` (plus import / syntax backstops, shared via
+  `@excitedjs/eslint-config`) makes `/packages/*/src/**` a hard error; use
+  `node:fs/promises` and the async `child_process` API. `tests/**` allows sync
+  `fs` fixtures but still bans sync `child_process` (two audited exemptions
+  carry reasoned `eslint-disable`s). `runtime/logger.ts` keeps
+  `pino.destination({ sync: true })` deliberately — a config flag, not a `*Sync`
+  call. Enforced by `rush lint` (CI + pre-commit). The config is pure-syntactic,
+  so `no-floating-promises` is unavailable: audit a newly-`async` function's
+  callers by hand. See `.agents/decisions/no-sync-io-lint-gate.md`.
 - **No new runtime dependencies on dev tools.** PR #6 removed `tsx`; do
   not reintroduce it for bin launchers. The launchers exec `node` on
   compiled `dist/` output.

--- a/common/changes/@excitedjs/dreamux/no-sync-io-lint-gate_2026-06-05-00-00.json
+++ b/common/changes/@excitedjs/dreamux/no-sync-io-lint-gate_2026-06-05-00-00.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Remove all synchronous blocking IO from package source (fs/promises + async child_process) and add a permanent ESLint gate (n/no-sync + import/syntax backstops via the shared @excitedjs/eslint-config) wired through rush lint, CI, and the pre-commit hook (issue #85)",
+      "type": "patch",
+      "packageName": "@excitedjs/dreamux"
+    }
+  ],
+  "packageName": "@excitedjs/dreamux",
+  "email": "053700@gmail.com"
+}

--- a/common/changes/@excitedjs/feishu-channel/no-sync-io-lint-gate_2026-06-05-00-00.json
+++ b/common/changes/@excitedjs/feishu-channel/no-sync-io-lint-gate_2026-06-05-00-00.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Adopt the shared @excitedjs/eslint-config flat config and the synchronous-blocking-IO lint gate (issue #85); no runtime change",
+      "type": "patch",
+      "packageName": "@excitedjs/feishu-channel"
+    }
+  ],
+  "packageName": "@excitedjs/feishu-channel",
+  "email": "053700@gmail.com"
+}

--- a/common/changes/@excitedjs/feishu-transport/no-sync-io-lint-gate_2026-06-05-00-00.json
+++ b/common/changes/@excitedjs/feishu-transport/no-sync-io-lint-gate_2026-06-05-00-00.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Adopt the shared @excitedjs/eslint-config flat config and the synchronous-blocking-IO lint gate (issue #85); no runtime change",
+      "type": "patch",
+      "packageName": "@excitedjs/feishu-transport"
+    }
+  ],
+  "packageName": "@excitedjs/feishu-transport",
+  "email": "053700@gmail.com"
+}

--- a/common/config/rush/command-line.json
+++ b/common/config/rush/command-line.json
@@ -31,6 +31,15 @@
       "enableParallelism": true,
       "ignoreMissingScript": true,
       "incremental": false
+    },
+    {
+      "name": "lint",
+      "commandKind": "bulk",
+      "summary": "Run each project's `npm run lint` (eslint).",
+      "description": "Bulk-runs ESLint across every package that declares a `lint` script. Enforces the synchronous-blocking-IO ban (issue #85) via @excitedjs/eslint-config. Pure-syntactic — needs no prior build.",
+      "enableParallelism": true,
+      "ignoreMissingScript": true,
+      "incremental": false
     }
   ]
 }

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -16,9 +16,15 @@ importers:
         specifier: workspace:*
         version: link:../feishu-transport
     devDependencies:
+      '@excitedjs/eslint-config':
+        specifier: workspace:*
+        version: link:../../eslint-config
       '@types/node':
         specifier: ^22.10.0
         version: 22.19.19
+      eslint:
+        specifier: ^9.39.0
+        version: 9.39.4
       typescript:
         specifier: ^5.7.0
         version: 5.9.3
@@ -35,9 +41,15 @@ importers:
         specifier: ^15.0.12
         version: 15.0.12
     devDependencies:
+      '@excitedjs/eslint-config':
+        specifier: workspace:*
+        version: link:../../eslint-config
       '@types/node':
         specifier: ^22.10.0
         version: 22.19.19
+      eslint:
+        specifier: ^9.39.0
+        version: 9.39.4
       typescript:
         specifier: ^5.7.0
         version: 5.9.3
@@ -75,6 +87,9 @@ importers:
         specifier: ^17.7.2
         version: 17.7.2
     devDependencies:
+      '@excitedjs/eslint-config':
+        specifier: workspace:*
+        version: link:../eslint-config
       '@types/node':
         specifier: ^22.10.0
         version: 22.19.19
@@ -84,12 +99,31 @@ importers:
       '@types/yargs':
         specifier: ^17.0.35
         version: 17.0.35
+      eslint:
+        specifier: ^9.39.0
+        version: 9.39.4
       typescript:
         specifier: ^5.7.0
         version: 5.9.3
       vitest:
         specifier: ^2.1.0
         version: 2.1.9(@types/node@22.19.19)
+
+  ../../packages/eslint-config:
+    dependencies:
+      '@eslint-community/eslint-plugin-eslint-comments':
+        specifier: ^4.7.2
+        version: 4.7.2(eslint@9.39.4)
+      eslint-plugin-n:
+        specifier: 17.18.0
+        version: 17.18.0(eslint@9.39.4)
+      typescript-eslint:
+        specifier: ^8.60.1
+        version: 8.60.1(eslint@9.39.4)(typescript@5.9.3)
+    devDependencies:
+      eslint:
+        specifier: ^9.39.0
+        version: 9.39.4
 
 packages:
 
@@ -239,10 +273,74 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@eslint-community/eslint-plugin-eslint-comments@4.7.2':
+    resolution: {integrity: sha512-LF03qURSwEWm2dz5wtdDCzNk+7Opl0X7q6I3undsaIuNsEiNvRV3BCtqu14Q/6Pzg1tBj44LcxpW2EpSLZStZw==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0
+
+  '@eslint-community/eslint-utils@4.9.1':
+    resolution: {integrity: sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      eslint: ^6.0.0 || ^7.0.0 || >=8.0.0
+
+  '@eslint-community/regexpp@4.12.2':
+    resolution: {integrity: sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==}
+    engines: {node: ^12.0.0 || ^14.0.0 || >=16.0.0}
+
+  '@eslint/config-array@0.21.2':
+    resolution: {integrity: sha512-nJl2KGTlrf9GjLimgIru+V/mzgSK0ABCDQRvxw5BjURL7WfH5uoWmizbH7QB6MmnMBd8cIC9uceWnezL1VZWWw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@eslint/config-helpers@0.4.2':
+    resolution: {integrity: sha512-gBrxN88gOIf3R7ja5K9slwNayVcZgK6SOUORm2uBzTeIEfeVaIhOpCtTox3P6R7o2jLFwLFTLnC7kU/RGcYEgw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@eslint/core@0.17.0':
+    resolution: {integrity: sha512-yL/sLrpmtDaFEiUj1osRP4TI2MDz1AddJL+jZ7KSqvBuliN4xqYY54IfdN8qD8Toa6g1iloph1fxQNkjOxrrpQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@eslint/eslintrc@3.3.5':
+    resolution: {integrity: sha512-4IlJx0X0qftVsN5E+/vGujTRIFtwuLbNsVUe7TO6zYPDR1O6nFwvwhIKEKSrl6dZchmYBITazxKoUYOjdtjlRg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@eslint/js@9.39.4':
+    resolution: {integrity: sha512-nE7DEIchvtiFTwBw4Lfbu59PG+kCofhjsKaCWzxTpt4lfRjRMqG6uMBzKXuEcyXhOHoUp9riAm7/aWYGhXZ9cw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@eslint/object-schema@2.1.7':
+    resolution: {integrity: sha512-VtAOaymWVfZcmZbp6E2mympDIHvyjXs/12LqWYjVw6qjrfF+VK+fyG33kChz3nnK+SU5/NeHOqrTEHS8sXO3OA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@eslint/plugin-kit@0.4.1':
+    resolution: {integrity: sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
   '@excitedjs/tm@2.2.1':
     resolution: {integrity: sha512-iKpFk4neJ1ebr/GCaJ0mXhZagIFrHRLJ+vndUSfaJZcSQ3CabtLljSNU/IGhT/HZCapCxTzMUG48e8d+fl8KGQ==}
     engines: {node: '>=22.7.0'}
     hasBin: true
+
+  '@humanfs/core@0.19.2':
+    resolution: {integrity: sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==}
+    engines: {node: '>=18.18.0'}
+
+  '@humanfs/node@0.16.8':
+    resolution: {integrity: sha512-gE1eQNZ3R++kTzFUpdGlpmy8kDZD/MLyHqDwqjkVQI0JMdI1D51sy1H958PNXYkM2rAac7e5/CnIKZrHtPh3BQ==}
+    engines: {node: '>=18.18.0'}
+
+  '@humanfs/types@0.15.0':
+    resolution: {integrity: sha512-ZZ1w0aoQkwuUuC7Yf+7sdeaNfqQiiLcSRbfI08oAxqLtpXQr9AIVX7Ay7HLDuiLYAaFPu8oBYNq/QIi9URHJ3Q==}
+    engines: {node: '>=18.18.0'}
+
+  '@humanwhocodes/module-importer@1.0.1':
+    resolution: {integrity: sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==}
+    engines: {node: '>=12.22'}
+
+  '@humanwhocodes/retry@0.4.3':
+    resolution: {integrity: sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==}
+    engines: {node: '>=18.18'}
 
   '@jridgewell/sourcemap-codec@1.5.5':
     resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
@@ -421,6 +519,9 @@ packages:
   '@types/estree@1.0.9':
     resolution: {integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==}
 
+  '@types/json-schema@7.0.15':
+    resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
+
   '@types/node@22.19.19':
     resolution: {integrity: sha512-dyh/xO2Fh5bYrfWaaqGrRQQGkNdmYw6AmaAUvYeUMNTWQtvb796ikLdmTchRmOlOiIJ1TDXfWgVx1QkUlQ6Hew==}
 
@@ -432,6 +533,65 @@ packages:
 
   '@types/yargs@17.0.35':
     resolution: {integrity: sha512-qUHkeCyQFxMXg79wQfTtfndEC+N9ZZg76HJftDJp+qH2tV7Gj4OJi7l+PiWwJ+pWtW8GwSmqsDj/oymhrTWXjg==}
+
+  '@typescript-eslint/eslint-plugin@8.60.1':
+    resolution: {integrity: sha512-JQ4S5GB0tfjO8BuJ4fcX+HodkzJjYBV+7OJ+wLygaX7OGQ7FudyHL4NSCA6ob+w3Yn+5MkKIozOwQhXeM7opVg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      '@typescript-eslint/parser': ^8.60.1
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: '>=4.8.4 <6.1.0'
+
+  '@typescript-eslint/parser@8.60.1':
+    resolution: {integrity: sha512-A0M6ua6H252bVjPvvtSgl2QA4+ET9S5Mtkb2GDyTxIhH/C4qDItT7RQNO5PhMC6NXGYXOR9dIalcDDgBKT7oFA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: '>=4.8.4 <6.1.0'
+
+  '@typescript-eslint/project-service@8.60.1':
+    resolution: {integrity: sha512-eXkTH2bxmXlqD1RnOPmLZ9ZM9D3VwSx04JOwBnP9RQ+yUA5a2Mu7SfW8uaV2Aon53NJzZlZYuX7tn91Izf+xaw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '>=4.8.4 <6.1.0'
+
+  '@typescript-eslint/scope-manager@8.60.1':
+    resolution: {integrity: sha512-gvI5OQoptnxQnchOirukCuQ55svJSTuD/4k5+pC267xyBtYry748R9/c3tYUzb/iE6RZfllRz2lVulLCHkTm4w==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@typescript-eslint/tsconfig-utils@8.60.1':
+    resolution: {integrity: sha512-nh8w4qAteiKuZu3pSSzG/yGKpw0OlkrKnzFmbVRenKaD4qc+7i1GrmZaLVkr8rk4uipiPGMOW4YsM6WmKZ5CvA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '>=4.8.4 <6.1.0'
+
+  '@typescript-eslint/type-utils@8.60.1':
+    resolution: {integrity: sha512-sdwTrpjosW7ANQYJ39ZBF1ZyEMEGVB2UsikrserVM/30a/F1dTLnu9bGxEdosugyu5caigjLrR2qiD11asjI1A==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: '>=4.8.4 <6.1.0'
+
+  '@typescript-eslint/types@8.60.1':
+    resolution: {integrity: sha512-4h0tY8ppCkdCzcrl2YM5M3my0xsE1Tf8om3owEu5oPWmXwkKRmk0j0LGDzYBGUcAlesEbxBhazqu/K4cu3Ug7w==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@typescript-eslint/typescript-estree@8.60.1':
+    resolution: {integrity: sha512-alpRkfG8hlVE5kdJW2GkfgDgXxold3e8e4l6EnmhRmRLbekgAPCCGDVD++sABy9FcgPFroq+uFcCSM1vR57Cew==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '>=4.8.4 <6.1.0'
+
+  '@typescript-eslint/utils@8.60.1':
+    resolution: {integrity: sha512-h2MPBLoNtjc3qZWfY3Tl51yPorQ2McHn8pJfcMNTcIvrrZrr90Ykffit0yjrPFWQcRcUxzH20+6OcVdW4yHtUg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: '>=4.8.4 <6.1.0'
+
+  '@typescript-eslint/visitor-keys@8.60.1':
+    resolution: {integrity: sha512-EbGRQg4FhrmwLodl+t3JNAnXHWVr9Vp+Zl1QBZVPY4ByfkzIT8cX3K6QWODHtkIZqqJVEWvhHSx3v5PDHsaQag==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   '@vitest/expect@2.1.9':
     resolution: {integrity: sha512-UJCIkTBenHeKT1TTlKMJWy1laZewsRIzYighyYiJKZreqtdxSos/S1t+ktRMQWu2CKqaarrkeszJx1cgC5tGZw==}
@@ -466,6 +626,19 @@ packages:
     resolution: {integrity: sha512-A9gOqLdi6cV4ibazAjcQufGj0B1y/vDqYrcuP6d/6x8P27gRS8643Dj9o1dEKtB6O7fwxb2FgBmJS2mX7gpvdw==}
     engines: {node: '>=14.6'}
 
+  acorn-jsx@5.3.2:
+    resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
+    peerDependencies:
+      acorn: ^6.0.0 || ^7.0.0 || ^8.0.0
+
+  acorn@8.16.0:
+    resolution: {integrity: sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==}
+    engines: {node: '>=0.4.0'}
+    hasBin: true
+
+  ajv@6.15.0:
+    resolution: {integrity: sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==}
+
   ansi-regex@5.0.1:
     resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
     engines: {node: '>=8'}
@@ -473,6 +646,9 @@ packages:
   ansi-styles@4.3.0:
     resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
     engines: {node: '>=8'}
+
+  argparse@2.0.1:
+    resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
 
   assertion-error@2.0.1:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
@@ -488,6 +664,23 @@ packages:
   axios@1.13.6:
     resolution: {integrity: sha512-ChTCHMouEe2kn713WHbQGcuYrr6fXTBiu460OTwWrWob16g1bXn4vtz07Ope7ewMozJAnEquLk5lWQWtBig9DQ==}
 
+  balanced-match@1.0.2:
+    resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
+
+  balanced-match@4.0.4:
+    resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
+    engines: {node: 18 || 20 || >=22}
+
+  brace-expansion@1.1.15:
+    resolution: {integrity: sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==}
+
+  brace-expansion@2.1.1:
+    resolution: {integrity: sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==}
+
+  brace-expansion@5.0.6:
+    resolution: {integrity: sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==}
+    engines: {node: 18 || 20 || >=22}
+
   cac@6.7.14:
     resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
     engines: {node: '>=8'}
@@ -500,9 +693,17 @@ packages:
     resolution: {integrity: sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==}
     engines: {node: '>= 0.4'}
 
+  callsites@3.1.0:
+    resolution: {integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==}
+    engines: {node: '>=6'}
+
   chai@5.3.3:
     resolution: {integrity: sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==}
     engines: {node: '>=18'}
+
+  chalk@4.1.2:
+    resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
+    engines: {node: '>=10'}
 
   check-error@2.1.3:
     resolution: {integrity: sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==}
@@ -523,6 +724,9 @@ packages:
     resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
     engines: {node: '>= 0.8'}
 
+  concat-map@0.0.1:
+    resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
+
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
@@ -540,6 +744,9 @@ packages:
     resolution: {integrity: sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==}
     engines: {node: '>=6'}
 
+  deep-is@0.1.4:
+    resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
+
   delayed-stream@1.0.0:
     resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
     engines: {node: '>=0.4.0'}
@@ -550,6 +757,10 @@ packages:
 
   emoji-regex@8.0.0:
     resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
+
+  enhanced-resolve@5.22.2:
+    resolution: {integrity: sha512-0rxICaFZ7NQho/sHely2bvOPRP0Eu2B0NZ9zM54YvRvWMn7jfz3DmnOZDR9LlXDdDcqntAVc6Hfy4gr/tdH/Ag==}
+    engines: {node: '>=10.13.0'}
 
   es-define-property@1.0.1:
     resolution: {integrity: sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==}
@@ -579,8 +790,76 @@ packages:
     resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
     engines: {node: '>=6'}
 
+  escape-string-regexp@4.0.0:
+    resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
+    engines: {node: '>=10'}
+
+  eslint-compat-utils@0.5.1:
+    resolution: {integrity: sha512-3z3vFexKIEnjHE3zCMRo6fn/e44U7T1khUjg+Hp0ZQMCigh28rALD0nPFBcGZuiLC5rLZa2ubQHDRln09JfU2Q==}
+    engines: {node: '>=12'}
+    peerDependencies:
+      eslint: '>=6.0.0'
+
+  eslint-plugin-es-x@7.8.0:
+    resolution: {integrity: sha512-7Ds8+wAAoV3T+LAKeu39Y5BzXCrGKrcISfgKEqTS4BDN8SFEDQd0S43jiQ8vIa3wUKD07qitZdfzlenSi8/0qQ==}
+    engines: {node: ^14.18.0 || >=16.0.0}
+    peerDependencies:
+      eslint: '>=8'
+
+  eslint-plugin-n@17.18.0:
+    resolution: {integrity: sha512-hvZ/HusueqTJ7VDLoCpjN0hx4N4+jHIWTXD4TMLHy9F23XkDagR9v+xQWRWR57yY55GPF8NnD4ox9iGTxirY8A==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: '>=8.23.0'
+
+  eslint-scope@8.4.0:
+    resolution: {integrity: sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  eslint-visitor-keys@3.4.3:
+    resolution: {integrity: sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+
+  eslint-visitor-keys@4.2.1:
+    resolution: {integrity: sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  eslint-visitor-keys@5.0.1:
+    resolution: {integrity: sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+
+  eslint@9.39.4:
+    resolution: {integrity: sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    hasBin: true
+    peerDependencies:
+      jiti: '*'
+    peerDependenciesMeta:
+      jiti:
+        optional: true
+
+  espree@10.4.0:
+    resolution: {integrity: sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  esquery@1.7.0:
+    resolution: {integrity: sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==}
+    engines: {node: '>=0.10'}
+
+  esrecurse@4.3.0:
+    resolution: {integrity: sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==}
+    engines: {node: '>=4.0'}
+
+  estraverse@5.3.0:
+    resolution: {integrity: sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==}
+    engines: {node: '>=4.0'}
+
   estree-walker@3.0.3:
     resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
+  esutils@2.0.3:
+    resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
+    engines: {node: '>=0.10.0'}
 
   execa@9.6.1:
     resolution: {integrity: sha512-9Be3ZoN4LmYR90tUoVu2te2BsbzHfhJyfEiAVfz7N5/zv+jduIfLrV2xdQXOHbaD6KgpGdO9PRPM1Y4Q9QkPkA==}
@@ -589,6 +868,15 @@ packages:
   expect-type@1.3.0:
     resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
     engines: {node: '>=12.0.0'}
+
+  fast-deep-equal@3.1.3:
+    resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
+
+  fast-json-stable-stringify@2.1.0:
+    resolution: {integrity: sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==}
+
+  fast-levenshtein@2.0.6:
+    resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
 
   fast-string-truncated-width@3.0.3:
     resolution: {integrity: sha512-0jjjIEL6+0jag3l2XWWizO64/aZVtpiGE3t0Zgqxv0DPuxiMjvB3M24fCyhZUO4KomJQPj3LTSUnDP3GpdwC0g==}
@@ -599,9 +887,33 @@ packages:
   fast-wrap-ansi@0.2.2:
     resolution: {integrity: sha512-7F2Fl+TjRSenLqlU3UjSH0iyqopqoZIu7eZVpEirP2g1GtWa2G/ecEmBdgz31+Mxr+ELclgg6sokpSFIQiZ02Q==}
 
+  fdir@6.5.0:
+    resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
+    engines: {node: '>=12.0.0'}
+    peerDependencies:
+      picomatch: ^3 || ^4
+    peerDependenciesMeta:
+      picomatch:
+        optional: true
+
   figures@6.1.0:
     resolution: {integrity: sha512-d+l3qxjSesT4V7v2fh+QnmFnUWv9lSpjarhShNTgBOfA0ttejbQUAlHLitbjkoRiDulW0OPoQPYIGhIC8ohejg==}
     engines: {node: '>=18'}
+
+  file-entry-cache@8.0.0:
+    resolution: {integrity: sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==}
+    engines: {node: '>=16.0.0'}
+
+  find-up@5.0.0:
+    resolution: {integrity: sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==}
+    engines: {node: '>=10'}
+
+  flat-cache@4.0.1:
+    resolution: {integrity: sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==}
+    engines: {node: '>=16'}
+
+  flatted@3.4.2:
+    resolution: {integrity: sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==}
 
   follow-redirects@1.16.0:
     resolution: {integrity: sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==}
@@ -640,9 +952,31 @@ packages:
     resolution: {integrity: sha512-kVCxPF3vQM/N0B1PmoqVUqgHP+EeVjmZSQn+1oCRPxd2P21P2F19lIgbR3HBosbB1PUhOAoctJnfEn2GbN2eZA==}
     engines: {node: '>=18'}
 
+  get-tsconfig@4.14.0:
+    resolution: {integrity: sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==}
+
+  glob-parent@6.0.2:
+    resolution: {integrity: sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==}
+    engines: {node: '>=10.13.0'}
+
+  globals@14.0.0:
+    resolution: {integrity: sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==}
+    engines: {node: '>=18'}
+
+  globals@15.15.0:
+    resolution: {integrity: sha512-7ACyT3wmyp3I61S4fG682L0VA2RGD9otkqGJIwNUMF1SWUombIIk+af1unuDYgMm082aHYwD+mzJvv9Iu8dsgg==}
+    engines: {node: '>=18'}
+
   gopd@1.2.0:
     resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
     engines: {node: '>= 0.4'}
+
+  graceful-fs@4.2.11:
+    resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
+
+  has-flag@4.0.0:
+    resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
+    engines: {node: '>=8'}
 
   has-symbols@1.1.0:
     resolution: {integrity: sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==}
@@ -660,9 +994,33 @@ packages:
     resolution: {integrity: sha512-eKCa6bwnJhvxj14kZk5NCPc6Hb6BdsU9DZcOnmQKSnO1VKrfV0zCvtttPZUsBvjmNDn8rpcJfpwSYnHBjc95MQ==}
     engines: {node: '>=18.18.0'}
 
+  ignore@5.3.2:
+    resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
+    engines: {node: '>= 4'}
+
+  ignore@7.0.5:
+    resolution: {integrity: sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==}
+    engines: {node: '>= 4'}
+
+  import-fresh@3.3.1:
+    resolution: {integrity: sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==}
+    engines: {node: '>=6'}
+
+  imurmurhash@0.1.4:
+    resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
+    engines: {node: '>=0.8.19'}
+
+  is-extglob@2.1.1:
+    resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
+    engines: {node: '>=0.10.0'}
+
   is-fullwidth-code-point@3.0.0:
     resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==}
     engines: {node: '>=8'}
+
+  is-glob@4.0.3:
+    resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
+    engines: {node: '>=0.10.0'}
 
   is-plain-obj@4.1.0:
     resolution: {integrity: sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==}
@@ -678,6 +1036,30 @@ packages:
 
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
+
+  js-yaml@4.2.0:
+    resolution: {integrity: sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==}
+    hasBin: true
+
+  json-buffer@3.0.1:
+    resolution: {integrity: sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==}
+
+  json-schema-traverse@0.4.1:
+    resolution: {integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==}
+
+  json-stable-stringify-without-jsonify@1.0.1:
+    resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
+
+  keyv@4.5.4:
+    resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
+
+  levn@0.4.1:
+    resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
+    engines: {node: '>= 0.8.0'}
+
+  locate-path@6.0.0:
+    resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
+    engines: {node: '>=10'}
 
   lodash.identity@3.0.0:
     resolution: {integrity: sha512-AupTIzdLQxJS5wIYUQlgGyk2XRTfGXA+MCghDHqZk0pzUNYvd3EESS6dkChNauNYVIutcb0dfHw1ri9Q1yPV8Q==}
@@ -714,6 +1096,17 @@ packages:
     resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
     engines: {node: '>= 0.6'}
 
+  minimatch@10.2.5:
+    resolution: {integrity: sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==}
+    engines: {node: 18 || 20 || >=22}
+
+  minimatch@3.1.5:
+    resolution: {integrity: sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==}
+
+  minimatch@9.0.9:
+    resolution: {integrity: sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==}
+    engines: {node: '>=16 || 14 >=14.17'}
+
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
@@ -721,6 +1114,9 @@ packages:
     resolution: {integrity: sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
+
+  natural-compare@1.4.0:
+    resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
 
   npm-run-path@6.0.0:
     resolution: {integrity: sha512-9qny7Z9DsQU8Ou39ERsPU4OZQlSTP47ShQzuKZ6PRXpYLtIFgl/DEBYEXKlvcEa+9tHVcK8CF81Y2V72qaZhWA==}
@@ -734,9 +1130,29 @@ packages:
     resolution: {integrity: sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA==}
     engines: {node: '>=14.0.0'}
 
+  optionator@0.9.4:
+    resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
+    engines: {node: '>= 0.8.0'}
+
+  p-limit@3.1.0:
+    resolution: {integrity: sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==}
+    engines: {node: '>=10'}
+
+  p-locate@5.0.0:
+    resolution: {integrity: sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==}
+    engines: {node: '>=10'}
+
+  parent-module@1.0.1:
+    resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
+    engines: {node: '>=6'}
+
   parse-ms@4.0.0:
     resolution: {integrity: sha512-TXfryirbmq34y8QBwgqCVLi+8oA3oWx2eAnSn62ITyEhEYaWRlVZ2DvMM9eZbMs/RfxPu/PK/aBLyGj4IrqMHw==}
     engines: {node: '>=18'}
+
+  path-exists@4.0.0:
+    resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
+    engines: {node: '>=8'}
 
   path-key@3.1.1:
     resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
@@ -756,6 +1172,10 @@ packages:
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
 
+  picomatch@4.0.4:
+    resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
+    engines: {node: '>=12'}
+
   pino-abstract-transport@2.0.0:
     resolution: {integrity: sha512-F63x5tizV6WCh4R6RHyi2Ml+M70DNRXt/+HANowMflpgGFMAym/VKm6G7ZOQRjqN7XbGxK1Lg9t6ZrtzOaivMw==}
 
@@ -774,6 +1194,10 @@ packages:
     resolution: {integrity: sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==}
     engines: {node: ^10 || ^12 || >=14}
 
+  prelude-ls@1.2.1:
+    resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
+    engines: {node: '>= 0.8.0'}
+
   pretty-ms@9.3.0:
     resolution: {integrity: sha512-gjVS5hOP+M3wMm5nmNOucbIrqudzs9v/57bWRHQWLYklXqoXKrVfYW2W9+glfGsqtPgpiz5WwyEEB+ksXIx3gQ==}
     engines: {node: '>=18'}
@@ -787,6 +1211,10 @@ packages:
 
   proxy-from-env@1.1.0:
     resolution: {integrity: sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==}
+
+  punycode@2.3.1:
+    resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
+    engines: {node: '>=6'}
 
   qs@6.15.2:
     resolution: {integrity: sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==}
@@ -803,6 +1231,13 @@ packages:
     resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
     engines: {node: '>=0.10.0'}
 
+  resolve-from@4.0.0:
+    resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
+    engines: {node: '>=4'}
+
+  resolve-pkg-maps@1.0.0:
+    resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
+
   rollup@4.60.4:
     resolution: {integrity: sha512-WHeFSbZYsPu3+bLoNRUuAO+wavNlocOPf3wSHTP7hcFKVnJeWsYlCDbr3mTS14FCizf9ccIxXA8sGL8zKeQN3g==}
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
@@ -811,6 +1246,11 @@ packages:
   safe-stable-stringify@2.5.0:
     resolution: {integrity: sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA==}
     engines: {node: '>=10'}
+
+  semver@7.8.2:
+    resolution: {integrity: sha512-c8jsqUZm3omBOI66G90z1Dyw5z622G8oLG+omfsHBJf3CWQTlOcwOjvOG6wtiNfW6anKm/eA39LMwMtMez2TiQ==}
+    engines: {node: '>=10'}
+    hasBin: true
 
   shebang-command@2.0.0:
     resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
@@ -879,6 +1319,18 @@ packages:
     resolution: {integrity: sha512-aulFJcD6YK8V1G7iRB5tigAP4TsHBZZrOV8pjV++zdUwmeV8uzbY7yn6h9MswN62adStNZFuCIx4haBnRuMDaw==}
     engines: {node: '>=18'}
 
+  strip-json-comments@3.1.1:
+    resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
+    engines: {node: '>=8'}
+
+  supports-color@7.2.0:
+    resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
+    engines: {node: '>=8'}
+
+  tapable@2.3.3:
+    resolution: {integrity: sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==}
+    engines: {node: '>=6'}
+
   thread-stream@3.2.0:
     resolution: {integrity: sha512-zLBvqpwr4Esa0kRjcrzGU6zL25lePWaCLMx0RQFrmteozIfeNdaMLpG5U7PeHzvlFkAWaRKA9/KVW4F60iB+qw==}
 
@@ -887,6 +1339,10 @@ packages:
 
   tinyexec@0.3.2:
     resolution: {integrity: sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==}
+
+  tinyglobby@0.2.17:
+    resolution: {integrity: sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==}
+    engines: {node: '>=12.0.0'}
 
   tinypool@1.1.1:
     resolution: {integrity: sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==}
@@ -900,6 +1356,23 @@ packages:
     resolution: {integrity: sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==}
     engines: {node: '>=14.0.0'}
 
+  ts-api-utils@2.5.0:
+    resolution: {integrity: sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==}
+    engines: {node: '>=18.12'}
+    peerDependencies:
+      typescript: '>=4.8.4'
+
+  type-check@0.4.0:
+    resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
+    engines: {node: '>= 0.8.0'}
+
+  typescript-eslint@8.60.1:
+    resolution: {integrity: sha512-6m5hkkRAp8lKvhVpcprAIn5KkehQEh+47oHH2VGnExEh7dhNxXlg6GPAOIu6TxbVQxhebrJDvjl3020ooiWCMA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: '>=4.8.4 <6.1.0'
+
   typescript@5.9.3:
     resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
     engines: {node: '>=14.17'}
@@ -911,6 +1384,9 @@ packages:
   unicorn-magic@0.3.0:
     resolution: {integrity: sha512-+QBBXBCvifc56fsbuxZQ6Sic3wqqc3WWaqxs58gvJrcOuN83HGTCwz3oS5phzU9LthRNE9VrJCFCLUgHeeFnfA==}
     engines: {node: '>=18'}
+
+  uri-js@4.4.1:
+    resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
 
   vite-node@2.1.9:
     resolution: {integrity: sha512-AM9aQ/IPrW/6ENLQg3AGY4K1N2TGZdR5e4gu/MmmR2xR3Ll1+dib+nook92g4TV3PXVyeyxdWwtaCAiUL0hMxA==}
@@ -983,6 +1459,10 @@ packages:
     engines: {node: '>=8'}
     hasBin: true
 
+  word-wrap@1.2.5:
+    resolution: {integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==}
+    engines: {node: '>=0.10.0'}
+
   wrap-ansi@7.0.0:
     resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
     engines: {node: '>=10'}
@@ -1014,6 +1494,10 @@ packages:
   yargs@17.7.2:
     resolution: {integrity: sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==}
     engines: {node: '>=12'}
+
+  yocto-queue@0.1.0:
+    resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
+    engines: {node: '>=10'}
 
   yoctocolors@2.1.2:
     resolution: {integrity: sha512-CzhO+pFNo8ajLM2d2IW/R93ipy99LWjtwblvC1RsoSUMZgyLbYFr221TnSNT7GjGdYui6P459mw9JH/g/zW2ug==}
@@ -1102,7 +1586,75 @@ snapshots:
   '@esbuild/win32-x64@0.21.5':
     optional: true
 
+  '@eslint-community/eslint-plugin-eslint-comments@4.7.2(eslint@9.39.4)':
+    dependencies:
+      escape-string-regexp: 4.0.0
+      eslint: 9.39.4
+      ignore: 7.0.5
+
+  '@eslint-community/eslint-utils@4.9.1(eslint@9.39.4)':
+    dependencies:
+      eslint: 9.39.4
+      eslint-visitor-keys: 3.4.3
+
+  '@eslint-community/regexpp@4.12.2': {}
+
+  '@eslint/config-array@0.21.2':
+    dependencies:
+      '@eslint/object-schema': 2.1.7
+      debug: 4.4.3
+      minimatch: 3.1.5
+    transitivePeerDependencies:
+      - supports-color
+
+  '@eslint/config-helpers@0.4.2':
+    dependencies:
+      '@eslint/core': 0.17.0
+
+  '@eslint/core@0.17.0':
+    dependencies:
+      '@types/json-schema': 7.0.15
+
+  '@eslint/eslintrc@3.3.5':
+    dependencies:
+      ajv: 6.15.0
+      debug: 4.4.3
+      espree: 10.4.0
+      globals: 14.0.0
+      ignore: 5.3.2
+      import-fresh: 3.3.1
+      js-yaml: 4.2.0
+      minimatch: 3.1.5
+      strip-json-comments: 3.1.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@eslint/js@9.39.4': {}
+
+  '@eslint/object-schema@2.1.7': {}
+
+  '@eslint/plugin-kit@0.4.1':
+    dependencies:
+      '@eslint/core': 0.17.0
+      levn: 0.4.1
+
   '@excitedjs/tm@2.2.1': {}
+
+  '@humanfs/core@0.19.2':
+    dependencies:
+      '@humanfs/types': 0.15.0
+
+  '@humanfs/node@0.16.8':
+    dependencies:
+      '@humanfs/core': 0.19.2
+      '@humanfs/types': 0.15.0
+      '@humanwhocodes/retry': 0.4.3
+
+  '@humanfs/types@0.15.0': {}
+
+  '@humanwhocodes/module-importer@1.0.1': {}
+
+  '@humanwhocodes/retry@0.4.3': {}
 
   '@jridgewell/sourcemap-codec@1.5.5': {}
 
@@ -1227,6 +1779,8 @@ snapshots:
 
   '@types/estree@1.0.9': {}
 
+  '@types/json-schema@7.0.15': {}
+
   '@types/node@22.19.19':
     dependencies:
       undici-types: 6.21.0
@@ -1240,6 +1794,97 @@ snapshots:
   '@types/yargs@17.0.35':
     dependencies:
       '@types/yargs-parser': 21.0.3
+
+  '@typescript-eslint/eslint-plugin@8.60.1(@typescript-eslint/parser@8.60.1(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4)(typescript@5.9.3)':
+    dependencies:
+      '@eslint-community/regexpp': 4.12.2
+      '@typescript-eslint/parser': 8.60.1(eslint@9.39.4)(typescript@5.9.3)
+      '@typescript-eslint/scope-manager': 8.60.1
+      '@typescript-eslint/type-utils': 8.60.1(eslint@9.39.4)(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.60.1(eslint@9.39.4)(typescript@5.9.3)
+      '@typescript-eslint/visitor-keys': 8.60.1
+      eslint: 9.39.4
+      ignore: 7.0.5
+      natural-compare: 1.4.0
+      ts-api-utils: 2.5.0(typescript@5.9.3)
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/parser@8.60.1(eslint@9.39.4)(typescript@5.9.3)':
+    dependencies:
+      '@typescript-eslint/scope-manager': 8.60.1
+      '@typescript-eslint/types': 8.60.1
+      '@typescript-eslint/typescript-estree': 8.60.1(typescript@5.9.3)
+      '@typescript-eslint/visitor-keys': 8.60.1
+      debug: 4.4.3
+      eslint: 9.39.4
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/project-service@8.60.1(typescript@5.9.3)':
+    dependencies:
+      '@typescript-eslint/tsconfig-utils': 8.60.1(typescript@5.9.3)
+      '@typescript-eslint/types': 8.60.1
+      debug: 4.4.3
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/scope-manager@8.60.1':
+    dependencies:
+      '@typescript-eslint/types': 8.60.1
+      '@typescript-eslint/visitor-keys': 8.60.1
+
+  '@typescript-eslint/tsconfig-utils@8.60.1(typescript@5.9.3)':
+    dependencies:
+      typescript: 5.9.3
+
+  '@typescript-eslint/type-utils@8.60.1(eslint@9.39.4)(typescript@5.9.3)':
+    dependencies:
+      '@typescript-eslint/types': 8.60.1
+      '@typescript-eslint/typescript-estree': 8.60.1(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.60.1(eslint@9.39.4)(typescript@5.9.3)
+      debug: 4.4.3
+      eslint: 9.39.4
+      ts-api-utils: 2.5.0(typescript@5.9.3)
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/types@8.60.1': {}
+
+  '@typescript-eslint/typescript-estree@8.60.1(typescript@5.9.3)':
+    dependencies:
+      '@typescript-eslint/project-service': 8.60.1(typescript@5.9.3)
+      '@typescript-eslint/tsconfig-utils': 8.60.1(typescript@5.9.3)
+      '@typescript-eslint/types': 8.60.1
+      '@typescript-eslint/visitor-keys': 8.60.1
+      debug: 4.4.3
+      minimatch: 10.2.5
+      semver: 7.8.2
+      tinyglobby: 0.2.17
+      ts-api-utils: 2.5.0(typescript@5.9.3)
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/utils@8.60.1(eslint@9.39.4)(typescript@5.9.3)':
+    dependencies:
+      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.4)
+      '@typescript-eslint/scope-manager': 8.60.1
+      '@typescript-eslint/types': 8.60.1
+      '@typescript-eslint/typescript-estree': 8.60.1(typescript@5.9.3)
+      eslint: 9.39.4
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/visitor-keys@8.60.1':
+    dependencies:
+      '@typescript-eslint/types': 8.60.1
+      eslint-visitor-keys: 5.0.1
 
   '@vitest/expect@2.1.9':
     dependencies:
@@ -1283,11 +1928,26 @@ snapshots:
 
   '@xmldom/xmldom@0.9.10': {}
 
+  acorn-jsx@5.3.2(acorn@8.16.0):
+    dependencies:
+      acorn: 8.16.0
+
+  acorn@8.16.0: {}
+
+  ajv@6.15.0:
+    dependencies:
+      fast-deep-equal: 3.1.3
+      fast-json-stable-stringify: 2.1.0
+      json-schema-traverse: 0.4.1
+      uri-js: 4.4.1
+
   ansi-regex@5.0.1: {}
 
   ansi-styles@4.3.0:
     dependencies:
       color-convert: 2.0.1
+
+  argparse@2.0.1: {}
 
   assertion-error@2.0.1: {}
 
@@ -1303,6 +1963,23 @@ snapshots:
     transitivePeerDependencies:
       - debug
 
+  balanced-match@1.0.2: {}
+
+  balanced-match@4.0.4: {}
+
+  brace-expansion@1.1.15:
+    dependencies:
+      balanced-match: 1.0.2
+      concat-map: 0.0.1
+
+  brace-expansion@2.1.1:
+    dependencies:
+      balanced-match: 1.0.2
+
+  brace-expansion@5.0.6:
+    dependencies:
+      balanced-match: 4.0.4
+
   cac@6.7.14: {}
 
   call-bind-apply-helpers@1.0.2:
@@ -1315,6 +1992,8 @@ snapshots:
       call-bind-apply-helpers: 1.0.2
       get-intrinsic: 1.3.0
 
+  callsites@3.1.0: {}
+
   chai@5.3.3:
     dependencies:
       assertion-error: 2.0.1
@@ -1322,6 +2001,11 @@ snapshots:
       deep-eql: 5.0.2
       loupe: 3.2.1
       pathval: 2.0.1
+
+  chalk@4.1.2:
+    dependencies:
+      ansi-styles: 4.3.0
+      supports-color: 7.2.0
 
   check-error@2.1.3: {}
 
@@ -1341,6 +2025,8 @@ snapshots:
     dependencies:
       delayed-stream: 1.0.0
 
+  concat-map@0.0.1: {}
+
   cross-spawn@7.0.6:
     dependencies:
       path-key: 3.1.1
@@ -1353,6 +2039,8 @@ snapshots:
 
   deep-eql@5.0.2: {}
 
+  deep-is@0.1.4: {}
+
   delayed-stream@1.0.0: {}
 
   dunder-proto@1.0.1:
@@ -1362,6 +2050,11 @@ snapshots:
       gopd: 1.2.0
 
   emoji-regex@8.0.0: {}
+
+  enhanced-resolve@5.22.2:
+    dependencies:
+      graceful-fs: 4.2.11
+      tapable: 2.3.3
 
   es-define-property@1.0.1: {}
 
@@ -1408,9 +2101,103 @@ snapshots:
 
   escalade@3.2.0: {}
 
+  escape-string-regexp@4.0.0: {}
+
+  eslint-compat-utils@0.5.1(eslint@9.39.4):
+    dependencies:
+      eslint: 9.39.4
+      semver: 7.8.2
+
+  eslint-plugin-es-x@7.8.0(eslint@9.39.4):
+    dependencies:
+      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.4)
+      '@eslint-community/regexpp': 4.12.2
+      eslint: 9.39.4
+      eslint-compat-utils: 0.5.1(eslint@9.39.4)
+
+  eslint-plugin-n@17.18.0(eslint@9.39.4):
+    dependencies:
+      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.4)
+      enhanced-resolve: 5.22.2
+      eslint: 9.39.4
+      eslint-plugin-es-x: 7.8.0(eslint@9.39.4)
+      get-tsconfig: 4.14.0
+      globals: 15.15.0
+      ignore: 5.3.2
+      minimatch: 9.0.9
+      semver: 7.8.2
+
+  eslint-scope@8.4.0:
+    dependencies:
+      esrecurse: 4.3.0
+      estraverse: 5.3.0
+
+  eslint-visitor-keys@3.4.3: {}
+
+  eslint-visitor-keys@4.2.1: {}
+
+  eslint-visitor-keys@5.0.1: {}
+
+  eslint@9.39.4:
+    dependencies:
+      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.4)
+      '@eslint-community/regexpp': 4.12.2
+      '@eslint/config-array': 0.21.2
+      '@eslint/config-helpers': 0.4.2
+      '@eslint/core': 0.17.0
+      '@eslint/eslintrc': 3.3.5
+      '@eslint/js': 9.39.4
+      '@eslint/plugin-kit': 0.4.1
+      '@humanfs/node': 0.16.8
+      '@humanwhocodes/module-importer': 1.0.1
+      '@humanwhocodes/retry': 0.4.3
+      '@types/estree': 1.0.9
+      ajv: 6.15.0
+      chalk: 4.1.2
+      cross-spawn: 7.0.6
+      debug: 4.4.3
+      escape-string-regexp: 4.0.0
+      eslint-scope: 8.4.0
+      eslint-visitor-keys: 4.2.1
+      espree: 10.4.0
+      esquery: 1.7.0
+      esutils: 2.0.3
+      fast-deep-equal: 3.1.3
+      file-entry-cache: 8.0.0
+      find-up: 5.0.0
+      glob-parent: 6.0.2
+      ignore: 5.3.2
+      imurmurhash: 0.1.4
+      is-glob: 4.0.3
+      json-stable-stringify-without-jsonify: 1.0.1
+      lodash.merge: 4.6.2
+      minimatch: 3.1.5
+      natural-compare: 1.4.0
+      optionator: 0.9.4
+    transitivePeerDependencies:
+      - supports-color
+
+  espree@10.4.0:
+    dependencies:
+      acorn: 8.16.0
+      acorn-jsx: 5.3.2(acorn@8.16.0)
+      eslint-visitor-keys: 4.2.1
+
+  esquery@1.7.0:
+    dependencies:
+      estraverse: 5.3.0
+
+  esrecurse@4.3.0:
+    dependencies:
+      estraverse: 5.3.0
+
+  estraverse@5.3.0: {}
+
   estree-walker@3.0.3:
     dependencies:
       '@types/estree': 1.0.9
+
+  esutils@2.0.3: {}
 
   execa@9.6.1:
     dependencies:
@@ -1429,6 +2216,12 @@ snapshots:
 
   expect-type@1.3.0: {}
 
+  fast-deep-equal@3.1.3: {}
+
+  fast-json-stable-stringify@2.1.0: {}
+
+  fast-levenshtein@2.0.6: {}
+
   fast-string-truncated-width@3.0.3: {}
 
   fast-string-width@3.0.2:
@@ -1439,9 +2232,29 @@ snapshots:
     dependencies:
       fast-string-width: 3.0.2
 
+  fdir@6.5.0(picomatch@4.0.4):
+    optionalDependencies:
+      picomatch: 4.0.4
+
   figures@6.1.0:
     dependencies:
       is-unicode-supported: 2.1.0
+
+  file-entry-cache@8.0.0:
+    dependencies:
+      flat-cache: 4.0.1
+
+  find-up@5.0.0:
+    dependencies:
+      locate-path: 6.0.0
+      path-exists: 4.0.0
+
+  flat-cache@4.0.1:
+    dependencies:
+      flatted: 3.4.2
+      keyv: 4.5.4
+
+  flatted@3.4.2: {}
 
   follow-redirects@1.16.0: {}
 
@@ -1483,7 +2296,23 @@ snapshots:
       '@sec-ant/readable-stream': 0.4.1
       is-stream: 4.0.1
 
+  get-tsconfig@4.14.0:
+    dependencies:
+      resolve-pkg-maps: 1.0.0
+
+  glob-parent@6.0.2:
+    dependencies:
+      is-glob: 4.0.3
+
+  globals@14.0.0: {}
+
+  globals@15.15.0: {}
+
   gopd@1.2.0: {}
+
+  graceful-fs@4.2.11: {}
+
+  has-flag@4.0.0: {}
 
   has-symbols@1.1.0: {}
 
@@ -1497,7 +2326,24 @@ snapshots:
 
   human-signals@8.0.1: {}
 
+  ignore@5.3.2: {}
+
+  ignore@7.0.5: {}
+
+  import-fresh@3.3.1:
+    dependencies:
+      parent-module: 1.0.1
+      resolve-from: 4.0.0
+
+  imurmurhash@0.1.4: {}
+
+  is-extglob@2.1.1: {}
+
   is-fullwidth-code-point@3.0.0: {}
+
+  is-glob@4.0.3:
+    dependencies:
+      is-extglob: 2.1.1
 
   is-plain-obj@4.1.0: {}
 
@@ -1506,6 +2352,29 @@ snapshots:
   is-unicode-supported@2.1.0: {}
 
   isexe@2.0.0: {}
+
+  js-yaml@4.2.0:
+    dependencies:
+      argparse: 2.0.1
+
+  json-buffer@3.0.1: {}
+
+  json-schema-traverse@0.4.1: {}
+
+  json-stable-stringify-without-jsonify@1.0.1: {}
+
+  keyv@4.5.4:
+    dependencies:
+      json-buffer: 3.0.1
+
+  levn@0.4.1:
+    dependencies:
+      prelude-ls: 1.2.1
+      type-check: 0.4.0
+
+  locate-path@6.0.0:
+    dependencies:
+      p-locate: 5.0.0
 
   lodash.identity@3.0.0: {}
 
@@ -1531,9 +2400,23 @@ snapshots:
     dependencies:
       mime-db: 1.52.0
 
+  minimatch@10.2.5:
+    dependencies:
+      brace-expansion: 5.0.6
+
+  minimatch@3.1.5:
+    dependencies:
+      brace-expansion: 1.1.15
+
+  minimatch@9.0.9:
+    dependencies:
+      brace-expansion: 2.1.1
+
   ms@2.1.3: {}
 
   nanoid@3.3.12: {}
+
+  natural-compare@1.4.0: {}
 
   npm-run-path@6.0.0:
     dependencies:
@@ -1544,7 +2427,30 @@ snapshots:
 
   on-exit-leak-free@2.1.2: {}
 
+  optionator@0.9.4:
+    dependencies:
+      deep-is: 0.1.4
+      fast-levenshtein: 2.0.6
+      levn: 0.4.1
+      prelude-ls: 1.2.1
+      type-check: 0.4.0
+      word-wrap: 1.2.5
+
+  p-limit@3.1.0:
+    dependencies:
+      yocto-queue: 0.1.0
+
+  p-locate@5.0.0:
+    dependencies:
+      p-limit: 3.1.0
+
+  parent-module@1.0.1:
+    dependencies:
+      callsites: 3.1.0
+
   parse-ms@4.0.0: {}
+
+  path-exists@4.0.0: {}
 
   path-key@3.1.1: {}
 
@@ -1555,6 +2461,8 @@ snapshots:
   pathval@2.0.1: {}
 
   picocolors@1.1.1: {}
+
+  picomatch@4.0.4: {}
 
   pino-abstract-transport@2.0.0:
     dependencies:
@@ -1587,6 +2495,8 @@ snapshots:
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
+  prelude-ls@1.2.1: {}
+
   pretty-ms@9.3.0:
     dependencies:
       parse-ms: 4.0.0
@@ -1610,6 +2520,8 @@ snapshots:
 
   proxy-from-env@1.1.0: {}
 
+  punycode@2.3.1: {}
+
   qs@6.15.2:
     dependencies:
       side-channel: 1.1.0
@@ -1619,6 +2531,10 @@ snapshots:
   real-require@0.2.0: {}
 
   require-directory@2.1.1: {}
+
+  resolve-from@4.0.0: {}
+
+  resolve-pkg-maps@1.0.0: {}
 
   rollup@4.60.4:
     dependencies:
@@ -1652,6 +2568,8 @@ snapshots:
       fsevents: 2.3.3
 
   safe-stable-stringify@2.5.0: {}
+
+  semver@7.8.2: {}
 
   shebang-command@2.0.0:
     dependencies:
@@ -1719,6 +2637,14 @@ snapshots:
 
   strip-final-newline@4.0.0: {}
 
+  strip-json-comments@3.1.1: {}
+
+  supports-color@7.2.0:
+    dependencies:
+      has-flag: 4.0.0
+
+  tapable@2.3.3: {}
+
   thread-stream@3.2.0:
     dependencies:
       real-require: 0.2.0
@@ -1727,17 +2653,45 @@ snapshots:
 
   tinyexec@0.3.2: {}
 
+  tinyglobby@0.2.17:
+    dependencies:
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
+
   tinypool@1.1.1: {}
 
   tinyrainbow@1.2.0: {}
 
   tinyspy@3.0.2: {}
 
+  ts-api-utils@2.5.0(typescript@5.9.3):
+    dependencies:
+      typescript: 5.9.3
+
+  type-check@0.4.0:
+    dependencies:
+      prelude-ls: 1.2.1
+
+  typescript-eslint@8.60.1(eslint@9.39.4)(typescript@5.9.3):
+    dependencies:
+      '@typescript-eslint/eslint-plugin': 8.60.1(@typescript-eslint/parser@8.60.1(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4)(typescript@5.9.3)
+      '@typescript-eslint/parser': 8.60.1(eslint@9.39.4)(typescript@5.9.3)
+      '@typescript-eslint/typescript-estree': 8.60.1(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.60.1(eslint@9.39.4)(typescript@5.9.3)
+      eslint: 9.39.4
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - supports-color
+
   typescript@5.9.3: {}
 
   undici-types@6.21.0: {}
 
   unicorn-magic@0.3.0: {}
+
+  uri-js@4.4.1:
+    dependencies:
+      punycode: 2.3.1
 
   vite-node@2.1.9(@types/node@22.19.19):
     dependencies:
@@ -1810,6 +2764,8 @@ snapshots:
       siginfo: 2.0.0
       stackback: 0.0.2
 
+  word-wrap@1.2.5: {}
+
   wrap-ansi@7.0.0:
     dependencies:
       ansi-styles: 4.3.0
@@ -1833,5 +2789,7 @@ snapshots:
       string-width: 4.2.3
       y18n: 5.0.8
       yargs-parser: 21.1.1
+
+  yocto-queue@0.1.0: {}
 
   yoctocolors@2.1.2: {}

--- a/common/git-hooks/pre-commit
+++ b/common/git-hooks/pre-commit
@@ -1,26 +1,78 @@
 #!/bin/sh
-# Anti-leak guardrail — local pre-commit secret scan.
+# Local pre-commit pre-flight. Two fast, non-authoritative gates that shorten
+# the feedback loop before CI:
 #
-# dreamux is a PUBLIC repo: company-internal content (Feishu ids, tokens,
-# private-mirror registry URLs, secrets) must never be committed. This hook is
-# a fast local pre-flight that scans the *staged* changes with gitleaks before
-# they become a commit, using the committed .gitleaks.toml config.
+#   1. no-sync-io (issue #85) — lint staged TypeScript against each package's
+#      ESLint flat config (the n/no-sync ban + import / syntax backstops). src/**
+#      is a hard error on any *Sync IO; tests/** is audited via reasoned disables.
+#   2. anti-leak — scan the *staged* changes with gitleaks. dreamux is a PUBLIC
+#      repo: company-internal content (Feishu ids, tokens, private-mirror
+#      registry URLs, secrets) must never be committed.
 #
-# If gitleaks isn't installed it warn-and-passes: the GitHub Actions job runs
-# the authoritative `gitleaks detect` over the full history and is the real,
-# non-bypassable gate. This hook only shortens the feedback loop.
+# Both gates warn-and-pass when their tool isn't installed: the GitHub Actions
+# jobs (`rush lint`; `gitleaks detect` over the full history) are the real,
+# non-bypassable gates. This hook only shortens the loop.
 #
 # Rush installs this script into .git/hooks on `rush install` / `rush update`.
 # If your hooks aren't wired up yet, point git at this directory manually:
 #   git config core.hooksPath common/git-hooks
 
+repo_root=$(git rev-parse --show-toplevel)
+
+# --- 1. no-sync-io gate (issue #85) ------------------------------------------
+# Lint only the staged .ts files, each against its owning package's flat config.
+staged_ts=$(git diff --cached --name-only --diff-filter=ACM -- '*.ts')
+if [ -n "$staged_ts" ]; then
+  eslint_failed=0
+  eslint_missing=0
+  oldifs=$IFS
+  IFS='
+'
+  set -f # filenames are literal; do not glob-expand them
+  for f in $staged_ts; do
+    [ -n "$f" ] || continue
+    # Walk up to the nearest ancestor holding an eslint.config.js (package root).
+    d=$(dirname "$f")
+    pkg=""
+    while [ "$d" != "." ] && [ "$d" != "/" ]; do
+      if [ -f "$repo_root/$d/eslint.config.js" ]; then
+        pkg=$d
+        break
+      fi
+      d=$(dirname "$d")
+    done
+    [ -n "$pkg" ] || continue
+    eslint_bin="$repo_root/$pkg/node_modules/.bin/eslint"
+    if [ ! -x "$eslint_bin" ]; then
+      eslint_missing=1
+      continue
+    fi
+    rel=${f#"$pkg"/}
+    if ! (
+      cd "$repo_root/$pkg" || exit 1
+      "$eslint_bin" "$rel"
+    ); then
+      eslint_failed=1
+    fi
+  done
+  set +f
+  IFS=$oldifs
+  if [ "$eslint_failed" = 1 ]; then
+    echo "[no-sync-io] ESLint flagged staged TypeScript (issue #85 sync-IO gate)." >&2
+    echo "[no-sync-io] Fix it before committing — CI runs the same rule." >&2
+    exit 1
+  fi
+  if [ "$eslint_missing" = 1 ]; then
+    echo "[no-sync-io] eslint not installed in a package — skipped there; CI will enforce." >&2
+  fi
+fi
+
+# --- 2. anti-leak gate -------------------------------------------------------
 if ! command -v gitleaks >/dev/null 2>&1; then
   echo "[anti-leak] gitleaks not installed — skipping local scan; CI will enforce." >&2
   echo "[anti-leak] install: https://github.com/gitleaks/gitleaks#installing" >&2
   exit 0
 fi
-
-repo_root=$(git rev-parse --show-toplevel)
 
 if ! gitleaks protect --staged \
   --config "$repo_root/.gitleaks.toml" \

--- a/packages/channel/feishu-channel/eslint.config.js
+++ b/packages/channel/feishu-channel/eslint.config.js
@@ -1,0 +1,6 @@
+// Thin re-export of the shared synchronous-blocking-IO lint gate (issue #85).
+// The single source of rules/scoping is @excitedjs/eslint-config; this file
+// only wires it into this package so `npm run lint` / `rush lint` pick it up.
+import config from '@excitedjs/eslint-config';
+
+export default config;

--- a/packages/channel/feishu-channel/package.json
+++ b/packages/channel/feishu-channel/package.json
@@ -23,6 +23,7 @@
   "scripts": {
     "build": "tsc -p tsconfig.json",
     "typecheck": "tsc -p tsconfig.json --noEmit",
+    "lint": "eslint .",
     "test": "vitest run",
     "test:watch": "vitest",
     "clean": "rm -rf dist",
@@ -32,7 +33,9 @@
     "@excitedjs/feishu-transport": "workspace:*"
   },
   "devDependencies": {
+    "@excitedjs/eslint-config": "workspace:*",
     "@types/node": "^22.10.0",
+    "eslint": "^9.39.0",
     "typescript": "^5.7.0",
     "vitest": "^2.1.0"
   }

--- a/packages/channel/feishu-transport/eslint.config.js
+++ b/packages/channel/feishu-transport/eslint.config.js
@@ -1,0 +1,6 @@
+// Thin re-export of the shared synchronous-blocking-IO lint gate (issue #85).
+// The single source of rules/scoping is @excitedjs/eslint-config; this file
+// only wires it into this package so `npm run lint` / `rush lint` pick it up.
+import config from '@excitedjs/eslint-config';
+
+export default config;

--- a/packages/channel/feishu-transport/package.json
+++ b/packages/channel/feishu-transport/package.json
@@ -28,6 +28,7 @@
   "scripts": {
     "build": "tsc -p tsconfig.json",
     "typecheck": "tsc -p tsconfig.json --noEmit",
+    "lint": "eslint .",
     "test": "vitest run",
     "test:watch": "vitest",
     "clean": "rm -rf dist",
@@ -38,7 +39,9 @@
     "marked": "^15.0.12"
   },
   "devDependencies": {
+    "@excitedjs/eslint-config": "workspace:*",
     "@types/node": "^22.10.0",
+    "eslint": "^9.39.0",
     "typescript": "^5.7.0",
     "vitest": "^2.1.0"
   }

--- a/packages/dreamux/eslint.config.js
+++ b/packages/dreamux/eslint.config.js
@@ -1,0 +1,6 @@
+// Thin re-export of the shared synchronous-blocking-IO lint gate (issue #85).
+// The single source of rules/scoping is @excitedjs/eslint-config; this file
+// only wires it into this package so `npm run lint` / `rush lint` pick it up.
+import config from '@excitedjs/eslint-config';
+
+export default config;

--- a/packages/dreamux/package.json
+++ b/packages/dreamux/package.json
@@ -27,6 +27,7 @@
   "scripts": {
     "build": "tsc -p tsconfig.json",
     "typecheck": "tsc -p tsconfig.json --noEmit",
+    "lint": "eslint .",
     "test": "vitest run",
     "test:watch": "vitest",
     "clean": "rm -rf dist",
@@ -44,9 +45,11 @@
     "plist": "^5.0.0"
   },
   "devDependencies": {
+    "@excitedjs/eslint-config": "workspace:*",
     "@types/node": "^22.10.0",
     "@types/ws": "^8.5.13",
     "@types/yargs": "^17.0.35",
+    "eslint": "^9.39.0",
     "typescript": "^5.7.0",
     "vitest": "^2.1.0"
   }

--- a/packages/dreamux/src/admin/socket.ts
+++ b/packages/dreamux/src/admin/socket.ts
@@ -7,13 +7,7 @@
  */
 
 import { createServer, type Server as NetServer, type Socket } from 'node:net';
-import {
-  chmodSync,
-  existsSync,
-  readFileSync,
-  rmSync,
-  writeFileSync,
-} from 'node:fs';
+import { chmod, readFile, rm, writeFile } from 'node:fs/promises';
 
 import type { Server } from '../server.js';
 import {
@@ -32,9 +26,9 @@ export interface AdminSocketServer {
 export interface AdminSocketOptions {
   /**
    * Override the chmod implementation. Tests inject a throwing fn to assert
-   * the fail-fast cleanup path (PR #3 review #2). Default: `fs.chmodSync`.
+   * the fail-fast cleanup path (PR #3 review #2). Default: `fs/promises.chmod`.
    */
-  chmodFn?: (path: string, mode: number) => void;
+  chmodFn?: (path: string, mode: number) => void | Promise<void>;
   /**
    * Override the liveness probe for the lockfile holder PID. Production uses
    * `process.kill(pid, 0)`; tests inject a stub so they can assert behavior
@@ -60,7 +54,7 @@ export function createAdminSocketServer(
   socketPath: string,
   options: AdminSocketOptions = {},
 ): AdminSocketServer {
-  const chmod = options.chmodFn ?? chmodSync;
+  const chmodFn = options.chmodFn ?? chmod;
   const isAlive = options.isPidAlive ?? defaultIsPidAlive;
   const myPid = options.selfPid ?? process.pid;
   const lockPath = `${socketPath}.lock`;
@@ -80,14 +74,12 @@ export function createAdminSocketServer(
       // hold it, nobody else can be inside this start() concurrently.
       // Stale pidfiles (dead holder) are reclaimed up to RECLAIM_ATTEMPTS
       // times; a live holder always loses the race.
-      acquirePidLock(lockPath, myPid, isAlive);
+      await acquirePidLock(lockPath, myPid, isAlive);
       holdLock = true;
 
       try {
         // Lock is held — stale socket cleanup is now race-free.
-        if (existsSync(socketPath)) {
-          rmSync(socketPath, { force: true });
-        }
+        await rm(socketPath, { force: true });
 
         netServer = createServer((sock) => handleConnection(server, sock));
         await new Promise<void>((res, rej) => {
@@ -98,7 +90,7 @@ export function createAdminSocketServer(
         // PR #3 review #2: chmod is a hard requirement, not best-effort —
         // a 0666 admin socket exposes server-ctl methods to every local user.
         try {
-          chmod(socketPath, 0o600);
+          await chmodFn(socketPath, 0o600);
         } catch (e) {
           const chmodErr = e instanceof Error ? e.message : String(e);
           throw new Error(
@@ -115,11 +107,11 @@ export function createAdminSocketServer(
           await new Promise<void>((res) => closing.close(() => res()));
         }
         try {
-          rmSync(socketPath, { force: true });
+          await rm(socketPath, { force: true });
         } catch {
           /* best-effort */
         }
-        releasePidLock(lockPath, myPid);
+        await releasePidLock(lockPath, myPid);
         holdLock = false;
         throw err;
       }
@@ -130,13 +122,13 @@ export function createAdminSocketServer(
         await new Promise<void>((res) => netServer!.close(() => res()));
         netServer = null;
         try {
-          rmSync(socketPath, { force: true });
+          await rm(socketPath, { force: true });
         } catch {
           /* */
         }
       }
       if (holdLock) {
-        releasePidLock(lockPath, myPid);
+        await releasePidLock(lockPath, myPid);
         holdLock = false;
       }
     },
@@ -155,19 +147,19 @@ export function createAdminSocketServer(
  * RECLAIM_ATTEMPTS bounds the retry so a pathologically broken filesystem
  * doesn't spin forever.
  */
-function acquirePidLock(
+async function acquirePidLock(
   lockPath: string,
   myPid: number,
   isAlive: (pid: number) => boolean,
-): void {
+): Promise<void> {
   for (let attempt = 0; attempt < RECLAIM_ATTEMPTS; attempt++) {
     try {
-      writeFileSync(lockPath, `${myPid}\n`, { flag: 'wx', mode: 0o600 });
+      await writeFile(lockPath, `${myPid}\n`, { flag: 'wx', mode: 0o600 });
       return;
     } catch (err) {
       if ((err as NodeJS.ErrnoException).code !== 'EEXIST') throw err;
     }
-    const holder = readPidFile(lockPath);
+    const holder = await readPidFile(lockPath);
     if (holder === myPid) {
       // Re-entrant — shouldn't happen in normal use, but treat as held.
       return;
@@ -184,7 +176,7 @@ function acquirePidLock(
     // same stale file simply wins this round of `wx`, and we'll see *their*
     // live PID on the next iteration and bail out.
     try {
-      rmSync(lockPath, { force: true });
+      await rm(lockPath, { force: true });
     } catch {
       /* concurrent reclaim — retry the wx open */
     }
@@ -200,19 +192,19 @@ function acquirePidLock(
  * file was already reclaimed by a competitor (e.g. we were paused long
  * enough for our PID to look dead) must not delete the new holder's lock.
  */
-function releasePidLock(lockPath: string, myPid: number): void {
-  if (readPidFile(lockPath) !== myPid) return;
+async function releasePidLock(lockPath: string, myPid: number): Promise<void> {
+  if ((await readPidFile(lockPath)) !== myPid) return;
   try {
-    rmSync(lockPath, { force: true });
+    await rm(lockPath, { force: true });
   } catch {
     /* best-effort */
   }
 }
 
-function readPidFile(path: string): number | null {
+async function readPidFile(path: string): Promise<number | null> {
   let txt: string;
   try {
-    txt = readFileSync(path, 'utf8').trim();
+    txt = (await readFile(path, 'utf8')).trim();
   } catch {
     return null;
   }

--- a/packages/dreamux/src/channel/chat-bots-store.ts
+++ b/packages/dreamux/src/channel/chat-bots-store.ts
@@ -19,14 +19,7 @@
  * sanitized into a path segment. Owner-only (0600); writes are atomic.
  */
 
-import {
-  chmodSync,
-  existsSync,
-  mkdirSync,
-  readFileSync,
-  renameSync,
-  writeFileSync,
-} from 'node:fs';
+import { chmod, mkdir, readFile, rename, writeFile } from 'node:fs/promises';
 import { dirname } from 'node:path';
 
 import { dispatcherChatBotsPath } from '../runtime/paths.js';
@@ -121,24 +114,28 @@ function peerBotsFrom(entry: ChatBotsEntry, openIds: string[]): PeerBot[] {
  * file is not security-critical — it only affects peer-bot discovery — so a
  * load failure degrades to an empty store rather than throwing.
  */
-export function loadChatBots(dispatcherId: string): ChatBotsState {
+export async function loadChatBots(
+  dispatcherId: string,
+): Promise<ChatBotsState> {
   const path = dispatcherChatBotsPath(dispatcherId);
-  if (!existsSync(path)) return defaultChatBotsState();
   try {
-    const parsed = JSON.parse(readFileSync(path, 'utf8')) as unknown;
+    const parsed = JSON.parse(await readFile(path, 'utf8')) as unknown;
     return normalizeChatBots(parsed);
   } catch {
     return defaultChatBotsState();
   }
 }
 
-export function saveChatBots(dispatcherId: string, state: ChatBotsState): void {
+export async function saveChatBots(
+  dispatcherId: string,
+  state: ChatBotsState,
+): Promise<void> {
   const path = dispatcherChatBotsPath(dispatcherId);
-  mkdirSync(dirname(path), { recursive: true });
+  await mkdir(dirname(path), { recursive: true });
   const tmp = `${path}.tmp-${process.pid}-${tmpCounter++}`;
-  writeFileSync(tmp, `${JSON.stringify(state, null, 2)}\n`, { mode: 0o600 });
-  chmodSync(tmp, 0o600);
-  renameSync(tmp, path);
+  await writeFile(tmp, `${JSON.stringify(state, null, 2)}\n`, { mode: 0o600 });
+  await chmod(tmp, 0o600);
+  await rename(tmp, path);
 }
 
 function entryFor(state: ChatBotsState, chatId: string): ChatBotsEntry {
@@ -150,32 +147,32 @@ function entryFor(state: ChatBotsState, chatId: string): ChatBotsEntry {
 }
 
 /** Record a passively observed peer bot as *known* (awareness only). */
-export function observeKnownBot(
+export async function observeKnownBot(
   dispatcherId: string,
   chatId: string,
   bot: PeerBot,
-): void {
+): Promise<void> {
   if (bot.openId === '') return;
-  const state = loadChatBots(dispatcherId);
+  const state = await loadChatBots(dispatcherId);
   const entry = entryFor(state, chatId);
   let changed = recordName(entry, bot);
   if (!entry.known.includes(bot.openId)) {
     entry.known.push(bot.openId);
     changed = true;
   }
-  if (changed) saveChatBots(dispatcherId, state);
+  if (changed) await saveChatBots(dispatcherId, state);
 }
 
 /**
  * Record peer bots introduced by an allowlisted `/introduce` as *trusted*.
  * Trusted bots are also known. Returns the open_ids newly added to trust.
  */
-export function trustIntroducedBots(
+export async function trustIntroducedBots(
   dispatcherId: string,
   chatId: string,
   bots: PeerBot[],
-): string[] {
-  const state = loadChatBots(dispatcherId);
+): Promise<string[]> {
+  const state = await loadChatBots(dispatcherId);
   const entry = entryFor(state, chatId);
   const added: string[] = [];
   let changed = false;
@@ -196,7 +193,7 @@ export function trustIntroducedBots(
   // (issue #69). Re-introducing already-trusted bots changes nothing, so it
   // does not re-arm the one-shot.
   if (added.length > 0) markBaseline(entry);
-  if (changed) saveChatBots(dispatcherId, state);
+  if (changed) await saveChatBots(dispatcherId, state);
   return added;
 }
 
@@ -206,11 +203,11 @@ export function trustIntroducedBots(
  * enqueue, injects the trusted bots when `needsBaseline`, and clears via
  * `clearBaselineIfCurrent` only after a successful submission.
  */
-export function pendingBaseline(
+export async function pendingBaseline(
   dispatcherId: string,
   chatId: string,
-): PendingBaseline {
-  const entry = loadChatBots(dispatcherId).chats[chatId];
+): Promise<PendingBaseline> {
+  const entry = (await loadChatBots(dispatcherId)).chats[chatId];
   if (entry === undefined) {
     return { needsBaseline: false, generation: 0, trusted: [] };
   }
@@ -227,25 +224,25 @@ export function pendingBaseline(
  * that arrived mid-enqueue bumps the generation, so this no-ops rather than
  * dropping the newer pending context (issue #69).
  */
-export function clearBaselineIfCurrent(
+export async function clearBaselineIfCurrent(
   dispatcherId: string,
   chatId: string,
   generation: number,
-): void {
-  const state = loadChatBots(dispatcherId);
+): Promise<void> {
+  const state = await loadChatBots(dispatcherId);
   const entry = state.chats[chatId];
   if (entry === undefined || !entry.needsBaseline) return;
   if (entry.baselineGeneration !== generation) return;
   entry.needsBaseline = false;
-  saveChatBots(dispatcherId, state);
+  await saveChatBots(dispatcherId, state);
 }
 
 /** Known and trusted peer bots for one chat (the `list_chat_bots` tool). */
-export function listChatBots(
+export async function listChatBots(
   dispatcherId: string,
   chatId: string,
-): ChatBotsListing {
-  const entry = loadChatBots(dispatcherId).chats[chatId];
+): Promise<ChatBotsListing> {
+  const entry = (await loadChatBots(dispatcherId)).chats[chatId];
   if (entry === undefined) return { known: [], trusted: [] };
   return {
     known: peerBotsFrom(entry, entry.known),
@@ -254,8 +251,11 @@ export function listChatBots(
 }
 
 /** The trust set the gate consults for one chat. */
-export function trustedBotIds(dispatcherId: string, chatId: string): Set<string> {
-  return new Set(loadChatBots(dispatcherId).chats[chatId]?.trusted ?? []);
+export async function trustedBotIds(
+  dispatcherId: string,
+  chatId: string,
+): Promise<Set<string>> {
+  return new Set((await loadChatBots(dispatcherId)).chats[chatId]?.trusted ?? []);
 }
 
 /**
@@ -263,12 +263,12 @@ export function trustedBotIds(dispatcherId: string, chatId: string): Set<string>
  * baseline injection. Idempotent by event id — a redelivered event is a no-op.
  * Returns true when the event was newly recorded.
  */
-export function recordBotAdded(
+export async function recordBotAdded(
   dispatcherId: string,
   chatId: string,
   eventId: string,
-): boolean {
-  const state = loadChatBots(dispatcherId);
+): Promise<boolean> {
+  const state = await loadChatBots(dispatcherId);
   const entry = entryFor(state, chatId);
   if (eventId !== '' && entry.seenEventIds.includes(eventId)) return false;
   if (eventId !== '') {
@@ -276,7 +276,7 @@ export function recordBotAdded(
     while (entry.seenEventIds.length > MAX_SEEN_EVENT_IDS) entry.seenEventIds.shift();
   }
   markBaseline(entry);
-  saveChatBots(dispatcherId, state);
+  await saveChatBots(dispatcherId, state);
   return true;
 }
 

--- a/packages/dreamux/src/channel/feishu-gate.ts
+++ b/packages/dreamux/src/channel/feishu-gate.ts
@@ -3,13 +3,7 @@ import {
   isBotSenderType,
   type Mention,
 } from '@excitedjs/feishu-transport';
-import {
-  chmodSync,
-  existsSync,
-  mkdirSync,
-  readFileSync,
-  writeFileSync,
-} from 'node:fs';
+import { chmod, mkdir, readFile, writeFile } from 'node:fs/promises';
 import { dirname } from 'node:path';
 
 import { dispatcherAccessPath } from '../runtime/paths.js';
@@ -113,10 +107,19 @@ export function defaultDispatcherAccessState(): DispatcherAccessState {
   };
 }
 
-export function loadDispatcherAccess(dispatcherId: string): DispatcherAccessState {
+export async function loadDispatcherAccess(
+  dispatcherId: string,
+): Promise<DispatcherAccessState> {
   const path = dispatcherAccessPath(dispatcherId);
-  if (!existsSync(path)) return defaultDispatcherAccessState();
-  const raw = readFileSync(path, 'utf8');
+  let raw: string;
+  try {
+    raw = await readFile(path, 'utf8');
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === 'ENOENT') {
+      return defaultDispatcherAccessState();
+    }
+    throw err;
+  }
   let parsed: unknown;
   try {
     parsed = JSON.parse(raw);
@@ -127,14 +130,14 @@ export function loadDispatcherAccess(dispatcherId: string): DispatcherAccessStat
   return readDispatcherAccess(parsed, path);
 }
 
-export function saveDispatcherAccess(
+export async function saveDispatcherAccess(
   dispatcherId: string,
   access: DispatcherAccessState,
-): void {
+): Promise<void> {
   const path = dispatcherAccessPath(dispatcherId);
-  mkdirSync(dirname(path), { recursive: true });
-  writeFileSync(path, `${JSON.stringify(access, null, 2)}\n`, { mode: 0o600 });
-  chmodSync(path, 0o600);
+  await mkdir(dirname(path), { recursive: true });
+  await writeFile(path, `${JSON.stringify(access, null, 2)}\n`, { mode: 0o600 });
+  await chmod(path, 0o600);
 }
 
 export function dreamuxFeishuGate(

--- a/packages/dreamux/src/cli/doctor.ts
+++ b/packages/dreamux/src/cli/doctor.ts
@@ -1,7 +1,17 @@
-import { existsSync, readFileSync } from 'node:fs';
+import { access, readFile } from 'node:fs/promises';
 import { homedir, userInfo } from 'node:os';
 
 import { parse as parsePlist, type PlistValue } from 'plist';
+
+/** Async existence probe — the fs/promises replacement for `existsSync`. */
+async function pathExists(path: string): Promise<boolean> {
+  try {
+    await access(path);
+    return true;
+  } catch {
+    return false;
+  }
+}
 
 import { codexArgsToCli, parseCodexArgs } from '../runtime/codex-args.js';
 import {
@@ -90,12 +100,12 @@ export async function runDreamuxDoctor(
   const runner = options.runner ?? new ExecaCommandRunner();
   const checks: DoctorCheck[] = [];
   const configDir = globalConfigDir();
-  const { config, configFile } = readConfigForDoctor(configDir, checks);
+  const { config, configFile } = await readConfigForDoctor(configDir, checks);
   setRuntimeConfig(config);
 
   checks.push({
     name: 'state directory',
-    ok: existsSync(stateRoot()),
+    ok: await pathExists(stateRoot()),
     detail: stateRoot(),
   });
 
@@ -130,7 +140,11 @@ export async function runDreamuxDoctor(
     options.nodeProbe ?? defaultServiceNodeProbe,
   );
 
-  const dispatchers = readDispatchers(config, options.env ?? process.env, service);
+  const dispatchers = await readDispatchers(
+    config,
+    options.env ?? process.env,
+    service,
+  );
   if (dispatchers.length === 0) {
     checks.push({
       name: 'dispatchers',
@@ -172,12 +186,12 @@ export function printDoctorResult(result: DreamuxDoctorResult): void {
   }
 }
 
-function readConfigForDoctor(
+async function readConfigForDoctor(
   configDir: string,
   checks: DoctorCheck[],
-): { config: DreamuxConfig; configFile: string } {
+): Promise<{ config: DreamuxConfig; configFile: string }> {
   try {
-    const loaded = loadConfig({ configDir });
+    const loaded = await loadConfig({ configDir });
     checks.push({
       name: 'config',
       ok: true,
@@ -198,39 +212,41 @@ function readConfigForDoctor(
   }
 }
 
-function readDispatchers(
+async function readDispatchers(
   config: DreamuxConfig,
   env: NodeJS.ProcessEnv,
   service: ServiceStatus,
-): DispatcherDoctorReport[] {
-  return config.dispatchers.map((dispatcher) => {
-    const codexArgs = parseCodexArgs(dispatcherCodexArgsJson(dispatcher), {
-      approvalPolicy: config.codex.approval_policy,
-      sandboxMode: config.codex.sandbox_mode,
-      extraArgs: config.codex.extra_args,
-    });
-    const codexCliArgs = codexArgsToCli(codexArgs);
-    const context = dispatcherCodexHomeDoctorContext(dispatcher.id, {
-      codexCliArgs,
-      dispatcherCwd: dispatcher.cwd ?? dispatcherCodexCwd(dispatcher.id),
-    });
-    const foreground = validateDispatcherCodexHome(context, {
-      env,
-      codexCliArgs,
-    });
-    const managedServiceEnv = service.environment ?? {};
-    const managedService = service.installed
-      ? validateDispatcherCodexHome(context, {
-          env: managedServiceEnv,
-          codexCliArgs,
-        })
-      : null;
-    return {
-      id: dispatcher.id,
-      foreground,
-      managedService,
-    };
-  });
+): Promise<DispatcherDoctorReport[]> {
+  return Promise.all(
+    config.dispatchers.map(async (dispatcher) => {
+      const codexArgs = parseCodexArgs(dispatcherCodexArgsJson(dispatcher), {
+        approvalPolicy: config.codex.approval_policy,
+        sandboxMode: config.codex.sandbox_mode,
+        extraArgs: config.codex.extra_args,
+      });
+      const codexCliArgs = codexArgsToCli(codexArgs);
+      const context = dispatcherCodexHomeDoctorContext(dispatcher.id, {
+        codexCliArgs,
+        dispatcherCwd: dispatcher.cwd ?? dispatcherCodexCwd(dispatcher.id),
+      });
+      const foreground = await validateDispatcherCodexHome(context, {
+        env,
+        codexCliArgs,
+      });
+      const managedServiceEnv = service.environment ?? {};
+      const managedService = service.installed
+        ? await validateDispatcherCodexHome(context, {
+            env: managedServiceEnv,
+            codexCliArgs,
+          })
+        : null;
+      return {
+        id: dispatcher.id,
+        foreground,
+        managedService,
+      };
+    }),
+  );
 }
 
 function dispatcherCodexArgsJson(dispatcher: DispatcherConfig): string {
@@ -261,7 +277,7 @@ async function launchdStatus(
   runner: CommandRunner,
   uid?: number,
 ): Promise<ServiceStatus> {
-  const installed = existsSync(unitPath);
+  const installed = await pathExists(unitPath);
   const target = launchdTarget(uid);
   let raw = '';
   let loaded = false;
@@ -273,7 +289,7 @@ async function launchdStatus(
   }
   const pid = parseLaunchdPid(raw);
   const unitFile = installed
-    ? parseLaunchdPlist(readFileSync(unitPath, 'utf8'))
+    ? parseLaunchdPlist(await readFile(unitPath, 'utf8'))
     : { environment: null, execStart: null };
   return {
     platform: 'launchd',
@@ -314,14 +330,15 @@ async function systemdStatus(
   } catch {
     raw = '';
   }
-  const unitFile = existsSync(unitPath)
-    ? parseSystemdUnit(readFileSync(unitPath, 'utf8'))
+  const installed = await pathExists(unitPath);
+  const unitFile = installed
+    ? parseSystemdUnit(await readFile(unitPath, 'utf8'))
     : { environment: null, execStart: null };
   const props = parseSystemdProperties(raw);
   return {
     platform: 'systemd',
     unitPath,
-    installed: existsSync(unitPath),
+    installed,
     enabled,
     loaded: props['LoadState'] === 'loaded',
     running: active || props['ActiveState'] === 'active',

--- a/packages/dreamux/src/cli/dreamux.ts
+++ b/packages/dreamux/src/cli/dreamux.ts
@@ -7,7 +7,7 @@
  */
 
 import { spawn } from 'node:child_process';
-import { existsSync, readFileSync } from 'node:fs';
+import { access, readFile } from 'node:fs/promises';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
@@ -437,6 +437,16 @@ function printServiceWarnings(
   }
 }
 
+/** Async existence probe — the fs/promises replacement for `existsSync`. */
+async function pathExists(path: string): Promise<boolean> {
+  try {
+    await access(path);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 function buildConfigCommands(y: Argv): Argv {
   return y
     .command(
@@ -451,13 +461,13 @@ function buildConfigCommands(y: Argv): Argv {
       'show',
       'Print the dreamux global config file',
       (yy) => yy,
-      () => {
+      async () => {
         const file = globalConfigFile();
-        if (!existsSync(file)) {
+        if (!(await pathExists(file))) {
           throw new Error(`config file does not exist: ${file}`);
         }
-        assertConfigFileMode(file);
-        const raw = readFileSync(file, 'utf8');
+        await assertConfigFileMode(file);
+        const raw = await readFile(file, 'utf8');
         process.stdout.write(redactConfigForDisplay(raw, file));
       },
     )

--- a/packages/dreamux/src/cli/server.ts
+++ b/packages/dreamux/src/cli/server.ts
@@ -15,7 +15,7 @@
  * Per-dispatcher Feishu secrets live in the dreamux JSON config.
  */
 
-import { mkdirSync } from 'node:fs';
+import { mkdir } from 'node:fs/promises';
 
 import { Server } from '../server.js';
 import { loadConfig } from '../runtime/config.js';
@@ -39,13 +39,13 @@ async function main(): Promise<void> {
 
   // Load ~/.dreamux/config.json before anything else starts. Missing or invalid
   // config is a setup error; `dreamux serve` must not silently create defaults.
-  const { config, configFile } = loadConfig();
+  const { config, configFile } = await loadConfig();
 
-  mkdirSync(stateRoot(), { recursive: true });
-  mkdirSync(logsRoot(), { recursive: true });
-  mkdirSync(codexAppServerLogDir(), { recursive: true });
-  mkdirSync(feishuChannelLogDir(), { recursive: true });
-  mkdirSync(feishuMcpLogDir(), { recursive: true });
+  await mkdir(stateRoot(), { recursive: true });
+  await mkdir(logsRoot(), { recursive: true });
+  await mkdir(codexAppServerLogDir(), { recursive: true });
+  await mkdir(feishuChannelLogDir(), { recursive: true });
+  await mkdir(feishuMcpLogDir(), { recursive: true });
 
   // The CLI is the only constructor of file-backed loggers; everything else
   // (tests) gets stderr-only defaults. Both stream to stderr too, so a

--- a/packages/dreamux/src/codex/supervisor.ts
+++ b/packages/dreamux/src/codex/supervisor.ts
@@ -18,14 +18,7 @@ import {
   type ChildProcess,
   type SpawnOptions,
 } from 'node:child_process';
-import {
-  closeSync,
-  existsSync,
-  mkdirSync,
-  openSync,
-  rmSync,
-  statSync,
-} from 'node:fs';
+import { mkdir, open, rm, stat } from 'node:fs/promises';
 import { dirname } from 'node:path';
 
 export interface CodexProcessOptions {
@@ -90,26 +83,29 @@ export class CodexProcess {
       ...(this.opts.extraArgs ?? []),
     ];
 
-    mkdirSync(dirname(this.opts.socketPath), { recursive: true });
-    mkdirSync(this.opts.cwd, { recursive: true });
-    mkdirSync(dirname(this.opts.stdoutLogPath), { recursive: true });
+    await mkdir(dirname(this.opts.socketPath), { recursive: true });
+    await mkdir(this.opts.cwd, { recursive: true });
+    await mkdir(dirname(this.opts.stdoutLogPath), { recursive: true });
     // Stale socket from a previous crashed run would otherwise prevent
     // the daemon from binding.
-    if (existsSync(this.opts.socketPath)) {
-      try {
-        rmSync(this.opts.socketPath, { force: true });
-      } catch {
-        /* ignore — bind will fail loudly if it really is busy */
-      }
+    try {
+      await rm(this.opts.socketPath, { force: true });
+    } catch {
+      /* ignore — bind will fail loudly if it really is busy */
     }
 
-    const stdoutFd = openSync(this.opts.stdoutLogPath, 'a', 0o600);
-    const stderrFd = openSync(this.opts.stderrLogPath, 'a', 0o600);
+    // Open the log files as FileHandles and hand their fds to the child's
+    // stdio. The handles are kept in locals (referenced by the finally below)
+    // so they cannot be garbage-collected — and thus closed out from under the
+    // child — between open and spawn. They are closed once the child owns the
+    // inherited fds, matching the previous openSync/closeSync timing.
+    const stdoutHandle = await open(this.opts.stdoutLogPath, 'a', 0o600);
+    const stderrHandle = await open(this.opts.stderrLogPath, 'a', 0o600);
     const spawnOpts: SpawnOptions = {
       cwd: this.opts.cwd,
       env: this.opts.env ?? process.env,
       detached: true, // its own process group, so we can group-kill on reap
-      stdio: ['ignore', stdoutFd, stderrFd],
+      stdio: ['ignore', stdoutHandle.fd, stderrHandle.fd],
     };
 
     let child: ChildProcess;
@@ -129,8 +125,8 @@ export class CodexProcess {
         });
       });
     } finally {
-      closeSync(stdoutFd);
-      closeSync(stderrFd);
+      await stdoutHandle.close();
+      await stderrHandle.close();
     }
 
     if (child.pid === undefined) {
@@ -184,12 +180,10 @@ export class CodexProcess {
       // the exact failure this guards against.
       killProcessGroup(pid, 'SIGKILL');
     }
-    if (existsSync(this.opts.socketPath)) {
-      try {
-        rmSync(this.opts.socketPath, { force: true });
-      } catch {
-        /* best effort */
-      }
+    try {
+      await rm(this.opts.socketPath, { force: true });
+    } catch {
+      /* best effort */
     }
     this.child = null;
   }
@@ -202,13 +196,11 @@ async function waitForSocket(
 ): Promise<void> {
   const deadline = Date.now() + timeoutMs;
   while (Date.now() < deadline) {
-    if (existsSync(path)) {
-      try {
-        const st = statSync(path);
-        if (st.isSocket()) return;
-      } catch {
-        /* race; keep polling */
-      }
+    try {
+      const st = await stat(path);
+      if (st.isSocket()) return;
+    } catch {
+      /* not bound yet or race; keep polling */
     }
     if (!isProcessAlive(pid)) {
       throw new Error(

--- a/packages/dreamux/src/daemon/install.ts
+++ b/packages/dreamux/src/daemon/install.ts
@@ -54,12 +54,12 @@ export async function runDaemonInstall(
 
   // Fail loudly when the operator has not run onboard yet — daemon install
   // re-registers an existing setup, it does not create one.
-  const { config } = loadConfig({ configDir: globalConfigDir() });
+  const { config } = await loadConfig({ configDir: globalConfigDir() });
   setRuntimeConfig(config);
 
   const codexBin = dryRun
     ? config.codex.bin
-    : resolveServiceExecutable(config.codex.bin, env);
+    : await resolveServiceExecutable(config.codex.bin, env);
   // Pin the managed service to a stable system Node (issue #83) rather than the
   // current process Node — otherwise running `daemon install` from a
   // version-manager Node would re-pin the service to that unstable Node.

--- a/packages/dreamux/src/daemon/restart-intent.ts
+++ b/packages/dreamux/src/daemon/restart-intent.ts
@@ -20,13 +20,7 @@
  *     start`) does not claim a stale notice.
  */
 
-import {
-  existsSync,
-  mkdirSync,
-  readFileSync,
-  rmSync,
-  writeFileSync,
-} from 'node:fs';
+import { mkdir, readFile, rm, writeFile } from 'node:fs/promises';
 import { dirname } from 'node:path';
 
 import { restartIntentPath } from '../runtime/paths.js';
@@ -64,7 +58,9 @@ export interface WriteRestartIntentOptions {
  * Persist the restart marker. Must be called *before* triggering the service
  * manager restart so the marker is durable if the caller is killed.
  */
-export function writeRestartIntent(options: WriteRestartIntentOptions): string {
+export async function writeRestartIntent(
+  options: WriteRestartIntentOptions,
+): Promise<string> {
   const path = options.path ?? restartIntentPath();
   const file: RestartIntentFile = {
     version: 1,
@@ -76,8 +72,8 @@ export function writeRestartIntent(options: WriteRestartIntentOptions): string {
         : DEFAULT_RESTART_ANNOUNCE,
     targets: dedupeNonEmpty(options.targets),
   };
-  mkdirSync(dirname(path), { recursive: true });
-  writeFileSync(path, `${JSON.stringify(file, null, 2)}\n`, { mode: 0o600 });
+  await mkdir(dirname(path), { recursive: true });
+  await writeFile(path, `${JSON.stringify(file, null, 2)}\n`, { mode: 0o600 });
   return path;
 }
 
@@ -89,9 +85,11 @@ export function writeRestartIntent(options: WriteRestartIntentOptions): string {
  * self-update path where the caller is reaped before reaching here keeps the
  * marker (durability), which is the intended behaviour (issue #78).
  */
-export function clearRestartIntent(path: string = restartIntentPath()): void {
+export async function clearRestartIntent(
+  path: string = restartIntentPath(),
+): Promise<void> {
   try {
-    rmSync(path, { force: true });
+    await rm(path, { force: true });
   } catch {
     /* best effort */
   }
@@ -116,7 +114,7 @@ export interface NotifyResumedRestartOptions {
 export async function notifyResumedRestart(
   options: NotifyResumedRestartOptions,
 ): Promise<void> {
-  const path = writeRestartIntent({
+  const path = await writeRestartIntent({
     targets: options.targets,
     ...(options.announce !== undefined ? { announce: options.announce } : {}),
     now: options.now,
@@ -125,7 +123,7 @@ export async function notifyResumedRestart(
   try {
     await options.runControl();
   } catch (err) {
-    clearRestartIntent(path);
+    await clearRestartIntent(path);
     throw err;
   }
 }
@@ -154,19 +152,20 @@ export class RestartIntentConsumer {
    * missing / malformed / expired marker yields an empty consumer (and the
    * stale file is removed). This is the only reader of the marker file.
    */
-  static load(options: { now: number; path?: string } = { now: 0 }): RestartIntentConsumer {
+  static async load(
+    options: { now: number; path?: string } = { now: 0 },
+  ): Promise<RestartIntentConsumer> {
     const path = options.path ?? restartIntentPath();
     const empty = new RestartIntentConsumer('', 0, new Set());
-    if (!existsSync(path)) return empty;
     let parsed: RestartIntentFile | null = null;
     try {
-      parsed = JSON.parse(readFileSync(path, 'utf8')) as RestartIntentFile;
+      parsed = JSON.parse(await readFile(path, 'utf8')) as RestartIntentFile;
     } catch {
       parsed = null;
     }
     // Single reader: drop the file regardless of validity so it never replays.
     try {
-      rmSync(path, { force: true });
+      await rm(path, { force: true });
     } catch {
       /* best effort */
     }

--- a/packages/dreamux/src/dispatcher/runtime.ts
+++ b/packages/dreamux/src/dispatcher/runtime.ts
@@ -16,7 +16,7 @@
  *     and post a visible warning to the next source chat.
  */
 
-import { mkdirSync } from 'node:fs';
+import { mkdir } from 'node:fs/promises';
 import { dirname } from 'node:path';
 
 import type {
@@ -157,19 +157,19 @@ export class DispatcherRuntime {
     this.restarting = false;
     this.clearRestartTimer();
     this.setStatus('starting');
-    this.deps.dispatchers.setStatus(this.dispatcherId, 'starting', {
+    await this.deps.dispatchers.setStatus(this.dispatcherId, 'starting', {
       last_started_at: Date.now(),
     });
 
     try {
       await this.startCodexRuntime();
-      this.markReady();
+      await this.markReady();
 
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
       this.log('error', `start failed: ${msg}`, err);
       this.setStatus('degraded');
-      this.deps.dispatchers.setStatus(this.dispatcherId, 'degraded', {
+      await this.deps.dispatchers.setStatus(this.dispatcherId, 'degraded', {
         last_error: msg,
       });
       await this.cleanupOnFailure();
@@ -205,7 +205,7 @@ export class DispatcherRuntime {
       if (this.process !== process) return;
       this.handleChildExit(exit);
     });
-    mkdirSync(dirname(socketPath), { recursive: true });
+    await mkdir(dirname(socketPath), { recursive: true });
     await process.start();
 
     const clientFactory =
@@ -264,7 +264,7 @@ export class DispatcherRuntime {
         {},
       );
       this.threadId = res.thread.id;
-      this.deps.dispatchers.setThreadId(this.dispatcherId, this.threadId);
+      await this.deps.dispatchers.setThreadId(this.dispatcherId, this.threadId);
       this.log('info', `started fresh thread ${this.threadId}`);
       return;
     }
@@ -287,7 +287,7 @@ export class DispatcherRuntime {
         {},
       );
       this.threadId = res.thread.id;
-      this.deps.dispatchers.recordLostThread(
+      await this.deps.dispatchers.recordLostThread(
         this.dispatcherId,
         existing,
         this.threadId,
@@ -318,10 +318,10 @@ export class DispatcherRuntime {
     this.stopping = true;
     this.clearRestartTimer();
     this.setStatus('stopping');
-    this.deps.dispatchers.setStatus(this.dispatcherId, 'stopping');
+    await this.deps.dispatchers.setStatus(this.dispatcherId, 'stopping');
     await this.teardownCodexRuntime();
     this.setStatus('stopped');
-    this.deps.dispatchers.setStatus(this.dispatcherId, 'stopped');
+    await this.deps.dispatchers.setStatus(this.dispatcherId, 'stopped');
   }
 
   private async cleanupOnFailure(): Promise<void> {
@@ -374,9 +374,16 @@ export class DispatcherRuntime {
     const delay = this.restartDelayMs(attempt);
     this.log('warn', `${reason}; restarting in ${delay}ms`);
     this.setStatus('degraded');
-    this.deps.dispatchers.setStatus(this.dispatcherId, 'degraded', {
-      last_error: reason,
-    });
+    // scheduleRestart runs from synchronous event handlers (ws close, child
+    // exit); the durable status write is best-effort here — persist it without
+    // blocking, logging (never throwing) on failure. The restart timer's later
+    // 'starting'/'ready' writes are awaited, so they cannot be reordered behind
+    // this one within the backoff delay.
+    void this.deps.dispatchers
+      .setStatus(this.dispatcherId, 'degraded', { last_error: reason })
+      .catch((err) =>
+        this.log('warn', 'failed to persist degraded status', err),
+      );
     this.restartTimer = setTimeout(() => {
       this.restartTimer = null;
       void this.restartCodexRuntime(reason);
@@ -388,7 +395,7 @@ export class DispatcherRuntime {
     this.restarting = true;
     let retryReason: string | null = null;
     this.setStatus('starting');
-    this.deps.dispatchers.setStatus(this.dispatcherId, 'starting', {
+    await this.deps.dispatchers.setStatus(this.dispatcherId, 'starting', {
       last_started_at: Date.now(),
     });
     try {
@@ -400,13 +407,13 @@ export class DispatcherRuntime {
         return;
       }
       this.restartAttempts = 0;
-      this.markReady();
+      await this.markReady();
       this.log('info', `restarted codex app-server after: ${reason}`);
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
       this.log('error', `restart failed: ${msg}`, err);
       this.setStatus('degraded');
-      this.deps.dispatchers.setStatus(this.dispatcherId, 'degraded', {
+      await this.deps.dispatchers.setStatus(this.dispatcherId, 'degraded', {
         last_error: msg,
       });
       await this.teardownCodexRuntime();
@@ -435,9 +442,9 @@ export class DispatcherRuntime {
     this.restartTimer = null;
   }
 
-  private markReady(): void {
+  private async markReady(): Promise<void> {
     this.setStatus('ready');
-    this.deps.dispatchers.setStatus(this.dispatcherId, 'ready', {
+    await this.deps.dispatchers.setStatus(this.dispatcherId, 'ready', {
       last_ready_at: Date.now(),
       last_error: null,
     });

--- a/packages/dreamux/src/onboard/dispatcher-skill.ts
+++ b/packages/dreamux/src/onboard/dispatcher-skill.ts
@@ -1,4 +1,4 @@
-import { existsSync, readFileSync } from 'node:fs';
+import { readFile } from 'node:fs/promises';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
@@ -14,13 +14,13 @@ const DISPATCHER_SKILL_SOURCE = join(
   'SKILL.md',
 );
 
-export function installDispatcherSkill(options: {
+export async function installDispatcherSkill(options: {
   skillPath: string;
   ledger: OnboardFileLedger;
   dryRun: boolean;
-}): void {
-  const content = readDispatcherSkill();
-  writeTextFile(
+}): Promise<void> {
+  const content = await readDispatcherSkill();
+  await writeTextFile(
     options.skillPath,
     content,
     options.ledger,
@@ -29,9 +29,15 @@ export function installDispatcherSkill(options: {
   );
 }
 
-function readDispatcherSkill(): string {
-  if (!existsSync(DISPATCHER_SKILL_SOURCE)) {
-    throw new Error(`missing bundled dispatcher skill: ${DISPATCHER_SKILL_SOURCE}`);
+async function readDispatcherSkill(): Promise<string> {
+  try {
+    return await readFile(DISPATCHER_SKILL_SOURCE, 'utf8');
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === 'ENOENT') {
+      throw new Error(
+        `missing bundled dispatcher skill: ${DISPATCHER_SKILL_SOURCE}`,
+      );
+    }
+    throw err;
   }
-  return readFileSync(DISPATCHER_SKILL_SOURCE, 'utf8');
 }

--- a/packages/dreamux/src/onboard/ledger.ts
+++ b/packages/dreamux/src/onboard/ledger.ts
@@ -1,12 +1,15 @@
-import {
-  existsSync,
-  mkdirSync,
-  readFileSync,
-  readdirSync,
-  statSync,
-  writeFileSync,
-} from 'node:fs';
+import { access, mkdir, readFile, readdir, stat, writeFile } from 'node:fs/promises';
 import { dirname, join } from 'node:path';
+
+/** Async existence probe — the fs/promises replacement for `existsSync`. */
+async function pathExists(path: string): Promise<boolean> {
+  try {
+    await access(path);
+    return true;
+  } catch {
+    return false;
+  }
+}
 
 import type {
   OnboardFileLedger,
@@ -44,47 +47,47 @@ export interface WriteOptions {
 
 export type FileSnapshot = Map<string, Buffer>;
 
-export function ensureDirectory(
+export async function ensureDirectory(
   path: string,
   ledger: OnboardFileLedger,
   reason: string,
   options: { dryRun?: boolean } = {},
-): void {
-  if (existsSync(path)) {
-    if (!statSync(path).isDirectory()) {
+): Promise<void> {
+  if (await pathExists(path)) {
+    if (!(await stat(path)).isDirectory()) {
       throw new Error(`expected directory but found a file: ${path}`);
     }
     ledger.record(path, 'unchanged', reason);
     return;
   }
   if (!options.dryRun) {
-    mkdirSync(path, { recursive: true });
+    await mkdir(path, { recursive: true });
   }
   ledger.record(path, 'created', reason);
 }
 
-export function writeTextFile(
+export async function writeTextFile(
   path: string,
   content: string,
   ledger: OnboardFileLedger,
   reason: string,
   options: WriteOptions = {},
-): OnboardFileStatus {
+): Promise<OnboardFileStatus> {
   const parent = dirname(path);
-  ensureDirectory(parent, ledger, `parent directory for ${reason}`, {
+  await ensureDirectory(parent, ledger, `parent directory for ${reason}`, {
     dryRun: options.dryRun,
   });
 
   let status: OnboardFileStatus;
-  if (!existsSync(path)) {
+  if (!(await pathExists(path))) {
     status = 'created';
   } else {
-    const current = readFileSync(path, 'utf8');
+    const current = await readFile(path, 'utf8');
     status = current === content ? 'unchanged' : 'modified';
   }
 
   if (!options.dryRun && status !== 'unchanged') {
-    writeFileSync(path, content, {
+    await writeFile(path, content, {
       mode: options.mode,
     });
   }
@@ -92,23 +95,23 @@ export function writeTextFile(
   return status;
 }
 
-export function ensureTextFile(
+export async function ensureTextFile(
   path: string,
   initialContent: string,
   ledger: OnboardFileLedger,
   reason: string,
   options: WriteOptions = {},
-): OnboardFileStatus {
+): Promise<OnboardFileStatus> {
   const parent = dirname(path);
-  ensureDirectory(parent, ledger, `parent directory for ${reason}`, {
+  await ensureDirectory(parent, ledger, `parent directory for ${reason}`, {
     dryRun: options.dryRun,
   });
-  if (existsSync(path)) {
+  if (await pathExists(path)) {
     ledger.record(path, 'unchanged', reason);
     return 'unchanged';
   }
   if (!options.dryRun) {
-    writeFileSync(path, initialContent, {
+    await writeFile(path, initialContent, {
       mode: options.mode,
     });
   }
@@ -116,33 +119,33 @@ export function ensureTextFile(
   return 'created';
 }
 
-export function snapshotFiles(root: string): FileSnapshot {
+export async function snapshotFiles(root: string): Promise<FileSnapshot> {
   const out: FileSnapshot = new Map();
-  if (!existsSync(root)) return out;
+  if (!(await pathExists(root))) return out;
   const stack = [root];
   while (stack.length > 0) {
     const current = stack.pop();
     if (current === undefined) continue;
-    const stat = statSync(current);
-    if (stat.isFile()) {
-      out.set(current, readFileSync(current));
+    const info = await stat(current);
+    if (info.isFile()) {
+      out.set(current, await readFile(current));
       continue;
     }
-    if (!stat.isDirectory()) continue;
-    for (const entry of readdirSync(current)) {
+    if (!info.isDirectory()) continue;
+    for (const entry of await readdir(current)) {
       stack.push(join(current, entry));
     }
   }
   return out;
 }
 
-export function recordFileTreeChanges(
+export async function recordFileTreeChanges(
   root: string,
   before: FileSnapshot,
   ledger: OnboardFileLedger,
   reason: string,
-): void {
-  const after = snapshotFiles(root);
+): Promise<void> {
+  const after = await snapshotFiles(root);
   for (const [path, content] of after) {
     const previous = before.get(path);
     const status =

--- a/packages/dreamux/src/onboard/run.ts
+++ b/packages/dreamux/src/onboard/run.ts
@@ -1,4 +1,4 @@
-import { existsSync } from 'node:fs';
+import { access } from 'node:fs/promises';
 
 import { codexArgsToCli, parseCodexArgs } from '../runtime/codex-args.js';
 import {
@@ -68,10 +68,10 @@ export async function runOnboard(
   const runner = options.runner ?? new ExecaCommandRunner();
   const env = options.env ?? process.env;
   const configPath = globalConfigFile({ configDir: answers.configDir });
-  const existingConfig = readExistingDreamuxConfig(answers.configDir);
+  const existingConfig = await readExistingDreamuxConfig(answers.configDir);
   const dreamuxConfig = dreamuxConfigFromAnswers(answers, existingConfig);
   const serviceCodexBin = answers.registerService && !answers.dryRun
-    ? resolveServiceExecutable(dreamuxConfig.codex.bin, env)
+    ? await resolveServiceExecutable(dreamuxConfig.codex.bin, env)
     : dreamuxConfig.codex.bin;
   const serviceNodeBin = answers.registerService && !answers.dryRun
     ? await selectServiceNodeBin({
@@ -89,16 +89,16 @@ export async function runOnboard(
   };
   setRuntimeConfig(dreamuxConfig);
 
-  ensureDirectory(answers.configDir, ledger, 'dreamux config directory', {
+  await ensureDirectory(answers.configDir, ledger, 'dreamux config directory', {
     dryRun: answers.dryRun,
   });
-  ensureDirectory(stateRoot(), ledger, 'dreamux state directory', {
+  await ensureDirectory(stateRoot(), ledger, 'dreamux state directory', {
     dryRun: answers.dryRun,
   });
-  ensureDirectory(logsRoot(), ledger, 'dreamux logs directory', {
+  await ensureDirectory(logsRoot(), ledger, 'dreamux logs directory', {
     dryRun: answers.dryRun,
   });
-  writeTextFile(
+  await writeTextFile(
     configPath,
     stringifyConfig(dreamuxConfig),
     ledger,
@@ -107,35 +107,35 @@ export async function runOnboard(
   );
 
   const codexHome = dispatcherCodexHome(answers.dispatcherId);
-  ensureDirectory(codexHome, ledger, 'global Codex home', {
+  await ensureDirectory(codexHome, ledger, 'global Codex home', {
     dryRun: answers.dryRun,
   });
-  ensureDirectory(
+  await ensureDirectory(
     dispatcherAppServerControlDir(answers.dispatcherId),
     ledger,
     'dispatcher app-server control directory',
     { dryRun: answers.dryRun },
   );
-  ensureDirectory(
+  await ensureDirectory(
     effectiveAnswers.dispatcherCwd,
     ledger,
     'dispatcher cwd',
     { dryRun: answers.dryRun },
   );
-  ensureDirectory(
+  await ensureDirectory(
     dispatcherWorkspaceCodexSkillsDir(effectiveAnswers.dispatcherCwd),
     ledger,
     'workspace-local Codex skills directory',
     { dryRun: answers.dryRun },
   );
 
-  installDispatcherSkill({
+  await installDispatcherSkill({
     skillPath: dispatcherWorkspaceSkillPath(effectiveAnswers.dispatcherCwd),
     ledger,
     dryRun: answers.dryRun,
   });
 
-  const doctor = runDispatcherDoctor(effectiveAnswers, dreamuxConfig, env);
+  const doctor = await runDispatcherDoctor(effectiveAnswers, dreamuxConfig, env);
   if (!effectiveAnswers.dryRun && !doctor.ok) {
     throw new Error(formatDoctorFailure(effectiveAnswers, doctor));
   }
@@ -175,18 +175,28 @@ function formatServiceLaunchFailure(errors: string[]): string {
   ].join('\n');
 }
 
-function readExistingDreamuxConfig(configDir: string) {
+async function readExistingDreamuxConfig(configDir: string) {
   const configPath = globalConfigFile({ configDir });
-  assertNoLegacyTomlOnly({ configDir });
-  if (!existsSync(configPath)) return undefined;
-  return loadConfig({ configDir }).config;
+  await assertNoLegacyTomlOnly({ configDir });
+  if (!(await pathExists(configPath))) return undefined;
+  return (await loadConfig({ configDir })).config;
 }
 
-function runDispatcherDoctor(
+/** Async existence probe — the fs/promises replacement for `existsSync`. */
+async function pathExists(path: string): Promise<boolean> {
+  try {
+    await access(path);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function runDispatcherDoctor(
   answers: EffectiveOnboardAnswers,
   dreamuxConfig: ReturnType<typeof dreamuxConfigFromAnswers>,
   env: NodeJS.ProcessEnv,
-): DispatcherCodexHomeDoctorResult {
+): Promise<DispatcherCodexHomeDoctorResult> {
   const codexArgs = parseCodexArgs(dispatcherCodexArgsJson(), {
     approvalPolicy: dreamuxConfig.codex.approval_policy,
     sandboxMode: dreamuxConfig.codex.sandbox_mode,
@@ -207,7 +217,7 @@ function runDispatcherDoctor(
   const doctorEnv = answers.registerService
     ? managedServiceEnvironment(answers)
     : env;
-  return validateDispatcherCodexHome(context, {
+  return await validateDispatcherCodexHome(context, {
     env: doctorEnv,
     codexCliArgs,
   });

--- a/packages/dreamux/src/onboard/service.ts
+++ b/packages/dreamux/src/onboard/service.ts
@@ -1,7 +1,17 @@
-import { accessSync, constants, existsSync, rmSync } from 'node:fs';
-import { realpath } from 'node:fs/promises';
+import { constants } from 'node:fs';
+import { access, realpath, rm } from 'node:fs/promises';
 import { homedir } from 'node:os';
 import { delimiter, dirname, isAbsolute, join, resolve } from 'node:path';
+
+/** Async existence probe — the fs/promises replacement for `existsSync`. */
+async function pathExists(path: string): Promise<boolean> {
+  try {
+    await access(path);
+    return true;
+  } catch {
+    return false;
+  }
+}
 
 import { build as buildPlist } from 'plist';
 import { expandHome } from '../runtime/config.js';
@@ -87,14 +97,14 @@ export async function installUserService(
   const logDir = logsRoot();
   const stdoutLog = join(logDir, 'daemon.stdout.log');
   const stderrLog = join(logDir, 'daemon.stderr.log');
-  ensureDirectory(logDir, options.ledger, 'daemon log directory', {
+  await ensureDirectory(logDir, options.ledger, 'daemon log directory', {
     dryRun: options.answers.dryRun,
   });
-  ensureTextFile(stdoutLog, '', options.ledger, 'daemon stdout log', {
+  await ensureTextFile(stdoutLog, '', options.ledger, 'daemon stdout log', {
     mode: 0o600,
     dryRun: options.answers.dryRun,
   });
-  ensureTextFile(stderrLog, '', options.ledger, 'daemon stderr log', {
+  await ensureTextFile(stderrLog, '', options.ledger, 'daemon stderr log', {
     mode: 0o600,
     dryRun: options.answers.dryRun,
   });
@@ -103,7 +113,7 @@ export async function installUserService(
     unit.platform === 'launchd'
       ? renderLaunchdPlist(options.answers, stdoutLog, stderrLog)
       : renderSystemdUnit(options.answers, stdoutLog, stderrLog);
-  const unitStatus = writeTextFile(
+  const unitStatus = await writeTextFile(
     unit.path,
     content,
     options.ledger,
@@ -232,24 +242,24 @@ export async function validateManagedServiceLaunch(
   };
 }
 
-export function resolveServiceExecutable(
+export async function resolveServiceExecutable(
   command: string,
   env: NodeJS.ProcessEnv = process.env,
-): string {
+): Promise<string> {
   const trimmed = command.trim();
   if (trimmed === '') {
     throw new Error('managed service executable path is empty');
   }
   if (trimmed.includes('/') || trimmed.startsWith('~')) {
     const candidate = resolve(expandHome(trimmed));
-    assertExecutable(candidate, command);
+    await assertExecutable(candidate, command);
     return candidate;
   }
 
   for (const dir of (env['PATH'] ?? '').split(delimiter)) {
     if (dir === '') continue;
     const candidate = join(dir, trimmed);
-    if (isExecutable(candidate)) return candidate;
+    if (await isExecutable(candidate)) return candidate;
   }
 
   throw new Error(
@@ -274,7 +284,7 @@ export function nodeVersionSatisfies(raw: string): boolean {
  */
 export interface ServiceNodeProbe {
   realpath: (path: string) => Promise<string>;
-  isExecutable: (path: string) => boolean;
+  isExecutable: (path: string) => Promise<boolean>;
 }
 
 export const defaultServiceNodeProbe: ServiceNodeProbe = {
@@ -375,7 +385,7 @@ export async function selectServiceNodeBin(
 ): Promise<string> {
   const probe = options.probe ?? defaultServiceNodeProbe;
   for (const candidate of stableNodeCandidates(options.platform)) {
-    if (!probe.isExecutable(candidate)) continue;
+    if (!(await probe.isExecutable(candidate))) continue;
     if ((await detectServiceNodeVersionManager(candidate, probe)) !== null) {
       continue;
     }
@@ -446,7 +456,7 @@ export async function stabilizeHomebrewCellarNode(
   links.push(`${cellar.prefix}/opt/node/bin/node`, `${cellar.prefix}/bin/node`);
 
   for (const link of links) {
-    if (!probe.isExecutable(link)) continue;
+    if (!(await probe.isExecutable(link))) continue;
     try {
       if ((await probe.realpath(link)) === resolved) return link;
     } catch {
@@ -481,14 +491,14 @@ function uniqueNonEmpty(values: string[]): string[] {
   return out;
 }
 
-function assertExecutable(path: string, label: string): void {
-  if (isExecutable(path)) return;
+async function assertExecutable(path: string, label: string): Promise<void> {
+  if (await isExecutable(path)) return;
   throw new Error(`managed service executable is not runnable: ${label}`);
 }
 
-function isExecutable(path: string): boolean {
+async function isExecutable(path: string): Promise<boolean> {
   try {
-    accessSync(path, constants.X_OK);
+    await access(path, constants.X_OK);
     return true;
   } catch {
     return false;
@@ -635,8 +645,8 @@ export async function removeUserService(
     );
   }
 
-  const existed = existsSync(unit.path);
-  if (existed && !dryRun) rmSync(unit.path, { force: true });
+  const existed = await pathExists(unit.path);
+  if (existed && !dryRun) await rm(unit.path, { force: true });
 
   if (unit.platform === 'systemd') {
     await runServiceBestEffort(options.runner, 'systemctl', ['--user', 'daemon-reload'], dryRun);

--- a/packages/dreamux/src/onboard/uninstall.ts
+++ b/packages/dreamux/src/onboard/uninstall.ts
@@ -1,6 +1,16 @@
-import { existsSync, rmSync } from 'node:fs';
+import { access, rm } from 'node:fs/promises';
 import { homedir } from 'node:os';
 import { basename, join, resolve, sep } from 'node:path';
+
+/** Async existence probe — the fs/promises replacement for `existsSync`. */
+async function pathExists(path: string): Promise<boolean> {
+  try {
+    await access(path);
+    return true;
+  } catch {
+    return false;
+  }
+}
 
 import { ExecaCommandRunner } from './commands.js';
 import { removeUserService } from './service.js';
@@ -54,14 +64,14 @@ export async function runUninstall(
   const configDir = normalizePath(options.configDir ?? globalConfigDir());
   const entries: UninstallEntry[] = [];
   const warnings: string[] = [];
-  warnIfConfigIsNotReadable(configDir, warnings);
+  await warnIfConfigIsNotReadable(configDir, warnings);
   const stateDir = normalizePath(stateRoot());
   const logDir = normalizePath(logsRoot());
 
   assertSafeOwnedDirectory(stateDir, 'dreamux state directory');
   assertSafeOwnedDirectory(logDir, 'dreamux logs directory');
   assertSafeOwnedDirectory(configDir, 'dreamux config directory');
-  const workspaceSkillPaths = collectWorkspaceSkillPaths(configDir);
+  const workspaceSkillPaths = await collectWorkspaceSkillPaths(configDir);
 
   // Service removal (unit-only) is shared with `dreamux daemon uninstall`.
   const removal = await removeUserService({
@@ -77,10 +87,10 @@ export async function runUninstall(
     reason: `${removal.platform} unit`,
   });
 
-  reportWorkspaceSkills(workspaceSkillPaths, entries);
-  removeOwnedDirectory(stateDir, entries, 'dreamux state directory', dryRun);
-  removeOwnedDirectory(logDir, entries, 'dreamux logs directory', dryRun);
-  removeOwnedDirectory(configDir, entries, 'dreamux config directory', dryRun);
+  await reportWorkspaceSkills(workspaceSkillPaths, entries);
+  await removeOwnedDirectory(stateDir, entries, 'dreamux state directory', dryRun);
+  await removeOwnedDirectory(logDir, entries, 'dreamux logs directory', dryRun);
+  await removeOwnedDirectory(configDir, entries, 'dreamux config directory', dryRun);
 
   return {
     entries: entries.sort((a, b) => a.path.localeCompare(b.path)),
@@ -92,11 +102,14 @@ export async function runUninstall(
   };
 }
 
-function warnIfConfigIsNotReadable(configDir: string, warnings: string[]): void {
+async function warnIfConfigIsNotReadable(
+  configDir: string,
+  warnings: string[],
+): Promise<void> {
   try {
-    assertNoLegacyTomlOnly({ configDir });
-    if (!existsSync(globalConfigFile({ configDir }))) return;
-    loadConfig({ configDir });
+    await assertNoLegacyTomlOnly({ configDir });
+    if (!(await pathExists(globalConfigFile({ configDir })))) return;
+    await loadConfig({ configDir });
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
     warnings.push(
@@ -105,9 +118,9 @@ function warnIfConfigIsNotReadable(configDir: string, warnings: string[]): void 
   }
 }
 
-function collectWorkspaceSkillPaths(configDir: string): string[] {
+async function collectWorkspaceSkillPaths(configDir: string): Promise<string[]> {
   try {
-    return loadConfig({ configDir }).config.dispatchers
+    return (await loadConfig({ configDir })).config.dispatchers
       .map(dispatcherWorkspaceSkillPathFromConfig)
       .filter((path): path is string => path !== null);
   } catch {
@@ -122,41 +135,41 @@ function dispatcherWorkspaceSkillPathFromConfig(
   return dispatcherWorkspaceSkillPath(dispatcher.cwd);
 }
 
-function reportWorkspaceSkills(
+async function reportWorkspaceSkills(
   paths: string[],
   entries: UninstallEntry[],
-): void {
+): Promise<void> {
   for (const path of uniquePaths(paths)) {
     entries.push({
       path,
-      status: existsSync(path) ? 'skipped' : 'missing',
+      status: (await pathExists(path)) ? 'skipped' : 'missing',
       reason: 'workspace-local dispatcher skill (not removed)',
     });
   }
 }
 
-function removeOwnedDirectory(
+async function removeOwnedDirectory(
   path: string,
   entries: UninstallEntry[],
   reason: string,
   dryRun: boolean,
-): void {
+): Promise<void> {
   assertSafeOwnedDirectory(path, reason);
-  removePath(path, entries, reason, dryRun);
+  await removePath(path, entries, reason, dryRun);
 }
 
-function removePath(
+async function removePath(
   path: string,
   entries: UninstallEntry[],
   reason: string,
   dryRun: boolean,
-): void {
-  if (!existsSync(path)) {
+): Promise<void> {
+  if (!(await pathExists(path))) {
     entries.push({ path, status: 'missing', reason });
     return;
   }
   if (!dryRun) {
-    rmSync(path, {
+    await rm(path, {
       recursive: true,
       force: true,
     });

--- a/packages/dreamux/src/runtime/config.ts
+++ b/packages/dreamux/src/runtime/config.ts
@@ -9,16 +9,18 @@
 
 import { homedir } from 'node:os';
 import { dirname, isAbsolute, join } from 'node:path';
-import {
-  closeSync,
-  existsSync,
-  mkdirSync,
-  openSync,
-  readFileSync,
-  statSync,
-  writeSync,
-} from 'node:fs';
+import { access, mkdir, open, readFile, stat } from 'node:fs/promises';
 import { validateDispatcherId } from './dispatcher-id.js';
+
+/** Async existence probe — the fs/promises replacement for `existsSync`. */
+async function pathExists(path: string): Promise<boolean> {
+  try {
+    await access(path);
+    return true;
+  } catch {
+    return false;
+  }
+}
 
 export interface DreamuxConfig {
   codex: {
@@ -94,24 +96,28 @@ export function legacyGlobalConfigFile(
   return join(globalConfigDir(overrides), 'config.toml');
 }
 
-export function loadOrInitConfig(
+export async function loadOrInitConfig(
   overrides: ConfigPathOverrides = {},
-): { config: DreamuxConfig; configFile: string; createdOnThisBoot: boolean } {
+): Promise<{
+  config: DreamuxConfig;
+  configFile: string;
+  createdOnThisBoot: boolean;
+}> {
   const file = globalConfigFile(overrides);
-  assertNoLegacyTomlOnly(overrides);
-  mkdirSync(dirname(file), { recursive: true });
+  await assertNoLegacyTomlOnly(overrides);
+  await mkdir(dirname(file), { recursive: true });
 
-  const createdOnThisBoot = atomicWriteIfAbsent(file, DEFAULT_CONFIG_JSON);
-  const config = readConfigFile(file);
+  const createdOnThisBoot = await atomicWriteIfAbsent(file, DEFAULT_CONFIG_JSON);
+  const config = await readConfigFile(file);
   return { config, configFile: file, createdOnThisBoot };
 }
 
-export function loadConfig(
+export async function loadConfig(
   overrides: ConfigPathOverrides = {},
-): { config: DreamuxConfig; configFile: string } {
+): Promise<{ config: DreamuxConfig; configFile: string }> {
   const file = globalConfigFile(overrides);
-  assertNoLegacyTomlOnly(overrides);
-  return { config: readConfigFile(file), configFile: file };
+  await assertNoLegacyTomlOnly(overrides);
+  return { config: await readConfigFile(file), configFile: file };
 }
 
 export function stringifyConfig(config: DreamuxConfig): string {
@@ -133,15 +139,15 @@ export function redactConfigForDisplay(raw: string, file: string): string {
   return `${JSON.stringify(parsed, null, 2)}\n`;
 }
 
-function readConfigFile(file: string): DreamuxConfig {
-  if (!existsSync(file)) {
+async function readConfigFile(file: string): Promise<DreamuxConfig> {
+  if (!(await pathExists(file))) {
     throw new Error(
       `dreamux config is missing at ${file}.\n` +
         'Run `dreamux onboard` to create it before starting the server.',
     );
   }
-  assertConfigFileMode(file);
-  const raw = readFileSync(file, 'utf8');
+  await assertConfigFileMode(file);
+  const raw = await readFile(file, 'utf8');
   let parsed: unknown;
   try {
     parsed = JSON.parse(raw);
@@ -155,12 +161,12 @@ function readConfigFile(file: string): DreamuxConfig {
   return mergeWithDefaults(parsed, file);
 }
 
-export function assertNoLegacyTomlOnly(
+export async function assertNoLegacyTomlOnly(
   overrides: ConfigPathOverrides = {},
-): void {
+): Promise<void> {
   const jsonFile = globalConfigFile(overrides);
   const tomlFile = legacyGlobalConfigFile(overrides);
-  if (existsSync(jsonFile) || !existsSync(tomlFile)) return;
+  if ((await pathExists(jsonFile)) || !(await pathExists(tomlFile))) return;
   throw new Error(
     `legacy dreamux config detected at ${tomlFile}, but ${jsonFile} does not exist.\n` +
       'dreamux no longer reads TOML config and will not create default JSON over an existing install.\n' +
@@ -168,25 +174,28 @@ export function assertNoLegacyTomlOnly(
   );
 }
 
-function atomicWriteIfAbsent(file: string, content: string): boolean {
-  let fd: number;
+async function atomicWriteIfAbsent(
+  file: string,
+  content: string,
+): Promise<boolean> {
+  let handle;
   try {
-    fd = openSync(file, 'wx', 0o600);
+    handle = await open(file, 'wx', 0o600);
   } catch (err) {
     if ((err as NodeJS.ErrnoException).code === 'EEXIST') return false;
     throw err;
   }
   try {
-    writeSync(fd, content);
+    await handle.writeFile(content);
   } finally {
-    closeSync(fd);
+    await handle.close();
   }
   return true;
 }
 
-export function assertConfigFileMode(file: string): void {
+export async function assertConfigFileMode(file: string): Promise<void> {
   if (process.platform === 'win32') return;
-  const mode = statSync(file).mode & 0o777;
+  const mode = (await stat(file)).mode & 0o777;
   if (mode === 0o600) return;
   throw new Error(
     `dreamux config file must be mode 0600: ${file} has mode 0${mode.toString(8)}`,

--- a/packages/dreamux/src/runtime/dispatcher-codex-home.ts
+++ b/packages/dreamux/src/runtime/dispatcher-codex-home.ts
@@ -1,8 +1,15 @@
-import {
-  existsSync,
-  readFileSync,
-} from 'node:fs';
+import { access, readFile } from 'node:fs/promises';
 import { join, normalize, sep } from 'node:path';
+
+/** Async existence probe — the fs/promises replacement for `existsSync`. */
+async function pathExists(path: string): Promise<boolean> {
+  try {
+    await access(path);
+    return true;
+  } catch {
+    return false;
+  }
+}
 
 import { parse as parseToml, TomlError } from 'smol-toml';
 
@@ -71,10 +78,10 @@ export function dispatcherCodexHomeDoctorContext(
   };
 }
 
-export function validateDispatcherCodexHome(
+export async function validateDispatcherCodexHome(
   input: string | DispatcherCodexHomeDoctorContext,
   options: DoctorOptions = {},
-): DispatcherCodexHomeDoctorResult {
+): Promise<DispatcherCodexHomeDoctorResult> {
   const context =
     typeof input === 'string'
       ? dispatcherCodexHomeDoctorContext(input, {
@@ -87,9 +94,9 @@ export function validateDispatcherCodexHome(
   const errors: string[] = [];
   const env = options.env ?? process.env;
 
-  if (existsSync(context.configPath)) {
+  if (await pathExists(context.configPath)) {
     try {
-      const parsed = parseToml(readFileSync(context.configPath, 'utf8'));
+      const parsed = parseToml(await readFile(context.configPath, 'utf8'));
       if (!isRecord(parsed)) {
         errors.push(`Codex config must be a TOML table: ${context.configPath}`);
       }
@@ -98,7 +105,7 @@ export function validateDispatcherCodexHome(
     }
   }
 
-  if (!existsSync(context.codexHome)) {
+  if (!(await pathExists(context.codexHome))) {
     errors.push(`missing Codex home directory: ${context.codexHome}`);
   }
   if (isTmpPath(context.socketPath)) {
@@ -112,11 +119,11 @@ export function validateDispatcherCodexHome(
       `dispatcher app-server socket path is too long for Unix sockets (${bytes} bytes > ${DISPATCHER_APP_SERVER_SOCKET_PATH_MAX_BYTES} safe bytes): ${context.socketPath}`,
     );
   }
-  if (!dispatcherSkillExists(context.skillPath)) {
+  if (!(await dispatcherSkillExists(context.skillPath))) {
     errors.push(`missing dispatcher skill: ${context.skillPath}`);
   }
 
-  if (!hasAuth(context.codexHome, env)) {
+  if (!(await hasAuth(context.codexHome, env))) {
     errors.push(
       `missing Codex auth state in ${context.codexHome} or a supported auth environment variable`,
     );
@@ -132,7 +139,7 @@ export function validateDispatcherCodexHome(
 export async function assertDispatcherCodexHomeReady(
   context: DispatcherCodexHomeDoctorContext,
 ): Promise<void> {
-  const result = validateDispatcherCodexHome(context);
+  const result = await validateDispatcherCodexHome(context);
   if (result.ok) return;
   throw new Error(formatDispatcherCodexHomeErrors(result));
 }
@@ -156,12 +163,15 @@ function formatTomlError(err: unknown, file: string): string {
   return `Codex config parse error in ${file}: ${msg}`;
 }
 
-function dispatcherSkillExists(skillPath: string): boolean {
-  return existsSync(skillPath);
+async function dispatcherSkillExists(skillPath: string): Promise<boolean> {
+  return pathExists(skillPath);
 }
 
-function hasAuth(codexHome: string, env: NodeJS.ProcessEnv): boolean {
-  if (existsSync(join(codexHome, 'auth.json'))) return true;
+async function hasAuth(
+  codexHome: string,
+  env: NodeJS.ProcessEnv,
+): Promise<boolean> {
+  if (await pathExists(join(codexHome, 'auth.json'))) return true;
   return ['OPENAI_API_KEY', 'CODEX_API_KEY', 'CODEX_ACCESS_TOKEN'].some(
     (name) => {
       const value = env[name];

--- a/packages/dreamux/src/runtime/dispatcher-store.ts
+++ b/packages/dreamux/src/runtime/dispatcher-store.ts
@@ -1,10 +1,4 @@
-import {
-  existsSync,
-  mkdirSync,
-  readFileSync,
-  rmSync,
-  writeFileSync,
-} from 'node:fs';
+import { mkdir, readFile, rm, writeFile } from 'node:fs/promises';
 import { dirname } from 'node:path';
 
 import type { DispatcherConfig, DreamuxConfig } from './config.js';
@@ -58,12 +52,28 @@ interface DispatcherStatusFile {
 
 export class DispatcherStore {
   private readonly rows = new Map<string, DispatcherRow>();
+  private readonly seedDispatchers: readonly DispatcherConfig[];
 
   constructor(config: DreamuxConfig) {
     const now = Date.now();
+    this.seedDispatchers = config.dispatchers;
+    // Build in-memory rows from config only. Persisted per-dispatcher status
+    // files are merged later by `hydrate()`: that read is async and must not
+    // run in a constructor.
     for (const dispatcher of config.dispatchers) {
-      const row = rowFromConfig(dispatcher, now);
-      this.rows.set(row.dispatcher_id, row);
+      this.rows.set(dispatcher.id, rowDefaults(dispatcher, now));
+    }
+  }
+
+  /**
+   * Merge each dispatcher's persisted `status.json` into its in-memory row.
+   * Restores thread_id / status / timestamps across restarts. The server calls
+   * this once during `start()`, before any dispatcher is launched. Idempotent.
+   */
+  async hydrate(): Promise<void> {
+    const now = Date.now();
+    for (const dispatcher of this.seedDispatchers) {
+      this.rows.set(dispatcher.id, await rowFromConfig(dispatcher, now));
     }
   }
 
@@ -131,12 +141,12 @@ export class DispatcherStore {
     return this.list().filter((row) => row.enabled === 1);
   }
 
-  remove(id: string): void {
+  async remove(id: string): Promise<void> {
     this.rows.delete(id);
-    rmSync(dispatcherStatusPath(id), { force: true });
+    await rm(dispatcherStatusPath(id), { force: true });
   }
 
-  setStatus(
+  async setStatus(
     id: string,
     status: DispatcherStatus,
     extras: {
@@ -144,7 +154,7 @@ export class DispatcherStore {
       last_started_at?: number;
       last_ready_at?: number;
     } = {},
-  ): void {
+  ): Promise<void> {
     const row = this.mustRow(id);
     row.status = status;
     row.updated_at = Date.now();
@@ -155,28 +165,28 @@ export class DispatcherStore {
     if (extras.last_ready_at !== undefined) {
       row.last_ready_at = extras.last_ready_at;
     }
-    this.persist(row);
+    await this.persist(row);
   }
 
-  setThreadId(id: string, threadId: string): void {
+  async setThreadId(id: string, threadId: string): Promise<void> {
     const row = this.mustRow(id);
     row.thread_id = threadId;
     row.updated_at = Date.now();
-    this.persist(row);
+    await this.persist(row);
   }
 
-  recordLostThread(
+  async recordLostThread(
     id: string,
     lostThreadId: string,
     newThreadId: string,
     error: string,
-  ): void {
+  ): Promise<void> {
     const row = this.mustRow(id);
     row.thread_id = newThreadId;
     row.last_lost_thread_id = lostThreadId;
     row.last_error = error;
     row.updated_at = Date.now();
-    this.persist(row);
+    await this.persist(row);
   }
 
   private mustRow(id: string): DispatcherRow {
@@ -185,8 +195,8 @@ export class DispatcherStore {
     return row;
   }
 
-  private persist(row: DispatcherRow): void {
-    mkdirSync(dirname(dispatcherStatusPath(row.dispatcher_id)), {
+  private async persist(row: DispatcherRow): Promise<void> {
+    await mkdir(dirname(dispatcherStatusPath(row.dispatcher_id)), {
       recursive: true,
     });
     const status: DispatcherStatusFile = {
@@ -200,7 +210,7 @@ export class DispatcherStore {
       last_error: row.last_error,
       last_lost_thread_id: row.last_lost_thread_id,
     };
-    writeFileSync(
+    await writeFile(
       dispatcherStatusPath(row.dispatcher_id),
       `${JSON.stringify(status, null, 2)}\n`,
       { mode: 0o600 },
@@ -208,17 +218,35 @@ export class DispatcherStore {
   }
 }
 
-function rowFromConfig(config: DispatcherConfig, now: number): DispatcherRow {
-  const status = readStatusFile(config.id);
+/** Config-only row (no persisted status); used before `hydrate()` runs. */
+function rowDefaults(config: DispatcherConfig, now: number): DispatcherRow {
   return {
     dispatcher_id: config.id,
     bot_app_id: config.feishu.app_id,
     bot_secret_ref: `config:${config.id}`,
     codex_args_json: dispatcherCodexArgsJson(config),
     codex_cwd: config.cwd,
+    thread_id: null,
+    status: 'declared',
+    enabled: config.enabled ? 1 : 0,
+    created_at: now,
+    updated_at: now,
+    last_started_at: null,
+    last_ready_at: null,
+    last_error: null,
+    last_lost_thread_id: null,
+  };
+}
+
+async function rowFromConfig(
+  config: DispatcherConfig,
+  now: number,
+): Promise<DispatcherRow> {
+  const status = await readStatusFile(config.id);
+  return {
+    ...rowDefaults(config, now),
     thread_id: status?.thread_id ?? null,
     status: status?.status ?? 'declared',
-    enabled: config.enabled ? 1 : 0,
     created_at: status?.updated_at ?? now,
     updated_at: status?.updated_at ?? now,
     last_started_at: status?.last_started_at ?? null,
@@ -244,11 +272,14 @@ function dispatcherCodexArgsJson(config: DispatcherConfig): string {
   return JSON.stringify(raw);
 }
 
-function readStatusFile(id: string): DispatcherStatusFile | null {
+async function readStatusFile(
+  id: string,
+): Promise<DispatcherStatusFile | null> {
   const path = dispatcherStatusPath(id);
-  if (!existsSync(path)) return null;
   try {
-    const raw = JSON.parse(readFileSync(path, 'utf8')) as Partial<DispatcherStatusFile>;
+    const raw = JSON.parse(
+      await readFile(path, 'utf8'),
+    ) as Partial<DispatcherStatusFile>;
     if (raw.version !== 1 || raw.dispatcher_id !== id) return null;
     return {
       version: 1,

--- a/packages/dreamux/src/runtime/logger.ts
+++ b/packages/dreamux/src/runtime/logger.ts
@@ -16,8 +16,18 @@
  *     reparsing stream).
  *   - `sync: true` everywhere. The shim and tests need synchronous writes; the
  *     server avoids a flush-on-shutdown lifecycle. No log line is lost on exit.
- *   - Files are opened `0o600` (mkdir + open + chmod), matching the Codex
- *     supervisor and the `0600` posture of `config.json` / state files.
+ *     This is a deliberate, kept design choice (issue #85): `pino.destination`'s
+ *     `sync` is a config flag, not a `*Sync` call, so it is outside the
+ *     synchronous-blocking-IO lint gate, and switching to an async destination
+ *     would force a `flushSync()` in a `process.on('exit')` handler — re-adding
+ *     unavoidable sync IO in the one truly sync-only context, plus a log-tail
+ *     loss risk in the short-lived `feishu-mcp` shim.
+ *   - Files are created `0o600` and their parent directory `mkdir`-ed by
+ *     `pino.destination` itself (`{ mkdir: true, mode: 0o600 }`). That open is
+ *     internal to pino/SonicBoom, not application sync IO, so `createLogger`
+ *     stays synchronous (the `Server` constructor builds loggers synchronously)
+ *     while our own code holds no `fs.*Sync` calls. Matches the `0600` posture
+ *     of `config.json` / state files.
  *   - Credentials are removed declaratively via pino `redact`. Message *bodies*
  *     are NOT redacted — they are simply never passed to the logger (callers
  *     log ids, never `parsed_text` / `rawContent` / reply text).
@@ -26,8 +36,7 @@
  *     inject a tmp `filePath`; they must not expect an env var to move logs.
  */
 
-import { chmodSync, mkdirSync, openSync } from 'node:fs';
-import { dirname } from 'node:path';
+import { chmod } from 'node:fs/promises';
 
 import type { TransportLogger } from '@excitedjs/feishu-transport';
 import pino, {
@@ -90,15 +99,31 @@ function resolveLevel(level?: pino.Level): pino.Level {
 }
 
 /**
- * Open a log file at `path` with owner-only permissions. Creates the parent
- * directory, appends, and chmods to `0o600` so a pre-existing wider-permission
- * file is tightened rather than trusted.
+ * Open a log file at `path` with owner-only permissions. pino/SonicBoom creates
+ * the parent directory (`mkdir: true`) and the append-mode file with `0o600`
+ * (`mode`) itself; that open is internal to pino, not application sync IO, so
+ * this stays a synchronous factory with no `fs.*Sync` of our own (issue #85).
+ *
+ * `mode` is applied only when SonicBoom *creates* the file; a pre-existing
+ * wider-permission log (an older build, or manual tampering) would otherwise
+ * keep its looser bits. We tighten it to 0600 defensively with a fire-and-forget
+ * async `chmod`: `createLogger` stays synchronous (the `Server` constructor
+ * builds loggers synchronously), and async `chmod` is not a `*Sync` call, so the
+ * issue #85 gate holds while the `0600` posture of `config.json` / state files
+ * is preserved. Errors are swallowed — the create-time `mode` already covers the
+ * common (new-file) path.
  */
 function openLogFileStream(path: string): DestinationStream {
-  mkdirSync(dirname(path), { recursive: true });
-  const fd = openSync(path, 'a', 0o600);
-  chmodSync(path, 0o600);
-  return pino.destination({ fd, sync: true });
+  const stream = pino.destination({
+    dest: path,
+    mkdir: true,
+    mode: 0o600,
+    sync: true,
+  });
+  void chmod(path, 0o600).catch(() => {
+    /* best-effort hardening of a pre-existing wider-permission file */
+  });
+  return stream;
 }
 
 export function createLogger(opts: CreateLoggerOptions = {}): DreamuxLogger {

--- a/packages/dreamux/src/server.ts
+++ b/packages/dreamux/src/server.ts
@@ -226,9 +226,13 @@ export class Server {
 
   /** Bring up admin socket + all enabled dispatchers. */
   async start(): Promise<void> {
+    // Restore each dispatcher's persisted status.json into the in-memory store
+    // before any row is listed or launched (the constructor only seeded
+    // config-derived defaults — the status read is async).
+    await this.repos.dispatchers.hydrate();
     // Load (and delete) any restart marker before bringing dispatchers up, so
     // the snapshot is in memory when each resumed dispatcher claims its notice.
-    this.restartIntent = RestartIntentConsumer.load({ now: Date.now() });
+    this.restartIntent = await RestartIntentConsumer.load({ now: Date.now() });
 
     this.admin = createAdminSocketServer(
       this,
@@ -331,13 +335,13 @@ export class Server {
     try {
       await runtime.start();
       await bot.start({
-        onBotMemberAdded: (added) => {
+        onBotMemberAdded: async (added) => {
           // Issue #62 Phase 1/4: record that the bot joined a chat so a later
           // baseline can be injected. Idempotent by event id; no notification.
-          recordBotAdded(id, added.chatId, added.eventId);
+          await recordBotAdded(id, added.chatId, added.eventId);
         },
         onMessage: async (event: FeishuInboundEvent) => {
-          const access = loadDispatcherAccess(id);
+          const access = await loadDispatcherAccess(id);
 
           // Issue #62: peer-bot awareness + `/introduce`, evaluated before the
           // delivery gate. A bot seen in an authorized chat becomes *known*
@@ -349,7 +353,7 @@ export class Server {
             isBotSenderType(event.senderType) &&
             access.group.allow_chats.includes(event.chatId)
           ) {
-            observeKnownBot(id, event.chatId, {
+            await observeKnownBot(id, event.chatId, {
               openId: event.senderId,
               ...(event.senderName !== '' ? { name: event.senderName } : {}),
             });
@@ -362,7 +366,9 @@ export class Server {
             });
             if (denyReason === null) {
               const peers = introducedPeers(event.mentions, bot.botOpenId);
-              if (peers.length > 0) trustIntroducedBots(id, event.chatId, peers);
+              if (peers.length > 0) {
+                await trustIntroducedBots(id, event.chatId, peers);
+              }
               channelLog.info(
                 {
                   chat_id: event.chatId,
@@ -391,6 +397,10 @@ export class Server {
             );
           }
 
+          const trustedBots =
+            event.chatType === 'group'
+              ? await trustedBotIds(id, event.chatId)
+              : undefined;
           const gate = dreamuxFeishuGate({
             senderId: event.senderId,
             senderType: event.senderType,
@@ -398,11 +408,9 @@ export class Server {
             chatType: event.chatType,
             mentions: event.mentions,
             botOpenId: bot.botOpenId,
-            ...(event.chatType === 'group'
-              ? { trustedBotIds: trustedBotIds(id, event.chatId) }
-              : {}),
+            ...(trustedBots !== undefined ? { trustedBotIds: trustedBots } : {}),
           }, access);
-          saveDispatcherAccess(id, gate.access);
+          await saveDispatcherAccess(id, gate.access);
           if (gate.warning !== null) {
             channelLog.warn(
               { chat_id: event.chatId, warning: gate.warning },
@@ -428,7 +436,9 @@ export class Server {
           // `/introduce` / bot-added that re-arms the flag mid-enqueue is not
           // clobbered by the clear below.
           const baseline =
-            event.chatType === 'group' ? pendingBaseline(id, event.chatId) : null;
+            event.chatType === 'group'
+              ? await pendingBaseline(id, event.chatId)
+              : null;
           const injectBots =
             baseline !== null && baseline.needsBaseline && baseline.trusted.length > 0;
           const input: InboundTurnInput = {
@@ -466,7 +476,7 @@ export class Server {
             // actually submitted, and only if the generation is still current.
             // `duplicate` / `stopped` / `failed` leave the context pending.
             if (injectBots) {
-              clearBaselineIfCurrent(id, event.chatId, baseline.generation);
+              await clearBaselineIfCurrent(id, event.chatId, baseline.generation);
             }
             await setInboundReaction(
               id,
@@ -642,10 +652,10 @@ export class Server {
    * the model-facing `list_chat_bots` MCP tool. Reads the per-dispatcher
    * chat-bots store directly, so it does not require a running dispatcher slot.
    */
-  listChatBotsFromMcp(
+  async listChatBotsFromMcp(
     input: ServerMcpListChatBotsInput,
-  ): ServerMcpListChatBotsResult {
-    const listing = listChatBots(input.dispatcherId, input.chatId);
+  ): Promise<ServerMcpListChatBotsResult> {
+    const listing = await listChatBots(input.dispatcherId, input.chatId);
     return {
       chat_id: input.chatId,
       known: listing.known.map(toWireChatBot),

--- a/packages/dreamux/tests/bin-launcher.test.ts
+++ b/packages/dreamux/tests/bin-launcher.test.ts
@@ -8,6 +8,7 @@
  */
 
 import { describe, it, expect, beforeAll } from 'vitest';
+// eslint-disable-next-line no-restricted-imports -- black-box launcher acceptance test: it execs the compiled `dreamux`/`tm` bins as real child processes and asserts on captured stdout/exit code; spawnSync keeps each case one synchronous assertion with no async lifecycle to leak between tests (issue #85 test-scope carve-out).
 import { spawnSync } from 'node:child_process';
 import {
   existsSync,

--- a/packages/dreamux/tests/codex-live.test.ts
+++ b/packages/dreamux/tests/codex-live.test.ts
@@ -24,6 +24,7 @@
  */
 
 import { describe, it, expect } from 'vitest';
+// eslint-disable-next-line no-restricted-imports -- live-Codex probe: a one-shot `execSync` reads the operator's interactive Codex auth/login state to decide whether the live model-gate case can run at all; it is setup, not the code under test, and must complete before the suite proceeds (issue #85 test-scope carve-out).
 import { execSync } from 'node:child_process';
 import { existsSync, mkdtempSync, rmSync } from 'node:fs';
 import { homedir } from 'node:os';

--- a/packages/dreamux/tests/codex-live.test.ts
+++ b/packages/dreamux/tests/codex-live.test.ts
@@ -447,7 +447,7 @@ describe('codex live integration', () => {
       // Onboard the live sender onto the global allow-user list so the folded
       // group messages are delivered (empty `allow_users` authorizes nobody
       // under the follow-user gate).
-      saveDispatcherAccess('live', {
+      await saveDispatcherAccess('live', {
         version: 2,
         allow_users: ['sender-live'],
         group: { policy: 'follow-user', allow_chats: [], require_mention: true },

--- a/packages/dreamux/tests/dispatcher-codex-home.test.ts
+++ b/packages/dreamux/tests/dispatcher-codex-home.test.ts
@@ -38,7 +38,7 @@ describe('global Codex home doctor', () => {
     rmSync(runtimeDir, { recursive: true, force: true });
   });
 
-  it('places app-server sockets under the dreamux dispatcher runtime directory', () => {
+  it('places app-server sockets under the dreamux dispatcher runtime directory', async () => {
     expect(dispatcherSocketPath('flow')).toBe(
       join(dispatcherAppServerControlDir('flow'), 'codex.sock'),
     );
@@ -50,8 +50,8 @@ describe('global Codex home doctor', () => {
       .toBeLessThanOrEqual(DISPATCHER_APP_SERVER_SOCKET_PATH_MAX_BYTES);
   });
 
-  it('reports every missing Codex home requirement', () => {
-    const result = validateDispatcherCodexHome('flow', { env: {} });
+  it('reports every missing Codex home requirement', async () => {
+    const result = await validateDispatcherCodexHome('flow', { env: {} });
 
     expect(result.ok).toBe(false);
     expect(result.errors).toEqual(
@@ -63,28 +63,28 @@ describe('global Codex home doctor', () => {
     );
   });
 
-  it('accepts a minimal global Codex home prepared by onboard', () => {
+  it('accepts a minimal global Codex home prepared by onboard', async () => {
     writeDispatcherHome('flow');
 
-    const result = validateDispatcherCodexHome('flow', { env: {} });
+    const result = await validateDispatcherCodexHome('flow', { env: {} });
 
     expect(result.ok).toBe(true);
     expect(result.errors).toEqual([]);
   });
 
-  it('does not require a Codex config file in the global Codex home', () => {
+  it('does not require a Codex config file in the global Codex home', async () => {
     writeDispatcherHome('flow');
 
-    const result = validateDispatcherCodexHome('flow', { env: {} });
+    const result = await validateDispatcherCodexHome('flow', { env: {} });
 
     expect(result.ok).toBe(true);
     expect(result.errors).toEqual([]);
   });
 
-  it('ignores runtime CLI overrides when checking static Codex home readiness', () => {
+  it('ignores runtime CLI overrides when checking static Codex home readiness', async () => {
     writeDispatcherHome('flow');
 
-    const result = validateDispatcherCodexHome('flow', {
+    const result = await validateDispatcherCodexHome('flow', {
       codexCliArgs: [
         '-c',
         'sandbox_mode=workspace-write',
@@ -97,20 +97,18 @@ describe('global Codex home doctor', () => {
     expect(result.ok).toBe(true);
   });
 
-  it('rejects too-long app-server socket paths before bind', () => {
+  it('rejects too-long app-server socket paths before bind', async () => {
     process.env['HOME'] = join(runtimeDir, 'h'.repeat(90));
 
-    expect(() =>
+    await expect(
       validateDispatcherCodexHome('dispatcher-with-long-id', { env: {} }),
-    ).toThrow(
-      /Codex socket path is too long/,
-    );
+    ).rejects.toThrow(/Codex socket path is too long/);
   });
 
-  it('requires auth environment variables to be non-empty and accepts CODEX_ACCESS_TOKEN', () => {
+  it('requires auth environment variables to be non-empty and accepts CODEX_ACCESS_TOKEN', async () => {
     writeDispatcherHome('flow', { writeAuth: false });
 
-    const emptyAuth = validateDispatcherCodexHome('flow', {
+    const emptyAuth = await validateDispatcherCodexHome('flow', {
       env: { OPENAI_API_KEY: '' },
     });
     expect(emptyAuth.ok).toBe(false);
@@ -118,13 +116,13 @@ describe('global Codex home doctor', () => {
       'missing Codex auth state',
     );
 
-    const accessToken = validateDispatcherCodexHome('flow', {
+    const accessToken = await validateDispatcherCodexHome('flow', {
       env: { CODEX_ACCESS_TOKEN: 'token-test' },
     });
     expect(accessToken.ok).toBe(true);
   });
 
-  it('reports invalid caller-provided Codex config paths', () => {
+  it('reports invalid caller-provided Codex config paths', async () => {
     writeDispatcherHome('flow');
     const badConfigPath = join(runtimeDir, 'bad-config.toml');
     writeFileSync(badConfigPath, 'not toml =');
@@ -132,7 +130,7 @@ describe('global Codex home doctor', () => {
       codexCliArgs: ['-c', 'sandbox_mode=danger-full-access'],
     });
 
-    const result = validateDispatcherCodexHome({
+    const result = await validateDispatcherCodexHome({
       ...context,
       configPath: badConfigPath,
     }, { env: {} });
@@ -143,10 +141,10 @@ describe('global Codex home doctor', () => {
     );
   });
 
-  it('rejects missing workspace-local dispatcher skills', () => {
+  it('rejects missing workspace-local dispatcher skills', async () => {
     writeDispatcherHome('flow', { installDispatcherSkill: false });
 
-    const result = validateDispatcherCodexHome('flow', { env: {} });
+    const result = await validateDispatcherCodexHome('flow', { env: {} });
 
     expect(result.ok).toBe(false);
     expect(formatDispatcherCodexHomeErrors(result)).toContain(

--- a/packages/dreamux/tests/e2e.test.ts
+++ b/packages/dreamux/tests/e2e.test.ts
@@ -246,7 +246,7 @@ describe('dreamux cross-module e2e', () => {
     // Onboard the canonical sender onto the global allow-user list so a
     // mentioned group message is delivered (empty `allow_users` authorizes
     // nobody under the follow-user gate).
-    saveDispatcherAccess('flow', {
+    await saveDispatcherAccess('flow', {
       version: 2,
       allow_users: ['sender-test'],
       group: { policy: 'follow-user', allow_chats: [], require_mention: true },
@@ -348,7 +348,9 @@ describe('dreamux cross-module e2e', () => {
     );
     await waitFor(() => codexInputs.length === 1);
     await waitFor(() => bot.reactions.length === 2);
-    expect(loadDispatcherAccess('flow').observed_chats).toEqual(['chat-group-a']);
+    expect((await loadDispatcherAccess('flow')).observed_chats).toEqual([
+      'chat-group-a',
+    ]);
 
     await server.shutdown();
     server = buildServer({ runtimeDir, fake, bot });

--- a/packages/dreamux/tests/feishu-gate.test.ts
+++ b/packages/dreamux/tests/feishu-gate.test.ts
@@ -232,20 +232,20 @@ describe('dispatcher access state files', () => {
     rmSync(root, { recursive: true, force: true });
   });
 
-  it('defaults a missing access.json to the secure follow-user shape', () => {
-    const loaded = loadDispatcherAccess('flow');
+  it('defaults a missing access.json to the secure follow-user shape', async () => {
+    const loaded = await loadDispatcherAccess('flow');
     expect(loaded).toEqual(defaultDispatcherAccessState());
     expect(loaded.version).toBe(2);
     expect(loaded.allow_users).toEqual([]);
     expect(loaded.group.policy).toBe('follow-user');
   });
 
-  it('writes owner-only v2 state and round-trips', () => {
+  it('writes owner-only v2 state and round-trips', async () => {
     const access = state({
       allow_users: ['sender-allowed'],
       observed_chats: ['chat-group-a'],
     });
-    saveDispatcherAccess('flow', access);
+    await saveDispatcherAccess('flow', access);
 
     const path = dispatcherAccessPath('flow');
     expect(existsSync(path)).toBe(true);
@@ -259,23 +259,23 @@ describe('dispatcher access state files', () => {
     // The legacy fields must not be written back.
     expect(onDisk.dm).toBeUndefined();
     expect(onDisk.group.follow_users).toBeUndefined();
-    expect(loadDispatcherAccess('flow')).toEqual(access);
+    expect(await loadDispatcherAccess('flow')).toEqual(access);
   });
 
   describe('v1 → v2 migration', () => {
-    it('lifts legacy dm.allow_users into the global list (follow-user)', () => {
+    it('lifts legacy dm.allow_users into the global list (follow-user)', async () => {
       writeRawAccess('flow', {
         version: 1,
         dm: { allow_users: ['user-a'] },
         group: { allow_chats: [], follow_users: [], require_mention: true },
       });
-      const access = loadDispatcherAccess('flow');
+      const access = await loadDispatcherAccess('flow');
       expect(access.version).toBe(2);
       expect(access.allow_users).toEqual(['user-a']);
       expect(access.group.policy).toBe('follow-user');
     });
 
-    it('preserves a legacy follow_users restriction as follow-user, not allowlist', () => {
+    it('preserves a legacy follow_users restriction as follow-user, not allowlist', async () => {
       // Both lists set: the sender restriction must NOT be silently relaxed to
       // chat-only allowlist gating (that would let any chat member talk).
       writeRawAccess('flow', {
@@ -287,13 +287,13 @@ describe('dispatcher access state files', () => {
           require_mention: true,
         },
       });
-      const access = loadDispatcherAccess('flow');
+      const access = await loadDispatcherAccess('flow');
       expect(access.allow_users).toEqual(['user-a']);
       expect(access.group.policy).toBe('follow-user');
       expect(access.group.allow_chats).toEqual(['chat-group-a']);
     });
 
-    it('infers allowlist when only a chat allowlist is configured', () => {
+    it('infers allowlist when only a chat allowlist is configured', async () => {
       writeRawAccess('flow', {
         version: 1,
         dm: { allow_users: [] },
@@ -303,10 +303,10 @@ describe('dispatcher access state files', () => {
           require_mention: true,
         },
       });
-      expect(loadDispatcherAccess('flow').group.policy).toBe('allowlist');
+      expect((await loadDispatcherAccess('flow')).group.policy).toBe('allowlist');
     });
 
-    it('merges and de-duplicates dm.allow_users and group.follow_users', () => {
+    it('merges and de-duplicates dm.allow_users and group.follow_users', async () => {
       writeRawAccess('flow', {
         version: 1,
         dm: { allow_users: ['user-a', 'user-b'] },
@@ -316,14 +316,14 @@ describe('dispatcher access state files', () => {
           require_mention: true,
         },
       });
-      expect(loadDispatcherAccess('flow').allow_users).toEqual([
+      expect((await loadDispatcherAccess('flow')).allow_users).toEqual([
         'user-a',
         'user-b',
         'user-c',
       ]);
     });
 
-    it('honors an explicit group.policy over inference', () => {
+    it('honors an explicit group.policy over inference', async () => {
       writeRawAccess('flow', {
         version: 2,
         allow_users: ['user-a'],
@@ -333,16 +333,16 @@ describe('dispatcher access state files', () => {
           require_mention: true,
         },
       });
-      expect(loadDispatcherAccess('flow').group.policy).toBe('allowlist');
+      expect((await loadDispatcherAccess('flow')).group.policy).toBe('allowlist');
     });
 
-    it('rejects an invalid group.policy', () => {
+    it('rejects an invalid group.policy', async () => {
       writeRawAccess('flow', {
         version: 2,
         allow_users: [],
         group: { policy: 'nonsense', allow_chats: [], require_mention: true },
       });
-      expect(() => loadDispatcherAccess('flow')).toThrow(/group\.policy/);
+      await expect(loadDispatcherAccess('flow')).rejects.toThrow(/group\.policy/);
     });
   });
 });

--- a/packages/dreamux/tests/feishu-introduce.test.ts
+++ b/packages/dreamux/tests/feishu-introduce.test.ts
@@ -240,27 +240,29 @@ describe('chat-bots store — awareness vs trust are separate', () => {
     rmSync(root, { recursive: true, force: true });
   });
 
-  it('observing a bot records awareness but never trust', () => {
-    observeKnownBot('d1', 'chat-a', { openId: 'peer-a', name: 'Peer A' });
-    const entry = loadChatBots('d1').chats['chat-a'];
+  it('observing a bot records awareness but never trust', async () => {
+    await observeKnownBot('d1', 'chat-a', { openId: 'peer-a', name: 'Peer A' });
+    const entry = (await loadChatBots('d1')).chats['chat-a'];
     expect(entry?.known).toEqual(['peer-a']);
     expect(entry?.trusted ?? []).toEqual([]);
-    expect(trustedBotIds('d1', 'chat-a').has('peer-a')).toBe(false);
+    expect((await trustedBotIds('d1', 'chat-a')).has('peer-a')).toBe(false);
   });
 
-  it('introducing a bot records trust (and awareness)', () => {
-    const added = trustIntroducedBots('d1', 'chat-a', [{ openId: 'peer-a', name: 'Peer A' }]);
+  it('introducing a bot records trust (and awareness)', async () => {
+    const added = await trustIntroducedBots('d1', 'chat-a', [
+      { openId: 'peer-a', name: 'Peer A' },
+    ]);
     expect(added).toEqual(['peer-a']);
-    const entry = loadChatBots('d1').chats['chat-a'];
+    const entry = (await loadChatBots('d1')).chats['chat-a'];
     expect(entry?.trusted).toEqual(['peer-a']);
     expect(entry?.known).toEqual(['peer-a']);
-    expect(trustedBotIds('d1', 'chat-a').has('peer-a')).toBe(true);
+    expect((await trustedBotIds('d1', 'chat-a')).has('peer-a')).toBe(true);
   });
 
-  it('recordBotAdded is idempotent by event id and flags a baseline', () => {
-    expect(recordBotAdded('d1', 'chat-a', 'evt-1')).toBe(true);
-    expect(recordBotAdded('d1', 'chat-a', 'evt-1')).toBe(false);
-    expect(loadChatBots('d1').chats['chat-a']?.needsBaseline).toBe(true);
+  it('recordBotAdded is idempotent by event id and flags a baseline', async () => {
+    expect(await recordBotAdded('d1', 'chat-a', 'evt-1')).toBe(true);
+    expect(await recordBotAdded('d1', 'chat-a', 'evt-1')).toBe(false);
+    expect((await loadChatBots('d1')).chats['chat-a']?.needsBaseline).toBe(true);
   });
 });
 
@@ -282,53 +284,57 @@ describe('chat-bots store — one-shot pending context (issue #69)', () => {
     rmSync(root, { recursive: true, force: true });
   });
 
-  it('arms a generation-stamped pending baseline carrying the trusted bots', () => {
-    trustIntroducedBots('d1', 'chat-a', [{ openId: 'peer-a', name: 'Peer A' }]);
-    const pending = pendingBaseline('d1', 'chat-a');
+  it('arms a generation-stamped pending baseline carrying the trusted bots', async () => {
+    await trustIntroducedBots('d1', 'chat-a', [{ openId: 'peer-a', name: 'Peer A' }]);
+    const pending = await pendingBaseline('d1', 'chat-a');
     expect(pending.needsBaseline).toBe(true);
     expect(pending.generation).toBe(1);
     expect(pending.trusted).toEqual([{ openId: 'peer-a', name: 'Peer A' }]);
   });
 
-  it('only trusted (not passively known) bots ride the pending baseline', () => {
-    observeKnownBot('d1', 'chat-a', { openId: 'known-only', name: 'Known' });
-    trustIntroducedBots('d1', 'chat-a', [{ openId: 'peer-a', name: 'Peer A' }]);
-    expect(pendingBaseline('d1', 'chat-a').trusted).toEqual([
+  it('only trusted (not passively known) bots ride the pending baseline', async () => {
+    await observeKnownBot('d1', 'chat-a', { openId: 'known-only', name: 'Known' });
+    await trustIntroducedBots('d1', 'chat-a', [{ openId: 'peer-a', name: 'Peer A' }]);
+    expect((await pendingBaseline('d1', 'chat-a')).trusted).toEqual([
       { openId: 'peer-a', name: 'Peer A' },
     ]);
   });
 
-  it('re-introducing an already-trusted bot does not re-arm the one-shot', () => {
-    trustIntroducedBots('d1', 'chat-a', [{ openId: 'peer-a' }]);
-    clearBaselineIfCurrent('d1', 'chat-a', pendingBaseline('d1', 'chat-a').generation);
-    expect(pendingBaseline('d1', 'chat-a').needsBaseline).toBe(false);
-    const added = trustIntroducedBots('d1', 'chat-a', [{ openId: 'peer-a' }]);
+  it('re-introducing an already-trusted bot does not re-arm the one-shot', async () => {
+    await trustIntroducedBots('d1', 'chat-a', [{ openId: 'peer-a' }]);
+    await clearBaselineIfCurrent(
+      'd1',
+      'chat-a',
+      (await pendingBaseline('d1', 'chat-a')).generation,
+    );
+    expect((await pendingBaseline('d1', 'chat-a')).needsBaseline).toBe(false);
+    const added = await trustIntroducedBots('d1', 'chat-a', [{ openId: 'peer-a' }]);
     expect(added).toEqual([]);
-    expect(pendingBaseline('d1', 'chat-a').needsBaseline).toBe(false);
+    expect((await pendingBaseline('d1', 'chat-a')).needsBaseline).toBe(false);
   });
 
-  it('clears the flag when the generation still matches the snapshot', () => {
-    trustIntroducedBots('d1', 'chat-a', [{ openId: 'peer-a' }]);
-    const snapshot = pendingBaseline('d1', 'chat-a');
-    clearBaselineIfCurrent('d1', 'chat-a', snapshot.generation);
-    expect(pendingBaseline('d1', 'chat-a').needsBaseline).toBe(false);
+  it('clears the flag when the generation still matches the snapshot', async () => {
+    await trustIntroducedBots('d1', 'chat-a', [{ openId: 'peer-a' }]);
+    const snapshot = await pendingBaseline('d1', 'chat-a');
+    await clearBaselineIfCurrent('d1', 'chat-a', snapshot.generation);
+    expect((await pendingBaseline('d1', 'chat-a')).needsBaseline).toBe(false);
   });
 
-  it('does NOT clear when a newer event bumped the generation mid-enqueue', () => {
-    trustIntroducedBots('d1', 'chat-a', [{ openId: 'peer-a' }]);
-    const stale = pendingBaseline('d1', 'chat-a'); // generation 1
+  it('does NOT clear when a newer event bumped the generation mid-enqueue', async () => {
+    await trustIntroducedBots('d1', 'chat-a', [{ openId: 'peer-a' }]);
+    const stale = await pendingBaseline('d1', 'chat-a'); // generation 1
     // A second /introduce arrives before the stale clear runs.
-    trustIntroducedBots('d1', 'chat-a', [{ openId: 'peer-b' }]); // generation 2
-    clearBaselineIfCurrent('d1', 'chat-a', stale.generation);
-    const after = pendingBaseline('d1', 'chat-a');
+    await trustIntroducedBots('d1', 'chat-a', [{ openId: 'peer-b' }]); // generation 2
+    await clearBaselineIfCurrent('d1', 'chat-a', stale.generation);
+    const after = await pendingBaseline('d1', 'chat-a');
     expect(after.needsBaseline).toBe(true);
     expect(after.trusted).toEqual([{ openId: 'peer-a' }, { openId: 'peer-b' }]);
   });
 
-  it('listChatBots returns known and trusted separately, with names', () => {
-    observeKnownBot('d1', 'chat-a', { openId: 'known-a', name: 'Known A' });
-    trustIntroducedBots('d1', 'chat-a', [{ openId: 'peer-a', name: 'Peer A' }]);
-    const listing = listChatBots('d1', 'chat-a');
+  it('listChatBots returns known and trusted separately, with names', async () => {
+    await observeKnownBot('d1', 'chat-a', { openId: 'known-a', name: 'Known A' });
+    await trustIntroducedBots('d1', 'chat-a', [{ openId: 'peer-a', name: 'Peer A' }]);
+    const listing = await listChatBots('d1', 'chat-a');
     expect(listing.known).toEqual([
       { openId: 'known-a', name: 'Known A' },
       { openId: 'peer-a', name: 'Peer A' },
@@ -336,9 +342,9 @@ describe('chat-bots store — one-shot pending context (issue #69)', () => {
     expect(listing.trusted).toEqual([{ openId: 'peer-a', name: 'Peer A' }]);
   });
 
-  it('returns empty listings/baseline for an unknown chat', () => {
-    expect(listChatBots('d1', 'nope')).toEqual({ known: [], trusted: [] });
-    expect(pendingBaseline('d1', 'nope')).toEqual({
+  it('returns empty listings/baseline for an unknown chat', async () => {
+    expect(await listChatBots('d1', 'nope')).toEqual({ known: [], trusted: [] });
+    expect(await pendingBaseline('d1', 'nope')).toEqual({
       needsBaseline: false,
       generation: 0,
       trusted: [],

--- a/packages/dreamux/tests/global-config.test.ts
+++ b/packages/dreamux/tests/global-config.test.ts
@@ -72,10 +72,10 @@ describe('global config (~/.dreamux/config.json)', () => {
     writeFileSync(file, content, { mode });
   }
 
-  it('first boot creates the config dir and JSON file', () => {
+  it('first boot creates the config dir and JSON file', async () => {
     expect(existsSync(join(configDir, 'config.json'))).toBe(false);
 
-    const { config, configFile, createdOnThisBoot } = loadOrInitConfig({
+    const { config, configFile, createdOnThisBoot } = await loadOrInitConfig({
       configDir,
     });
 
@@ -88,7 +88,7 @@ describe('global config (~/.dreamux/config.json)', () => {
     expect(config.dispatchers).toEqual([]);
   });
 
-  it('second boot reads the existing JSON file and does not overwrite it', () => {
+  it('second boot reads the existing JSON file and does not overwrite it', async () => {
     const file = globalConfigFile({ configDir });
     const original = stringifyConfig({
       codex: {
@@ -118,7 +118,7 @@ describe('global config (~/.dreamux/config.json)', () => {
     });
     writeConfigText(file, original);
 
-    const { config, createdOnThisBoot } = loadOrInitConfig({ configDir });
+    const { config, createdOnThisBoot } = await loadOrInitConfig({ configDir });
     expect(createdOnThisBoot).toBe(false);
     expect(config.codex.bin).toBe('/opt/codex');
     expect(config.codex.extra_args).toEqual(['--model', 'gpt-5']);
@@ -134,34 +134,34 @@ describe('global config (~/.dreamux/config.json)', () => {
     expect(readFileSync(file, 'utf8')).toBe(original);
   });
 
-  it('parse error fails fast with the config path', () => {
+  it('parse error fails fast with the config path', async () => {
     const file = globalConfigFile({ configDir });
     writeConfigText(file, `{"dispatchers": [`);
-    expect(() => loadOrInitConfig({ configDir })).toThrow(/config\.json/);
-    expect(() => loadOrInitConfig({ configDir })).toThrow(
+    await expect(loadOrInitConfig({ configDir })).rejects.toThrow(/config\.json/);
+    await expect(loadOrInitConfig({ configDir })).rejects.toThrow(
       /dreamux config parse error/,
     );
   });
 
-  it('fails fast when only the legacy TOML config exists', () => {
+  it('fails fast when only the legacy TOML config exists', async () => {
     const jsonFile = globalConfigFile({ configDir });
     const tomlFile = join(configDir, 'config.toml');
     writeFileSync(tomlFile, 'dispatchers = []\n');
 
-    expect(() => loadOrInitConfig({ configDir })).toThrow(
+    await expect(loadOrInitConfig({ configDir })).rejects.toThrow(
       /legacy dreamux config/,
     );
-    expect(() => loadConfig({ configDir })).toThrow(/dispatchers array/);
+    await expect(loadConfig({ configDir })).rejects.toThrow(/dispatchers array/);
     expect(existsSync(jsonFile)).toBe(false);
   });
 
-  it('loadConfig loudly fails when config.json is missing', () => {
-    expect(() => loadConfig({ configDir })).toThrow(/dreamux config is missing/);
-    expect(() => loadConfig({ configDir })).toThrow(/dreamux onboard/);
+  it('loadConfig loudly fails when config.json is missing', async () => {
+    await expect(loadConfig({ configDir })).rejects.toThrow(/dreamux config is missing/);
+    await expect(loadConfig({ configDir })).rejects.toThrow(/dreamux onboard/);
     expect(existsSync(globalConfigFile({ configDir }))).toBe(false);
   });
 
-  it('redacts Feishu app secrets for display', () => {
+  it('redacts Feishu app secrets for display', async () => {
     const raw = JSON.stringify({
       dispatchers: [
         {
@@ -192,19 +192,19 @@ describe('global config (~/.dreamux/config.json)', () => {
     });
   });
 
-  it('rejects invalid config values', () => {
+  it('rejects invalid config values', async () => {
     writeConfigObject({ codex: { approval_policy: 'ask-every-time' } });
-    expect(() => loadOrInitConfig({ configDir })).toThrow(
+    await expect(loadOrInitConfig({ configDir })).rejects.toThrow(
       /approval_policy='ask-every-time'/,
     );
 
     writeConfigObject({ state_path: '/tmp/custom-state' });
-    expect(() => loadOrInitConfig({ configDir })).toThrow(
+    await expect(loadOrInitConfig({ configDir })).rejects.toThrow(
       /state_path is not supported/,
     );
 
     writeConfigObject({ codex: { initialize_timeout_ms: 0 } });
-    expect(() => loadOrInitConfig({ configDir })).toThrow(
+    await expect(loadOrInitConfig({ configDir })).rejects.toThrow(
       /initialize_timeout_ms must be > 0/,
     );
 
@@ -217,12 +217,12 @@ describe('global config (~/.dreamux/config.json)', () => {
         },
       ],
     });
-    expect(() => loadOrInitConfig({ configDir })).toThrow(
+    await expect(loadOrInitConfig({ configDir })).rejects.toThrow(
       /enabled must be a boolean/,
     );
   });
 
-  it('accepts the MVP dispatcher array schema', () => {
+  it('accepts the MVP dispatcher array schema', async () => {
     writeConfigObject({
       dispatchers: [
         {
@@ -250,7 +250,7 @@ describe('global config (~/.dreamux/config.json)', () => {
       ],
     });
 
-    const { config } = loadConfig({ configDir });
+    const { config } = await loadConfig({ configDir });
     expect(config.dispatchers[0]).toMatchObject({
       id: 'dispatcher-a',
       enabled: true,
@@ -279,7 +279,7 @@ describe('global config (~/.dreamux/config.json)', () => {
     });
   });
 
-  it('rejects unsupported dispatcher secret fields', () => {
+  it('rejects unsupported dispatcher secret fields', async () => {
     writeConfigObject({
       dispatchers: [
         {
@@ -293,12 +293,12 @@ describe('global config (~/.dreamux/config.json)', () => {
       ],
     });
 
-    expect(() => loadConfig({ configDir })).toThrow(
+    await expect(loadConfig({ configDir })).rejects.toThrow(
       /callback_secret is not supported/,
     );
   });
 
-  it('keeps access out of config and validates extra_env fields', () => {
+  it('keeps access out of config and validates extra_env fields', async () => {
     writeConfigObject({
       dispatchers: [
         {
@@ -311,7 +311,7 @@ describe('global config (~/.dreamux/config.json)', () => {
         },
       ],
     });
-    expect(() => loadConfig({ configDir })).toThrow(
+    await expect(loadConfig({ configDir })).rejects.toThrow(
       /access is not supported/,
     );
 
@@ -331,12 +331,12 @@ describe('global config (~/.dreamux/config.json)', () => {
         },
       ],
     });
-    expect(() => loadConfig({ configDir })).toThrow(
+    await expect(loadConfig({ configDir })).rejects.toThrow(
       /codex\.extra_env\.EXAMPLE_FLAG must be a string/,
     );
   });
 
-  it('requires unique Feishu app_id values across all dispatchers', () => {
+  it('requires unique Feishu app_id values across all dispatchers', async () => {
     writeConfigObject({
       dispatchers: [
         {
@@ -357,12 +357,12 @@ describe('global config (~/.dreamux/config.json)', () => {
       ],
     });
 
-    expect(() => loadConfig({ configDir })).toThrow(
+    await expect(loadConfig({ configDir })).rejects.toThrow(
       /duplicates dispatcher 'flow'/,
     );
   });
 
-  it('rejects dispatcher ids that would not be stable path segments', () => {
+  it('rejects dispatcher ids that would not be stable path segments', async () => {
     writeConfigObject({
       dispatchers: [
         {
@@ -375,11 +375,11 @@ describe('global config (~/.dreamux/config.json)', () => {
       ],
     });
 
-    expect(() => loadConfig({ configDir })).toThrow(/dispatchers\[0\]\.id/);
-    expect(() => loadConfig({ configDir })).toThrow(/ASCII letters/);
+    await expect(loadConfig({ configDir })).rejects.toThrow(/dispatchers\[0\]\.id/);
+    await expect(loadConfig({ configDir })).rejects.toThrow(/ASCII letters/);
   });
 
-  it('requires non-empty Feishu app_id and app_secret values', () => {
+  it('requires non-empty Feishu app_id and app_secret values', async () => {
     writeConfigObject({
       dispatchers: [
         {
@@ -391,7 +391,7 @@ describe('global config (~/.dreamux/config.json)', () => {
         },
       ],
     });
-    expect(() => loadConfig({ configDir })).toThrow(
+    await expect(loadConfig({ configDir })).rejects.toThrow(
       /app_id must be a non-empty string/,
     );
 
@@ -406,46 +406,46 @@ describe('global config (~/.dreamux/config.json)', () => {
         },
       ],
     });
-    expect(() => loadConfig({ configDir })).toThrow(
+    await expect(loadConfig({ configDir })).rejects.toThrow(
       /app_secret must be a non-empty string/,
     );
   });
 
-  it('expandHome expands ~/ and bare ~', () => {
+  it('expandHome expands ~/ and bare ~', async () => {
     expect(expandHome('~/x')).toMatch(/[/\\]x$/);
     expect(expandHome('~/x').startsWith('/')).toBe(true);
     expect(expandHome('~')).not.toContain('~');
     expect(expandHome('/abs/path')).toBe('/abs/path');
   });
 
-  it('DREAMUX_CONFIG_DIR overrides ~/.dreamux when no explicit override', () => {
+  it('DREAMUX_CONFIG_DIR overrides ~/.dreamux when no explicit override', async () => {
     process.env['DREAMUX_CONFIG_DIR'] = configDir;
     expect(globalConfigDir()).toBe(configDir);
     expect(globalConfigFile()).toBe(join(configDir, 'config.json'));
   });
 
-  it('first-boot file is mode 0600', () => {
-    const { configFile, createdOnThisBoot } = loadOrInitConfig({ configDir });
+  it('first-boot file is mode 0600', async () => {
+    const { configFile, createdOnThisBoot } = await loadOrInitConfig({ configDir });
     expect(createdOnThisBoot).toBe(true);
     const mode = statSync(configFile).mode & 0o777;
     expect(mode).toBe(0o600);
   });
 
-  it('rejects existing config files that are not mode 0600', () => {
+  it('rejects existing config files that are not mode 0600', async () => {
     if (process.platform === 'win32') return;
     const file = globalConfigFile({ configDir });
     writeConfigText(file, JSON.stringify(BUILT_IN_DEFAULTS), 0o644);
 
-    expect(() => loadConfig({ configDir })).toThrow(/must be mode 0600/);
+    await expect(loadConfig({ configDir })).rejects.toThrow(/must be mode 0600/);
   });
 
-  it('throws when the config dir cannot be written', () => {
+  it('throws when the config dir cannot be written', async () => {
     if (process.getuid?.() === 0) return;
     const lockedParent = mkdtempSync(join(tmpdir(), 'dreamux-locked-'));
     const lockedChild = join(lockedParent, 'cfg');
     chmodSync(lockedParent, 0o500);
     try {
-      expect(() => loadOrInitConfig({ configDir: lockedChild })).toThrow(
+      await expect(loadOrInitConfig({ configDir: lockedChild })).rejects.toThrow(
         /EACCES|EPERM|permission/i,
       );
     } finally {
@@ -480,24 +480,24 @@ describe('runtime path precedence', () => {
     resetRuntimeConfig();
   });
 
-  it('runtimeRoot aliases stateRoot and ignores legacy env overrides', () => {
+  it('runtimeRoot aliases stateRoot and ignores legacy env overrides', async () => {
     writeConfigObjectAt(configDir, {});
-    const { config } = loadOrInitConfig({ configDir });
+    const { config } = await loadOrInitConfig({ configDir });
     setRuntimeConfig(config);
     process.env['CODEX_HOST_RUNTIME_DIR'] = '/tmp/from-env';
     expect(runtimeRoot()).toBe(stateRoot());
   });
 
-  it('adminSocketPath is fixed under stateRoot', () => {
+  it('adminSocketPath is fixed under stateRoot', async () => {
     writeConfigObjectAt(configDir, {});
-    const { config } = loadOrInitConfig({ configDir });
+    const { config } = await loadOrInitConfig({ configDir });
     setRuntimeConfig(config);
     process.env['CODEX_HOST_ADMIN_SOCKET'] = '/tmp/env-admin.sock';
     expect(adminSocketPath()).toBe(join(stateRoot(), 'admin.sock'));
     expect(serverJsonPath()).toBe(join(stateRoot(), 'server.json'));
   });
 
-  it('parseCodexArgs: per-dispatcher overrides config defaults', () => {
+  it('parseCodexArgs: per-dispatcher overrides config defaults', async () => {
     const parsed = parseCodexArgs(
       JSON.stringify({ approvalPolicy: 'on-failure' }),
       { approvalPolicy: 'never', extraArgs: ['--model', 'gpt-5'] },
@@ -506,7 +506,7 @@ describe('runtime path precedence', () => {
     expect(parsed.extraArgs).toEqual(['--model', 'gpt-5']);
   });
 
-  it('parseCodexArgs: per-dispatcher extraArgs append after config defaults', () => {
+  it('parseCodexArgs: per-dispatcher extraArgs append after config defaults', async () => {
     const parsed = parseCodexArgs(
       JSON.stringify({ extraArgs: ['--model', 'override'] }),
       { approvalPolicy: 'never', extraArgs: ['--model', 'default'] },
@@ -519,7 +519,7 @@ describe('runtime path precedence', () => {
     ]);
   });
 
-  it('parseCodexArgs hard-fails on invalid policy or sandbox mode', () => {
+  it('parseCodexArgs hard-fails on invalid policy or sandbox mode', async () => {
     expect(() =>
       parseCodexArgs(JSON.stringify({ approvalPolicy: 'untrusted-policy' })),
     ).toThrow(/refused/);
@@ -541,30 +541,30 @@ describe('sandbox_mode precedence', () => {
     resetRuntimeConfig();
   });
 
-  it('default config has sandbox_mode = workspace-write', () => {
+  it('default config has sandbox_mode = workspace-write', async () => {
     expect(BUILT_IN_DEFAULTS.codex.sandbox_mode).toBe('workspace-write');
-    const { config } = loadOrInitConfig({ configDir });
+    const { config } = await loadOrInitConfig({ configDir });
     expect(config.codex.sandbox_mode).toBe('workspace-write');
   });
 
-  it('config file value is loaded and validated', () => {
+  it('config file value is loaded and validated', async () => {
     writeConfigObjectAt(configDir, {
       codex: { sandbox_mode: 'danger-full-access' },
     });
-    const { config } = loadOrInitConfig({ configDir });
+    const { config } = await loadOrInitConfig({ configDir });
     expect(config.codex.sandbox_mode).toBe('danger-full-access');
   });
 
-  it('config rejects an invalid sandbox_mode at load time', () => {
+  it('config rejects an invalid sandbox_mode at load time', async () => {
     writeConfigObjectAt(configDir, {
       codex: { sandbox_mode: 'not-a-mode' },
     });
-    expect(() => loadOrInitConfig({ configDir })).toThrow(
+    await expect(loadOrInitConfig({ configDir })).rejects.toThrow(
       /sandbox_mode='not-a-mode'/,
     );
   });
 
-  it('parseCodexArgs: per-dispatcher sandboxMode overrides config default', () => {
+  it('parseCodexArgs: per-dispatcher sandboxMode overrides config default', async () => {
     const parsed = parseCodexArgs(
       JSON.stringify({ sandboxMode: 'read-only' }),
       { sandboxMode: 'danger-full-access' },
@@ -572,7 +572,7 @@ describe('sandbox_mode precedence', () => {
     expect(parsed.sandboxMode).toBe('read-only');
   });
 
-  it('codexArgsToCli emits `-c sandbox_mode=<value>` after approval_policy', () => {
+  it('codexArgsToCli emits `-c sandbox_mode=<value>` after approval_policy', async () => {
     const parsed = parseCodexArgs(
       JSON.stringify({
         approvalPolicy: 'never',

--- a/packages/dreamux/tests/logger.test.ts
+++ b/packages/dreamux/tests/logger.test.ts
@@ -7,7 +7,7 @@
  * honor DREAMUX_CONFIG_DIR, so injection — not an env var — is the seam.)
  */
 
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { mkdtempSync, readFileSync, rmSync, statSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
@@ -52,12 +52,16 @@ describe('logger factory', () => {
     expect(contents).toContain('"name":"server"');
   });
 
-  it('tightens a pre-existing wider-permission file to 0600', () => {
+  it('tightens a pre-existing wider-permission file to 0600', async () => {
     const filePath = join(dir, 'pre.log');
     writeFileSync(filePath, '', { mode: 0o644 });
     const logger = createLogger({ filePath, stderr: false });
     logger.info('x');
-    expect(statSync(filePath).mode & 0o777).toBe(0o600);
+    // The defensive re-tighten is a fire-and-forget async chmod (createLogger
+    // stays synchronous, the gate bans *Sync), so poll until it lands.
+    await vi.waitFor(() =>
+      expect(statSync(filePath).mode & 0o777).toBe(0o600),
+    );
   });
 
   it('redacts credential fields by default', () => {

--- a/packages/dreamux/tests/no-sync-io-gate.test.ts
+++ b/packages/dreamux/tests/no-sync-io-gate.test.ts
@@ -49,18 +49,49 @@ describe('no-sync-io lint gate (issue #85)', () => {
     expect(results[0]?.errorCount ?? 0).toBeGreaterThan(0);
   });
 
-  it('also flags a *Sync call aliased past the import backstop in src/**', async () => {
+  it('import backstop fires on a renamed *Sync import that n/no-sync misses', async () => {
+    // n/no-sync matches the *call site* by callee name. A renamed import is
+    // called as `read(...)` — name does not end in `Sync` — so n/no-sync alone
+    // would let it through. The `no-restricted-imports` backstop must catch the
+    // import. Asserting n/no-sync is ABSENT proves the backstop is independently
+    // load-bearing, not shadowed by the primary rule.
     const results = await lint(
       'src/__gate_alias__.ts',
       [
-        "import * as fs from 'node:fs';",
-        'export function read(p: string): string {',
-        "  return fs.readFileSync(p, 'utf8');",
+        "import { readFileSync as read } from 'node:fs';",
+        'export function load(p: string): string {',
+        "  return read(p, 'utf8');",
         '}',
         '',
       ].join('\n'),
     );
-    expect(ruleIds(results)).toContain('n/no-sync');
+    expect(ruleIds(results)).toContain('no-restricted-imports');
+    expect(ruleIds(results)).not.toContain('n/no-sync');
+  });
+
+  it('destructure backstop fires on a rebind that n/no-sync and the import backstop miss', async () => {
+    // `const { readFileSync: read } = fs` rebinds the Sync member away from any
+    // detectable call-site name (the call below is `read(...)`). The fixture
+    // pulls `fs` from a runtime value with no `import` at all, so neither
+    // n/no-sync nor the `no-restricted-imports` backstop can match — only
+    // `no-restricted-syntax` catches the destructure. Asserting the other two
+    // are ABSENT proves this backstop is independently load-bearing.
+    const results = await lint(
+      'src/__gate_destructure__.ts',
+      [
+        'export function load(p: string): string {',
+        '  const fs = globalThis as unknown as {',
+        '    readFileSync(path: string): string;',
+        '  };',
+        '  const { readFileSync: read } = fs;',
+        '  return read(p);',
+        '}',
+        '',
+      ].join('\n'),
+    );
+    expect(ruleIds(results)).toContain('no-restricted-syntax');
+    expect(ruleIds(results)).not.toContain('n/no-sync');
+    expect(ruleIds(results)).not.toContain('no-restricted-imports');
   });
 
   it('exempts synchronous fs IO in tests/** (sync fixtures are allowed)', async () => {

--- a/packages/dreamux/tests/no-sync-io-gate.test.ts
+++ b/packages/dreamux/tests/no-sync-io-gate.test.ts
@@ -1,0 +1,124 @@
+/**
+ * Executable contract for the issue #85 synchronous-blocking-IO lint gate.
+ *
+ * These tests run the real ESLint flat config (`@excitedjs/eslint-config`, wired
+ * through this package's `eslint.config.js`) against in-memory fixtures so the
+ * gate's behaviour is pinned, not just assumed:
+ *   - `src/**` is a hard error on any `*Sync` IO (`n/no-sync`);
+ *   - `tests/**` exempts `n/no-sync` (sync `fs` fixtures are allowed) but still
+ *     bans synchronous `child_process` via `no-restricted-imports`;
+ *   - an `eslint-disable` without a reason is itself an error
+ *     (`@eslint-community/eslint-comments/require-description`).
+ *
+ * The fixtures use file *paths* under `src/` and `tests/` (the files need not
+ * exist on disk) so the flat-config `files` globs select the right block. The
+ * banned constructs appear only inside `lintText` string arguments, so this test
+ * file itself stays clean under the gate.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { ESLint } from 'eslint';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+// tests/ -> package root holding eslint.config.js.
+const PACKAGE_ROOT = dirname(dirname(fileURLToPath(import.meta.url)));
+
+function lint(filePath: string, code: string): Promise<ESLint.LintResult[]> {
+  const eslint = new ESLint({ cwd: PACKAGE_ROOT });
+  return eslint.lintText(code, { filePath: join(PACKAGE_ROOT, filePath) });
+}
+
+function ruleIds(results: ESLint.LintResult[]): string[] {
+  return results.flatMap((r) => r.messages.map((m) => m.ruleId ?? ''));
+}
+
+describe('no-sync-io lint gate (issue #85)', () => {
+  it('flags synchronous fs IO in src/** as an n/no-sync error', async () => {
+    const results = await lint(
+      'src/__gate_fixture__.ts',
+      [
+        "import { readFileSync } from 'node:fs';",
+        'export function read(p: string): string {',
+        "  return readFileSync(p, 'utf8');",
+        '}',
+        '',
+      ].join('\n'),
+    );
+    expect(ruleIds(results)).toContain('n/no-sync');
+    expect(results[0]?.errorCount ?? 0).toBeGreaterThan(0);
+  });
+
+  it('also flags a *Sync call aliased past the import backstop in src/**', async () => {
+    const results = await lint(
+      'src/__gate_alias__.ts',
+      [
+        "import * as fs from 'node:fs';",
+        'export function read(p: string): string {',
+        "  return fs.readFileSync(p, 'utf8');",
+        '}',
+        '',
+      ].join('\n'),
+    );
+    expect(ruleIds(results)).toContain('n/no-sync');
+  });
+
+  it('exempts synchronous fs IO in tests/** (sync fixtures are allowed)', async () => {
+    const results = await lint(
+      'tests/__gate_fixture__.ts',
+      [
+        "import { mkdtempSync } from 'node:fs';",
+        "import { tmpdir } from 'node:os';",
+        "export const dir = mkdtempSync(tmpdir());",
+        '',
+      ].join('\n'),
+    );
+    expect(ruleIds(results)).not.toContain('n/no-sync');
+    expect(ruleIds(results)).not.toContain('no-restricted-imports');
+  });
+
+  it('still bans synchronous child_process in tests/**', async () => {
+    const results = await lint(
+      'tests/__gate_cp__.ts',
+      [
+        "import { execSync } from 'node:child_process';",
+        "export const out = execSync('echo hi');",
+        '',
+      ].join('\n'),
+    );
+    // n/no-sync is off for tests, but the child_process import backstop holds.
+    expect(ruleIds(results)).toContain('no-restricted-imports');
+    expect(results[0]?.errorCount ?? 0).toBeGreaterThan(0);
+  });
+
+  it('rejects an eslint-disable without a description', async () => {
+    const results = await lint(
+      'tests/__gate_disable__.ts',
+      [
+        '// eslint-disable-next-line no-restricted-imports',
+        "import { execSync } from 'node:child_process';",
+        "export const out = execSync('echo hi');",
+        '',
+      ].join('\n'),
+    );
+    expect(ruleIds(results)).toContain(
+      '@eslint-community/eslint-comments/require-description',
+    );
+  });
+
+  it('accepts a child_process disable that carries a reason', async () => {
+    const results = await lint(
+      'tests/__gate_disable_ok__.ts',
+      [
+        '// eslint-disable-next-line no-restricted-imports -- black-box CLI test needs a synchronous probe (issue #85 carve-out)',
+        "import { execSync } from 'node:child_process';",
+        "export const out = execSync('echo hi');",
+        '',
+      ].join('\n'),
+    );
+    expect(ruleIds(results)).not.toContain('no-restricted-imports');
+    expect(ruleIds(results)).not.toContain(
+      '@eslint-community/eslint-comments/require-description',
+    );
+  });
+});

--- a/packages/dreamux/tests/restart-intent.test.ts
+++ b/packages/dreamux/tests/restart-intent.test.ts
@@ -24,8 +24,8 @@ describe('restart intent marker', () => {
     rmSync(dir, { recursive: true, force: true });
   });
 
-  it('writes and reads a marker, then consumes per target exactly once', () => {
-    writeRestartIntent({
+  it('writes and reads a marker, then consumes per target exactly once', async () => {
+    await writeRestartIntent({
       targets: ['flow', 'ops'],
       announce: 'Restart completed.',
       now: 1_000,
@@ -33,7 +33,7 @@ describe('restart intent marker', () => {
     });
     expect(existsSync(path)).toBe(true);
 
-    const consumer = RestartIntentConsumer.load({ now: 2_000, path });
+    const consumer = await RestartIntentConsumer.load({ now: 2_000, path });
     // Loading deletes the file (single reader).
     expect(existsSync(path)).toBe(false);
 
@@ -45,8 +45,8 @@ describe('restart intent marker', () => {
     expect(consumer.claim('other', 2_000)).toBeNull();
   });
 
-  it('defaults the announce text and dedupes/trims targets', () => {
-    writeRestartIntent({
+  it('defaults the announce text and dedupes/trims targets', async () => {
+    await writeRestartIntent({
       targets: ['flow', ' flow ', '', 'ops'],
       now: 0,
       path,
@@ -59,9 +59,9 @@ describe('restart intent marker', () => {
     expect(file.targets).toEqual(['flow', 'ops']);
   });
 
-  it('ignores a marker past its TTL at load time', () => {
-    writeRestartIntent({ targets: ['flow'], now: 0, path });
-    const consumer = RestartIntentConsumer.load({
+  it('ignores a marker past its TTL at load time', async () => {
+    await writeRestartIntent({ targets: ['flow'], now: 0, path });
+    const consumer = await RestartIntentConsumer.load({
       now: DEFAULT_RESTART_INTENT_TTL_MS + 1,
       path,
     });
@@ -69,9 +69,9 @@ describe('restart intent marker', () => {
     expect(consumer.claim('flow', DEFAULT_RESTART_INTENT_TTL_MS + 1)).toBeNull();
   });
 
-  it('re-checks the TTL at claim time for late starters', () => {
-    writeRestartIntent({ targets: ['flow'], ttlMs: 100, now: 0, path });
-    const consumer = RestartIntentConsumer.load({ now: 50, path });
+  it('re-checks the TTL at claim time for late starters', async () => {
+    await writeRestartIntent({ targets: ['flow'], ttlMs: 100, now: 0, path });
+    const consumer = await RestartIntentConsumer.load({ now: 50, path });
     // Within TTL at load, but claimed after expiry.
     expect(consumer.claim('flow', 200)).toBeNull();
   });
@@ -106,11 +106,13 @@ describe('restart intent marker', () => {
     expect(existsSync(path)).toBe(false);
   });
 
-  it('yields an empty consumer for a missing or malformed marker', () => {
-    expect(RestartIntentConsumer.load({ now: 0, path }).claim('flow', 0)).toBeNull();
+  it('yields an empty consumer for a missing or malformed marker', async () => {
+    expect(
+      (await RestartIntentConsumer.load({ now: 0, path })).claim('flow', 0),
+    ).toBeNull();
 
     writeFileSync(path, 'not json', { mode: 0o600 });
-    const consumer = RestartIntentConsumer.load({ now: 0, path });
+    const consumer = await RestartIntentConsumer.load({ now: 0, path });
     expect(existsSync(path)).toBe(false);
     expect(consumer.claim('flow', 0)).toBeNull();
   });

--- a/packages/dreamux/tests/smoke.test.ts
+++ b/packages/dreamux/tests/smoke.test.ts
@@ -286,7 +286,7 @@ describe('dreamux MVP smoke', () => {
     // Empty `allow_users` now authorizes nobody (the follow-user fix), so
     // tests that exercise delivery need this seed; tests that assert a drop
     // override it or rely on a different gate reason (no mention, bot sender).
-    saveDispatcherAccess('flow', {
+    await saveDispatcherAccess('flow', {
       version: 2,
       allow_users: ['sender-test'],
       group: { policy: 'follow-user', allow_chats: [], require_mention: true },
@@ -812,7 +812,7 @@ describe('dreamux MVP smoke', () => {
   });
 
   it('reads access gate configuration from access.json and allows configured DMs', async () => {
-    saveDispatcherAccess('flow', {
+    await saveDispatcherAccess('flow', {
       version: 2,
       allow_users: ['sender-dm'],
       group: {
@@ -839,7 +839,7 @@ describe('dreamux MVP smoke', () => {
     }));
 
     await waitFor(() => fake.turnsHandled === 1);
-    const access = loadDispatcherAccess('flow');
+    const access = await loadDispatcherAccess('flow');
     expect(access.allow_users).toEqual(['sender-dm']);
     expect(access.group.policy).toEqual('allowlist');
     expect(access.group.allow_chats).toEqual(['chat-group-a']);
@@ -855,7 +855,7 @@ describe('dreamux MVP smoke', () => {
   });
 
   it('consumes a no-@ /introduce from an allowlisted sender and records trust without enqueue or reactions', async () => {
-    saveDispatcherAccess('flow', {
+    await saveDispatcherAccess('flow', {
       version: 2,
       allow_users: ['sender-test'],
       group: {
@@ -888,13 +888,13 @@ describe('dreamux MVP smoke', () => {
     expect(bot.sentMessages).toEqual([]);
     expect(bot.reactions).toEqual([]);
     // The peer bot is now trusted for this chat (and known), but not the sender.
-    const entry = loadChatBots('flow').chats['chat-group-a'];
+    const entry = (await loadChatBots('flow')).chats['chat-group-a'];
     expect(entry?.trusted).toEqual(['peer-bot-1']);
     expect(entry?.known).toEqual(['peer-bot-1']);
   });
 
   it('injects a one-shot group_bots context on the next group message after /introduce', async () => {
-    saveDispatcherAccess('flow', {
+    await saveDispatcherAccess('flow', {
       version: 2,
       allow_users: ['sender-test'],
       group: {
@@ -934,11 +934,11 @@ describe('dreamux MVP smoke', () => {
     await bot.inject(fakeInbound('chat-group-a', 'and again', 'msg-after-2'));
     await waitFor(() => codexInputs.length === 2);
     expect(codexInputs[1]).not.toContain('<group_bots');
-    expect(loadChatBots('flow').chats['chat-group-a']?.needsBaseline).toBe(false);
+    expect((await loadChatBots('flow')).chats['chat-group-a']?.needsBaseline).toBe(false);
   });
 
   it('mcp.list_chat_bots returns the chat known + trusted bots with names', async () => {
-    saveDispatcherAccess('flow', {
+    await saveDispatcherAccess('flow', {
       version: 2,
       allow_users: ['sender-test'],
       group: {
@@ -994,7 +994,7 @@ describe('dreamux MVP smoke', () => {
   });
 
   it('does NOT consume /introduce from a non-allowlisted sender (no trust, dropped by the gate)', async () => {
-    saveDispatcherAccess('flow', {
+    await saveDispatcherAccess('flow', {
       version: 2,
       allow_users: ['sender-test'],
       group: {
@@ -1032,7 +1032,7 @@ describe('dreamux MVP smoke', () => {
     // and the bot was not mentioned). No trust written, no enqueue, no reactions.
     expect(fake.turnsHandled).toBe(0);
     expect(bot.reactions).toEqual([]);
-    const entry = loadChatBots('flow').chats['chat-group-a'];
+    const entry = (await loadChatBots('flow')).chats['chat-group-a'];
     expect(entry?.trusted ?? []).not.toContain('peer-bot-2');
 
     // Issue #77: the unauthorized introduce is diagnosed before the gate runs,
@@ -1069,7 +1069,7 @@ describe('dreamux MVP smoke', () => {
     // unauthorized, and because the gate is mention-first the eventual drop
     // reason is `bot not mentioned` — which looks like the user simply forgot to
     // @ the bot, hiding the real cause that the issue #77 diagnostic names.
-    saveDispatcherAccess('flow', {
+    await saveDispatcherAccess('flow', {
       version: 2,
       allow_users: [],
       group: {
@@ -1105,7 +1105,7 @@ describe('dreamux MVP smoke', () => {
     await sleep(60);
     expect(fake.turnsHandled).toBe(0);
     expect(bot.reactions).toEqual([]);
-    expect(loadChatBots('flow').chats['chat-group-a']?.trusted ?? []).not.toContain('peer-bot-3');
+    expect((await loadChatBots('flow')).chats['chat-group-a']?.trusted ?? []).not.toContain('peer-bot-3');
 
     const lines = channel.lines();
     expect(lines.find((l) => l['msg'] === 'introduce detected but not authorized')).toMatchObject({
@@ -1123,7 +1123,7 @@ describe('dreamux MVP smoke', () => {
   });
 
   it('diagnoses an unauthorized /introduce when the chat is not allowlisted', async () => {
-    saveDispatcherAccess('flow', {
+    await saveDispatcherAccess('flow', {
       version: 2,
       allow_users: ['sender-test'],
       group: {
@@ -1158,7 +1158,7 @@ describe('dreamux MVP smoke', () => {
 
     await sleep(60);
     expect(fake.turnsHandled).toBe(0);
-    expect(loadChatBots('flow').chats['chat-group-a']?.trusted ?? []).not.toContain('peer-bot-4');
+    expect((await loadChatBots('flow')).chats['chat-group-a']?.trusted ?? []).not.toContain('peer-bot-4');
 
     expect(
       channel.lines().find((l) => l['msg'] === 'introduce detected but not authorized'),
@@ -1171,7 +1171,7 @@ describe('dreamux MVP smoke', () => {
   });
 
   it('diagnoses an unauthorized /introduce sent as a direct message (non_group)', async () => {
-    saveDispatcherAccess('flow', {
+    await saveDispatcherAccess('flow', {
       version: 2,
       allow_users: ['sender-test'],
       group: {
@@ -1219,7 +1219,7 @@ describe('dreamux MVP smoke', () => {
   });
 
   it('an authorized /introduce is consumed without emitting the unauthorized diagnostic', async () => {
-    saveDispatcherAccess('flow', {
+    await saveDispatcherAccess('flow', {
       version: 2,
       allow_users: ['sender-test'],
       group: {
@@ -1255,7 +1255,7 @@ describe('dreamux MVP smoke', () => {
     await sleep(60);
     // Consumed: trust written, no enqueue, and crucially no unauthorized diagnostic.
     expect(fake.turnsHandled).toBe(0);
-    expect(loadChatBots('flow').chats['chat-group-a']?.trusted).toEqual(['peer-bot-5']);
+    expect((await loadChatBots('flow')).chats['chat-group-a']?.trusted).toEqual(['peer-bot-5']);
     const lines = channel.lines();
     expect(lines.some((l) => l['msg'] === 'introduce consumed')).toBe(true);
     expect(lines.some((l) => l['msg'] === 'introduce detected but not authorized')).toBe(false);
@@ -1273,7 +1273,7 @@ describe('dreamux MVP smoke', () => {
     await bot.inject(fakeInbound('chat-group-a', 'first chat', 'msg-chat-a'));
     await bot.inject(fakeInbound('chat-group-b', 'second chat', 'msg-chat-b'));
 
-    const access = loadDispatcherAccess('flow');
+    const access = await loadDispatcherAccess('flow');
     expect(access.observed_chats).toEqual(['chat-group-a', 'chat-group-b']);
     expect(access.warnings).toEqual([TRUST_DOMAIN_WARNING]);
     expect(bot.reactions.map((reaction) => reaction.messageId)).toEqual([
@@ -1547,7 +1547,7 @@ describe('dreamux MVP smoke', () => {
     const config = configWithDispatcher();
     server = buildServer({ runtimeDir, fake, bot, config });
     // Pre-seed an existing thread_id so startup will try thread/resume.
-    server.repos.dispatchers.setThreadId('flow', 'thread_was_lost');
+    await server.repos.dispatchers.setThreadId('flow', 'thread_was_lost');
 
     await server.shutdown();
     await fake.close();
@@ -1572,12 +1572,12 @@ describe('dreamux MVP smoke', () => {
   it('injects a restart notice into a resumed target after daemon restart --notify-resumed', async () => {
     const config = configWithDispatcher();
     server = buildServer({ runtimeDir, fake, bot, config });
-    server.repos.dispatchers.setThreadId('flow', 'thread_seed');
+    await server.repos.dispatchers.setThreadId('flow', 'thread_seed');
     await server.start();
     await server.shutdown();
 
     // Marker written by `daemon restart --notify-resumed --dispatcher flow`.
-    writeRestartIntent({
+    await writeRestartIntent({
       targets: ['flow'],
       announce: 'Restart completed.',
       now: Date.now(),
@@ -1598,7 +1598,7 @@ describe('dreamux MVP smoke', () => {
   it('does not inject a restart notice without a marker (plain resume)', async () => {
     const config = configWithDispatcher();
     server = buildServer({ runtimeDir, fake, bot, config });
-    server.repos.dispatchers.setThreadId('flow', 'thread_seed');
+    await server.repos.dispatchers.setThreadId('flow', 'thread_seed');
     await server.start();
     await server.shutdown();
     codexInputs = [];

--- a/packages/dreamux/tests/smoke.test.ts
+++ b/packages/dreamux/tests/smoke.test.ts
@@ -1942,25 +1942,35 @@ describe('admin socket hardening', () => {
     // hit the cleanup branch.
     writeFileSync(sockPath, 'leftover-from-crash');
 
-    const a = createAdminSocketServer(stubServer, sockPath, { selfPid: 11111 });
+    // Both contenders treat both PIDs as live. This mirrors production, where
+    // two real `dreamux serve` processes each see the other's *real, live* PID:
+    // whoever loses the atomic `wx` lock race reads a live holder and bails
+    // *before* touching the socket (it never reclaims a live holder's lock).
+    // Lock acquisition is async, so which contender wins the `wx` race is
+    // scheduling-dependent — assert the invariant (exactly one wins, mutual
+    // exclusion) rather than a fixed winner.
+    const bothAlive = (pid: number): boolean => pid === 11111 || pid === 22222;
+    const a = createAdminSocketServer(stubServer, sockPath, {
+      selfPid: 11111,
+      isPidAlive: bothAlive,
+    });
     const b = createAdminSocketServer(stubServer, sockPath, {
       selfPid: 22222,
-      // From b's perspective, the holder pid 11111 is alive (a holds it).
-      isPidAlive: (pid) => pid === 11111,
+      isPidAlive: bothAlive,
     });
 
     const results = await Promise.allSettled([a.start(), b.start()]);
     const wonA = results[0].status === 'fulfilled';
     const wonB = results[1].status === 'fulfilled';
-    expect(wonA && !wonB).toBe(true);
+    expect(wonA !== wonB).toBe(true);
 
-    // a's socket file must still exist and still be listenable — i.e.
-    // b's losing path did NOT rmSync it out from under a.
+    // The winner's socket file must still exist and still be listenable — i.e.
+    // the loser's bail path did NOT rm it out from under the winner.
     const { existsSync, statSync } = await import('node:fs');
     expect(existsSync(sockPath)).toBe(true);
     expect(statSync(sockPath).isSocket()).toBe(true);
 
-    await a.close();
+    await (wonA ? a : b).close();
   });
 
   // Reclaim path: a pidfile naming a dead process is stale and must not

--- a/packages/eslint-config/README.md
+++ b/packages/eslint-config/README.md
@@ -1,0 +1,45 @@
+# @excitedjs/eslint-config
+
+Private (unpublished) workspace package: the single source of the dreamux
+monorepo's **synchronous-blocking-IO lint gate** (issue #85).
+
+dreamux is one Node process driving N dispatchers off a single event loop, so a
+`fs.*Sync` / `child_process.execSync|spawnSync` call in runtime code stalls every
+concurrent session. This config makes such calls a hard error in source.
+
+## What it enforces
+
+- **`n/no-sync`** (primary) — flags any callee whose name ends in `Sync`.
+- **`no-restricted-imports`** (backstop) — bans `Sync$` named imports from
+  `fs` / `child_process`, closing the renamed-import bypass.
+- **`no-restricted-syntax`** (backstop) — bans `const { readFileSync: x } = fs`
+  destructure rebinding.
+- **`eslint-comments/require-description`** + `reportUnusedDisableDirectives` —
+  every sync exemption must be a reasoned, non-stale inline disable.
+
+It is **focused**: no `eslint:recommended` / typescript-eslint recommended sets,
+and pure-syntactic (the typescript-eslint parser runs without
+`parserOptions.project`), so `rush lint` needs no prior build.
+
+## Scope
+
+| Glob | `n/no-sync` | Notes |
+| --- | --- | --- |
+| `src/**/*.ts` | error | runtime / CLI — no synchronous blocking IO |
+| `tests/**/*.ts` | off | synchronous fs fixtures allowed; sync `child_process` still banned |
+
+Tightening tests further (converting fixture IO to async) is deliberately
+deferred to a separate change — see issue #85.
+
+## Usage
+
+Each package re-exports it from a thin `eslint.config.js`:
+
+```js
+import config from '@excitedjs/eslint-config';
+export default config;
+```
+
+and adds `"lint": "eslint ."` plus `eslint` + `@excitedjs/eslint-config`
+(`workspace:*`) to devDependencies. `rush lint` fans the script out across the
+workspace.

--- a/packages/eslint-config/index.js
+++ b/packages/eslint-config/index.js
@@ -1,0 +1,160 @@
+/**
+ * Shared ESLint flat config for the dreamux monorepo (issue #85).
+ *
+ * Single purpose: forbid synchronous, event-loop-blocking IO in runtime / CLI
+ * source. dreamux is one Node process driving N dispatchers off a single event
+ * loop; any `fs.*Sync` / `child_process.execSync|spawnSync` call stalls every
+ * concurrent session. This config is the hard gate that keeps such calls out.
+ *
+ * Scope (see issue #85 convergence):
+ *   - `src/**\/*.ts`   — hard error. No synchronous blocking IO.
+ *   - `tests/**\/*.ts` — `n/no-sync` is OFF (synchronous fixture IO is fine in
+ *                        a test process that is not the server event loop). The
+ *                        sole remaining test restriction is on synchronous
+ *                        child_process imports, so new sync subprocess usage in
+ *                        tests still has to be justified with a reasoned
+ *                        disable. The two existing call sites
+ *                        (bin-launcher / codex-live) carry such disables.
+ *
+ * Rule set (issue #85 convergence — primary + backstops):
+ *   - n/no-sync .................. primary. Matches any callee whose name ends
+ *                                  in `Sync` (the Node convention), so it
+ *                                  catches `readFileSync()`, `fs.mkdirSync()`,
+ *                                  `execSync()`, etc. at the call site.
+ *   - no-restricted-imports ...... backstop #1. n/no-sync matches the *call
+ *                                  site*, so a renamed import
+ *                                  `import { readFileSync as read }` followed by
+ *                                  `read()` would slip through. This bans the
+ *                                  `Sync$` named imports outright.
+ *   - no-restricted-syntax ....... backstop #2. Bans the destructure form
+ *                                  `const { readFileSync: read } = fs`, the
+ *                                  other way to rebind a Sync export away from
+ *                                  its detectable name.
+ *   - eslint-comments/require-description + reportUnusedDisableDirectives:
+ *                                  every `eslint-disable` for a sync exemption
+ *                                  must carry a written reason, and a stale
+ *                                  disable is itself an error. This is the
+ *                                  auditable exemption mechanism.
+ *
+ * This config intentionally does NOT pull in `eslint:recommended` or the
+ * typescript-eslint recommended sets: the issue is a focused sync-IO gate, not
+ * a repo-wide lint overhaul. It is pure-syntactic — the typescript-eslint
+ * parser is configured WITHOUT `parserOptions.project`, so no type information
+ * is needed and lint runs without a prior build.
+ */
+
+import tseslint from 'typescript-eslint';
+import n from 'eslint-plugin-n';
+import comments from '@eslint-community/eslint-plugin-eslint-comments';
+
+// eslint-plugin-n is pinned to 17.18.0 on purpose: from 17.19.0 onward
+// `n/no-sync` calls getParserServices() unconditionally to support a *typed*
+// `ignores` option, which forces `parserOptions.project` (type-aware linting)
+// even when no typed ignore is used. We deliberately keep this gate
+// pure-syntactic (no project / no build needed), and do not use typed ignores,
+// so we stay on the last syntactic-only release. Revisit the pin only together
+// with a move to type-aware linting.
+
+/** Modules whose synchronous (`*Sync`) exports must never be imported. */
+const FS_AND_CHILD_PROCESS = [
+  'node:fs',
+  'fs',
+  'node:child_process',
+  'child_process',
+];
+const CHILD_PROCESS_ONLY = ['node:child_process', 'child_process'];
+
+/** `no-restricted-imports` option banning `Sync$` named imports from `groups`. */
+function bannedSyncImports(groups, message) {
+  return [
+    'error',
+    {
+      patterns: [
+        {
+          group: groups,
+          importNamePattern: 'Sync$',
+          message,
+        },
+      ],
+    },
+  ];
+}
+
+/**
+ * `no-restricted-syntax` selector for `const { readFileSync: x } = fs` style
+ * destructuring of a `Sync$` member. Anchored to a destructure whose key ends
+ * in `Sync`; narrow enough to leave unrelated `*Sync`-keyed objects alone in
+ * practice, and any false positive is handled by a reasoned inline disable.
+ */
+const SYNC_DESTRUCTURE_SELECTOR = {
+  selector:
+    "VariableDeclarator > ObjectPattern > Property[key.name=/Sync$/][computed=false]",
+  message:
+    'Destructuring a synchronous (*Sync) member is banned in runtime/CLI source (issue #85). Use the node:fs/promises (async) API instead.',
+};
+
+const baseLanguageOptions = {
+  parser: tseslint.parser,
+  ecmaVersion: 2023,
+  sourceType: 'module',
+};
+
+const sharedPlugins = {
+  n,
+  '@eslint-community/eslint-comments': comments,
+};
+
+/**
+ * The shared flat-config array. Consuming packages re-export it from their own
+ * thin `eslint.config.js`; the `files` globs are relative to each package root,
+ * which all share the `src/` + `tests/` layout.
+ */
+export default [
+  {
+    ignores: ['**/dist/**', '**/node_modules/**'],
+  },
+  // Runtime / CLI source: synchronous blocking IO is a hard error.
+  {
+    files: ['src/**/*.ts'],
+    languageOptions: baseLanguageOptions,
+    plugins: sharedPlugins,
+    linterOptions: {
+      reportUnusedDisableDirectives: 'error',
+    },
+    rules: {
+      'n/no-sync': ['error', { allowAtRootLevel: false }],
+      'no-restricted-imports': bannedSyncImports(
+        FS_AND_CHILD_PROCESS,
+        'Synchronous IO is banned in runtime/CLI source (issue #85): it blocks the single dreamux event loop. Import from node:fs/promises, or use the async child_process API.',
+      ),
+      'no-restricted-syntax': ['error', SYNC_DESTRUCTURE_SELECTOR],
+      '@eslint-community/eslint-comments/require-description': [
+        'error',
+        { ignore: [] },
+      ],
+    },
+  },
+  // Tests: synchronous fs fixtures are fine (not the server event loop). Only
+  // synchronous child_process stays banned so new sync subprocess usage still
+  // needs a reasoned disable.
+  {
+    files: ['tests/**/*.ts'],
+    languageOptions: baseLanguageOptions,
+    plugins: sharedPlugins,
+    linterOptions: {
+      reportUnusedDisableDirectives: 'error',
+    },
+    rules: {
+      'n/no-sync': 'off',
+      'no-restricted-imports': bannedSyncImports(
+        CHILD_PROCESS_ONLY,
+        'Synchronous child_process (execSync/spawnSync) is banned even in tests (issue #85). Prefer the async API; if a black-box CLI test genuinely needs it, justify with a reasoned eslint-disable.',
+      ),
+      'no-restricted-syntax': 'off',
+      '@eslint-community/eslint-comments/require-description': [
+        'error',
+        { ignore: [] },
+      ],
+    },
+  },
+];

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "@excitedjs/eslint-config",
+  "version": "0.0.0",
+  "description": "Shared ESLint flat config for the dreamux monorepo. Single source of the synchronous-blocking-IO ban: n/no-sync as the primary rule, with no-restricted-imports / no-restricted-syntax backstops against alias and destructure bypass, disable-comment reason enforcement, and reportUnusedDisableDirectives.",
+  "license": "MIT",
+  "type": "module",
+  "main": "./index.js",
+  "exports": {
+    ".": "./index.js"
+  },
+  "files": [
+    "index.js"
+  ],
+  "scripts": {
+    "build": "node -e \"\""
+  },
+  "dependencies": {
+    "@eslint-community/eslint-plugin-eslint-comments": "^4.7.2",
+    "eslint-plugin-n": "17.18.0",
+    "typescript-eslint": "^8.60.1"
+  },
+  "peerDependencies": {
+    "eslint": "^9.39.0"
+  },
+  "devDependencies": {
+    "eslint": "^9.39.0"
+  }
+}

--- a/rush.json
+++ b/rush.json
@@ -32,6 +32,11 @@
   "projectFolderMaxDepth": 3,
   "projects": [
     {
+      "packageName": "@excitedjs/eslint-config",
+      "projectFolder": "packages/eslint-config",
+      "shouldPublish": false
+    },
+    {
       "packageName": "@excitedjs/dreamux",
       "projectFolder": "packages/dreamux",
       "shouldPublish": true


### PR DESCRIPTION
关联 #85。

## 背景

dreamux 是单事件循环、宿主 N 个 dispatcher 的进程。任何 `fs`/`child_process` 的 `*Sync` 调用都会阻塞整个事件循环——一个 dispatcher 同步读 status 文件时，其余所有 dispatcher 的 inbound/outbound/Codex 流量都被卡住。本 PR 一次性清零存量同步 IO，并加一道永久 lint 门禁，防止新的同步 IO 回归。

## 改动

**源码异步化（`packages/*/src`）**
- 全量改用 `node:fs/promises` 与异步 `child_process`；async ripple 贯穿所有调用链：`DispatcherStore` mutator、`Server.start()` 内 `await store.hydrate()`、`resolveServiceExecutable`、onboard/doctor 链路、channel-store 与 access-state 写入。
- `codex/supervisor.ts`:`openSync`/fd → 异步 `FileHandle`,spawn 前持有引用避免 GC 提前关闭 fd。

**新私有包 `@excitedjs/eslint-config`（不发布，规则单一来源）**
- 主规则 `n/no-sync`(固定 `eslint-plugin-n@17.18.0`——最后一个纯语法、不依赖类型信息的版本)。
- 兜底:`no-restricted-imports`(别名导入 `*Sync`)、`no-restricted-syntax`(解构重绑定)、`require-description`、`reportUnusedDisableDirectives`。
- 作用域:`src/**` 硬 `error`;`tests/**` 关闭 `n/no-sync`(允许同步 fs fixture)但仍禁同步 `child_process`(两处审计豁免:`spawnSync`、`execSync`,均带理由 `eslint-disable`)。

**logger 设计保留**
- `runtime/logger.ts` 刻意保留 `pino.destination({ sync: true })`(配置标志,非 `*Sync` 调用,在门禁之外);并以 fire-and-forget 异步 `chmod` 保留对已存在宽权限日志文件收紧到 0600 的防御。

**接线与门禁**
- `rush lint` 批量命令;CI `rush` job 新增 lint 步骤;pre-commit 钩子新增 staged-TS eslint 预检(warn-and-pass)。
- 新增可执行门禁测试 `tests/no-sync-io-gate.test.ts`(验证 src 报错、tests 豁免、tests 仍禁 child_process、无理由 disable 被拒)。

**文档**
- `.agents/` 决策记录 + repo-structure/root 更新;`CLAUDE.md` 新增「禁止同步阻塞 IO」工程红线。

## 同步 IO 清零结果

`packages/*/src` 内真实 `*Sync` 调用:**0**(grep 核实;仅余注释/字符串中的字样)。

## 验证(本地全绿)

| 项 | 结果 |
|---|---|
| `rush build` | ✅ 4 包 |
| `rush lint` | ✅ src 零违规;tests 仅 2 处审计豁免 |
| `rush test` | ✅ 270 用例(含真实 codex live)通过 |
| `rush change --verify` | ✅ 3 个 change 文件 |
| `.agents/scripts/check.sh` | ✅ KB OK |
| `gitleaks` | ✅ no leaks |

## 已知约束

门禁为纯语法配置(无 `parserOptions.project`),故 `no-floating-promises` 不可用:新 async 化函数的调用方需人工核对(本次已逐一核对所有写入助手调用点)。