### PR TITLE
内置 dispatcher skills 并在启动时软链安装

### DIFF
--- a/.agents/components/dispatcher-skill.md
+++ b/.agents/components/dispatcher-skill.md
@@ -57,7 +57,12 @@ The runtime installer is intentionally symlink-only:
 
 - correct symlinks are left unchanged
 - stale or broken symlinks are replaced
+- a legacy copied `dispatcher` directory whose `SKILL.md` exactly matches a
+  known Dreamux-managed fingerprint is migrated to a symlink
 - real user files/directories are not overwritten; startup logs a diagnostic
+  and onboard reports the path as `skipped`
+- custom symlinks in these bundled skill slots are treated as replaceable
+  Dreamux-managed links; use a real file or directory to opt out
 - missing `.codex/skills` directories are created
 - a missing dispatcher cwd is a startup error because it likely means the
   configured dispatcher path is wrong

--- a/.agents/components/dispatcher-skill.md
+++ b/.agents/components/dispatcher-skill.md
@@ -1,27 +1,33 @@
 # Component: dispatcher skill
 
-`/packages/dreamux/skills/dispatcher/SKILL.md` is the bundled Codex
-skill that teaches dispatcher app-server sessions how to delegate product work
-through `tm`.
+`/packages/dreamux/skills/` contains the bundled Codex skills that Dreamux
+ships in the npm package:
 
-It is not installed through Codex plugin marketplaces. `dreamux onboard` copies
-the bundled skill into each dispatcher's workspace-local Codex skill directory:
+- `dispatcher` teaches dispatcher app-server sessions how to delegate product
+  work through `tm`.
+- `team-dev-workflow` covers multi-teammate review, design, merge, and unblock
+  coordination.
+- `dreamux-maintenance` covers installed Dreamux diagnosis and safe operation.
+
+They are not installed through Codex plugin marketplaces. `dreamux onboard` and
+dispatcher startup symlink the bundled skill directories into each dispatcher's
+workspace-local Codex skill directory:
 
 ```text
-<dispatcher cwd>/.codex/skills/dispatcher/SKILL.md
+<dispatcher cwd>/.codex/skills/<skill-name> -> <dreamux package>/skills/<skill-name>
 ```
 
 Dispatcher app-server processes do not set `CODEX_HOME`; they use Codex's
-global default home for auth, config, and memory. The dispatcher skill is
-workspace-local because it belongs to that dispatcher's command environment.
+global default home for auth, config, and memory. The bundled skills are
+workspace-local because they belong to that dispatcher's command environment.
 See [the dispatcher tm packaging decision](../decisions/dispatcher-tm-packaging.md).
 
 ## Files
 
 | Path | Role |
 |---|---|
-| `/packages/dreamux/skills/dispatcher/SKILL.md` | Bundled dispatcher skill shipped in the npm package |
-| `<dispatcher cwd>/.codex/skills/dispatcher/SKILL.md` | Installed copy written by `dreamux onboard` for one dispatcher |
+| `/packages/dreamux/skills/<skill-name>/` | Bundled skill directory shipped in the npm package |
+| `<dispatcher cwd>/.codex/skills/<skill-name>` | Workspace-local symlink installed for one dispatcher |
 | `/packages/dreamux/bin/tm` | Public wrapper that forwards to the package-local `@excitedjs/tm` executable |
 
 ## Runtime Boundary
@@ -38,9 +44,22 @@ The skill keeps the boundary from
 
 `@excitedjs/tm` is a direct dependency of `@excitedjs/dreamux`, and the package
 exports a `tm` bin wrapper. `dreamux serve` prepends the dreamux package bin
-directory to dispatcher app-server `PATH`, so the dispatcher skill must invoke
+directory to dispatcher app-server `PATH`, so the dispatcher skills must invoke
 bare `tm`.
 
 Do not reintroduce `npx`, `npm exec`, plugin marketplace installation, or
 `@excitedjs/tm@latest` in the dispatcher skill. The installed package version is
 the compatibility boundary.
+
+## Symlink Strategy
+
+The runtime installer is intentionally symlink-only:
+
+- correct symlinks are left unchanged
+- stale or broken symlinks are replaced
+- real user files/directories are not overwritten; startup logs a diagnostic
+- missing `.codex/skills` directories are created
+- a missing dispatcher cwd is a startup error because it likely means the
+  configured dispatcher path is wrong
+- unsupported symlink platforms or permission errors fail loudly instead of
+  copying bundled content

--- a/.agents/components/repo-structure.md
+++ b/.agents/components/repo-structure.md
@@ -48,7 +48,7 @@ verbatim through the move):
 | `db/migrations/0001_init.sql` | Legacy SQLite schema; targeted for removal by [top-level-design](../decisions/top-level-design.md) |
 | `bin/dreamux` | Public CLI launcher (`dreamux serve`, `dreamux dispatcher ...`) |
 | `bin/tm` | Public wrapper that forwards to the package-local `@excitedjs/tm` executable |
-| `skills/dispatcher/SKILL.md` | Bundled dispatcher Codex skill copied into each dispatcher's `<cwd>/.codex/skills/dispatcher/` by onboarding |
+| `skills/` | Bundled Codex skills symlinked into each dispatcher's `<cwd>/.codex/skills/<skill-name>` by onboarding and dispatcher startup |
 | `tests/` | vitest: smoke, bin-launcher, dispatcher Codex home doctor, codex live integration |
 
 ## Installation — the rush path only
@@ -140,11 +140,11 @@ multi-package release notes precise while still using Rush as the validator.
 | `~/.dreamux/state/<id>/codex.sock` | Runtime-created Codex app-server Unix socket for that dispatcher. | The server |
 | `~/.dreamux/logs/` | Server and per-dispatcher logs, including Codex app-server logs. | The server |
 | `~/.codex/` | Codex global default home: auth, memory, and config used by dispatcher app-server processes. | The operator / Codex |
-| `<dispatcher cwd>/.codex/skills/dispatcher/SKILL.md` | Dispatcher skill copied by `dreamux onboard`. | dreamux installer |
+| `<dispatcher cwd>/.codex/skills/<skill-name>` | Workspace-local bundled skill symlink. | dreamux installer |
 
 The split is load-bearing: a `rm -rf ~/.dreamux/state ~/.dreamux/logs`
 recovery never loses user-edited dreamux settings or global Codex auth.
 Dispatcher app-server processes do not set `CODEX_HOME`; they use Codex's
-global default home for auth, memory, and config. The dispatcher skill is
+global default home for auth, memory, and config. The bundled skills are
 workspace-local. See [top-level-design](../decisions/top-level-design.md) and
 [dispatcher-tm-packaging](../decisions/dispatcher-tm-packaging.md).

--- a/.agents/decisions/dispatcher-tm-packaging.md
+++ b/.agents/decisions/dispatcher-tm-packaging.md
@@ -2,7 +2,7 @@
 
 - **Status:** Accepted
 - **Date:** 2026-06-03
-- **Affects:** `@excitedjs/dreamux` package dependencies, package bins, dispatcher Codex environment, dispatcher skill installation
+- **Affects:** `@excitedjs/dreamux` package dependencies, package bins, dispatcher Codex environment, bundled skill installation
 - **PR / Issue:** Local architecture clarification on 2026-06-03; supersedes the `npx @excitedjs/tm` dispatcher-skill command shape and the global dispatcher-skill install path
 
 ## Context
@@ -34,24 +34,28 @@ dreamux package `bin/` directory to that child process `PATH`. The dispatcher
 skill must invoke bare `tm`, never `npx`, `npm exec`, or a version-qualified
 package command.
 
-`dreamux onboard` installs the bundled dispatcher skill into each dispatcher's
-workspace-local Codex skill directory:
+Dreamux ships a small set of bundled Codex skills in the npm package:
+`dispatcher`, `team-dev-workflow`, and `dreamux-maintenance`.
+
+`dreamux onboard` and dispatcher startup install these bundled skills into each
+dispatcher's workspace-local Codex skill directory as symlinks:
 
 ```text
-<dispatcher cwd>/.codex/skills/dispatcher/SKILL.md
+<dispatcher cwd>/.codex/skills/<skill-name> -> <dreamux package>/skills/<skill-name>
 ```
 
 This is intentionally not `~/.codex/skills/...`. The dispatcher skill is tied
-to the dispatcher workspace and command environment, while Codex auth, memory,
-and user configuration still follow Codex's normal global home.
+to the dispatcher workspace and command environment, and the workflow /
+maintenance skills should appear only in that same dispatcher context. Codex
+auth, memory, and user configuration still follow Codex's normal global home.
 
 The bundled source directory, installed directory, and skill frontmatter name
-must all use `dispatcher`. Older package-specific source-directory names must
-be renamed away before this design is implemented.
+must match for each shipped skill. Older package-specific source-directory names
+must be renamed away before this design is implemented.
 
-`dreamux uninstall` does not delete this workspace-local skill by default. It
+`dreamux uninstall` does not delete these workspace-local skills by default. It
 removes dreamux-owned config, state, logs, and service integration, then reports
-the workspace skill paths created by `onboard` so the operator can remove them
+the workspace skill paths created by Dreamux so the operator can remove them
 manually when desired. This avoids deleting files under arbitrary operator
 workspaces during a global uninstall.
 
@@ -65,15 +69,22 @@ workspaces during a global uninstall.
   normal package dependency update and release note.
 - Dispatcher prompts and skills stay short: use `tm spawn`, `tm send`, and
   `tm wait`.
-- Onboard must write the dispatcher skill once per dispatcher cwd. A machine
-  with multiple dispatchers may have multiple workspace-local installed copies.
-- Removing or recreating a dispatcher workspace can remove its installed skill;
-  rerun `dreamux onboard` for that dispatcher to restore it.
+- Onboard and dispatcher startup install bundled skills once per dispatcher cwd.
+  A machine with multiple dispatchers may have multiple workspace-local
+  symlink sets.
+- Correct symlinks are left unchanged. Stale or broken symlinks are replaced.
+  Real user files or directories are not overwritten; startup logs a diagnostic.
+- A missing `.codex/skills` directory is created, but a missing dispatcher cwd
+  is a startup error.
+- Unsupported symlink platforms or permission failures fail loudly; Dreamux does
+  not copy bundled skills as a fallback.
+- Removing or recreating a dispatcher workspace can remove its installed skill
+  symlinks; rerun `dreamux onboard` or restart the dispatcher to restore them.
 - dreamux must not silently mutate the operator's global `~/.codex/skills/`
-  for this dispatcher skill.
+  for these dispatcher-scoped skills.
 - Uninstall is intentionally asymmetric for workspace files: onboarding writes
-  the dispatcher skill into the operator's workspace, while uninstall only
-  reports that path.
+  symlinks into the operator's workspace, while uninstall only reports those
+  paths.
 
 ## Current source status
 
@@ -82,9 +93,10 @@ At the time of this decision, the branch already contains:
 - `@excitedjs/tm` as a `@excitedjs/dreamux` dependency.
 - `/packages/dreamux/bin/tm`.
 - dispatcher app-server `PATH` injection for the dreamux package bin directory.
-- `dreamux onboard` installs the bundled dispatcher skill to
-  `<dispatcher cwd>/.codex/skills/dispatcher/`.
-- The bundled skill source directory and frontmatter name are `dispatcher`.
+- `dreamux onboard` and dispatcher startup install bundled skill symlinks to
+  `<dispatcher cwd>/.codex/skills/<skill-name>`.
+- The bundled skill source directories and frontmatter names match their public
+  skill names.
 
 ## Alternatives considered
 

--- a/.agents/decisions/dispatcher-tm-packaging.md
+++ b/.agents/decisions/dispatcher-tm-packaging.md
@@ -73,7 +73,13 @@ workspaces during a global uninstall.
   A machine with multiple dispatchers may have multiple workspace-local
   symlink sets.
 - Correct symlinks are left unchanged. Stale or broken symlinks are replaced.
