### PR TITLE
扩充内置 dispatcher skill 的工作流指引

### DIFF
--- a/common/changes/@excitedjs/dreamux/dispatcher-skill-workflow-guidance_2026-06-05-19-30.json
+++ b/common/changes/@excitedjs/dreamux/dispatcher-skill-workflow-guidance_2026-06-05-19-30.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Restructure the bundled dispatcher skill into a router plus references, make the teammate engine a deliberate explicit choice instead of forcing codex, and add prompt-composition, router-posture, and inspect/resume workflow guidance.",
+      "type": "patch",
+      "packageName": "@excitedjs/dreamux"
+    }
+  ],
+  "packageName": "@excitedjs/dreamux",
+  "email": "053700@gmail.com"
+}

--- a/packages/dreamux/skills/dispatcher/SKILL.md
+++ b/packages/dreamux/skills/dispatcher/SKILL.md
@@ -1,28 +1,51 @@
 ---
 name: dispatcher
-description: Use from a Dreamux dispatcher thread when bounded repository work should be delegated to a tm-managed Codex teammate. Applies to spawning, sending, waiting, checking status, resuming, or summarizing teammate work through the tm CLI exposed by the Dreamux package.
+description: Use from a Dreamux dispatcher thread when bounded repository work should be delegated to a tm-managed teammate. Applies to spawning, sending, waiting, checking status, resuming, recovering, or summarizing teammate work through the tm CLI exposed by the Dreamux package.
 ---
 
 # Dispatcher
 
 Use this skill only from a Dreamux dispatcher session. Dreamux hosts the
-dispatcher Codex app-server and exposes `tm` on the dispatcher `PATH`; `tm`
-owns teammate lifecycle, history, and repository worktrees.
+dispatcher Codex app-server and exposes `tm` on the dispatcher `PATH`. `tm`
+owns teammate lifecycle, history, and repository worktrees; Dreamux does not.
+
+## Router Posture
+
+The dispatcher routes repository work to a teammate that lives in the target
+repo. It does not investigate that repo itself.
+
+- Hand the teammate the symptom and any concrete evidence, not your diagnosis.
+  Skip `grep`, file reads, and `git -C <repo>` probes done "to understand the
+  bug first". The teammate has the repo's own context and conventions;
+  pre-investigation burns dispatcher context and anchors the teammate to a
+  conclusion you drew before delegating.
+- Treat the user's framing adversarially. A request like "find which commit
+  broke X" embeds claims ("X is broken", "it is a regression") that may be
+  false. Pass such claims into the teammate brief as things to verify, not as
+  settled premises.
+- Keep repo-local instructions, git state, and tool output inside the teammate
+  context instead of mixing them into the dispatcher thread.
 
 ## Boundaries
 
-- Use `tm` from the dispatcher environment `PATH`. Dreamux injects its package
-  `bin/` directory into the dispatcher Codex app-server PATH.
-- Pass `--engine codex` on every `tm spawn`; do not rely on version-specific
-  defaults.
+- Invoke bare `tm` from the dispatcher environment `PATH`. Dreamux injects its
+  package `bin/` directory into the dispatcher app-server PATH.
 - Do not use `npx`, `npm exec --package @excitedjs/tm`, or a version-qualified
   `@excitedjs/tm`; the Dreamux package owns the compatible tm version.
-- Do not call dreamux admin APIs to create teammate state.
+- Choose the teammate engine deliberately. `tm spawn` takes `--engine`; the
+  engines it supports are listed in `tm spawn --help`. Pick by task shape and
+  by what the dispatcher environment actually provides -- a persistent,
+  resumable Codex daemon suits ongoing repo work; an engine whose CLI is not
+  installed or authenticated in this environment is not a usable choice. State
+  `--engine` explicitly so the selection is intentional rather than inherited
+  from a tm version default.
+- Do not call dreamux admin APIs to create or recover teammate state. The
+  server hosts the dispatcher; tm owns teammates.
 - Do not infer the target repository from the dispatcher cwd unless the user or
   operator explicitly made that cwd the requested repo.
 - Do not ask a tm-managed teammate to spawn another tm teammate.
 
