### PR TITLE
fix(feishu): follow-user 下 /introduce 对齐 gate 语义，忽略 allow_chats (#89)

### DIFF
--- a/.agents/domains/feishu-introduce.md
+++ b/.agents/domains/feishu-introduce.md
@@ -30,19 +30,48 @@ flags the chat for a future baseline injection; it emits no model notification.
 
 ## `/introduce` hard contract
 
-In a group, a `/introduce` message triggers **if and only if the sender is on
-the allowlist**. No `@`-mention of our bot is required, and the group's
-`require_mention` setting is ignored on this path.
+In a group, a `/introduce` message triggers **if and only if the sender is
+authorized to run it under the group's policy**. No `@`-mention of our bot is
+required, and the group's `require_mention` setting is ignored on this path.
 
-The authorization is sender-scoped, not group-scoped. `canRunIntroduce`
-(`channel/introduce.ts`) requires the chat to be explicitly in
-`group.allow_chats` **and** the sender to be on the global `allow_users` list
-(the same list that gates direct messages and `follow-user` group delivery).
-An empty `allow_users` authorizes nobody — "any member of an allowlisted group"
-is deliberately **not** a path, and `canRunIntroduce` never reuses a broad
-group-authorization predicate that would trust the group without checking the
-sender's identity. A bot sender is never on the human allowlist, so ambient
-self-introduction by an arbitrary bot does not trigger introduce.
+Authorization (`introduceDenyReason` / `canRunIntroduce` in
+`channel/introduce.ts`) **mirrors the delivery gate `dreamuxFeishuGate` for the
+same `group.policy`**, minus the `@`-mention requirement introduce deliberately
+waives:
+
+- `block` → never authorized (`group_blocked`); the gate drops every group
+  message, and a trust-changing command is no exception.
+- `follow-user` → `group.allow_chats` is **ignored**, exactly as the delivery
+  gate ignores it. The group needs no authorization; only the sender's
+  membership in the global `allow_users` list matters. An allow_user can
+  therefore `/introduce` in any group, including a brand-new one that is not in
+  `allow_chats`.
+- `allowlist` → the chat must be in `group.allow_chats` (the group is the unit
+  of trust) **and** the sender must be on `allow_users`. This sender check is an
+  intentional divergence from the delivery gate (issue #62): the delivery gate
+  lets any member of an allowlisted chat speak, but a trust-changing command is
+  sender-scoped — "any member of an allowlisted group" is deliberately **not** a
+  path to introduce.
+
+An empty `allow_users` authorizes nobody. A bot sender is never on the human
+allowlist, so ambient self-introduction by an arbitrary bot does not trigger
+introduce.
+
+> **Gate ↔ introduce parity.** The two paths must agree under `block` and
+> `follow-user`, and diverge under `allowlist` only by the sender check above.
+> This is asserted by a table-driven test in `tests/feishu-introduce.test.ts`
+> ("gate vs introduce parity") so accidental drift fails CI. The bug that
+> motivated this contract was exactly such a drift: issue #82 made
+> `dreamuxFeishuGate` policy-aware (so `follow-user` stopped checking
+> `allow_chats`) but left `canRunIntroduce` with a hardcoded `allow_chats`
+> requirement for *every* policy. The result: an `allow_users` sender could chat
+> in a brand-new `follow-user` group (after `@`-mentioning the bot) but could
+> never `/introduce` there — it was diagnosed as `chat_not_allowlisted`. Issues
+> #77 and #87 then built on the frozen behavior without revisiting it. The
+> awareness path in `server.ts` (`observeKnownBot`, gated on
+> `allow_chats.includes`) is the *same* hardcoded-`allow_chats` shape one layer
+> up — out of scope here (it tracks `known` bots, not trust), but a candidate
+> for the same follow-user alignment.
 
 Detection (`detectIntroduce`) is text-only and strips leading Feishu mention
 placeholder tokens before matching `^/introduce`, so an `@`-prefixed
@@ -82,8 +111,12 @@ most misleadingly as `bot not mentioned`, because the introduce path waives the
 mention requirement that the gate still enforces. To keep this one-glance
 diagnosable, `introduceDenyReason` (`channel/introduce.ts`) is the discriminated
 source of truth — `canRunIntroduce` is its boolean projection — returning a
-stable, grep-able code: `non_group`, `empty_sender_id`, `chat_not_allowlisted`,
-`sender_not_followed`. When `detectIntroduce` matches but the reason is
+stable, grep-able code: `non_group`, `empty_sender_id`, `group_blocked`,
+`chat_not_allowlisted`, `sender_not_followed`. `group_blocked` is the `block`
+policy; `chat_not_allowlisted` is the `allowlist` policy only (under
+`follow-user` the chat allowlist is ignored, so an off-allowlist sender there is
+`sender_not_followed`, never `chat_not_allowlisted`). When `detectIntroduce`
+matches but the reason is
 non-null, `server.ts` emits one channel log `introduce detected but not
 authorized` carrying only `chat_id`/`sender_id`/`message_id`/`reason` (never the
 message body, mentioned peer open_ids, or mention names), then continues into

--- a/common/changes/@excitedjs/dreamux/fix-introduce-follow-user-allowlist_2026-06-05-04-00.json
+++ b/common/changes/@excitedjs/dreamux/fix-introduce-follow-user-allowlist_2026-06-05-04-00.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Fix group /introduce authorization to follow the group policy: under follow-user it now ignores allow_chats and gates only on allow_users, matching the delivery gate; block is denied explicitly (group_blocked); allowlist is unchanged.",
+      "type": "patch",
+      "packageName": "@excitedjs/dreamux"
+    }
+  ],
+  "packageName": "@excitedjs/dreamux",
+  "email": "053700@gmail.com"
+}