-  Real user files or directories are not overwritten; startup logs a diagnostic.
+  A legacy copied `dispatcher` directory whose `SKILL.md` matches a known
+  Dreamux-managed fingerprint is migrated to a symlink. Real user files or
+  directories are not overwritten; startup logs a diagnostic and onboard reports
+  the path as `skipped`.
+- Custom symlinks at bundled skill paths are treated as Dreamux-managed links
+  and may be replaced. Operators who intentionally opt out should use a real
+  file or directory at that skill path.
 - A missing `.codex/skills` directory is created, but a missing dispatcher cwd
   is a startup error.
 - Unsupported symlink platforms or permission failures fail loudly; Dreamux does

--- a/.agents/decisions/global-bin-onboard-serve.md
+++ b/.agents/decisions/global-bin-onboard-serve.md
@@ -45,11 +45,11 @@ Design issue #18 around one published global bin, `dreamux`, with
 There are no legacy global-bin users to protect, so the implementation does
 not install `dreamux-server` or `server-ctl` and does not preserve old command
 forms as compatibility contracts. The package also exports a `tm` wrapper
-because the dispatcher skill depends on `@excitedjs/tm` as a direct dreamux
-dependency.
+because the bundled dispatcher skills depend on `@excitedjs/tm` as a direct
+dreamux dependency.
 
-`dreamux onboard` copies the bundled dispatcher Codex skill into the
-dispatcher workspace-local Codex skill directory, collects dispatcher and
+`dreamux onboard` installs bundled Codex skill symlinks into the dispatcher
+workspace-local Codex skill directory, collects dispatcher and
 channel configuration, and registers a native service manager entry.
 `dreamux serve` runs the existing server in the foreground and lets launchd or
 systemd keep it alive.
@@ -87,14 +87,13 @@ status, and uninstall operations.
 [amendment](#amendment-issue-78-daemon-group--linger).)*
 
 Dispatcher app-server processes do not set `CODEX_HOME`; they use Codex's
-global default home (`~/.codex`) for auth, config, and memory. The
-The consumer is still the dispatcher agent: the dispatcher is the long-lived
-Codex app-server, and its dispatcher skill is scoped to that agent's
-workspace. Onboarding installs that skill by directly copying the
-bundled `SKILL.md` into `<dispatcher cwd>/.codex/skills/dispatcher/SKILL.md`.
+global default home (`~/.codex`) for auth, config, and memory. The consumer is
+still the dispatcher agent: the dispatcher is the long-lived Codex app-server,
+and its bundled skills are scoped to that agent's workspace. Onboarding
+installs them as symlinks under `<dispatcher cwd>/.codex/skills/<skill-name>`.
 
 Skill installation, Codex global state, and app-server control state are
-separate concerns: the dispatcher skill is workspace-local, Codex's own
+separate concerns: the bundled skills are workspace-local, Codex's own
 auth/config/memory remain under the global Codex home, and dreamux app-server
 control sockets live under dreamux-owned state with a short socket leaf.
 dreamux does not generate or rewrite a Codex TOML config. Codex model/provider,
@@ -123,7 +122,7 @@ The dispatcher Codex app-server launched by `dreamux serve` must:
 - run outside Codex's restricted-network workspace profile, or at minimum
   use a network-enabled permission profile
 - use Codex's global default home, with no `CODEX_HOME` override
-- load the dispatcher skill from `<dispatcher cwd>/.codex/skills/dispatcher/`
+- load bundled skills from `<dispatcher cwd>/.codex/skills/<skill-name>`
 - have the dreamux package bin directory on `PATH`, so bare `tm` resolves to
   the package-local `@excitedjs/tm` wrapper
 - use dreamux-owned state paths defined by
@@ -131,7 +130,7 @@ The dispatcher Codex app-server launched by `dreamux serve` must:
 - keep Unix socket paths short enough for macOS and Linux `sun_path` limits
 
 Onboarding must be path-transparent: every file path created or modified
-by `dreamux onboard`, including the copied dispatcher skill and
+by `dreamux onboard`, including workspace-local bundled skill symlinks and
 service-manager registration, must be printed to the operator with its final
 status.
 
@@ -148,8 +147,8 @@ status.
 - `serve` should not daemonize itself. Service managers supervise the
   foreground process.
 - Onboarding intentionally keeps Codex auth/config/memory in Codex's global
-  default home while installing the dispatcher skill into the dispatcher's
-  workspace-local `.codex/skills/dispatcher/` directory. All touched paths must
+  default home while installing bundled skill symlinks into the dispatcher's
+  workspace-local `.codex/skills/` directory. All touched paths must
   be printed through the onboarding path ledger. App-server control sockets
   remain under dreamux runtime state.
 - The `dreamux` launcher passes its resolved absolute path through

--- a/.agents/decisions/top-level-design.md
+++ b/.agents/decisions/top-level-design.md
@@ -456,8 +456,12 @@ directory into:
 
 The workspace-local skills are intentionally not installed into the operator's
 global `~/.codex/skills`. The installer creates a missing `.codex/skills`
-parent, replaces stale or broken symlinks, and leaves real user files or
-directories untouched with a startup diagnostic.
+parent, replaces stale or broken symlinks, and migrates a legacy copied
+`dispatcher` directory only when its `SKILL.md` exactly matches a known
+Dreamux-managed fingerprint. Other real user files or directories are left
+untouched with a startup diagnostic and an onboard `skipped` ledger entry.
+Custom symlinks in these bundled skill slots are treated as Dreamux-managed
+links and may be replaced; use a real file or directory to opt out.
 
 `uninstall` removes dreamux-owned config, state, logs, and service integration
 by default. It reports workspace-local bundled skill paths, but it does not

--- a/.agents/decisions/top-level-design.md
+++ b/.agents/decisions/top-level-design.md
@@ -2,7 +2,7 @@
 
 - **Status:** Accepted
 - **Date:** 2026-06-03
-- **Affects:** server runtime, dispatcher lifecycle, Feishu channel, Codex MCP, admin/outbound IPC, global config, state files, logs, CLI admin surface, workspace-local dispatcher skill ownership
+- **Affects:** server runtime, dispatcher lifecycle, Feishu channel, Codex MCP, admin/outbound IPC, global config, state files, logs, CLI admin surface, workspace-local bundled skill ownership
 - **PR / Issue:** Local architecture clarification on 2026-06-03; supersedes the persistence and automatic-outbound parts of issue #2, the runtime-dir parts of `global-config-dir`, and loopback HTTP MCP as the default Feishu MCP transport
 
 ## Context
@@ -443,21 +443,25 @@ message body.
 a `tm` bin wrapper.
 
 When `dreamux` starts a dispatcher Codex thread, it injects the package `tm` bin
-location into that thread's `PATH`. This lets the dispatcher skill call bare
+location into that thread's `PATH`. This lets the dispatcher skills call bare
 `tm` without constructing long `npx` commands.
 
-During `onboard`, `dreamux` copies the bundled dispatcher skill into:
+The npm package ships bundled Codex skills under `/packages/dreamux/skills/`.
+During `onboard` and dispatcher startup, `dreamux` symlinks each bundled skill
+directory into:
 
 ```text
-<dispatcher cwd>/.codex/skills/dispatcher/SKILL.md
+<dispatcher cwd>/.codex/skills/<skill-name>
 ```
 
-The workspace-local skill is intentionally not installed into the operator's
-global `~/.codex/skills`.
+The workspace-local skills are intentionally not installed into the operator's
+global `~/.codex/skills`. The installer creates a missing `.codex/skills`
+parent, replaces stale or broken symlinks, and leaves real user files or
+directories untouched with a startup diagnostic.
 
 `uninstall` removes dreamux-owned config, state, logs, and service integration
-by default. It reports workspace-local dispatcher skill paths that were created
-by `onboard`, but it does not delete files under operator workspaces by default.
+by default. It reports workspace-local bundled skill paths, but it does not
+delete files under operator workspaces by default.
 
 ## CLI And Admin
 
@@ -541,5 +545,5 @@ resume path.
 - Codex app-server child or child-WebSocket failure triggers backoff restart and
   thread resume.
 - A stuck turn alone does not trigger child restart.
-- `uninstall` reports workspace-local dispatcher skill paths but does not delete
+- `uninstall` reports workspace-local bundled skill paths but does not delete
   them by default.

--- a/.agents/proposals/global-bin-onboard-serve.md
+++ b/.agents/proposals/global-bin-onboard-serve.md
@@ -11,8 +11,8 @@ binding behavior now lives in the accepted decision:
 
 - `@excitedjs/dreamux` exports `dreamux` plus the dispatcher-required `tm`
   wrapper.
-- `dreamux onboard` copies the bundled dispatcher Codex skill into each
-  dispatcher's workspace-local `.codex/skills/dispatcher/` directory.
+- `dreamux onboard` installs bundled Codex skill symlinks into each
+  dispatcher's workspace-local `.codex/skills/` directory.
 - Dispatcher app-server processes use Codex's global default home for auth,
   config, and memory; dreamux does not set `CODEX_HOME`.
 - dreamux-owned state defaults to `~/.dreamux/state/`, and logs default to

--- a/common/changes/@excitedjs/dreamux/bundled-skills_2026-06-05-13-05.json
+++ b/common/changes/@excitedjs/dreamux/bundled-skills_2026-06-05-13-05.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Bundle the dispatcher, team-dev-workflow, and dreamux-maintenance skills and install them as workspace-local symlinks for each dispatcher.",
+      "type": "patch",
+      "packageName": "@excitedjs/dreamux"
+    }
+  ],
+  "packageName": "@excitedjs/dreamux",
+  "email": "053700@gmail.com"
+}

--- a/packages/dreamux/skills/dispatcher/SKILL.md
+++ b/packages/dreamux/skills/dispatcher/SKILL.md
@@ -1,23 +1,24 @@
 ---
 name: dispatcher
-description: Use from a dreamux dispatcher thread when work should be delegated to a tm-managed Codex teammate in a specific repository. Applies to bounded engineering tasks, test runs, codebase inspections, or follow-up work where the dispatcher should spawn/send/wait through the tm CLI exposed by the dreamux package and report the result back to the source chat.
+description: Use from a Dreamux dispatcher thread when bounded repository work should be delegated to a tm-managed Codex teammate. Applies to spawning, sending, waiting, checking status, resuming, or summarizing teammate work through the tm CLI exposed by the Dreamux package.
 ---
 
 # Dispatcher
 
-Use this skill only from the dispatcher agent. The dreamux server hosts the
-dispatcher lifecycle; it does not own tm teammate daemons, teammate DB rows, or
-`teammate.*` admin methods.
+Use this skill only from a Dreamux dispatcher session. Dreamux hosts the
+dispatcher Codex app-server and exposes `tm` on the dispatcher `PATH`; `tm`
+owns teammate lifecycle, history, and repository worktrees.
 
 ## Boundaries
 
-- Use `tm` from the dispatcher environment PATH. dreamux injects its package
+- Use `tm` from the dispatcher environment `PATH`. Dreamux injects its package
   `bin/` directory into the dispatcher Codex app-server PATH.
-- Pass `--engine codex` on every `tm spawn`; `tm spawn` defaults to Claude.
-- Do not use `npx`, `npm exec --package @excitedjs/tm`, or
-  `@excitedjs/tm@latest`; the dreamux package owns the tm dependency version.
+- Pass `--engine codex` on every `tm spawn`; do not rely on version-specific
+  defaults.
+- Do not use `npx`, `npm exec --package @excitedjs/tm`, or a version-qualified
+  `@excitedjs/tm`; the Dreamux package owns the compatible tm version.
 - Do not call dreamux admin APIs to create teammate state.