-## Before Delegating
+## When To Delegate
 
 Delegate when the request is bounded and can be completed by one teammate:
 running tests, inspecting a code path, drafting a narrow patch, or collecting a
@@ -38,79 +61,44 @@ Resolve the repo path in this order:
 Use an absolute repo path for `tm spawn`. If the user gives a relative path,
 make it absolute only when its base is explicit.
 
-## Command Shape
+## Command Contract
 
-Preflight once per dispatcher session and trust live help for flags:
+`tm --help` is the top-level synopsis. `tm <verb> --help` owns each verb's
+flags, accepted arguments, exit codes, and exact stdout/stderr contract. This
+skill and its references own operational semantics and scenario selection; the
+live help owns the executable contract. Read the verb's own help before relying
+on a flag -- do not infer one verb's flags from another.
 
-```bash
-tm --help
-```
+## Scenario Routing
 
-## First-Turn Delegation
+Read the matching reference before reaching for the verb:
 
-1. Pick a flat teammate name: lowercase letters, digits, and hyphens; keep it
-   short and tied to the task, such as `tests-api` or `scan-auth`.
-2. Spawn with the repo path, Codex engine, intent, timeout, and full task
-   prompt:
+| Intent | Reference |
+|---|---|
+| Spawn a teammate, compose its prompt, send follow-up, collect the result | `references/dispatch-task.md` |
+| Look up, re-read, or resume a prior or dead teammate session | `references/inspect-and-resume.md` |
 
-```bash
-tm spawn /absolute/repo \
-  --name tests-api \
-  --engine codex \
-  --timeout 180 \
-  --intent "Run focused API tests and summarize failures" \
-  --prompt "Run the focused API tests. Report commands, failures, and the smallest next fix."
-```
+For multi-teammate review, design negotiation, merge, or unblock coordination,
+use the `team-dev-workflow` skill, which layers methodology on top of this one.
 
-3. If `tm spawn` exits `0`, use its printed reply as the teammate result. If it
-   exits `124`, the Codex turn did not finish within the sync window; wait
-   without `--fresh`:
+## Verified Reports
 
-```bash
-tm wait tests-api --timeout 180
-```
+A reply to the source chat that asserts an outcome must be verifiable from this
+turn's tool calls.
 
-4. Reply to the source chat with the teammate result, including the command
-   summary and any explicit failure.
+- Report only what `tm` returned. Do not invent a teammate result that was not
+  printed by a `tm` verb.
+- Verify any command, flag, or path before naming it; if you cannot verify it
+  this turn, say so rather than guessing a name.
+- Translate dispatcher-internal identifiers into plain language before the
+  message goes out. Issue and PR numbers the user can look up are shared
+  vocabulary; ad-hoc internal labels are not.
+- For public target repos, forbid internal domains, tokens, private
+  identifiers, and machine-local paths in commits, PRs/MRs, and comments in the
+  teammate brief.
 
-## Follow-Up Delegation
-
-If a teammate name already exists for the same task, send a follow-up instead
-of spawning a duplicate:
-
-```bash
-tm send tests-api \
-  --prompt "Use the previous context. Re-run the focused test after the latest fix and summarize only changed results."
-tm wait tests-api --timeout 180
-```
-
-## Status And Readback
-
-- Use `tm status <name>` when a teammate appears stuck.
-- Use `tm wait <name> --timeout <seconds>` to collect the next completed reply.
-- Use `tm last <name>` or `tm history` when recovering a prior result.
-- Report the command outcome, the teammate name, the repository path, and any
-  explicit failure. Do not invent a result that was not returned by `tm`.
-
-## Failure Reporting
-
-When a tm command fails, stop the delegation sequence and report:
-
-- which `tm` verb failed
-- the teammate name and repo path
-- the exit status if available
-- the first useful stderr/stdout lines
-- whether retrying the same teammate is safe
-
-Known early startup failure to report verbatim:
-
-```text
-codex daemon (pid N) exited before binding <socket path>
-```
-
-That means the Codex app-server daemon did not become reachable. Do not retry
-silently; report the environment failure and ask the operator to run Dreamux
-diagnostics in the dispatcher environment.
+## State Boundary
 
 Do not say the Dreamux server lost or recovered teammate state. The server does
