### PR TITLE
为 /introduce 增加频道层即时确认

### DIFF
--- a/.agents/domains/feishu-introduce.md
+++ b/.agents/domains/feishu-introduce.md
@@ -2,7 +2,8 @@
 
 - **Status:** Implemented (issue #62, first increment). Invite-code/pairing and
   rich attachments are deferred to follow-up PRs — see Deferred below.
-- **Source:** https://github.com/excitedjs/dreamux/issues/62
+- **Source:** https://github.com/excitedjs/dreamux/issues/62,
+  https://github.com/excitedjs/dreamux/issues/87
 - **Affects:** `packages/dreamux/src/feishu/bot.ts`,
   `packages/dreamux/src/channel/introduce.ts`,
   `packages/dreamux/src/channel/chat-bots-store.ts`,
@@ -49,6 +50,29 @@ placeholder tokens before matching `^/introduce`, so an `@`-prefixed
 introduced are the message's other mentions; they are recorded as **trusted**
 for that chat and the `/introduce` message is consumed (never delivered to Codex
 as a turn).
+
+## Authorized-introduce channel ack (issue #87)
+
+When an authorized group `/introduce` names at least one external peer bot, the
+channel sends one immediate best-effort ack to the group after the trust store
+write succeeds:
+
+```text
+✅ 已认识本群 N 个伙伴：@Name ...
+```
+
+The ack counts the peers mentioned in this `/introduce`, not only newly added
+trust entries. Re-introducing an already-trusted peer therefore still acks the
+current external mentions, matching the explicit user action. The channel
+excludes the dispatcher bot itself. If Feishu omits a peer display name, the ack
+uses `@伙伴` as the stable fallback rather than displaying a raw open_id.
+
+The ack is channel-owned and best-effort. A send failure is logged as
+`introduce ack failed` with structured fields (`dispatcher_id`, `chat_id`,
+`message_id`, `peer_count`, `err`), but it does not roll back trust, does not
+submit a Codex turn, does not add a reaction, and does not fail the message
+handler. An authorized `/introduce` with no external peer still consumes the
+command but sends no ack.
 
 ## Unauthorized-introduce diagnostic (issue #77)
 

--- a/common/changes/@excitedjs/dreamux/feat-introduce-channel-ack_2026-06-05-02-30.json
+++ b/common/changes/@excitedjs/dreamux/feat-introduce-channel-ack_2026-06-05-02-30.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Add a best-effort Feishu channel acknowledgement for authorized group /introduce commands.",
+      "type": "patch",
+      "packageName": "@excitedjs/dreamux"
+    }
+  ],
+  "packageName": "@excitedjs/dreamux",
+  "email": "053700@gmail.com"
+}

--- a/packages/dreamux/src/channel/introduce.ts
+++ b/packages/dreamux/src/channel/introduce.ts
@@ -26,6 +26,7 @@ import type { DispatcherAccessState } from './feishu-gate.js';
 import type { PeerBot } from './chat-bots-store.js';
 
 const INTRODUCE_RE = /^\/introduce(?:\s|$)/i;