-- Do not infer the tm repo path from the dispatcher cwd unless the user or
+- Do not infer the target repository from the dispatcher cwd unless the user or
   operator explicitly made that cwd the requested repo.
 - Do not ask a tm-managed teammate to spawn another tm teammate.
 
@@ -31,15 +32,15 @@ security-sensitive, or missing a repository path.
 Resolve the repo path in this order:
 
 1. An absolute path in the user request.
-2. `TM_DISPATCHER_DIR`, if set by the operator.
-3. Ask the user for the repo path. Do not guess.
+2. An explicit dispatcher environment variable set by the operator.
+3. Ask the user for the repo path.
 
 Use an absolute repo path for `tm spawn`. If the user gives a relative path,
 make it absolute only when its base is explicit.
 
 ## Command Shape
 
-Preflight once per dispatcher session:
+Preflight once per dispatcher session and trust live help for flags:
 
 ```bash
 tm --help
@@ -49,7 +50,8 @@ tm --help
 
 1. Pick a flat teammate name: lowercase letters, digits, and hyphens; keep it
    short and tied to the task, such as `tests-api` or `scan-auth`.
-2. Spawn with the repo path, intent, and the full task prompt:
+2. Spawn with the repo path, Codex engine, intent, timeout, and full task
+   prompt:
 
 ```bash
 tm spawn /absolute/repo \
@@ -82,6 +84,14 @@ tm send tests-api \
 tm wait tests-api --timeout 180
 ```
 
+## Status And Readback
+
+- Use `tm status <name>` when a teammate appears stuck.
+- Use `tm wait <name> --timeout <seconds>` to collect the next completed reply.
+- Use `tm last <name>` or `tm history` when recovering a prior result.
+- Report the command outcome, the teammate name, the repository path, and any
+  explicit failure. Do not invent a result that was not returned by `tm`.
+
 ## Failure Reporting
 
 When a tm command fails, stop the delegation sequence and report:
@@ -95,13 +105,12 @@ When a tm command fails, stop the delegation sequence and report:
 Known early startup failure to report verbatim:
 
 ```text
-codex daemon (pid N) exited before binding /tmp/teammate-codex/<name>/socket
+codex daemon (pid N) exited before binding <socket path>
 ```
 
 That means the Codex app-server daemon did not become reachable. Do not retry
-silently; report the environment failure and ask the operator to verify
-`codex app-server --listen unix:///tmp/dispatcher-check.sock` in the dispatcher
-environment.
+silently; report the environment failure and ask the operator to run Dreamux
+diagnostics in the dispatcher environment.
 
-Do not say the dreamux server lost or recovered teammate state. The server does
+Do not say the Dreamux server lost or recovered teammate state. The server does
 not own that state.

--- a/packages/dreamux/skills/dreamux-maintenance/SKILL.md
+++ b/packages/dreamux/skills/dreamux-maintenance/SKILL.md
@@ -1,0 +1,91 @@
+---
+name: dreamux-maintenance
+description: Diagnose and operate a Dreamux installation. Use when the user asks about dreamux serve or daemon startup, dispatcher status, missing replies, stuck turns, restart behavior, Codex app-server readiness, logs, config, or workspace-local bundled skills.
+---
+
+# Dreamux Maintenance
+
+Use this skill for operational diagnosis of an installed Dreamux host. Keep the
+work factual: read the current config, status, logs, and command help before
+explaining a failure or taking action.
+
+## Safety
+
+- Do not edit `~/.dreamux`, `~/.codex`, service units, shell startup files, or
+  environment variables without explaining the reason first.
+- Do not paste bot IDs, tokens, private chat IDs, internal hostnames, or
+  machine-local paths into public issues, PRs, or commits.
+- Prefer diagnostics and restart commands that preserve state. Do not remove
+  state or logs unless the operator explicitly asks.
+- Do not copy bundled skills into a dispatcher workspace. Dreamux installs them
+  as symlinks under `<dispatcher cwd>/.codex/skills/`.
+
+## Quick Triage
+
+1. Identify the host mode:
+   - foreground: `dreamux serve`
+   - service-managed: `dreamux daemon start`, `dreamux daemon stop`, or
+     `dreamux daemon restart`
+2. Read setup health:
+
+```bash
+dreamux doctor
+```
+
+3. Inspect the server and dispatcher:
+
+```bash
+dreamux status
+dreamux dispatcher list
+dreamux dispatcher status --id <dispatcher-id>
+```
+
+4. Inspect config without exposing secrets:
+
+```bash
+dreamux config path
+dreamux config show
+```
+
+5. Read only the relevant logs from `~/.dreamux/logs/`:
+   - `dreamux-server.log`
+   - `codex-app-server/<dispatcher-id>.log`
+   - `codex-app-server/<dispatcher-id>.stderr.log`
+   - `feishu-channel/<dispatcher-id>.log`
+   - `feishu-mcp/<dispatcher-id>.log`
+
+## Common Symptoms
+
+| Symptom | First checks |
+|---|---|
+| Dispatcher does not start | `dreamux doctor`, dispatcher cwd exists, Codex auth exists, bundled skill symlinks are readable. |
+| Inbound accepted but no reply | Dispatcher status, Codex app-server log, whether the turn is still active. |
+| Restart did not announce recovery | `dreamux daemon restart --notify-resumed --dispatcher <id>` was used, and the dispatcher resumed an existing thread. |
+| `tm` not found inside dispatcher | Dreamux package `bin/` directory is on dispatcher process `PATH`; rerun `dreamux doctor`. |
+| Skill changes did not appear | Verify `<dispatcher cwd>/.codex/skills/<name>` is a symlink to the installed Dreamux package skill directory. |
+
+## Turn Mechanics
+
+For questions about active turns, steering, background commands, and repeated
+responses after compaction, read `references/codex-turns.md`.
+
+## Restart Policy
+
+- If only the service wrapper changed, use `dreamux daemon restart`.
+- If a dispatcher is busy, prefer observing status first; restarting can drop
+  in-memory pending work.
+- To announce a controlled restart to resumed dispatchers:
+
+```bash
+dreamux daemon restart --notify-resumed --dispatcher <dispatcher-id>
+```
+
+## Closeout
+
+Report:
+
+- commands run
+- relevant status or log evidence
+- whether the issue is config, permissions, Codex app-server readiness,
+  dispatcher turn state, or product behavior
+- the smallest safe next action

--- a/packages/dreamux/skills/dreamux-maintenance/SKILL.md
+++ b/packages/dreamux/skills/dreamux-maintenance/SKILL.md
@@ -19,6 +19,9 @@ explaining a failure or taking action.
   state or logs unless the operator explicitly asks.
 - Do not copy bundled skills into a dispatcher workspace. Dreamux installs them
   as symlinks under `<dispatcher cwd>/.codex/skills/`.
+- Treat bundled skill paths as Dreamux-managed slots. A custom symlink at one
+  of those paths can be replaced by Dreamux; use a real directory or file only
+  when deliberately opting out of the bundled skill.
 
 ## Quick Triage
 
@@ -63,6 +66,8 @@ dreamux config show
 | Restart did not announce recovery | `dreamux daemon restart --notify-resumed --dispatcher <id>` was used, and the dispatcher resumed an existing thread. |
 | `tm` not found inside dispatcher | Dreamux package `bin/` directory is on dispatcher process `PATH`; rerun `dreamux doctor`. |
 | Skill changes did not appear | Verify `<dispatcher cwd>/.codex/skills/<name>` is a symlink to the installed Dreamux package skill directory. |
+| Skill path is a real file or directory | Dreamux leaves it untouched. If this is an intentional override, keep it; otherwise rename or remove it and restart the dispatcher. |
+| Skill symlink is broken after an upgrade | Restart the dispatcher or rerun `dreamux onboard`; startup recreates stale or broken bundled skill symlinks. |
 
 ## Turn Mechanics
 

--- a/packages/dreamux/skills/dreamux-maintenance/references/codex-turns.md
+++ b/packages/dreamux/skills/dreamux-maintenance/references/codex-turns.md
@@ -1,0 +1,50 @@
+# Codex Turns In Dreamux
+
+## What A Turn Is
+
+A turn is one model round opened by user input and kept alive until the model
+stops requesting tools. While a turn is active, additional input can be folded
+into that same turn and processed at the next model step.
+
+## Start Versus Steer
+
+- `turn/start` is aggregate behavior: it starts a fresh turn when idle and can
+  fold input into the currently active turn when busy.
+- `turn/steer` targets an active turn and should fail when no active turn
+  exists or the expected turn id does not match.
+
+Operational rule: when you need deterministic injection, identify whether a
+turn is active before choosing start or steer behavior.
+
+## Why Steering Is Not Instant
+
+Tool calls return control only at yield boundaries. If the active turn is
+waiting inside a long-running command or poll, injected input is usually not
+processed until that tool call yields and the model samples again.
+
+## Background Work Does Not Wake An Idle Model
+
+A background command completing is an event for the host, not new user input.
+If the dispatcher starts background work and ends the turn without polling,
+the model may not observe completion until another user input starts a turn.
+
+## Compaction Can Repeat Replies
+
+Long conversations can compact mid-turn. After compaction, the model may
+re-sample and repeat a prior response. Diagnose this by checking whether there
+was one inbound user message and a compaction marker between repeated assistant
+messages. Do not infer duplicate external delivery from repeated text alone.
+
+## Head-Of-Line Blocking
+
+Modern Dreamux dispatcher inbound should submit accepted messages without
+waiting for the previous turn to complete. If a later message waits behind a
+long turn, check whether the running version still uses a serial turn
+submission path or whether another gate rejected the later message.
+
+## App-Server Readiness
+
+Before business RPCs, the Codex app-server connection must complete the
+initialize handshake. A daemon that exits before binding its socket, fails the
+handshake, or cannot read workspace-local skills should be treated as a
+startup readiness failure, not as a chat delivery bug.

--- a/packages/dreamux/skills/team-dev-workflow/SKILL.md
+++ b/packages/dreamux/skills/team-dev-workflow/SKILL.md
@@ -1,0 +1,62 @@
+---
+name: team-dev-workflow
+description: Coordinate multi-teammate software development workflows from a Dreamux dispatcher: adversarial MR/PR review, design negotiation, merge readiness checks, cleanup, and unblocking a teammate. Use for coordination cycles, not ordinary single-repo edits.
+---
+
+# Team Development Workflow
+
+Use this skill when the dispatcher is coordinating people or teammates around a
+software change. It is methodology layered on top of the `dispatcher` skill:
+`dispatcher` owns `tm` mechanics, while this skill owns review, design, merge,
+and unblock workflow.
+
+## Confirm Scope
+
+Use this skill when:
+
+- An MR/PR needs independent adversarial review before merge.
+- A design direction is unsettled and two independent proposals should be
+  compared.
+- A reviewed MR/PR is ready to merge and the teammate/worktree/branch need
+  cleanup.
+- A teammate is blocked by git state, missing context, wrong base, or missed
+  review comments.
+
+Do not use this skill for a normal implementation request such as "fix this
+bug" or "add this endpoint". Delegate that as one bounded repository task with
+the `dispatcher` skill.
+
+## Coordinator Posture
+
+- Verify facts from the target repo and platform before deciding.
+- Do not edit target repo code from the coordinator context. Delegate repo work
+  to a teammate in that repo.
+- Keep prompts short: intent, coordinates, hard constraints, and requested
+  artifact.
+- When the target repo is public, explicitly forbid internal domains, tokens,
+  private identifiers, and machine-local paths in commits, MR/PRs, and comments.
+- Prefer one accountable teammate per branch or review thread; reuse it for
+  follow-up rather than spawning duplicates.
+
+## Scenario Routing
+
+Read the matching reference before acting:
+
+| Intent | Reference |
+|---|---|
+| Review an MR/PR or issue proposal adversarially | `references/review-cycle.md` |
+| Compare two design directions before implementation | `references/design-negotiation.md` |
+| Merge a reviewed change and clean up state | `references/merge-and-cleanup.md` |
+| Dispatch or unblock a teammate | `references/dispatch-and-unblock.md` |
+
+## Cross-Cutting Rules
+
+- Reviewers must be independent from authors. Fresh context matters more than
+  a specific vendor or model family.
+- The author does not review or merge its own work.
+- CI and merge mode are target-repo policy. Read the repo/platform rules before
+  acting.
+- Same-account automation may be unable to submit a formal approval or change
+  request. In that case, use a top-level MR/PR comment with a clear verdict.
+- A clean review means no blocking findings on the current head, with required
+  checks green.