--- a/packages/dreamux/src/channel/introduce.ts
+++ b/packages/dreamux/src/channel/introduce.ts
@@ -4,15 +4,31 @@
  * Trigger rule (deliberately different from claudemux):
  *
  *   In a group, a `/introduce` message triggers **if and only if the sender is
- *   on the allowlist**. No `@`-mention of our bot is required, and the group's
- *   `require_mention` setting is ignored on this path.
+ *   authorized to run it under the group's policy**. No `@`-mention of our bot
+ *   is required, and the group's `require_mention` setting is ignored on this
+ *   path.
  *
- *   "Sender on the allowlist" is sender-scoped, NOT group-scoped: it is not
- *   enough for the chat to be authorized — the *sender* must be explicitly
- *   allowlisted for the chat. An open group (no per-sender allowlist) does NOT
- *   authorize introduce. `canRunIntroduce` therefore never reuses a broad
- *   group-authorization predicate that would trust the group without checking
- *   the sender's identity.
+ * Authorization mirrors the delivery gate (`dreamuxFeishuGate`) for the same
+ * group policy, minus the @-mention requirement that introduce deliberately
+ * waives. The parity is exact except for two divergences that are intentional
+ * (issue #62), not accidental — keep them when "aligning" the two gates:
+ *
+ *   - `block`       — never authorized (the gate drops every group message).
+ *   - `follow-user` — the chat needs no authorization; `allow_chats` is ignored
+ *                     exactly as the gate ignores it. The sender must be on the
+ *                     global `allow_users` list.
+ *   - `allowlist`   — the chat must be named in `allow_chats` (the group is the
+ *                     unit of trust). The sender must ALSO be on `allow_users` —
+ *                     this is the #62 divergence: a trust-changing command is
+ *                     sender-scoped even in an allowlisted group, whereas the
+ *                     delivery gate lets any member of an allowlisted group
+ *                     speak. "Any member of an allowlisted group" is therefore
+ *                     deliberately NOT a path to introduce.
+ *
+ * Before issue #79/#82 made the gate policy-aware, introduce kept a hardcoded
+ * `chat_not_allowlisted` check for *every* policy — so an `allow_users` sender
+ * could chat in a brand-new `follow-user` group but could never `/introduce`
+ * there. That accidental split is the bug this contract now closes.
  *
  * The peer bots being introduced are the message's @-mentions (excluding our
  * own bot); the host records them as *trusted* for the chat. Recording a human