-not own that state.
+not own that state. Teammate liveness, history, and recovery flow through `tm`
+(see `references/inspect-and-resume.md`).

--- a/packages/dreamux/skills/dispatcher/references/dispatch-task.md
+++ b/packages/dreamux/skills/dispatcher/references/dispatch-task.md
@@ -1,0 +1,138 @@
+# Dispatch A Task
+
+## Trigger
+
+You are pushing bounded work into a target repo: bringing up a new teammate
+with its first task, or handing follow-up work to one that already owns the
+task. Skip this when you only need to recover or re-read a prior session
+(`inspect-and-resume.md`).
+
+## Steps
+
+1. Resolve the absolute repo path and the engine. Read `tm spawn --help` for
+   the supported engines and current flags; state `--engine` explicitly so the
+   choice is intentional.
+2. Choose the verb:
+   - New teammate plus first task in one call: `tm spawn <path> --prompt "..."`.
+   - New teammate, no task yet: `tm spawn <path>`.
+   - Existing teammate, new turn: `tm send <name> --prompt "..."`.
+   Reuse an existing teammate that already owns this task instead of spawning a
+   duplicate.
+3. Pick a flat teammate name: lowercase letters, digits, and hyphens, short and
+   tied to the task, such as `tests-api` or `scan-auth`. Pass
+   `--intent "short subject"` for work worth finding later; tm records it as a
+   queryable field in `tm history`.
+4. Compose the prompt against the two checklists below before sending.
+5. Run the blocking verb and wait for the reply (see "Wait phase").
+6. Report the verified result to the source chat (see "Closeout").
+
+```bash
+tm spawn /absolute/repo \
+  --name tests-api \
+  --engine <engine> \
+  --intent "Run focused API tests and summarize failures" \
+  --prompt "The API suite is reported failing after the latest auth change. Run the focused API tests, report the commands you ran, the failures, and the smallest next fix."
+```
+
+## Composing The Prompt
+
+Aim for roughly the length and shape the user would type if they dispatched the
+task themselves: a one-line business request plus only the conventions the
+teammate cannot infer. The failure mode is either omitting a fact the teammate
+cannot derive, or adding noise that anchors and misleads it.
+
+### Include
+
+The pieces a teammate cannot derive from its own checkout:
+
+1. **Intent.** The goal and why it matters, not a step-by-step recipe. The
+   teammate plans the steps; a recipe anchors it to your preconception and
+   stops it from finding a better path.
+2. **Branch and any PR/MR anchor.** Name the branch you expect it to work on,
+   stated as an expectation ("work on `feat/foo`"), not a pre-fetched
+   observation -- the teammate's own `git status` is the ground truth, and a
+   snapshot in the prompt may already be stale. Name the related PR/MR number
+   when one is relevant.
+3. **Hard context.** Boundary conditions the user actually stated, prior
+   decisions that bound the search space, and the symptom you observed --
+   load-bearing facts only.
+4. **Deliverable shape.** The artifact you want back: a verdict, a PR/MR, a
+   patch, a written report, or a one-line answer. Without this, teammates
+   sometimes return the wrong shape.
+
+### Keep Out
+
+1. **Noise.** Sub-question checklists, reminders of default behavior (read
+   before edit, do not fabricate), and generic exhortations ("be careful").
+   If the draft exceeds about ten lines, audit each line against "would the
+   teammate not otherwise know this".
+2. **Invented restrictions.** Do not add "don't open a new branch" / "don't
+   grep X" unless the action has a concrete cost the teammate cannot see, has
+   demonstrably caused a foot-gun on this task, or the user said so. Restating
+   a worry just removes the teammate's escalation room.
+3. **Fabricated user decisions.** Never write "the user decided X" when the
+   user did not say it. Vague input ("explore it", "go ahead") does not let you
+   pick an option on the user's behalf -- pass the open question through and let
+   the teammate raise it or report back.
+4. **Your theory of the cause.** Hand the symptom and any concrete evidence (a
+   stack trace, a log line, a diff fragment), not the conclusion you drew from
+   it. An unverified hypothesis injected as a premise is exactly what the
+   teammate has to detox before it can think.
+5. **Stale path hints.** When the target repo loads its own context (its
+   `CLAUDE.md` / `AGENTS.md` / knowledge base), write the prompt in the repo's
+   product terms rather than pasting file paths or "Read X first" hints. The
+   repo's own disclosure is more current than any snapshot the dispatcher
+   carries. Pointing at a session-local artifact you just created (a PR URL, a
+   `/tmp` file) is fine -- that is current state, not a stale knowledge path.
+
+## Wait Phase
+
+`tm spawn --prompt`, `tm send`, and `tm wait` can block for a full model turn.
+Use a `--timeout` and read the exit code:
+
+- **`0`** -- the reply landed within the timeout; stdout carries the reply text.
+- **`124`** -- the sync wait expired and the teammate is still running. Do not
+  respawn; the name is still taken. Collect the late result with
+  `tm wait <name> --timeout <seconds>`.
+- **`1`** -- true failure: no such teammate, broken send path, invalid repo or
+  name, or the command was rejected. Read stderr before deciding the next step.
+
+```bash
+tm wait tests-api --timeout 180
+```
+
+If a teammate looks hung mid-turn rather than simply slow, `tm status <name>`
+shows its pane and process ground truth so you can tell a stuck teammate from
+one still working.
+
+A second `tm send` to a teammate while an earlier send is still waiting steers
+it: the earlier send returns early with a note, and only the latest send keeps
+waiting. Use this to guide a running teammate. Confirm the verb's current
+behavior in `tm send --help`.
+
+When you build any wait loop, match expected result keywords (`merged`,
+`done`, an anticipated error code), never words from the prompt you just sent --
+the prompt text appears in the teammate's own turn and a prompt-word match
+returns instantly.
+
+## Failure Reporting
+
+When a `tm` command fails, stop the delegation sequence and report:
+
+- which `tm` verb failed
+- the teammate name and repo path
+- the exit status if available
+- the first useful stderr/stdout lines
+- whether retrying the same teammate is safe
+
+A startup readiness failure such as a daemon exiting before binding its socket
+means the teammate engine did not become reachable in the dispatcher
+environment. Do not retry silently; report it as an environment failure and
+ask the operator to run Dreamux diagnostics (`dreamux-maintenance` skill).
+
+## Closeout
+
+The source chat has the verified teammate result, including the command
+summary and any explicit failure. No duplicate teammate was spawned for a task
+an existing teammate already owned. Nothing was asserted that a `tm` verb did
+not return this turn.