--- a/packages/dreamux/skills/team-dev-workflow/references/design-negotiation.md
+++ b/packages/dreamux/skills/team-dev-workflow/references/design-negotiation.md
@@ -1,0 +1,40 @@
+# Design Negotiation
+
+## Trigger
+
+A design or architecture direction is unsettled, expensive to reverse, and has
+more than one plausible path. This is for choosing an approach before
+implementation, not for reviewing a finished MR/PR.
+
+## Steps
+
+1. Write one neutral input brief for all participants:
+   - business need and observable facts
+   - relevant repo paths, scripts, and constraints
+   - candidate approaches as reference only, not a forced shortlist
+   - required output shape
+   - validation expectations
+2. Dispatch two independent teammates in parallel with the same input brief.
+   Ask each to write a v1 proposal to a file.
+3. Wait for both v1 files and verify they exist before continuing.
+4. Swap the v1 files. Ask each teammate to read the other proposal and write a
+   v2 that states:
+   - what it adopts
+   - what it rebuts
+   - its revised recommendation
+   - remaining ambiguity
+5. Hand both v2 proposals to the human intact. The coordinator does not
+   synthesize a third proposal or preselect a winner.
+
+## Closeout
+
+The human receives two revised, independently argued proposals. If both v2s
+converge, report the convergence as evidence; still keep both proposals
+available.
+
+## Anti-Patterns
+
+- Do not tell either teammate about the other in the v1 round.
+- Do not skip the v2 cross-read.
+- Do not add a coordinator-authored compromise.
+- Do not let a teammate spawn its own reviewers for this cycle.

--- a/packages/dreamux/skills/team-dev-workflow/references/dispatch-and-unblock.md
+++ b/packages/dreamux/skills/team-dev-workflow/references/dispatch-and-unblock.md
@@ -1,0 +1,39 @@
+# Dispatch And Unblock
+
+## Trigger
+
+You are assigning a teammate to a target repo, or a teammate is blocked by git
+state, wrong base, missing context, or missed platform comments.
+
+## Steps
+
+1. Verify the target repository path and intended base branch before spawning.
+2. Reuse an existing teammate when it already owns the branch or MR/PR.
+3. Ensure the teammate brief includes only:
+   - intent
+   - branch, issue, or MR/PR coordinates
+   - hard constraints
+   - requested artifact
+4. Tell the teammate to sync its working branch before editing when the task
+   will produce commits.
+5. Tell the teammate to pull all current issue or MR/PR comments before acting.
+   Repeat this on follow-up turns when comments may have changed.
+6. For public targets, include the no-internal-content constraint explicitly.
+7. Set a short queryable task subject if the teammate tooling supports it.
+
+## Unblocking
+
+If a teammate cannot write git metadata because of sandbox permissions, the
+coordinator may run the git operation from outside the sandbox: fetch, create a
+branch, commit staged teammate-authored content, push, or clean a worktree. Do
+only the git movement needed to unblock. The teammate still owns analysis and
+content changes.
+
+If a teammate started from the wrong base, stop it, remove the bad worktree,
+reset the main checkout to the intended base, and spawn again. Do not ask a
+teammate to build on a known-bad branch unless the human accepts that risk.
+
+## Closeout
+
+The teammate is on the intended base, has current platform comments, has a
+minimal brief, and is no longer blocked on git or missing context.

--- a/packages/dreamux/skills/team-dev-workflow/references/merge-and-cleanup.md
+++ b/packages/dreamux/skills/team-dev-workflow/references/merge-and-cleanup.md
@@ -1,0 +1,37 @@
+# Merge And Cleanup
+
+## Trigger
+
+An MR/PR has a clean independent review on the current head and required checks
+are green.
+
+## Steps
+
+1. Re-read the current head SHA, required check status, draft state, and merge
+   state from the target platform.
+2. If the MR/PR is a draft, mark it ready before merging and confirm the head
+   SHA did not change.
+3. Scan the MR/PR title for bracketed CI-skip tokens. Remove or reword them
+   before squash merging so post-merge workflows are not skipped.
+4. Merge using the target repo's allowed mode and branch-deletion policy.
+5. Clean up the review cycle immediately:
+   - stop or close the reviewer teammate
+   - remove the review worktree
+   - delete the review branch if the cycle created one
+   - close the author teammate when its branch is no longer needed
+6. Record the final status in teammate history where the tooling supports it.
+
+## Closeout
+
+The change is on the target branch, required post-merge workflows are not
+accidentally skipped, and no temporary teammate, worktree, or review branch from
+the cycle remains active.
+
+## Exceptions
+
+| Case | Action |
+|---|---|
+| Merge state is unclear | Check required status checks specifically; optional jobs may be noisy. |
+| Same-account formal approval is missing | Use the clean review comment as the gate when platform policy allows owner/admin merge. |
+| Worktree removal refuses | Use the platform or git command intended for forced worktree cleanup; the branch already landed. |
+| Cleanup must be delayed | State what remains and when it will be removed. |

--- a/packages/dreamux/skills/team-dev-workflow/references/review-cycle.md
+++ b/packages/dreamux/skills/team-dev-workflow/references/review-cycle.md
@@ -1,0 +1,46 @@
+# Review Cycle
+
+## Trigger
+
+An MR/PR or issue proposal needs adversarial review before it can merge or move
+to implementation.
+
+Skip this cycle only when the change is trivial, the human already accepted the
+risk, or an equally rigorous independent review already exists on the current
+head.
+
+## Steps
+
+1. Identify the author, branch, MR/PR or issue number, and current head SHA.
+2. Confirm the target repo and platform visibility. If public, include a
+   no-internal-content constraint in the reviewer brief.
+3. Confirm the change is ready to review: current branch pushed, required
+   checks known, and merge state readable.
+4. Reuse an existing reviewer teammate only if it already owns this exact
+   branch or review thread. Otherwise spawn one independent reviewer.
+5. Give the reviewer an adversarial brief:
+   - verify the author's claims instead of trusting them
+   - inspect the current diff against the target base
+   - run or justify focused verification
+   - report P0/P1/P2 findings with file and line references
+   - do not edit, commit, push, or merge
+6. Bucket the verdict:
+   - no P0/P1: eligible for merge once required checks are green
+   - P0/P1: send the author a fix brief quoting the findings exactly
+   - P2 only: merge with follow-up or ask for a cheap one-shot fix
+7. Recheck with the same reviewer after any force-push. Anchor the recheck on
+   the prior findings, new head SHA, and reported fixes.
+
+## Closeout
+
+The current head has an independent clean verdict, required checks are green,
+and any remaining non-blocking follow-up is explicit.
+
+## Exceptions
+
+| Case | Action |
+|---|---|
+| Base advanced | Ask the author to rebase or merge the target base, then re-run checks. |
+| Reviewer and author disagree | Escalate both positions to the human; do not silently pick a side. |
+| Formal review action is rejected | Post the same verdict as a top-level MR/PR comment. |
+| A reviewed line moved after force-push | Quote the problem statement so the reviewer can relocate it. |

--- a/packages/dreamux/src/dispatcher/runtime.ts
+++ b/packages/dreamux/src/dispatcher/runtime.ts
@@ -53,6 +53,7 @@ import {
   type DispatcherCodexHomeDoctor,
 } from '../runtime/dispatcher-codex-home.js';
 import { dispatcherProcessEnv } from '../runtime/package-bin.js';
+import { installBundledWorkspaceSkills } from '../runtime/bundled-skills.js';
 
 const DEFAULT_RESTART_BACKOFF_BASE_MS = 1000;
 const DEFAULT_RESTART_BACKOFF_MAX_MS = 30_000;