@@ -43,6 +59,7 @@ export interface IntroduceAuthInput {
 export type IntroduceDenyReason =
   | 'non_group'
   | 'empty_sender_id'
+  | 'group_blocked'
   | 'chat_not_allowlisted'
   | 'sender_not_followed';
 
@@ -51,10 +68,16 @@ export type IntroduceDenyReason =
  * is authorized. This is the single source of truth for the issue #62 hard
  * contract; `canRunIntroduce` is the boolean projection of it.
  *
- * Sender-scoped, not group-scoped: the chat must be explicitly allowlisted AND
- * the sender must be on the global `allow_users` list (the same list that gates
- * direct messages and `follow-user` group delivery). Empty allowlists do not
- * authorize anyone — there is no "any member of an allowlisted group" path.
+ * Policy-aware, mirroring `dreamuxFeishuGate`'s group branch for the same policy
+ * (minus the @-mention requirement introduce waives):
+ *   - `block`       → `group_blocked` (the gate drops every group message).
+ *   - `follow-user` → `allow_chats` is ignored exactly as the gate ignores it;
+ *                     only the sender's membership in `allow_users` matters.
+ *   - `allowlist`   → the chat must be in `allow_chats` (chat-as-unit-of-trust)
+ *                     AND the sender must be on `allow_users` (the #62 sender
+ *                     scoping that the delivery gate does not impose).
+ * Empty allowlists authorize nobody — there is no "any member of an allowlisted
+ * group" path.
  */
 export function introduceDenyReason(
   access: DispatcherAccessState,
@@ -62,11 +85,20 @@ export function introduceDenyReason(
 ): IntroduceDenyReason | null {
   if (input.chatType !== 'group') return 'non_group';
   if (input.senderId === '') return 'empty_sender_id';
-  // The chat must be explicitly allowlisted. Under the `follow-user` policy an
-  // empty `allow_chats` means "every chat" for normal delivery, but a
-  // trust-changing command always requires the chat to be named, so introduce
-  // never fires in an incidental group regardless of the group policy.
-  if (!access.group.allow_chats.includes(input.chatId)) return 'chat_not_allowlisted';
+  const policy = access.group.policy;
+  // `block` drops every group message; a trust-changing command is no exception.
+  // (Before this was explicit, `block` blocked introduce only by accident — its
+  // empty `allow_chats` tripped `chat_not_allowlisted`. Once `follow-user` stops
+  // checking `allow_chats`, the block case needs its own guard.)
+  if (policy === 'block') return 'group_blocked';
+  // Under `allowlist` the group is the unit of trust, so the chat must be named.
+  // Under `follow-user` the chat allowlist is intentionally ignored — the group
+  // needs no authorization, exactly as the delivery gate ignores it. This is the
+  // line that was previously hardcoded for every policy and split introduce from
+  // the gate (issue #82 made the gate policy-aware but left this behind).
+  if (policy === 'allowlist' && !access.group.allow_chats.includes(input.chatId)) {
+    return 'chat_not_allowlisted';
+  }
   // The sender must be on the global allow-user list — the same list that gates
   // direct messages and `follow-user` group delivery. An empty list authorizes
   // nobody, keeping the rule sender-scoped rather than "any member of an

--- a/packages/dreamux/tests/feishu-introduce.test.ts
+++ b/packages/dreamux/tests/feishu-introduce.test.ts
@@ -49,39 +49,102 @@ function textContent(text: string): string {
   return JSON.stringify({ text });
 }
 
-describe('canRunIntroduce — sender-scoped, not group-scoped', () => {
+describe('canRunIntroduce — allowlist policy: sender-scoped, not group-scoped', () => {
   it('authorizes an allowlisted sender in an allowlisted chat', () => {
-    const access = state({ allow_users: ['user-a'], group: { allow_chats: ['chat-a'] } });
+    const access = state({
+      allow_users: ['user-a'],
+      group: { policy: 'allowlist', allow_chats: ['chat-a'] },
+    });
     expect(
       canRunIntroduce(access, { chatType: 'group', chatId: 'chat-a', senderId: 'user-a' }),
     ).toBe(true);
   });
 
   it('rejects a non-allowlisted sender even in an allowlisted chat', () => {
-    const access = state({ allow_users: ['user-a'], group: { allow_chats: ['chat-a'] } });
+    const access = state({
+      allow_users: ['user-a'],
+      group: { policy: 'allowlist', allow_chats: ['chat-a'] },
+    });
     expect(
       canRunIntroduce(access, { chatType: 'group', chatId: 'chat-a', senderId: 'user-x' }),
     ).toBe(false);
   });
 
   it('rejects an allowlisted sender in a chat that is not allowlisted', () => {
-    const access = state({ allow_users: ['user-a'], group: { allow_chats: ['chat-a'] } });
+    const access = state({
+      allow_users: ['user-a'],
+      group: { policy: 'allowlist', allow_chats: ['chat-a'] },
+    });
     expect(
       canRunIntroduce(access, { chatType: 'group', chatId: 'chat-other', senderId: 'user-a' }),
     ).toBe(false);
   });
 
   it('does NOT treat "any member of an allowlisted group" as authorized (empty allowlist)', () => {
-    const access = state({ allow_users: [], group: { allow_chats: ['chat-a'] } });
+    const access = state({
+      allow_users: [],
+      group: { policy: 'allowlist', allow_chats: ['chat-a'] },
+    });
     expect(
       canRunIntroduce(access, { chatType: 'group', chatId: 'chat-a', senderId: 'anyone' }),
     ).toBe(false);
   });
 
   it('never fires for direct messages', () => {
-    const access = state({ allow_users: ['user-a'], group: { allow_chats: ['chat-a'] } });
+    const access = state({
+      allow_users: ['user-a'],
+      group: { policy: 'allowlist', allow_chats: ['chat-a'] },
+    });
     expect(
       canRunIntroduce(access, { chatType: 'p2p', chatId: 'chat-a', senderId: 'user-a' }),
+    ).toBe(false);
+  });
+});
+
+describe('canRunIntroduce — follow-user policy: allow_chats is ignored', () => {
+  // The bug this PR fixes: under `follow-user` the delivery gate ignores
+  // `allow_chats`, but introduce used to demand the chat be named anyway, so an
+  // `allow_users` sender could chat in a brand-new group yet never `/introduce`
+  // there. Authorization must now mirror the gate: only `allow_users` matters.
+  it('authorizes an allow_user in a group that is NOT in allow_chats', () => {
+    const access = state({
+      allow_users: ['user-a'],
+      group: { policy: 'follow-user', allow_chats: [] },
+    });
+    expect(
+      canRunIntroduce(access, { chatType: 'group', chatId: 'brand-new-chat', senderId: 'user-a' }),
+    ).toBe(true);
+  });
+
+  it('authorizes an allow_user even when allow_chats names only other chats', () => {
+    const access = state({
+      allow_users: ['user-a'],
+      group: { policy: 'follow-user', allow_chats: ['some-other-chat'] },
+    });
+    expect(
+      canRunIntroduce(access, { chatType: 'group', chatId: 'brand-new-chat', senderId: 'user-a' }),
+    ).toBe(true);
+  });
+
+  it('rejects a sender who is not on allow_users, regardless of the chat', () => {
+    const access = state({
+      allow_users: ['user-a'],
+      group: { policy: 'follow-user', allow_chats: [] },
+    });
+    expect(
+      canRunIntroduce(access, { chatType: 'group', chatId: 'brand-new-chat', senderId: 'stranger' }),
+    ).toBe(false);
+  });
+});
+
+describe('canRunIntroduce — block policy never authorizes', () => {
+  it('rejects even an allow_user in an otherwise-named chat', () => {
+    const access = state({
+      allow_users: ['user-a'],
+      group: { policy: 'block', allow_chats: ['chat-a'] },
+    });
+    expect(
+      canRunIntroduce(access, { chatType: 'group', chatId: 'chat-a', senderId: 'user-a' }),
     ).toBe(false);
   });
 });
@@ -91,49 +154,122 @@ describe('introduceDenyReason — stable diagnostic codes (issue #77)', () => {
   // rejection point and is logged verbatim, so an operator can tell an
   // introduce blocked by the allowlist apart from an ordinary gate drop.
   it('returns null (authorized) for an allowlisted sender in an allowlisted chat', () => {
-    const access = state({ allow_users: ['user-a'], group: { allow_chats: ['chat-a'] } });
+    const access = state({
+      allow_users: ['user-a'],
+      group: { policy: 'allowlist', allow_chats: ['chat-a'] },
+    });
     expect(
       introduceDenyReason(access, { chatType: 'group', chatId: 'chat-a', senderId: 'user-a' }),
     ).toBeNull();
   });
 
+  it('returns null (authorized) for an allow_user in an unconfigured follow-user group', () => {
+    const access = state({
+      allow_users: ['user-a'],
+      group: { policy: 'follow-user', allow_chats: [] },
+    });
+    expect(
+      introduceDenyReason(access, {
+        chatType: 'group',
+        chatId: 'brand-new-chat',
+        senderId: 'user-a',
+      }),
+    ).toBeNull();
+  });
+
   it('reports non_group for a direct message', () => {
-    const access = state({ allow_users: ['user-a'], group: { allow_chats: ['chat-a'] } });
+    const access = state({
+      allow_users: ['user-a'],
+      group: { policy: 'allowlist', allow_chats: ['chat-a'] },
+    });
     expect(
       introduceDenyReason(access, { chatType: 'p2p', chatId: 'chat-a', senderId: 'user-a' }),
     ).toBe('non_group');
   });
 
   it('reports empty_sender_id when the sender id is missing', () => {
-    const access = state({ allow_users: ['user-a'], group: { allow_chats: ['chat-a'] } });
+    const access = state({
+      allow_users: ['user-a'],
+      group: { policy: 'allowlist', allow_chats: ['chat-a'] },
+    });
     expect(
       introduceDenyReason(access, { chatType: 'group', chatId: 'chat-a', senderId: '' }),
     ).toBe('empty_sender_id');
   });
 
-  it('reports chat_not_allowlisted when the chat is not explicitly allowlisted', () => {
-    const access = state({ allow_users: ['user-a'], group: { allow_chats: ['chat-a'] } });
+  it('reports group_blocked under the block policy', () => {
+    const access = state({
+      allow_users: ['user-a'],
+      group: { policy: 'block', allow_chats: ['chat-a'] },
+    });
+    expect(
+      introduceDenyReason(access, { chatType: 'group', chatId: 'chat-a', senderId: 'user-a' }),
+    ).toBe('group_blocked');
+  });
+
+  it('reports chat_not_allowlisted under allowlist when the chat is not named', () => {
+    const access = state({
+      allow_users: ['user-a'],
+      group: { policy: 'allowlist', allow_chats: ['chat-a'] },
+    });
     expect(
       introduceDenyReason(access, { chatType: 'group', chatId: 'chat-other', senderId: 'user-a' }),
     ).toBe('chat_not_allowlisted');
   });
 
+  it('does NOT report chat_not_allowlisted under follow-user (allow_chats is ignored)', () => {
+    const access = state({
+      allow_users: ['user-a'],
+      group: { policy: 'follow-user', allow_chats: ['some-other-chat'] },
+    });
+    expect(
+      introduceDenyReason(access, { chatType: 'group', chatId: 'chat-other', senderId: 'user-a' }),
+    ).toBeNull();
+  });
+
   it('reports sender_not_followed when allow_users is empty (the misleading case)', () => {
-    const access = state({ allow_users: [], group: { allow_chats: ['chat-a'] } });
+    const access = state({
+      allow_users: [],
+      group: { policy: 'allowlist', allow_chats: ['chat-a'] },
+    });
     expect(
       introduceDenyReason(access, { chatType: 'group', chatId: 'chat-a', senderId: 'anyone' }),
     ).toBe('sender_not_followed');
   });
 
   it('reports sender_not_followed when allow_users is non-empty but excludes the sender', () => {
-    const access = state({ allow_users: ['user-a'], group: { allow_chats: ['chat-a'] } });
+    const access = state({
+      allow_users: ['user-a'],
+      group: { policy: 'allowlist', allow_chats: ['chat-a'] },
+    });
     expect(
       introduceDenyReason(access, { chatType: 'group', chatId: 'chat-a', senderId: 'user-x' }),
     ).toBe('sender_not_followed');
   });
 
+  it('reports sender_not_followed under follow-user for a non-allow_user (NOT chat_not_allowlisted)', () => {
+    // The regression guard for this PR: a stranger in an unconfigured follow-user
+    // group must be denied for being off the allowlist, never for the chat being
+    // unlisted — that proves the chat check is skipped under follow-user.
+    const access = state({
+      allow_users: ['user-a'],
+      group: { policy: 'follow-user', allow_chats: [] },
+    });
+    expect(
+      introduceDenyReason(access, {
+        chatType: 'group',
+        chatId: 'brand-new-chat',
+        senderId: 'stranger',
+      }),
+    ).toBe('sender_not_followed');
+  });
+
   it('stays consistent with canRunIntroduce across every branch', () => {
-    const access = state({ allow_users: ['user-a'], group: { allow_chats: ['chat-a'] } });
+    const cases: DispatcherAccessState[] = [
+      state({ allow_users: ['user-a'], group: { policy: 'allowlist', allow_chats: ['chat-a'] } }),
+      state({ allow_users: ['user-a'], group: { policy: 'follow-user', allow_chats: [] } }),
+      state({ allow_users: ['user-a'], group: { policy: 'block', allow_chats: ['chat-a'] } }),
+    ];
     const inputs = [
       { chatType: 'group', chatId: 'chat-a', senderId: 'user-a' },
       { chatType: 'p2p', chatId: 'chat-a', senderId: 'user-a' },
@@ -141,10 +277,70 @@ describe('introduceDenyReason — stable diagnostic codes (issue #77)', () => {
       { chatType: 'group', chatId: 'chat-other', senderId: 'user-a' },
       { chatType: 'group', chatId: 'chat-a', senderId: 'user-x' },
     ];
-    for (const input of inputs) {
-      expect(canRunIntroduce(access, input)).toBe(introduceDenyReason(access, input) === null);
+    for (const access of cases) {
+      for (const input of inputs) {
+        expect(canRunIntroduce(access, input)).toBe(introduceDenyReason(access, input) === null);
+      }
     }
   });
+});
+
+describe('gate vs introduce parity — follow-user semantics must not drift', () => {
+  // The user asked review to verify that the normal delivery gate and the
+  // introduce gate agree under follow-user. Encode it so accidental drift fails
+  // CI rather than relying on a human reviewer. We hold the @-mention satisfied
+  // (introduce waives it; the gate requires it) and the sender human, then
+  // compare `dreamuxFeishuGate` deliver/drop against introduce authorization.
+  //
+  // They must agree for `block` and `follow-user`. Under `allowlist` they
+  // diverge BY DESIGN (issue #62): the gate lets any member of an allowlisted
+  // chat speak, but introduce additionally requires the sender on `allow_users`
+  // because it changes trust. That one divergence is asserted explicitly below.
+  const POLICIES = ['block', 'follow-user', 'allowlist'] as const;
+  const MENTION: Mention[] = [{ key: '@_bot', id: { open_id: 'self-bot' } }];
+
+  for (const policy of POLICIES) {
+    for (const chatInList of [false, true]) {
+      for (const senderInList of [false, true]) {
+        it(`policy=${policy} chatInList=${chatInList} senderInList=${senderInList}`, () => {
+          const access = state({
+            allow_users: senderInList ? ['user-a'] : [],
+            group: { policy, allow_chats: chatInList ? ['chat-a'] : [] },
+          });
+          const gate = dreamuxFeishuGate(
+            {
+              senderId: 'user-a',
+              senderType: 'user',
+              chatId: 'chat-a',
+              chatType: 'group',
+              mentions: MENTION,
+              botOpenId: 'self-bot',
+              now: 1_700_000_000_000,
+            },
+            access,
+          );
+          const gateDelivers = gate.action === 'deliver';
+          const introAuthorized =
+            introduceDenyReason(access, {
+              chatType: 'group',
+              chatId: 'chat-a',
+              senderId: 'user-a',
+            }) === null;
+
+          const intentionalAllowlistDivergence =
+            policy === 'allowlist' && chatInList && !senderInList;
+          if (intentionalAllowlistDivergence) {
+            // Gate delivers (any member of the allowlisted chat), introduce does
+            // not (trust-changing command is sender-scoped, #62).
+            expect(gateDelivers).toBe(true);
+            expect(introAuthorized).toBe(false);
+          } else {
+            expect(introAuthorized).toBe(gateDelivers);
+          }
+        });
+      }
+    }
+  }
 });
 
 describe('detectIntroduce — no @-mention required', () => {

--- a/packages/dreamux/tests/smoke.test.ts
+++ b/packages/dreamux/tests/smoke.test.ts
@@ -901,6 +901,167 @@ describe('dreamux MVP smoke', () => {
     expect(entry?.known).toEqual(['peer-bot-1']);
   });
 
+  it('follow-user: consumes a bare /introduce from an allow_user in an UNCONFIGURED group', async () => {
+    // The reported bug: under follow-user the delivery gate ignores allow_chats,
+    // but introduce used to demand the chat be named — so an allow_user in a
+    // brand-new group could never /introduce. allow_chats is empty here and the
+    // chat is not listed, yet the command must consume, trust, and ack.
+    await saveDispatcherAccess('flow', {
+      version: 2,
+      allow_users: ['sender-test'],
+      group: {
+        policy: 'follow-user',
+        allow_chats: [],
+        require_mention: true,
+      },
+      observed_chats: [],
+      warnings: [],
+      last_gate: null,
+    });
+    server = buildServer({ runtimeDir, fake, bot });
+    server.repos.dispatchers.create({
+      dispatcher_id: 'flow',
+      bot_app_id: 'app-smoke',
+      bot_secret_ref: 'env:UNUSED',
+    });
+    await server.start();
+
+    // No @-mention of our bot — only the peer bot being introduced is mentioned.
+    await bot.inject(
+      fakeInbound('chat-group-new', '/introduce', 'msg-introduce-fu-bare', {
+        mentions: [{ key: '@_user_9', id: { open_id: 'peer-bot-fu-1' }, name: 'Peer' }],
+      }),
+    );
+
+    await sleep(60);
+    expect(fake.turnsHandled).toBe(0);
+    expect(bot.sentMessages).toEqual([
+      {
+        chatId: 'chat-group-new',
+        target: { chatId: 'chat-group-new' },
+        text: '✅ 已认识本群 1 个伙伴：@Peer',
+        messageIds: ['message-fake-1'],
+      },
+    ]);
+    expect(bot.reactions).toEqual([]);
+    const entry = (await loadChatBots('flow')).chats['chat-group-new'];
+    expect(entry?.trusted).toEqual(['peer-bot-fu-1']);
+    expect(entry?.known).toEqual(['peer-bot-fu-1']);
+  });
+
+  it('follow-user: consumes an @-bot /introduce from an allow_user in an UNCONFIGURED group', async () => {
+    // Mentioning our bot must not change the introduce path — it still consumes,
+    // trusts, and acks without reaching Codex (the mention requirement is waived
+    // for introduce, not required).
+    await saveDispatcherAccess('flow', {
+      version: 2,
+      allow_users: ['sender-test'],
+      group: {
+        policy: 'follow-user',
+        allow_chats: [],
+        require_mention: true,
+      },
+      observed_chats: [],
+      warnings: [],
+      last_gate: null,
+    });
+    server = buildServer({ runtimeDir, fake, bot });
+    server.repos.dispatchers.create({
+      dispatcher_id: 'flow',
+      bot_app_id: 'app-smoke',
+      bot_secret_ref: 'env:UNUSED',
+    });
+    await server.start();
+
+    // @ our bot AND the peer bot being introduced.
+    await bot.inject(
+      fakeInbound('chat-group-new', '/introduce', 'msg-introduce-fu-at', {
+        mentions: [
+          { key: '@_user_1', id: { open_id: 'fake-open-id-app-smoke' }, name: 'Dispatcher' },
+          { key: '@_user_9', id: { open_id: 'peer-bot-fu-2' }, name: 'Peer' },
+        ],
+      }),
+    );
+
+    await sleep(60);
+    expect(fake.turnsHandled).toBe(0);
+    expect(bot.sentMessages).toEqual([
+      {
+        chatId: 'chat-group-new',
+        target: { chatId: 'chat-group-new' },
+        text: '✅ 已认识本群 1 个伙伴：@Peer',
+        messageIds: ['message-fake-1'],
+      },
+    ]);
+    expect(bot.reactions).toEqual([]);
+    const entry = (await loadChatBots('flow')).chats['chat-group-new'];
+    expect(entry?.trusted).toEqual(['peer-bot-fu-2']);
+    expect(entry?.known).toEqual(['peer-bot-fu-2']);
+  });
+
+  it('follow-user: does NOT consume /introduce from a non-allow_user in an UNCONFIGURED group', async () => {
+    // The regression guard: a stranger in an unconfigured follow-user group must
+    // be denied for being off the allowlist (`sender_not_followed`), NEVER for
+    // the chat being unlisted — that proves the chat check is skipped under
+    // follow-user. Normal gate behavior is preserved: it still falls through and
+    // drops as `bot not mentioned`.
+    await saveDispatcherAccess('flow', {
+      version: 2,
+      allow_users: ['sender-test'],
+      group: {
+        policy: 'follow-user',
+        allow_chats: [],
+        require_mention: true,
+      },
+      observed_chats: [],
+      warnings: [],
+      last_gate: null,
+    });
+    const channel = captureLogger('channel');
+    server = buildServer({
+      runtimeDir,
+      fake,
+      bot,
+      channelLoggerFactory: () => channel.logger,
+    });
+    server.repos.dispatchers.create({
+      dispatcher_id: 'flow',
+      bot_app_id: 'app-smoke',
+      bot_secret_ref: 'env:UNUSED',
+    });
+    await server.start();
+
+    await bot.inject(
+      fakeInbound('chat-group-new', '/introduce', 'msg-introduce-fu-stranger', {
+        senderId: 'stranger',
+        mentions: [{ key: '@_user_9', id: { open_id: 'peer-bot-fu-3' }, name: 'Peer' }],
+      }),
+    );
+
+    await sleep(60);
+    expect(fake.turnsHandled).toBe(0);
+    expect(bot.sentMessages).toEqual([]);
+    expect(bot.reactions).toEqual([]);
+    expect((await loadChatBots('flow')).chats['chat-group-new']?.trusted ?? []).not.toContain(
+      'peer-bot-fu-3',
+    );
+
+    const lines = channel.lines();
+    expect(lines.find((l) => l['msg'] === 'introduce detected but not authorized')).toMatchObject({
+      chat_id: 'chat-group-new',
+      sender_id: 'stranger',
+      message_id: 'msg-introduce-fu-stranger',
+      // Must be sender-scoped, not chat-scoped — the whole point of the fix.
+      reason: 'sender_not_followed',
+    });
+    // Normal follow-user gate still runs and drops the stranger's message.
+    expect(
+      lines.some(
+        (l) => l['msg'] === 'feishu inbound dropped' && l['reason'] === 'bot not mentioned',
+      ),
+    ).toBe(true);
+  });
+
   it('does not ack an authorized /introduce with no external peer', async () => {
     await saveDispatcherAccess('flow', {
       version: 2,

--- a/packages/dreamux/tests/smoke.test.ts
+++ b/packages/dreamux/tests/smoke.test.ts
@@ -902,16 +902,17 @@ describe('dreamux MVP smoke', () => {
   });
 
   it('follow-user: consumes a bare /introduce from an allow_user in an UNCONFIGURED group', async () => {
-    // The reported bug: under follow-user the delivery gate ignores allow_chats,
-    // but introduce used to demand the chat be named — so an allow_user in a
-    // brand-new group could never /introduce. allow_chats is empty here and the
-    // chat is not listed, yet the command must consume, trust, and ack.
+    // The reported bug (#89): under follow-user the delivery gate ignores
+    // allow_chats, but introduce used to demand the chat be named — so an
+    // allow_user in a group not in allow_chats could never /introduce. This
+    // reproduces the literal runtime state: allow_chats names ANOTHER group, the
+    // current chat is absent, yet the command must consume, trust, and ack.
     await saveDispatcherAccess('flow', {
       version: 2,
       allow_users: ['sender-test'],
       group: {
         policy: 'follow-user',
-        allow_chats: [],
+        allow_chats: ['chat-group-other'],
         require_mention: true,
       },
       observed_chats: [],


### PR DESCRIPTION
关联 #89。

## 问题

`follow-user` 模式下，全局 `allow_users` 里的用户在一个**未配置进 `allow_chats`** 的群里发 `/introduce`，命令不被 consume：诊断 `reason=chat_not_allowlisted`，随后落到普通 gate。无论是否 @ 当前 bot 都一样，因为卡点是 `allow_chats` 校验，而非 @。

## 修复

把 `introduceDenyReason()` 改成 **policy-aware**，与投递 gate `dreamuxFeishuGate()` 在同一 policy 下对齐：

| policy | introduce 授权 | 与 gate 关系 |
| --- | --- | --- |
| `block` | 一律拒绝（新 reason `group_blocked`） | 一致：gate drop 所有群消息 |
| `follow-user` | **忽略 `allow_chats`**，只看 sender ∈ `allow_users` | 一致（gate 也忽略 `allow_chats`） |
| `allowlist` | chat ∈ `allow_chats` **且** sender ∈ `allow_users` | 故意差异（#62）：gate 允许群内任意成员，但改 trust 的命令是 sender-scoped |

`group_blocked` 是必需的、不只是诊断：旧代码在 `block` 下是靠空 `allow_chats` 触发 `chat_not_allowlisted` 才**意外**拦住 introduce 的；一旦 `follow-user` 不再校验 `allow_chats`，`block` 必须有独立守卫，否则 allow_user 会在 block 群里把 introduce consume + 写 trust。

## 验收覆盖（对应 #89）

- 单元：每个 policy / reason code（含 `group_blocked`、`follow-user` 下 `sender_not_followed` 而非 `chat_not_allowlisted`）；
- **gate ↔ introduce 一致性表驱动测试**：枚举 `policy × chatInList × senderInList`，断言两个函数在 `block`/`follow-user` 下结果一致、仅在 `allowlist` 的 sender 检查处按 #62 故意分裂 —— 让未来的意外漂移直接挂 CI；
- smoke 集成：`follow-user` 未配置群下 (1) bare `/introduce` (2) @ bot `/introduce` 均 consume/写 trust/发 ack/不进 Codex；(3) 非 allow_user 不 consume、诊断 `reason=sender_not_followed`、保留普通 gate drop；
- 既有 `allowlist` authorized/unauthorized 测试改为显式 `policy: 'allowlist'`，行为不回退；
- 普通 follow-user gate 语义、#87 的 ack 均不回退。

## 复盘：为什么前几版没修到这个点

根因是提交 `434be09`（#82）：它把投递 gate 改成 policy-aware（`follow-user` 不再校验 `allow_chats`），却在**同一个 PR**里于 `introduce.ts` **刻意保留**对 `allow_chats` 的硬校验，注释明确写 “regardless of the group policy”。于是两条授权路径分裂 —— 投递跟着 sender 走，introduce 仍要求群被预先登记。这不是疏漏，而是一处方向错误的显式决定。随后 #77（诊断日志，把行为标注为 “byte-identical / 纯可观测性增强”）和 #87（ack）都在这个已冻结的行为上叠加，没有回看普通 gate 与 introduce gate 在 `follow-user` 下是否仍一致。教训：当一条安全 gate 变成 policy-aware 时，必须同步审计所有共享同一 access 语义的旁路（introduce、awareness 等），否则会留下“投递放行但 introduce 拒绝”这类隐性分裂。

## 后续 review 提示

请专门核对**普通 gate 与 introduce gate 在 `follow-user` 下的语义一致性**（本 PR 的表驱动测试已固化）。另外，`server.ts` 的 awareness 路径 `observeKnownBot`（同样硬编码 `allow_chats.includes`）是**同一形状**的分裂：`follow-user` 未配置群里 peer bot 不会被记入 `known`。本 PR **不改**它（它只影响 `known` 追踪，不影响 trust，6 个验收点都不涉及），但留作同向对齐的后续候选。