+const UNKNOWN_PEER_LABEL = '伙伴';
 
 export interface IntroduceAuthInput {
   chatType: string;
@@ -153,4 +154,27 @@ export function introducedPeers(
     peers.push(m.name !== undefined ? { openId, name: m.name } : { openId });
   }
   return peers;
+}
+
+/**
+ * User-visible channel ack for an authorized `/introduce`. The fallback avoids
+ * exposing raw open_id values when Feishu did not provide a display name.
+ */
+export function introduceAckText(peers: PeerBot[]): string | null {
+  if (peers.length === 0) return null;
+  const items = peers.map((peer) => `@${displayNameForAck(peer)}`).join(' ');
+  return `✅ 已认识本群 ${peers.length} 个伙伴：${items}`;
+}
+
+function displayNameForAck(peer: PeerBot): string {
+  const name = peer.name !== undefined ? safeInlineText(peer.name) : '';
+  return name !== '' ? name : UNKNOWN_PEER_LABEL;
+}
+
+function safeInlineText(value: string): string {
+  return value
+    .replace(/[\u0000-\u001f\u007f]+/g, ' ')
+    .replace(/[`*[\]]/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
 }

--- a/packages/dreamux/src/server.ts
+++ b/packages/dreamux/src/server.ts
@@ -30,6 +30,7 @@ import {
 } from './channel/feishu-gate.js';
 import {
   detectIntroduce,
+  introduceAckText,
   introduceDenyReason,
   introducedPeers,
 } from './channel/introduce.js';
@@ -135,6 +136,47 @@ interface InboundReactionLedgerEntry {
   chatId: string;
   reactionId: string;
   state: InboundReactionState;
+}
+
+async function sendIntroduceAck(input: {
+  dispatcherId: string;
+  bot: FeishuBot;
+  log: DreamuxLogger;
+  chatId: string;
+  messageId: string;
+  peers: PeerBot[];
+}): Promise<void> {
+  const text = introduceAckText(input.peers);
+  if (text === null) return;
+  let result: { messageIds: string[] };
+  try {
+    result = await input.bot.send(
+      channelOutboundToFeishuTarget({ conversationId: input.chatId }),
+      text,
+    );
+  } catch (err) {
+    input.log.error(
+      {
+        dispatcher_id: input.dispatcherId,
+        chat_id: input.chatId,
+        message_id: input.messageId,
+        peer_count: input.peers.length,
+        err: errInfo(err),
+      },
+      'introduce ack failed',
+    );
+    return;
+  }
+  input.log.info(
+    {
+      dispatcher_id: input.dispatcherId,
+      chat_id: input.chatId,
+      message_id: input.messageId,
+      peer_count: input.peers.length,
+      message_ids: result.messageIds,
+    },
+    'introduce ack sent',
+  );
 }
 
 export interface ServerMcpReplyInput {
@@ -368,6 +410,14 @@ export class Server {
               const peers = introducedPeers(event.mentions, bot.botOpenId);
               if (peers.length > 0) {
                 await trustIntroducedBots(id, event.chatId, peers);
+                await sendIntroduceAck({
+                  dispatcherId: id,
+                  bot,
+                  log: channelLog,
+                  chatId: event.chatId,
+                  messageId: event.messageId,
+                  peers,
+                });
               }
               channelLog.info(
                 {

--- a/packages/dreamux/tests/feishu-introduce.test.ts
+++ b/packages/dreamux/tests/feishu-introduce.test.ts
@@ -19,6 +19,7 @@ import {
 import {
   canRunIntroduce,
   detectIntroduce,
+  introduceAckText,
   introduceDenyReason,
   introducedPeers,
 } from '../src/channel/introduce.js';
@@ -196,6 +197,27 @@ describe('introducedPeers', () => {
       { openId: 'peer-a', name: 'Peer A' },
       { openId: 'peer-b' },
     ]);
+  });
+});
+
+describe('introduceAckText', () => {
+  it('counts every introduced peer and renders display names', () => {
+    expect(
+      introduceAckText([
+        { openId: 'peer-a', name: 'Peer A' },
+        { openId: 'peer-b', name: 'Peer B' },
+      ]),
+    ).toBe('✅ 已认识本群 2 个伙伴：@Peer A @Peer B');
+  });
+
+  it('uses a stable non-id fallback when Feishu omits a display name', () => {
+    expect(introduceAckText([{ openId: 'peer-a' }])).toBe(
+      '✅ 已认识本群 1 个伙伴：@伙伴',
+    );
+  });
+
+  it('returns null when there is no external peer to acknowledge', () => {
+    expect(introduceAckText([])).toBeNull();
   });
 });
 

--- a/packages/dreamux/tests/smoke.test.ts
+++ b/packages/dreamux/tests/smoke.test.ts
@@ -883,14 +883,154 @@ describe('dreamux MVP smoke', () => {
     );
 
     await sleep(60);
-    // Consumed before the gate: no Codex turn, no outbound, no reactions.
+    // Consumed before the gate: no Codex turn or reactions. The channel sends
+    // one immediate best-effort ack to the group, not a threaded reply.
     expect(fake.turnsHandled).toBe(0);
-    expect(bot.sentMessages).toEqual([]);
+    expect(bot.sentMessages).toEqual([
+      {
+        chatId: 'chat-group-a',
+        target: { chatId: 'chat-group-a' },
+        text: '✅ 已认识本群 1 个伙伴：@Peer',
+        messageIds: ['message-fake-1'],
+      },
+    ]);
     expect(bot.reactions).toEqual([]);
     // The peer bot is now trusted for this chat (and known), but not the sender.
     const entry = (await loadChatBots('flow')).chats['chat-group-a'];
     expect(entry?.trusted).toEqual(['peer-bot-1']);
     expect(entry?.known).toEqual(['peer-bot-1']);
+  });
+
+  it('does not ack an authorized /introduce with no external peer', async () => {
+    await saveDispatcherAccess('flow', {
+      version: 2,
+      allow_users: ['sender-test'],
+      group: {
+        policy: 'allowlist',
+        allow_chats: ['chat-group-a'],
+        require_mention: true,
+      },
+      observed_chats: [],
+      warnings: [],
+      last_gate: null,
+    });
+    server = buildServer({ runtimeDir, fake, bot });
+    server.repos.dispatchers.create({
+      dispatcher_id: 'flow',
+      bot_app_id: 'app-smoke',
+      bot_secret_ref: 'env:UNUSED',
+    });
+    await server.start();
+
+    await bot.inject(
+      fakeInbound('chat-group-a', '/introduce', 'msg-introduce-self-only', {
+        mentions: [
+          {
+            key: '@_user_1',
+            id: { open_id: 'fake-open-id-app-smoke' },
+            name: 'Dispatcher',
+          },
+        ],
+      }),
+    );
+
+    await sleep(60);
+    expect(fake.turnsHandled).toBe(0);
+    expect(bot.sentMessages).toEqual([]);
+    expect(bot.reactions).toEqual([]);
+    expect((await loadChatBots('flow')).chats['chat-group-a']?.trusted ?? []).toEqual([]);
+  });
+
+  it('keeps /introduce trust when the best-effort ack send fails', async () => {
+    await saveDispatcherAccess('flow', {
+      version: 2,
+      allow_users: ['sender-test'],
+      group: {
+        policy: 'allowlist',
+        allow_chats: ['chat-group-a'],
+        require_mention: true,
+      },
+      observed_chats: [],
+      warnings: [],
+      last_gate: null,
+    });
+    const channel = captureLogger('channel');
+    bot.setSendError(new Error('feishu send boom'));
+    server = buildServer({
+      runtimeDir,
+      fake,
+      bot,
+      channelLoggerFactory: () => channel.logger,
+    });
+    server.repos.dispatchers.create({
+      dispatcher_id: 'flow',
+      bot_app_id: 'app-smoke',
+      bot_secret_ref: 'env:UNUSED',
+    });
+    await server.start();
+
+    await expect(
+      bot.inject(
+        fakeInbound('chat-group-a', '/introduce', 'msg-introduce-ack-fails', {
+          mentions: [{ key: '@_user_9', id: { open_id: 'peer-bot-ack-fail' }, name: 'Peer' }],
+        }),
+      ),
+    ).resolves.toBeUndefined();
+
+    expect(fake.turnsHandled).toBe(0);
+    expect(bot.sentMessages).toEqual([]);
+    expect(bot.reactions).toEqual([]);
+    expect((await loadChatBots('flow')).chats['chat-group-a']?.trusted).toEqual([
+      'peer-bot-ack-fail',
+    ]);
+    const failed = channel.lines().find((l) => l['msg'] === 'introduce ack failed');
+    expect(failed).toMatchObject({
+      dispatcher_id: 'flow',
+      chat_id: 'chat-group-a',
+      message_id: 'msg-introduce-ack-fails',
+      peer_count: 1,
+    });
+    expect((failed?.['err'] as { message: string }).message).toBe('feishu send boom');
+    expect(channel.lines().some((l) => l['msg'] === 'introduce consumed')).toBe(true);
+  });
+
+  it('acks already-trusted peers when they are reintroduced', async () => {
+    await saveDispatcherAccess('flow', {
+      version: 2,
+      allow_users: ['sender-test'],
+      group: {
+        policy: 'allowlist',
+        allow_chats: ['chat-group-a'],
+        require_mention: true,
+      },
+      observed_chats: [],
+      warnings: [],
+      last_gate: null,
+    });
+    server = buildServer({ runtimeDir, fake, bot });
+    server.repos.dispatchers.create({
+      dispatcher_id: 'flow',
+      bot_app_id: 'app-smoke',
+      bot_secret_ref: 'env:UNUSED',
+    });
+    await server.start();
+
+    const intro = (messageId: string): FeishuInboundEvent =>
+      fakeInbound('chat-group-a', '/introduce', messageId, {
+        mentions: [{ key: '@_user_9', id: { open_id: 'peer-bot-repeat' }, name: 'Peer Bot' }],
+      });
+    await bot.inject(intro('msg-introduce-repeat-1'));
+    await bot.inject(intro('msg-introduce-repeat-2'));
+
+    expect(fake.turnsHandled).toBe(0);
+    expect(bot.reactions).toEqual([]);
+    expect((await loadChatBots('flow')).chats['chat-group-a']?.trusted).toEqual([
+      'peer-bot-repeat',
+    ]);
+    expect(bot.sentMessages.map((message) => message.text)).toEqual([
+      '✅ 已认识本群 1 个伙伴：@Peer Bot',
+      '✅ 已认识本群 1 个伙伴：@Peer Bot',
+    ]);
   });
 
   it('injects a one-shot group_bots context on the next group message after /introduce', async () => {
@@ -1031,6 +1171,7 @@ describe('dreamux MVP smoke', () => {
     // Not consumed as introduce; falls to the gate and is dropped (not allowlisted,
     // and the bot was not mentioned). No trust written, no enqueue, no reactions.
     expect(fake.turnsHandled).toBe(0);
+    expect(bot.sentMessages).toEqual([]);
     expect(bot.reactions).toEqual([]);
     const entry = (await loadChatBots('flow')).chats['chat-group-a'];
     expect(entry?.trusted ?? []).not.toContain('peer-bot-2');


### PR DESCRIPTION
## 变更

- 在 authorized group `/introduce` 写入 peer trust 后，发送一条频道层即时确认：`✅ 已认识本群 N 个伙伴：@Name ...`。
- ack 按本次 external mentions 计数；已 trusted 的 peer 重新 `/introduce` 仍会确认，不只看 newly-added。
- ack 为 best-effort：发送失败只记录 `introduce ack failed` 结构化日志，不回滚 trust、不进入 Codex turn、不添加 reaction、不让 handler 失败。
- 缺少 display name 时使用 `@伙伴` 作为稳定 fallback，避免展示 raw id。
- 更新 `/introduce` 协议文档，并补齐 handler 与 helper 覆盖。

Fixes #87

## 验证

- `node common/scripts/install-run-rush.js update`
- `node common/scripts/install-run-rush.js build`
- `node ../../common/scripts/install-run-rushx.js test -- tests/feishu-introduce.test.ts tests/smoke.test.ts`（实际跑完整 dreamux test suite：23 files / 285 tests）
- `node_modules/.bin/vitest run tests/feishu-introduce.test.ts tests/smoke.test.ts`（2 files / 86 tests）
- `node common/scripts/install-run-rush.js lint`
- `node common/scripts/install-run-rush.js typecheck`
- `node common/scripts/install-run-rush.js change --verify --target-branch origin/main --no-fetch`
- `.agents/scripts/check.sh`

CI：通过（gitleaks、rush change、KB、author email、shellcheck、macOS/Ubuntu Rush 矩阵）。