@@ -181,6 +182,22 @@ export class DispatcherRuntime {
     const cwd = this.row.codex_cwd ?? dispatcherCodexCwd(this.dispatcherId);
     const socketPath = dispatcherSocketPath(this.dispatcherId);
     const extraArgs = this.deps.resolveExtraArgs?.(this.row) ?? [];
+    const skillInstallResults = await installBundledWorkspaceSkills({
+      dispatcherCwd: cwd,
+    });
+    for (const result of skillInstallResults) {
+      if (result.status === 'skipped') {
+        this.log(
+          'warn',
+          `bundled skill '${result.skillName}' not installed at ${result.targetPath}: ${result.reason}`,
+        );
+      } else if (result.status === 'linked' || result.status === 'replaced') {
+        this.log(
+          'info',
+          `bundled skill '${result.skillName}' ${result.status} at ${result.targetPath}`,
+        );
+      }
+    }
     if (this.deps.codexHomeDoctor !== undefined) {
       await this.deps.codexHomeDoctor(
         dispatcherCodexHomeDoctorContext(this.dispatcherId, {

--- a/packages/dreamux/src/onboard/dispatcher-skill.ts
+++ b/packages/dreamux/src/onboard/dispatcher-skill.ts
@@ -1,43 +1,25 @@
-import { readFile } from 'node:fs/promises';
-import { dirname, join } from 'node:path';
-import { fileURLToPath } from 'node:url';
-
-import { writeTextFile } from './ledger.js';
+import { installBundledWorkspaceSkills } from '../runtime/bundled-skills.js';
 import type { OnboardFileLedger } from './types.js';
 
-const HERE = dirname(fileURLToPath(import.meta.url));
-const PACKAGE_ROOT = dirname(dirname(HERE));
-const DISPATCHER_SKILL_SOURCE = join(
-  PACKAGE_ROOT,
-  'skills',
-  'dispatcher',
-  'SKILL.md',
-);
-
 export async function installDispatcherSkill(options: {
-  skillPath: string;
+  dispatcherCwd: string;
   ledger: OnboardFileLedger;
   dryRun: boolean;
 }): Promise<void> {
-  const content = await readDispatcherSkill();
-  await writeTextFile(
-    options.skillPath,
-    content,
-    options.ledger,
-    'workspace-local dispatcher skill',
-    { mode: 0o600, dryRun: options.dryRun },
-  );
-}
-
-async function readDispatcherSkill(): Promise<string> {
-  try {
-    return await readFile(DISPATCHER_SKILL_SOURCE, 'utf8');
-  } catch (err) {
-    if ((err as NodeJS.ErrnoException).code === 'ENOENT') {
-      throw new Error(
-        `missing bundled dispatcher skill: ${DISPATCHER_SKILL_SOURCE}`,
-      );
-    }
-    throw err;
+  const results = await installBundledWorkspaceSkills({
+    dispatcherCwd: options.dispatcherCwd,
+    dryRun: options.dryRun,
+  });
+  for (const result of results) {
+    const status = result.status === 'linked'
+      ? 'created'
+      : result.status === 'replaced'
+        ? 'modified'
+        : 'unchanged';
+    options.ledger.record(
+      result.targetPath,
+      status,
+      `workspace-local bundled skill symlink: ${result.skillName}`,
+    );
   }
 }

--- a/packages/dreamux/src/onboard/dispatcher-skill.ts
+++ b/packages/dreamux/src/onboard/dispatcher-skill.ts
@@ -15,11 +15,16 @@ export async function installDispatcherSkill(options: {
       ? 'created'
       : result.status === 'replaced'
         ? 'modified'
-        : 'unchanged';
+        : result.status === 'skipped'
+          ? 'skipped'
+          : 'unchanged';
+    const reason = result.status === 'skipped'
+      ? `workspace-local bundled skill symlink skipped: ${result.skillName}; ${result.reason}`
+      : `workspace-local bundled skill symlink: ${result.skillName}`;
     options.ledger.record(
       result.targetPath,
       status,
-      `workspace-local bundled skill symlink: ${result.skillName}`,
+      reason,
     );
   }
 }

--- a/packages/dreamux/src/onboard/ledger.ts
+++ b/packages/dreamux/src/onboard/ledger.ts
@@ -17,6 +17,8 @@ import type {
   OnboardFileStatus,
 } from './types.js';
 
+type WriteFileStatus = Exclude<OnboardFileStatus, 'skipped'>;
+
 export class TransparentFileLedger implements OnboardFileLedger {
   private readonly seen = new Map<string, OnboardFileLedgerEntry>();
 
@@ -72,13 +74,13 @@ export async function writeTextFile(
   ledger: OnboardFileLedger,
   reason: string,
   options: WriteOptions = {},
-): Promise<OnboardFileStatus> {
+): Promise<WriteFileStatus> {
   const parent = dirname(path);
   await ensureDirectory(parent, ledger, `parent directory for ${reason}`, {
     dryRun: options.dryRun,
   });
 
-  let status: OnboardFileStatus;
+  let status: WriteFileStatus;
   if (!(await pathExists(path))) {
     status = 'created';
   } else {
@@ -101,7 +103,7 @@ export async function ensureTextFile(
   ledger: OnboardFileLedger,
   reason: string,
   options: WriteOptions = {},
-): Promise<OnboardFileStatus> {
+): Promise<WriteFileStatus> {
   const parent = dirname(path);
   await ensureDirectory(parent, ledger, `parent directory for ${reason}`, {
     dryRun: options.dryRun,
@@ -164,5 +166,6 @@ function mergeStatus(
 ): OnboardFileStatus {
   if (a === 'created' || b === 'created') return 'created';
   if (a === 'modified' || b === 'modified') return 'modified';
+  if (a === 'skipped' || b === 'skipped') return 'skipped';
   return 'unchanged';
 }

--- a/packages/dreamux/src/onboard/run.ts
+++ b/packages/dreamux/src/onboard/run.ts
@@ -11,7 +11,6 @@ import {
   dispatcherAppServerControlDir,
   dispatcherCodexHome,
   dispatcherWorkspaceCodexSkillsDir,
-  dispatcherWorkspaceSkillPath,
   logsRoot,
   setRuntimeConfig,
   stateRoot,
@@ -130,7 +129,7 @@ export async function runOnboard(
   );
 
   await installDispatcherSkill({
-    skillPath: dispatcherWorkspaceSkillPath(effectiveAnswers.dispatcherCwd),
+    dispatcherCwd: effectiveAnswers.dispatcherCwd,
     ledger,
     dryRun: answers.dryRun,
   });

--- a/packages/dreamux/src/onboard/types.ts
+++ b/packages/dreamux/src/onboard/types.ts
@@ -1,6 +1,6 @@
 import type { DispatcherCodexHomeDoctorResult } from '../runtime/dispatcher-codex-home.js';
 
-export type OnboardFileStatus = 'created' | 'modified' | 'unchanged';
+export type OnboardFileStatus = 'created' | 'modified' | 'unchanged' | 'skipped';
 
 export interface OnboardFileLedgerEntry {
   path: string;

--- a/packages/dreamux/src/onboard/uninstall.ts
+++ b/packages/dreamux/src/onboard/uninstall.ts
@@ -24,7 +24,7 @@ import {
   type DispatcherConfig,
 } from '../runtime/config.js';
 import {
-  dispatcherWorkspaceSkillPath,
+  dispatcherWorkspaceSkillDirs,
   logsRoot,
   stateRoot,
 } from '../runtime/paths.js';
@@ -121,18 +121,17 @@ async function warnIfConfigIsNotReadable(
 async function collectWorkspaceSkillPaths(configDir: string): Promise<string[]> {
   try {
     return (await loadConfig({ configDir })).config.dispatchers
-      .map(dispatcherWorkspaceSkillPathFromConfig)
-      .filter((path): path is string => path !== null);
+      .flatMap(dispatcherWorkspaceSkillPathsFromConfig);
   } catch {
     return [];
   }
 }
 
-function dispatcherWorkspaceSkillPathFromConfig(
+function dispatcherWorkspaceSkillPathsFromConfig(
   dispatcher: DispatcherConfig,
-): string | null {
-  if (dispatcher.cwd === null || dispatcher.cwd.trim() === '') return null;
-  return dispatcherWorkspaceSkillPath(dispatcher.cwd);
+): string[] {
+  if (dispatcher.cwd === null || dispatcher.cwd.trim() === '') return [];
+  return dispatcherWorkspaceSkillDirs(dispatcher.cwd);
 }
 
 async function reportWorkspaceSkills(
@@ -143,7 +142,7 @@ async function reportWorkspaceSkills(
     entries.push({
       path,
       status: (await pathExists(path)) ? 'skipped' : 'missing',
-      reason: 'workspace-local dispatcher skill (not removed)',
+      reason: 'workspace-local bundled skill (not removed)',
     });
   }
 }

--- a/packages/dreamux/src/runtime/bundled-skills.ts
+++ b/packages/dreamux/src/runtime/bundled-skills.ts
@@ -1,0 +1,207 @@
+import { access, lstat, mkdir, realpath, stat, symlink, unlink } from 'node:fs/promises';
+import { resolve } from 'node:path';
+
+import {
+  BUNDLED_SKILL_NAMES,
+  bundledSkillDir,
+  dispatcherWorkspaceCodexSkillsDir,
+  dispatcherWorkspaceSkillDir,
+  type BundledSkillName,
+} from './paths.js';
+
+/** Async existence probe - the fs/promises replacement for existsSync. */
+async function pathExists(path: string): Promise<boolean> {
+  try {
+    await access(path);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export type BundledSkillInstallStatus =
+  | 'linked'
+  | 'replaced'
+  | 'unchanged'
+  | 'skipped';
+
+export interface BundledSkillInstallResult {
+  skillName: BundledSkillName;
+  sourcePath: string;
+  targetPath: string;
+  status: BundledSkillInstallStatus;
+  reason: string;
+}
+
+export interface InstallBundledSkillsOptions {
+  dispatcherCwd: string;
+  dryRun?: boolean;
+  platform?: NodeJS.Platform;
+}
+
+export async function installBundledWorkspaceSkills(
+  options: InstallBundledSkillsOptions,
+): Promise<BundledSkillInstallResult[]> {
+  const platform = options.platform ?? process.platform;
+  if (platform === 'win32') {
+    throw new Error(
+      'workspace-local bundled skills require directory symlinks; Windows is not supported by this installer',
+    );
+  }
+
+  await assertDispatcherCwd(options.dispatcherCwd, options.dryRun ?? false);
+  const skillsDir = dispatcherWorkspaceCodexSkillsDir(options.dispatcherCwd);
+  if (!options.dryRun) {
+    await mkdir(skillsDir, { recursive: true });
+  }
+
+  const results: BundledSkillInstallResult[] = [];
+  for (const skillName of BUNDLED_SKILL_NAMES) {
+    results.push(
+      await installOneSkill({
+        dispatcherCwd: options.dispatcherCwd,
+        skillName,
+        dryRun: options.dryRun ?? false,
+      }),
+    );
+  }
+  return results;
+}
+
+async function assertDispatcherCwd(
+  dispatcherCwd: string,
+  allowMissing: boolean,
+): Promise<void> {
+  let info;
+  try {
+    info = await stat(dispatcherCwd);
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === 'ENOENT') {
+      if (allowMissing) return;
+      throw new Error(`dispatcher cwd does not exist: ${dispatcherCwd}`);
+    }
+    throw err;
+  }
+  if (!info.isDirectory()) {
+    throw new Error(`dispatcher cwd is not a directory: ${dispatcherCwd}`);
+  }
+}
+
+async function installOneSkill(options: {
+  dispatcherCwd: string;
+  skillName: BundledSkillName;
+  dryRun: boolean;
+}): Promise<BundledSkillInstallResult> {
+  const sourcePath = bundledSkillDir(options.skillName);
+  const targetPath = dispatcherWorkspaceSkillDir(
+    options.dispatcherCwd,
+    options.skillName,
+  );
+  await assertBundledSkillSource(options.skillName, sourcePath);
+
+  let targetInfo;
+  try {
+    targetInfo = await lstat(targetPath);
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code !== 'ENOENT') throw err;
+  }
+
+  if (targetInfo === undefined) {
+    if (!options.dryRun) {
+      await createSkillSymlink(sourcePath, targetPath, options.skillName);
+    }
+    return {
+      skillName: options.skillName,
+      sourcePath,
+      targetPath,
+      status: 'linked',
+      reason: 'created workspace-local bundled skill symlink',
+    };
+  }
+
+  if (!targetInfo.isSymbolicLink()) {
+    return {
+      skillName: options.skillName,
+      sourcePath,
+      targetPath,
+      status: 'skipped',
+      reason:
+        'existing non-symlink skill path was left untouched; remove or rename it to use the bundled skill',
+    };
+  }
+
+  const currentTarget = await resolvedSymlinkTarget(targetPath);
+  const sourceRealPath = await realpath(sourcePath);
+  if (currentTarget === sourceRealPath) {
+    return {
+      skillName: options.skillName,
+      sourcePath,
+      targetPath,
+      status: 'unchanged',
+      reason: 'workspace-local bundled skill symlink already points to this package',
+    };
+  }
+
+  if (!options.dryRun) {
+    await unlink(targetPath);
+    await createSkillSymlink(sourcePath, targetPath, options.skillName);
+  }
+  return {
+    skillName: options.skillName,
+    sourcePath,
+    targetPath,
+    status: 'replaced',
+    reason: 'replaced stale or broken workspace-local bundled skill symlink',
+  };
+}
+
+async function assertBundledSkillSource(
+  skillName: BundledSkillName,
+  sourcePath: string,
+): Promise<void> {
+  let info;
+  try {
+    info = await stat(sourcePath);
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === 'ENOENT') {
+      throw new Error(`missing bundled skill '${skillName}': ${sourcePath}`);
+    }
+    throw err;
+  }
+  if (!info.isDirectory()) {
+    throw new Error(`bundled skill '${skillName}' is not a directory: ${sourcePath}`);
+  }
+  const skillFile = resolve(sourcePath, 'SKILL.md');
+  if (!(await pathExists(skillFile))) {
+    throw new Error(`bundled skill '${skillName}' is missing SKILL.md: ${skillFile}`);
+  }
+}
+
+async function resolvedSymlinkTarget(path: string): Promise<string | null> {
+  try {
+    return await realpath(path);
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code !== 'ENOENT') throw err;
+    return null;
+  }
+}
+
+async function createSkillSymlink(
+  sourcePath: string,
+  targetPath: string,
+  skillName: BundledSkillName,
+): Promise<void> {
+  try {
+    await symlink(sourcePath, targetPath, 'dir');
+  } catch (err) {
+    const detail = err instanceof Error ? err.message : String(err);
+    const code = (err as NodeJS.ErrnoException).code;
+    const hint =
+      code === 'EPERM' || code === 'EACCES' || code === 'ENOTSUP' || code === 'EINVAL'
+        ? ' Check filesystem permissions and symlink support; dreamux does not copy bundled skills as a fallback.'
+        : '';
+    throw new Error(
+      `failed to install bundled skill '${skillName}' as a symlink at ${targetPath}: ${detail}.${hint}`,
+    );
+  }
+}

--- a/packages/dreamux/src/runtime/bundled-skills.ts
+++ b/packages/dreamux/src/runtime/bundled-skills.ts
@@ -1,5 +1,17 @@
-import { access, lstat, mkdir, realpath, stat, symlink, unlink } from 'node:fs/promises';
-import { resolve } from 'node:path';
+import { createHash, randomUUID } from 'node:crypto';
+import {
+  access,
+  lstat,
+  mkdir,
+  readFile,
+  readdir,
+  realpath,
+  rename,
+  rm,
+  stat,
+  symlink,
+} from 'node:fs/promises';
+import { dirname, resolve } from 'node:path';
 
 import {
   BUNDLED_SKILL_NAMES,
@@ -24,6 +36,12 @@ export type BundledSkillInstallStatus =
   | 'replaced'
   | 'unchanged'
   | 'skipped';
+
+const LEGACY_COPIED_DISPATCHER_SKILL_SHA256 = new Set([
+  // Pre-symlink Dreamux wrote exactly this dispatcher SKILL.md copy.
+  // Only exact unmodified copies are migrated automatically.
+  '4dca0986d2e7ecde171ac3436718eaa1fefe599dacfdc2d20c90d2cf1d443be1',
+]);
 
 export interface BundledSkillInstallResult {
   skillName: BundledSkillName;
@@ -120,6 +138,28 @@ async function installOneSkill(options: {
   }
 
   if (!targetInfo.isSymbolicLink()) {
+    const legacyCopiedSkill = await isLegacyCopiedDispatcherSkill({
+      skillName: options.skillName,
+      targetPath,
+      targetInfo,
+    });
+    if (legacyCopiedSkill) {
+      if (!options.dryRun) {
+        await replaceLegacyCopiedDirectoryWithSymlink(
+          sourcePath,
+          targetPath,
+          options.skillName,
+        );
+      }
+      return {
+        skillName: options.skillName,
+        sourcePath,
+        targetPath,
+        status: 'replaced',
+        reason:
+          'migrated a legacy Dreamux-copied dispatcher skill directory to the bundled symlink',
+      };
+    }
     return {
       skillName: options.skillName,
       sourcePath,
@@ -143,8 +183,7 @@ async function installOneSkill(options: {
   }
 
   if (!options.dryRun) {
-    await unlink(targetPath);
-    await createSkillSymlink(sourcePath, targetPath, options.skillName);
+    await replaceSkillSymlink(sourcePath, targetPath, options.skillName);
   }
   return {
     skillName: options.skillName,
@@ -177,6 +216,28 @@ async function assertBundledSkillSource(
   }
 }
 
+async function isLegacyCopiedDispatcherSkill(options: {
+  skillName: BundledSkillName;
+  targetPath: string;
+  targetInfo: Awaited<ReturnType<typeof lstat>>;
+}): Promise<boolean> {
+  if (options.skillName !== 'dispatcher' || !options.targetInfo.isDirectory()) {
+    return false;
+  }
+  try {
+    const entries = await readdir(options.targetPath);
+    if (entries.length !== 1 || entries[0] !== 'SKILL.md') return false;
+    const skillFile = resolve(options.targetPath, 'SKILL.md');
+    const skillInfo = await stat(skillFile);
+    if (!skillInfo.isFile()) return false;
+    const content = await readFile(skillFile);
+    const hash = createHash('sha256').update(content).digest('hex');
+    return LEGACY_COPIED_DISPATCHER_SKILL_SHA256.has(hash);
+  } catch {
+    return false;
+  }
+}
+
 async function resolvedSymlinkTarget(path: string): Promise<string | null> {
   try {
     return await realpath(path);
@@ -202,6 +263,55 @@ async function createSkillSymlink(
         : '';
     throw new Error(
       `failed to install bundled skill '${skillName}' as a symlink at ${targetPath}: ${detail}.${hint}`,
+    );
+  }
+}
+
+async function replaceSkillSymlink(
+  sourcePath: string,
+  targetPath: string,
+  skillName: BundledSkillName,
+): Promise<void> {
+  const temporaryTarget = resolve(
+    dirname(targetPath),
+    `.${skillName}.dreamux-next-${randomUUID()}`,
+  );
+  try {
+    await createSkillSymlink(sourcePath, temporaryTarget, skillName);
+    await rename(temporaryTarget, targetPath);
+  } catch (err) {
+    await rm(temporaryTarget, { force: true, recursive: false }).catch(() => {});
+    const detail = err instanceof Error ? err.message : String(err);
+    throw new Error(
+      `failed to replace bundled skill '${skillName}' symlink at ${targetPath}: ${detail}`,
+    );
+  }
+}
+
+async function replaceLegacyCopiedDirectoryWithSymlink(
+  sourcePath: string,
+  targetPath: string,
+  skillName: BundledSkillName,
+): Promise<void> {
+  const parent = dirname(targetPath);
+  const suffix = randomUUID();
+  const temporaryLink = resolve(parent, `.${skillName}.dreamux-next-${suffix}`);
+  const backupPath = resolve(parent, `.${skillName}.dreamux-legacy-${suffix}`);
+  let backupCreated = false;
+  try {
+    await createSkillSymlink(sourcePath, temporaryLink, skillName);
+    await rename(targetPath, backupPath);
+    backupCreated = true;
+    await rename(temporaryLink, targetPath);
+    await rm(backupPath, { recursive: true });
+  } catch (err) {
+    await rm(temporaryLink, { force: true, recursive: false }).catch(() => {});
+    if (backupCreated && !(await pathExists(targetPath))) {
+      await rename(backupPath, targetPath).catch(() => {});
+    }
+    const detail = err instanceof Error ? err.message : String(err);
+    throw new Error(
+      `failed to migrate legacy copied bundled skill '${skillName}' at ${targetPath}: ${detail}`,
     );
   }
 }

--- a/packages/dreamux/src/runtime/paths.ts
+++ b/packages/dreamux/src/runtime/paths.ts
@@ -21,7 +21,8 @@
  */
 
 import { homedir } from 'node:os';
-import { join } from 'node:path';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
 
 import {
   BUILT_IN_DEFAULTS,
@@ -30,6 +31,16 @@ import {
 import { validateDispatcherId } from './dispatcher-id.js';
 
 export const DREAMUX_UNIX_SOCKET_PATH_MAX_BYTES = 103;
+const HERE = dirname(fileURLToPath(import.meta.url));
+const PACKAGE_ROOT = dirname(dirname(HERE));
+
+export const BUNDLED_SKILL_NAMES = [
+  'dispatcher',
+  'team-dev-workflow',
+  'dreamux-maintenance',
+] as const;
+
+export type BundledSkillName = typeof BUNDLED_SKILL_NAMES[number];
 
 let currentConfig: DreamuxConfig = BUILT_IN_DEFAULTS;
 
@@ -116,8 +127,29 @@ export function dispatcherWorkspaceCodexSkillsDir(cwd: string): string {
   return join(cwd, '.codex', 'skills');
 }
 
+export function dispatcherWorkspaceSkillDir(
+  cwd: string,
+  skillName: BundledSkillName,
+): string {
+  return join(dispatcherWorkspaceCodexSkillsDir(cwd), skillName);
+}
+
+export function dispatcherWorkspaceSkillDirs(cwd: string): string[] {
+  return BUNDLED_SKILL_NAMES.map((skillName) =>
+    dispatcherWorkspaceSkillDir(cwd, skillName),
+  );
+}
+
 export function dispatcherWorkspaceSkillPath(cwd: string): string {
-  return join(dispatcherWorkspaceCodexSkillsDir(cwd), 'dispatcher', 'SKILL.md');
+  return join(dispatcherWorkspaceSkillDir(cwd, 'dispatcher'), 'SKILL.md');
+}
+
+export function bundledSkillsDir(): string {
+  return join(PACKAGE_ROOT, 'skills');
+}
+
+export function bundledSkillDir(skillName: BundledSkillName): string {
+  return join(bundledSkillsDir(), skillName);
 }
 
 export function dispatcherAppServerControlDir(id: string): string {

--- a/packages/dreamux/tests/bundled-skills.test.ts
+++ b/packages/dreamux/tests/bundled-skills.test.ts
@@ -76,6 +76,42 @@ describe('bundled workspace skill installer', () => {
     expect(realpathSync(target)).toBe(realpathSync(bundledSkillDir('dispatcher')));
   });
 
+  it('migrates the legacy copied dispatcher skill directory to a symlink', async () => {
+    const target = dispatcherWorkspaceSkillDir(dispatcherCwd, 'dispatcher');
+    mkdirSync(target, { recursive: true });
+    writeFileSync(join(target, 'SKILL.md'), LEGACY_COPIED_DISPATCHER_SKILL);
+
+    const results = await installBundledWorkspaceSkills({ dispatcherCwd });
+    const dispatcherResult = results.find((result) =>
+      result.skillName === 'dispatcher'
+    );
+
+    expect(dispatcherResult?.status).toBe('replaced');
+    expect(dispatcherResult?.reason).toContain('legacy Dreamux-copied');
+    expect(lstatSync(target).isSymbolicLink()).toBe(true);
+    expect(realpathSync(target)).toBe(realpathSync(bundledSkillDir('dispatcher')));
+  });
+
+  it('does not migrate a modified legacy dispatcher skill directory', async () => {
+    const target = dispatcherWorkspaceSkillDir(dispatcherCwd, 'dispatcher');
+    mkdirSync(target, { recursive: true });
+    writeFileSync(
+      join(target, 'SKILL.md'),
+      `${LEGACY_COPIED_DISPATCHER_SKILL}\n# local edit\n`,
+    );
+
+    const results = await installBundledWorkspaceSkills({ dispatcherCwd });
+    const dispatcherResult = results.find((result) =>
+      result.skillName === 'dispatcher'
+    );
+
+    expect(dispatcherResult?.status).toBe('skipped');
+    expect(lstatSync(target).isSymbolicLink()).toBe(false);
+    expect(readFileSync(join(target, 'SKILL.md'), 'utf8')).toContain(
+      '# local edit',
+    );
+  });
+
   it('does not overwrite an existing real skill directory', async () => {
     const target = dispatcherWorkspaceSkillDir(dispatcherCwd, 'team-dev-workflow');
     mkdirSync(target, { recursive: true });
@@ -89,6 +125,21 @@ describe('bundled workspace skill installer', () => {
     expect(conflict?.status).toBe('skipped');
     expect(lstatSync(target).isSymbolicLink()).toBe(false);
     expect(readFileSync(join(target, 'SKILL.md'), 'utf8')).toBe('# user skill\n');
+  });
+
+  it('does not overwrite an existing real skill file', async () => {
+    const target = dispatcherWorkspaceSkillDir(dispatcherCwd, 'dreamux-maintenance');
+    mkdirSync(dirname(target), { recursive: true });
+    writeFileSync(target, '# user file skill\n');
+
+    const results = await installBundledWorkspaceSkills({ dispatcherCwd });
+    const conflict = results.find((result) =>
+      result.skillName === 'dreamux-maintenance'
+    );
+
+    expect(conflict?.status).toBe('skipped');
+    expect(lstatSync(target).isFile()).toBe(true);
+    expect(readFileSync(target, 'utf8')).toBe('# user file skill\n');
   });
 
   it('rejects a missing dispatcher cwd instead of creating it', async () => {
@@ -117,3 +168,112 @@ describe('bundled workspace skill installer', () => {
     ).rejects.toThrow('directory symlinks');
   });
 });
+
+const LEGACY_COPIED_DISPATCHER_SKILL = `---
+name: dispatcher
+description: Use from a dreamux dispatcher thread when work should be delegated to a tm-managed Codex teammate in a specific repository. Applies to bounded engineering tasks, test runs, codebase inspections, or follow-up work where the dispatcher should spawn/send/wait through the tm CLI exposed by the dreamux package and report the result back to the source chat.
+---
+
+# Dispatcher
+
+Use this skill only from the dispatcher agent. The dreamux server hosts the
+dispatcher lifecycle; it does not own tm teammate daemons, teammate DB rows, or
+\`teammate.*\` admin methods.
+
+## Boundaries
+
+- Use \`tm\` from the dispatcher environment PATH. dreamux injects its package
+  \`bin/\` directory into the dispatcher Codex app-server PATH.
+- Pass \`--engine codex\` on every \`tm spawn\`; \`tm spawn\` defaults to Claude.
+- Do not use \`npx\`, \`npm exec --package @excitedjs/tm\`, or
+  \`@excitedjs/tm@latest\`; the dreamux package owns the tm dependency version.
+- Do not call dreamux admin APIs to create teammate state.
+- Do not infer the tm repo path from the dispatcher cwd unless the user or
+  operator explicitly made that cwd the requested repo.
+- Do not ask a tm-managed teammate to spawn another tm teammate.
+
+## Before Delegating
+
+Delegate when the request is bounded and can be completed by one teammate:
+running tests, inspecting a code path, drafting a narrow patch, or collecting a
+specific result. Handle the work directly when the request is tiny, ambiguous,
+security-sensitive, or missing a repository path.
+
+Resolve the repo path in this order:
+
+1. An absolute path in the user request.
+2. \`TM_DISPATCHER_DIR\`, if set by the operator.
+3. Ask the user for the repo path. Do not guess.
+
+Use an absolute repo path for \`tm spawn\`. If the user gives a relative path,
+make it absolute only when its base is explicit.
+
+## Command Shape
+
+Preflight once per dispatcher session:
+
+\`\`\`bash
+tm --help
+\`\`\`
+
+## First-Turn Delegation
+
+1. Pick a flat teammate name: lowercase letters, digits, and hyphens; keep it
+   short and tied to the task, such as \`tests-api\` or \`scan-auth\`.
+2. Spawn with the repo path, intent, and the full task prompt:
+
+\`\`\`bash
+tm spawn /absolute/repo \\
+  --name tests-api \\
+  --engine codex \\
+  --timeout 180 \\
+  --intent "Run focused API tests and summarize failures" \\
+  --prompt "Run the focused API tests. Report commands, failures, and the smallest next fix."
+\`\`\`
+
+3. If \`tm spawn\` exits \`0\`, use its printed reply as the teammate result. If it
+   exits \`124\`, the Codex turn did not finish within the sync window; wait
+   without \`--fresh\`:
+
+\`\`\`bash
+tm wait tests-api --timeout 180
+\`\`\`
+
+4. Reply to the source chat with the teammate result, including the command
+   summary and any explicit failure.
+
+## Follow-Up Delegation
+
+If a teammate name already exists for the same task, send a follow-up instead
+of spawning a duplicate:
+
+\`\`\`bash
+tm send tests-api \\
+  --prompt "Use the previous context. Re-run the focused test after the latest fix and summarize only changed results."
+tm wait tests-api --timeout 180
+\`\`\`
+
+## Failure Reporting
+
+When a tm command fails, stop the delegation sequence and report:
+
+- which \`tm\` verb failed
+- the teammate name and repo path
+- the exit status if available
+- the first useful stderr/stdout lines
+- whether retrying the same teammate is safe
+
+Known early startup failure to report verbatim:
+
+\`\`\`text
+codex daemon (pid N) exited before binding /tmp/teammate-codex/<name>/socket
+\`\`\`
+
+That means the Codex app-server daemon did not become reachable. Do not retry
+silently; report the environment failure and ask the operator to verify
+\`codex app-server --listen unix:///tmp/dispatcher-check.sock\` in the dispatcher
+environment.
+
+Do not say the dreamux server lost or recovered teammate state. The server does
+not own that state.
+`;

--- a/packages/dreamux/tests/bundled-skills.test.ts
+++ b/packages/dreamux/tests/bundled-skills.test.ts
@@ -1,0 +1,119 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import {
+  existsSync,
+  lstatSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  realpathSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+
+import {
+  installBundledWorkspaceSkills,
+} from '../src/runtime/bundled-skills.js';
+import {
+  BUNDLED_SKILL_NAMES,
+  bundledSkillDir,
+  dispatcherWorkspaceSkillDir,
+} from '../src/runtime/paths.js';
+
+describe('bundled workspace skill installer', () => {
+  let root: string;
+  let dispatcherCwd: string;
+
+  beforeEach(() => {
+    root = mkdtempSync(join(tmpdir(), 'dreamux-bundled-skills-'));
+    dispatcherCwd = join(root, 'dispatcher');
+    mkdirSync(dispatcherCwd, { recursive: true });
+  });
+
+  afterEach(() => {
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  it('installs every bundled skill as a workspace-local symlink', async () => {
+    const results = await installBundledWorkspaceSkills({ dispatcherCwd });
+
+    expect(results.map((result) => [result.skillName, result.status])).toEqual(
+      BUNDLED_SKILL_NAMES.map((skillName) => [skillName, 'linked']),
+    );
+    for (const skillName of BUNDLED_SKILL_NAMES) {
+      const target = dispatcherWorkspaceSkillDir(dispatcherCwd, skillName);
+      expect(lstatSync(target).isSymbolicLink()).toBe(true);
+      expect(realpathSync(target)).toBe(realpathSync(bundledSkillDir(skillName)));
+      expect(existsSync(join(target, 'SKILL.md'))).toBe(true);
+    }
+  });
+
+  it('leaves correct symlinks unchanged on repeated installs', async () => {
+    await installBundledWorkspaceSkills({ dispatcherCwd });
+
+    const second = await installBundledWorkspaceSkills({ dispatcherCwd });
+
+    expect(second.map((result) => result.status)).toEqual(
+      BUNDLED_SKILL_NAMES.map(() => 'unchanged'),
+    );
+  });
+
+  it('replaces stale or broken skill symlinks', async () => {
+    const wrongTarget = join(root, 'old-skill');
+    const target = dispatcherWorkspaceSkillDir(dispatcherCwd, 'dispatcher');
+    mkdirSync(wrongTarget, { recursive: true });
+    mkdirSync(dirname(target), { recursive: true });
+    symlinkSync(wrongTarget, target, 'dir');
+
+    const results = await installBundledWorkspaceSkills({ dispatcherCwd });
+    const dispatcherResult = results.find((result) =>
+      result.skillName === 'dispatcher'
+    );
+
+    expect(dispatcherResult?.status).toBe('replaced');
+    expect(realpathSync(target)).toBe(realpathSync(bundledSkillDir('dispatcher')));
+  });
+
+  it('does not overwrite an existing real skill directory', async () => {
+    const target = dispatcherWorkspaceSkillDir(dispatcherCwd, 'team-dev-workflow');
+    mkdirSync(target, { recursive: true });
+    writeFileSync(join(target, 'SKILL.md'), '# user skill\n');
+
+    const results = await installBundledWorkspaceSkills({ dispatcherCwd });
+    const conflict = results.find((result) =>
+      result.skillName === 'team-dev-workflow'
+    );
+
+    expect(conflict?.status).toBe('skipped');
+    expect(lstatSync(target).isSymbolicLink()).toBe(false);
+    expect(readFileSync(join(target, 'SKILL.md'), 'utf8')).toBe('# user skill\n');
+  });
+
+  it('rejects a missing dispatcher cwd instead of creating it', async () => {
+    await expect(
+      installBundledWorkspaceSkills({ dispatcherCwd: join(root, 'missing') }),
+    ).rejects.toThrow('dispatcher cwd does not exist');
+  });
+
+  it('allows missing dispatcher cwd during dry-run planning', async () => {
+    const missing = join(root, 'dry-run-missing');
+
+    const results = await installBundledWorkspaceSkills({
+      dispatcherCwd: missing,
+      dryRun: true,
+    });
+
+    expect(results.map((result) => result.status)).toEqual(
+      BUNDLED_SKILL_NAMES.map(() => 'linked'),
+    );
+    expect(existsSync(missing)).toBe(false);
+  });
+
+  it('fails explicitly on Windows instead of copying skills', async () => {
+    await expect(
+      installBundledWorkspaceSkills({ dispatcherCwd, platform: 'win32' }),
+    ).rejects.toThrow('directory symlinks');
+  });
+});

--- a/packages/dreamux/tests/codex-live.test.ts
+++ b/packages/dreamux/tests/codex-live.test.ts
@@ -26,7 +26,7 @@
 import { describe, it, expect } from 'vitest';
 // eslint-disable-next-line no-restricted-imports -- live-Codex probe: a one-shot `execSync` reads the operator's interactive Codex auth/login state to decide whether the live model-gate case can run at all; it is setup, not the code under test, and must complete before the suite proceeds (issue #85 test-scope carve-out).
 import { execSync } from 'node:child_process';
-import { existsSync, mkdtempSync, rmSync } from 'node:fs';
+import { existsSync, mkdirSync, mkdtempSync, rmSync } from 'node:fs';
 import { homedir } from 'node:os';
 import { isAbsolute, join } from 'node:path';
 
@@ -442,6 +442,7 @@ describe('codex live integration', () => {
       let client: RecordingCodexWsClient | null = null;
       let server: Server | null = null;
 
+      mkdirSync(dispatcherCwd, { recursive: true });
       process.env['HOME'] = runtimeHome;
       process.env['CODEX_HOME'] = previousCodexHome ?? join(operatorHome, '.codex');
       // Onboard the live sender onto the global allow-user list so the folded

--- a/packages/dreamux/tests/e2e.test.ts
+++ b/packages/dreamux/tests/e2e.test.ts
@@ -6,7 +6,7 @@ import {
   writeFileSync,
 } from 'node:fs';
 import { tmpdir } from 'node:os';
-import { dirname, join } from 'node:path';
+import { join } from 'node:path';
 import { PassThrough } from 'node:stream';
 
 import {
@@ -34,7 +34,6 @@ import { BUILT_IN_DEFAULTS, type DreamuxConfig } from '../src/runtime/config.js'
 import {
   dispatcherCodexCwd,
   dispatcherCodexHome,
-  dispatcherWorkspaceSkillPath,
 } from '../src/runtime/paths.js';
 import { startFakeCodex, type FakeCodex } from './fake-codex.js';
 
@@ -223,11 +222,7 @@ function writeReadyDispatcherWorkspace(dispatcherId: string): void {
   writeFileSync(join(dispatcherCodexHome(dispatcherId), 'auth.json'), '{}', {
     mode: 0o600,
   });
-  const skillPath = dispatcherWorkspaceSkillPath(
-    dispatcherCodexCwd(dispatcherId),
-  );
-  mkdirSync(dirname(skillPath), { recursive: true });
-  writeFileSync(skillPath, '# test skill\n');
+  mkdirSync(dispatcherCodexCwd(dispatcherId), { recursive: true });
 }
 
 describe('dreamux cross-module e2e', () => {

--- a/packages/dreamux/tests/onboard.test.ts
+++ b/packages/dreamux/tests/onboard.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import {
   existsSync,
+  lstatSync,
   mkdirSync,
   mkdtempSync,
   readFileSync,
@@ -21,6 +22,7 @@ import type { CommandRunner, OnboardAnswers } from '../src/onboard/types.js';
 import type { ServiceNodeProbe } from '../src/onboard/service.js';
 import {
   dispatcherCodexHome,
+  dispatcherWorkspaceSkillDirs,
   dispatcherWorkspaceSkillPath,
   logsRoot,
   resetRuntimeConfig,
@@ -201,6 +203,9 @@ describe('dreamux onboard', () => {
     expect(
       existsSync(dispatcherWorkspaceSkillPath(answers.dispatcherCwd)),
     ).toBe(true);
+    for (const skillDir of dispatcherWorkspaceSkillDirs(answers.dispatcherCwd)) {
+      expect(lstatSync(skillDir).isSymbolicLink()).toBe(true);
+    }
     expect(
       existsSync(
         join(dispatcherCodexHome('flow'), 'skills', 'dispatcher', 'SKILL.md'),
@@ -210,9 +215,9 @@ describe('dreamux onboard', () => {
     expect(ledger.get(join(root, 'config', 'config.json'))?.status).toBe(
       'created',
     );
-    expect(
-      ledger.get(dispatcherWorkspaceSkillPath(answers.dispatcherCwd))?.status,
-    ).toBe('created');
+    for (const skillDir of dispatcherWorkspaceSkillDirs(answers.dispatcherCwd)) {
+      expect(ledger.get(skillDir)?.status).toBe('created');
+    }
     expect(
       ledger.get(
         join(root, 'home', '.config', 'systemd', 'user', 'dreamux.service'),

--- a/packages/dreamux/tests/onboard.test.ts
+++ b/packages/dreamux/tests/onboard.test.ts
@@ -23,6 +23,7 @@ import type { ServiceNodeProbe } from '../src/onboard/service.js';
 import {
   dispatcherCodexHome,
   dispatcherWorkspaceSkillDirs,
+  dispatcherWorkspaceSkillDir,
   dispatcherWorkspaceSkillPath,
   logsRoot,
   resetRuntimeConfig,
@@ -236,6 +237,39 @@ describe('dreamux onboard', () => {
     ).toBe('created');
     expect(result.files.map((entry) => entry.reason)).not.toContain(
       'dispatcher database',
+    );
+  });
+
+  it('reports skipped bundled skill conflicts during onboard', async () => {
+    const runner = new FakeRunner();
+    const answers = testAnswers({
+      configDir: join(root, 'config'),
+      runtimeDir: join(root, 'runtime'),
+      registerService: false,
+      startService: false,
+    });
+    writeGlobalCodexAuth(answers);
+    const conflictDir = dispatcherWorkspaceSkillDir(
+      answers.dispatcherCwd,
+      'dreamux-maintenance',
+    );
+    mkdirSync(conflictDir, { recursive: true });
+    writeFileSync(join(conflictDir, 'SKILL.md'), '# user maintenance skill\n');
+
+    const result = await runOnboard({
+      answers,
+      runner,
+      platform: 'linux',
+      homeDir: join(root, 'home'),
+      env: {},
+      nodeProbe: noSystemNodeProbe,
+    });
+
+    const ledger = new Map(result.files.map((entry) => [entry.path, entry]));
+    expect(ledger.get(conflictDir)?.status).toBe('skipped');
+    expect(ledger.get(conflictDir)?.reason).toContain('left untouched');
+    expect(readFileSync(join(conflictDir, 'SKILL.md'), 'utf8')).toBe(
+      '# user maintenance skill\n',
     );
   });
 

--- a/packages/dreamux/tests/runtime-paths.test.ts
+++ b/packages/dreamux/tests/runtime-paths.test.ts
@@ -5,6 +5,7 @@ import { join } from 'node:path';
 
 import {
   DREAMUX_UNIX_SOCKET_PATH_MAX_BYTES,
+  BUNDLED_SKILL_NAMES,
   adminSocketPath,
   codexAppServerLogDir,
   dispatcherAccessPath,
@@ -19,6 +20,7 @@ import {
   dispatcherSocketPath,
   dispatcherStatusPath,
   dispatcherWorkspaceCodexSkillsDir,
+  dispatcherWorkspaceSkillDirs,
   dispatcherWorkspaceSkillPath,
   dreamuxRoot,
   logsRoot,
@@ -79,6 +81,11 @@ describe('runtime paths', () => {
     );
     expect(dispatcherWorkspaceSkillPath(workspace)).toBe(
       join(workspace, '.codex', 'skills', 'dispatcher', 'SKILL.md'),
+    );
+    expect(dispatcherWorkspaceSkillDirs(workspace)).toEqual(
+      BUNDLED_SKILL_NAMES.map((skillName) =>
+        join(workspace, '.codex', 'skills', skillName),
+      ),
     );
   });
 

--- a/packages/dreamux/tests/smoke.test.ts
+++ b/packages/dreamux/tests/smoke.test.ts
@@ -13,8 +13,10 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import {
   existsSync,
+  lstatSync,
   mkdirSync,
   mkdtempSync,
+  realpathSync,
   rmSync,
   writeFileSync,
 } from 'node:fs';
@@ -47,7 +49,8 @@ import {
   dispatcherAppServerControlDir,
   dispatcherCodexCwd,
   dispatcherCodexHome,
-  dispatcherWorkspaceSkillPath,
+  bundledSkillDir,
+  dispatcherWorkspaceSkillDir,
   dispatcherSocketPath,
   restartIntentPath,
 } from '../src/runtime/paths.js';
@@ -232,11 +235,7 @@ function writeReadyDispatcherCodexHome(dispatcherId: string, dispatcherCwd?: str
   writeFileSync(join(dispatcherCodexHome(dispatcherId), 'auth.json'), '{}', {
     mode: 0o600,
   });
-  const skillPath = dispatcherWorkspaceSkillPath(
-    dispatcherCwd ?? dispatcherCodexCwd(dispatcherId),
-  );
-  mkdirSync(dirname(skillPath), { recursive: true });
-  writeFileSync(skillPath, '# test skill\n');
+  mkdirSync(dispatcherCwd ?? dispatcherCodexCwd(dispatcherId), { recursive: true });
 }
 
 function configWithDispatcher(
@@ -369,6 +368,14 @@ describe('dreamux MVP smoke', () => {
     expect(capturedCodexOptions[0]?.env?.['PATH']).toContain('/bin');
     expect(capturedCodexOptions[0]?.socketPath).toBe(
       dispatcherSocketPath('flow'),
+    );
+    const dispatcherSkillDir = dispatcherWorkspaceSkillDir(
+      dispatcherCodexCwd('flow'),
+      'dispatcher',
+    );
+    expect(lstatSync(dispatcherSkillDir).isSymbolicLink()).toBe(true);
+    expect(realpathSync(dispatcherSkillDir)).toBe(
+      realpathSync(bundledSkillDir('dispatcher')),
     );
   });
 

--- a/packages/dreamux/tests/smoke.test.ts
+++ b/packages/dreamux/tests/smoke.test.ts
@@ -276,6 +276,7 @@ describe('dreamux MVP smoke', () => {
     runtimeDir = mkdtempSync(join(tmpdir(), 'dreamux-'));
     previousHome = process.env['HOME'];
     process.env['HOME'] = join(runtimeDir, 'home');
+    mkdirSync(dispatcherCodexCwd('flow'), { recursive: true });
     codexInputs = [];
     fake = await startFakeCodex({
       replyFor: captureAndEchoCodexInput(codexInputs),

--- a/packages/dreamux/tests/uninstall.test.ts
+++ b/packages/dreamux/tests/uninstall.test.ts
@@ -13,7 +13,7 @@ import { dirname, join } from 'node:path';
 import { runUninstall } from '../src/onboard/uninstall.js';
 import type { CommandRunner } from '../src/onboard/types.js';
 import {
-  dispatcherWorkspaceSkillPath,
+  dispatcherWorkspaceSkillDirs,
   logsRoot,
   resetRuntimeConfig,
   stateRoot,
@@ -60,12 +60,14 @@ describe('dreamux uninstall', () => {
     const homeDir = join(root, 'home');
     const servicePath = join(homeDir, '.config', 'systemd', 'user', 'dreamux.service');
     const dispatcherCwd = join(root, 'workspace');
-    const workspaceSkillPath = dispatcherWorkspaceSkillPath(dispatcherCwd);
+    const workspaceSkillDirs = dispatcherWorkspaceSkillDirs(dispatcherCwd);
     mkdirSync(configDir, { recursive: true });
     mkdirSync(stateRoot(), { recursive: true });
     mkdirSync(logsRoot(), { recursive: true });
     mkdirSync(dirname(servicePath), { recursive: true });
-    mkdirSync(dirname(workspaceSkillPath), { recursive: true });
+    for (const skillDir of workspaceSkillDirs) {
+      mkdirSync(skillDir, { recursive: true });
+    }
     writeFileSync(join(configDir, 'config.json'), JSON.stringify({
       dispatchers: [
         {
@@ -85,7 +87,9 @@ describe('dreamux uninstall', () => {
       ],
     }), { mode: 0o600 });
     writeFileSync(join(logsRoot(), 'dreamux-server.log'), '');
-    writeFileSync(workspaceSkillPath, '# workspace skill\n');
+    for (const skillDir of workspaceSkillDirs) {
+      writeFileSync(join(skillDir, 'SKILL.md'), '# workspace skill\n');
+    }
     writeFileSync(servicePath, '[Service]\nExecStart=dreamux serve\n');
 
     const runner = new FakeRunner();
@@ -100,18 +104,20 @@ describe('dreamux uninstall', () => {
     expect(existsSync(stateRoot())).toBe(false);
     expect(existsSync(logsRoot())).toBe(false);
     expect(existsSync(servicePath)).toBe(false);
-    expect(existsSync(workspaceSkillPath)).toBe(true);
+    for (const skillDir of workspaceSkillDirs) {
+      expect(existsSync(skillDir)).toBe(true);
+    }
     expect(result.entries).toEqual(
       expect.arrayContaining([
         { status: 'removed', path: configDir, reason: 'dreamux config directory' },
         { status: 'removed', path: servicePath, reason: 'systemd unit' },
         { status: 'removed', path: stateRoot(), reason: 'dreamux state directory' },
         { status: 'removed', path: logsRoot(), reason: 'dreamux logs directory' },
-        {
-          status: 'skipped',
-          path: workspaceSkillPath,
-          reason: 'workspace-local dispatcher skill (not removed)',
-        },
+        ...workspaceSkillDirs.map((skillDir) => ({
+          status: 'skipped' as const,
+          path: skillDir,
+          reason: 'workspace-local bundled skill (not removed)',
+        })),
       ]),
     );
     expect(runner.calls.map((call) => [call.command, call.args])).toEqual([


### PR DESCRIPTION
## 变更

Closes #93

- 将三套英文、通用、脱敏的 Codex skills 放入 `@excitedjs/dreamux` 包内：
  - `dispatcher`
  - `team-dev-workflow`
  - `dreamux-maintenance`
- 新增 bundled skill installer，在 onboarding 和 dispatcher daemon 启动时把内置 skill 目录软链到 `<dispatcher cwd>/.codex/skills/<skill-name>`。
- 安装策略：正确软链不变；旧坏软链替换；真实用户目录/文件不覆盖并记录诊断；缺失 `.codex/skills` 自动创建；缺失 dispatcher cwd 或不支持软链的平台/权限错误会明确失败。
- 更新 uninstall 报告、运行时路径、测试 fixture、以及 `.agents/` 中的技能安装约定说明。

## 验证

- `node common/scripts/install-run-rush.js update`
- `node common/scripts/install-run-rush.js build --to @excitedjs/dreamux`
- `node common/scripts/install-run-rush.js test --to @excitedjs/dreamux`
- `node common/scripts/install-run-rush.js lint --to @excitedjs/dreamux`
- `.agents/scripts/check.sh`
- `npm pack --dry-run --json`（确认 `skills/dispatcher`、`skills/team-dev-workflow`、`skills/dreamux-maintenance` 均进入包内容）

## 注意

本地 pre-commit 提示未安装 `gitleaks`，因此本地 anti-leak 扫描跳过；CI 仍会执行仓库的 gitleaks gate。