--- a/packages/dreamux/skills/dispatcher/references/dispatch-task.md
+++ b/packages/dreamux/skills/dispatcher/references/dispatch-task.md
@@ -82,8 +82,10 @@ The pieces a teammate cannot derive from its own checkout:
    `CLAUDE.md` / `AGENTS.md` / knowledge base), write the prompt in the repo's
    product terms rather than pasting file paths or "Read X first" hints. The
    repo's own disclosure is more current than any snapshot the dispatcher
-   carries. Pointing at a session-local artifact you just created (a PR URL, a
-   `/tmp` file) is fine -- that is current state, not a stale knowledge path.
+   carries. Referencing a current session artifact you just produced, such as a
+   PR or issue number, is fine -- that is live state, not a stale knowledge
+   path. Keep any reference to a private or scratch location to the teammate's
+   own prompt; never let it reach a public commit, PR, or comment.
 
 ## Wait Phase
 

--- a/packages/dreamux/skills/dispatcher/references/inspect-and-resume.md
+++ b/packages/dreamux/skills/dispatcher/references/inspect-and-resume.md
@@ -37,9 +37,14 @@ tm history --id <full-or-prefix>
 tm resume --engine <engine> --repo /absolute/repo --id <sid-or-thread-id>
 ```
 
-`tm resume <name>` without an id delegates selection to the engine's own
-"latest session" behavior; use it only when you lack an id clue. Read
-`tm history --help` and `tm resume --help` for current fields and flags.
+Prefer `resumeCommand` or an explicit `--id` whenever you have one -- that is
+the unambiguous path. The name form `tm resume <name>` without an id does not
+hand the choice to the engine: tm itself probes its live, archived, and history
+state for that name and routes the single matching candidate. When more than one
+candidate matches, it asks for `--engine claude|codex` to break the tie rather
+than guessing. Use the name form only when you lack an id clue, and pass
+`--engine` if tm reports an ambiguous match. Read `tm history --help` and
+`tm resume --help` for current fields and flags.
 
 ## When The User Hands You A Session Id
 

--- a/packages/dreamux/skills/dispatcher/references/inspect-and-resume.md
+++ b/packages/dreamux/skills/dispatcher/references/inspect-and-resume.md
@@ -1,0 +1,74 @@
+# Inspect And Resume
+
+## Trigger
+
+You need to see what teammates are doing, re-read a reply, or continue a task
+whose teammate is gone (dispatcher restarted, teammate killed, host rebooted).
+Skip this when you are sending fresh work (`dispatch-task.md`).
+
+## Steps
+
+1. For a live snapshot of who is running and what they last said, read the
+   fleet state:
+
+```bash
+tm states
+```
+
+2. To re-read the last settled reply from a still-live teammate:
+
+```bash
+tm last <name>
+```
+
+3. To look up past or in-flight sessions for recovery, query history. It is
+   the tm-owned index that survives kills; default to a bounded field subset
+   for broad scans:
+
+```bash
+tm history --repo /absolute/repo --fields id,engine,name,state,intent,resumeCommand
+tm history --id <full-or-prefix>
+```
+
+4. To continue a dead session, prefer the row's `resumeCommand` over rebuilding
+   the command by hand. The explicit-id form is the reliable one:
+
+```bash
+tm resume --engine <engine> --repo /absolute/repo --id <sid-or-thread-id>
+```
+
+`tm resume <name>` without an id delegates selection to the engine's own
+"latest session" behavior; use it only when you lack an id clue. Read
+`tm history --help` and `tm resume --help` for current fields and flags.
+
+## When The User Hands You A Session Id
+
+If the user supplies a session id with a phrase like "this is the X result,
+take over", do not infer what "X" means from whatever is loudest in the current
+chat. The dispatcher did not witness that session, so its actual content is the
+authority. Verify the subject first -- `tm last <name>`, an independent check on
+the suspected target (e.g. the PR's own reviews/comments), or one short
+clarifying question -- before briefing a downstream teammate.
+
+When you send the first turn to a resumed teammate, ask it to summarize its
+existing conclusions rather than asserting the subject yourself. A wrong
+subject then surfaces as a push-back, not as invented compliance.
+
+## Closing Work
+
+When a task reaches a terminal state, record queryable close metadata at the
+kill boundary so later history scans can find the outcome:
+
+```bash
+tm kill <name> --status <merged|done|shelved|abandoned|blocked> --note "<short text>"
+```
+
+Confirm the current status values and note semantics in `tm kill --help`. Do
+not maintain a manual dispatcher ledger; `tm history` is the query surface and
+durable outcomes belong in the issue, PR, or repo artifact the teammate already
+worked on.
+
+## Closeout
+
+The recovered teammate is on the intended session, its subject is verified
+rather than assumed, and any terminal work carries a queryable close status.

--- a/packages/dreamux/skills/team-dev-workflow/SKILL.md
+++ b/packages/dreamux/skills/team-dev-workflow/SKILL.md
@@ -28,11 +28,15 @@ the `dispatcher` skill.
 
 ## Coordinator Posture
 
-- Verify facts from the target repo and platform before deciding.
-- Do not edit target repo code from the coordinator context. Delegate repo work
-  to a teammate in that repo.
+- Verify facts from the target repo and platform before deciding. Treat the
+  user's framing adversarially: route embedded claims (a "regression", a review
+  comment) into the brief as things to verify, not as settled premises.
+- Do not edit target repo code from the coordinator context, and do not
+  investigate it yourself. Hand the teammate the symptom and evidence, not your
+  diagnosis. Delegate repo work to a teammate in that repo.
 - Keep prompts short: intent, coordinates, hard constraints, and requested
-  artifact.
+  artifact. The `dispatcher` skill's `references/dispatch-task.md` has the full
+  include / keep-out prompt checklist; reuse it for every brief here.
 - When the target repo is public, explicitly forbid internal domains, tokens,
   private identifiers, and machine-local paths in commits, MR/PRs, and comments.
 - Prefer one accountable teammate per branch or review thread; reuse it for


### PR DESCRIPTION
## 背景

内置的三个 dispatcher skill（`dispatcher` / `team-dev-workflow` / `dreamux-maintenance`，#93 / #95）已经覆盖了基本机制，但 `dispatcher` skill 缺少实际派活时最关键的工作流指引，并且存在一处错误规则：要求每次 `tm spawn` 都强制 `--engine codex`。

## 改动

- **修正 engine 规则**：按实时 `tm spawn --help` 契约（默认 `claude`，引擎选项以 help 为准）和任务需要**显式**选择 `--engine`，不再强制 codex。tm 版本默认已稳定，原先“不要依赖版本默认值”的理由不再成立；强制单一引擎反而把真正的决策藏了起来。
- **新增 Router Posture**：dispatcher 只路由、不自己调查目标仓库——把症状和证据交给 teammate，而不是 dispatcher 端的诊断结论；对用户的措辞保持审慎，把其中隐含的断言（“这是回归”“review 意见”）作为待核实项写进 brief，而非当作既定前提。
- **新增 `references/dispatch-task.md`**：包含 prompt 的 include / keep-out 组合清单、spawn/send/wait 流程、退出码（0 / 124 / 1）处理与失败上报。
- **新增 `references/inspect-and-resume.md`**：覆盖 `tm states` / `history` / `last` / `resume` 的查询与恢复，以及可检索的收尾状态元数据。
- **`team-dev-workflow`**：在 coordinator posture 中交叉引用 prompt 清单，并强化“交症状而非诊断”。

SKILL.md 保持为 router + 少量横切规则，详细流程下沉到 references（Trigger / Steps / Closeout）。保留了 Dreamux server 不拥有 teammate 状态、由 tm 负责 teammate 生命周期/历史/worktree 的边界。

## 验证

- 对照本仓库依赖的 `@excitedjs/tm` 实时 `--help` 契约核对了所有 `tm` 用法。
- `vitest run tests/bundled-skills.test.ts tests/onboard.test.ts`：22 passed。
- 全量检查 skill 文件无内部域名 / token / 私有标识 / 机器本地路径；纯英文、纯 ASCII。
- 已补 `@excitedjs/dreamux` 的 rush change 文件。

Refs #93, #95