### PR TITLE
fix(feishu): 受信 peer bot 按 union_id 匹配，修复 introduce 后仍被丢弃

### DIFF
--- a/.agents/decisions/top-level-design.md
+++ b/.agents/decisions/top-level-design.md
@@ -219,12 +219,21 @@ reaction ledger.
 
 `chat-bots.json` stores per-dispatcher peer-bot discovery state, keyed by
 chat_id (issue #62). Each chat tracks a `known` set (bots passively observed in
-an authorized chat — awareness only) and a `trusted` set (bots introduced by an
-allowlisted `/introduce` — the only set the gate consults to let a peer bot's
-group message through). The two sets must never be conflated: observation never
-grants trust. It also records bot-added baseline bookkeeping (`needsBaseline`,
-`seenEventIds` for idempotent `im.chat.member.bot.added_v1` handling). It is
-server-owned discovery state, safe to delete; it holds no credentials.
+an authorized chat — awareness only) and a `trusted` set (peer-bot open_ids
+introduced by an allowlisted `/introduce`). The gate consults trust through
+`trustedBotIds()`, which folds the `trusted` open_ids together with a parallel
+`trustedUnionIds` set into one match set — a peer bot is let through when its
+send-time open_id **or** its union_id is trusted. The union bridge exists
+because a Feishu open_id is app-scoped, so a bot mentioned under one open_id can
+send under another; the union_id (stable across one developer's apps) reconnects
+them. `trustedUnionIds` is a load-bearing part of the trust contract, not
+disposable: dropping it on migration/cleanup would silently re-break the
+introduce→deliver path for any such bot. It is kept out of the display surfaces
+(`<group_bots>`, `list_chat_bots`), which stay open_id-only. The known/trusted
+sets must never be conflated: observation never grants trust. The file also
+records bot-added baseline bookkeeping (`needsBaseline`, `seenEventIds` for
+idempotent `im.chat.member.bot.added_v1` handling). It is server-owned discovery
+state, safe to delete; it holds no credentials.
 
 `codex.sock` is the Codex app-server WebSocket-over-Unix-socket endpoint for the
 dispatcher. It is not the Feishu MCP transport. The Feishu MCP default transport

--- a/.agents/domains/feishu-introduce.md
+++ b/.agents/domains/feishu-introduce.md
@@ -133,12 +133,27 @@ unchanged.
 - **trusted** — bots introduced by an allowlisted `/introduce`. Only this set
   lets a peer bot's group message through the gate.
 
-`dreamuxFeishuGate` drops every bot sender except one whose open_id is in the
-chat's trusted set (passed as `trustedBotIds`); a trusted bot is delivered
-without an `@`-mention because a bot cannot mention us. When `trustedBotIds` is
-omitted, no bot sender is ever delivered — preserving prior behavior. Recording
-a human open_id as "trusted" is harmless: the gate only bypasses for a bot
-*sender*, so a human entry never widens access.
+`dreamuxFeishuGate` drops every bot sender except one whose **open_id or
+union_id** is in the chat's trusted set (passed as `trustedBotIds`); a trusted
+bot is delivered without an `@`-mention because a bot cannot mention us. When
+`trustedBotIds` is omitted, no bot sender is ever delivered — preserving prior
+behavior. Recording a human open_id as "trusted" is harmless: the gate only
+bypasses for a bot *sender*, so a human entry never widens access.
+
+> **Why union_id, not open_id alone.** A Feishu `open_id` is scoped to one app,
+> so the same peer bot can present a different `open_id` when it is *mentioned*
+> in a `/introduce` (resolved in the mentioning context) than when it later
+> *sends* a message (resolved in ours). Matching trust on `open_id` alone then
+> drops the very bot the operator just introduced — observed live as a
+> `bot sender type: bot` drop right after an `introduce consumed` for the same
+> peer. `union_id` is stable for one entity across a developer's apps, so
+> `introducedPeers` records a peer's `union_id` when it differs from the
+> `open_id`, `chat-bots-store` keeps it in a separate `trustedUnionIds` list,
+> and `trustedBotIds()` folds both id kinds into the gate's match set. The
+> bridge is best-effort: it works when the `/introduce` mention and the inbound
+> sender both expose a `union_id` (permission-dependent), and never regresses
+> the open_id path. `trustedUnionIds` is deliberately kept out of the display
+> surfaces (`<group_bots>`, `list_chat_bots`), which stay open_id-only.
 
 ## One-shot trusted-bot context (issue #69)
 

--- a/common/changes/@excitedjs/dreamux/feishu-trusted-bot-union-id_2026-06-05-20-10.json
+++ b/common/changes/@excitedjs/dreamux/feishu-trusted-bot-union-id_2026-06-05-20-10.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Match trusted peer bots by union_id as well as open_id, so an introduced bot whose send-time open_id differs from its mention open_id is still delivered; the inbound drop diagnostic now carries sender_union_id",
+      "type": "patch",
+      "packageName": "@excitedjs/dreamux"
+    }
+  ],
+  "packageName": "@excitedjs/dreamux",
+  "email": "053700@gmail.com"
+}

--- a/common/changes/@excitedjs/feishu-transport/feishu-trusted-bot-union-id_2026-06-05-20-10.json
+++ b/common/changes/@excitedjs/feishu-transport/feishu-trusted-bot-union-id_2026-06-05-20-10.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "narrowMetaFromEvent now surfaces the sender union_id (sender_union_id) so hosts can match a peer bot whose app-scoped open_id differs between mention and send contexts",
+      "type": "patch",
+      "packageName": "@excitedjs/feishu-transport"
+    }
+  ],
+  "packageName": "@excitedjs/feishu-transport",
+  "email": "053700@gmail.com"
+}

--- a/packages/channel/feishu-transport/src/parse/content.ts
+++ b/packages/channel/feishu-transport/src/parse/content.ts
@@ -116,6 +116,12 @@ export function narrowMetaFromEvent(rawEvent: unknown): Record<string, unknown> 
     chat_id: asString(message.chat_id),
     chat_type: asString(message.chat_type),
     sender_id: asString(senderId?.open_id),
+    // The cross-app-stable identifier. A bot's `open_id` is scoped to one app,
+    // so the same bot can present different `open_id`s when mentioned (resolved
+    // in the mentioning context) versus when it sends (resolved in ours);
+    // `union_id` is stable for the same entity across one developer's apps and
+    // bridges that gap for peer-bot trust matching.
+    sender_union_id: asString(senderId?.union_id),
     sender_type: asString(sender.sender_type),
     root_id: asString(message.root_id),
     parent_id: asString(message.parent_id),

--- a/packages/channel/feishu-transport/tests/content.test.ts
+++ b/packages/channel/feishu-transport/tests/content.test.ts
@@ -134,6 +134,27 @@ describe('narrowMetaFromEvent', () => {
     })
   })
 
+  test('extracts the sender union_id when present', () => {
+    expect(
+      narrowMetaFromEvent({
+        event: {
+          sender: {
+            sender_type: 'bot',
+            sender_id: { open_id: 'ou_sent', union_id: 'on_union' },
+          },
+          message: { message_id: 'om_3', chat_id: 'oc_3', chat_type: 'group' },
+        },
+      }),
+    ).toEqual({
+      message_id: 'om_3',
+      chat_id: 'oc_3',
+      chat_type: 'group',
+      sender_id: 'ou_sent',
+      sender_union_id: 'on_union',
+      sender_type: 'bot',
+    })
+  })
+
   test('extracts metadata from already-unwrapped event payloads', () => {
     expect(
       narrowMetaFromEvent({

--- a/packages/dreamux/src/channel/chat-bots-store.ts
+++ b/packages/dreamux/src/channel/chat-bots-store.ts
@@ -35,6 +35,15 @@ export interface ChatBotsEntry {
   known: string[];
   /** Introduced peer-bot open_ids — the gate's trust set for this chat. */
   trusted: string[];
+  /**
+   * Introduced peer-bot `union_id`s, when a `/introduce` mention carried one
+   * that differs from its `open_id`. A bot's `open_id` is app-scoped, so a peer
+   * mentioned under one `open_id` can send under another; `union_id` is stable
+   * across one developer's apps and bridges that gap. Kept apart from `trusted`
+   * so display paths (`<group_bots>`, `list_chat_bots`) keep showing only
+   * `open_id`s — these feed the gate's match set only.
+   */
+  trustedUnionIds: string[];
   /** Best-effort open_id → display name map for known/trusted bots. */
   names: Record<string, string>;
   /**
@@ -61,6 +70,13 @@ export interface ChatBotsState {
 
 export interface PeerBot {
   openId: string;
+  /**
+   * The peer's `union_id` when Feishu provided one that differs from `openId`.
+   * Recorded so a bot mentioned under an app-scoped `open_id` can still be
+   * matched when it later sends under a different `open_id` (see
+   * `ChatBotsEntry.trustedUnionIds`).
+   */
+  unionId?: string;
   name?: string;
 }
 
@@ -88,6 +104,7 @@ function emptyEntry(): ChatBotsEntry {
   return {
     known: [],
     trusted: [],
+    trustedUnionIds: [],
     names: {},
     needsBaseline: false,
     baselineGeneration: 0,
@@ -188,6 +205,15 @@ export async function trustIntroducedBots(
       added.push(bot.openId);
       changed = true;
     }
+    if (
+      bot.unionId !== undefined &&
+      bot.unionId !== '' &&
+      bot.unionId !== bot.openId &&
+      !entry.trustedUnionIds.includes(bot.unionId)
+    ) {
+      entry.trustedUnionIds.push(bot.unionId);
+      changed = true;
+    }
   }
   // A newly trusted bot is pending discovery context for the next message
   // (issue #69). Re-introducing already-trusted bots changes nothing, so it
@@ -250,12 +276,18 @@ export async function listChatBots(
   };
 }
 
-/** The trust set the gate consults for one chat. */
+/**
+ * The trust set the gate consults for one chat — the chat's trusted `open_id`s
+ * plus any recorded `union_id`s. Both id kinds are folded into one set because
+ * the gate only does membership tests against a sender's `open_id` or
+ * `union_id`; the two never collide (Feishu prefixes them `ou_` vs `on_`).
+ */
 export async function trustedBotIds(
   dispatcherId: string,
   chatId: string,
 ): Promise<Set<string>> {
-  return new Set((await loadChatBots(dispatcherId)).chats[chatId]?.trusted ?? []);
+  const entry = (await loadChatBots(dispatcherId)).chats[chatId];
+  return new Set([...(entry?.trusted ?? []), ...(entry?.trustedUnionIds ?? [])]);
 }
 
 /**
@@ -307,6 +339,7 @@ function normalizeEntry(raw: unknown): ChatBotsEntry {
   const obj = raw as Record<string, unknown>;
   entry.known = stringArray(obj['known']);
   entry.trusted = stringArray(obj['trusted']);
+  entry.trustedUnionIds = stringArray(obj['trustedUnionIds']);
   entry.seenEventIds = stringArray(obj['seenEventIds']);
   entry.needsBaseline = obj['needsBaseline'] === true;
   entry.baselineGeneration =

--- a/packages/dreamux/src/channel/feishu-gate.ts
+++ b/packages/dreamux/src/channel/feishu-gate.ts
@@ -63,6 +63,14 @@ export interface GateDiagnostic {
 
 export interface DreamuxFeishuGateInput {
   senderId: string;
+  /**
+   * The sender's `union_id`, when Feishu provided one. A peer bot's `open_id`
+   * is app-scoped, so the `open_id` it sends under can differ from the one it
+   * was mentioned (and trusted) under. `union_id` is stable across one
+   * developer's apps, so the bot-trust check matches on it too. Optional;
+   * callers that do not track it preserve `open_id`-only matching.
+   */
+  senderUnionId?: string;
   senderType?: string;
   chatId: string;
   chatType: string;
@@ -187,8 +195,16 @@ export function dreamuxFeishuGate(
     // allowlisted `/introduce`. Trusted bots bypass the mention gate because a
     // bot cannot @-mention us; untrusted bots are dropped as before. This is
     // per-chat trust (`trustedBotIds` is scoped to this chat by the caller) and
-    // is never reached through the human `allow_users` list.
-    if (input.trustedBotIds?.has(input.senderId) ?? false) {
+    // is never reached through the human `allow_users` list. A bot's open_id is
+    // app-scoped, so it may have been introduced under a different open_id than
+    // the one it now sends under; the trust set also carries union_ids, matched
+    // here against the sender's union_id, to bridge that gap.
+    const trusted =
+      (input.trustedBotIds?.has(input.senderId) ?? false) ||
+      (input.senderUnionId !== undefined &&
+        input.senderUnionId !== '' &&
+        (input.trustedBotIds?.has(input.senderUnionId) ?? false));
+    if (trusted) {
       return deliver(access, input, now);
     }
     return drop(`bot sender type: ${input.senderType}`);

--- a/packages/dreamux/src/channel/introduce.ts
+++ b/packages/dreamux/src/channel/introduce.ts
@@ -183,7 +183,16 @@ export function introducedPeers(
     const openId = m.id?.open_id ?? m.id?.union_id ?? '';
     if (openId === '' || openId === selfOpenId || seen.has(openId)) continue;
     seen.add(openId);
-    peers.push(m.name !== undefined ? { openId, name: m.name } : { openId });
+    const peer: PeerBot = { openId };
+    if (m.name !== undefined) peer.name = m.name;
+    // Record the union_id only when it adds information — i.e. a distinct id
+    // from the open_id we keyed on. It lets the gate match this peer later even
+    // if it sends under a different (app-scoped) open_id.
+    const unionId = m.id?.union_id;
+    if (unionId !== undefined && unionId !== '' && unionId !== openId) {
+      peer.unionId = unionId;
+    }
+    peers.push(peer);
   }
   return peers;
 }

--- a/packages/dreamux/src/feishu/bot.ts
+++ b/packages/dreamux/src/feishu/bot.ts
@@ -46,6 +46,13 @@ export interface FeishuInboundEvent {
   chatId: string;
   chatType: string; // 'p2p' | 'group' | ...
   senderId: string;
+  /**
+   * The sender's `union_id`, when Feishu provides it. Unlike `senderId` (an
+   * app-scoped `open_id`), a `union_id` is stable for the same entity across
+   * one developer's apps, so it bridges the case where a peer bot is mentioned
+   * under one `open_id` but sends under another. Empty when absent.
+   */
+  senderUnionId: string;
   senderType: string;
   /**
    * Best-effort display name seam for future enrichers. Feishu
@@ -252,6 +259,7 @@ function normalizeInboundEvent(raw: unknown): FeishuInboundEvent | null {
   const chatId = payload.meta['chat_id'] ?? '';
   const chatType = payload.meta['chat_type'] ?? '';
   const senderId = payload.meta['sender_id'] ?? '';
+  const senderUnionId = payload.meta['sender_union_id'] ?? '';
   const senderType = payload.meta['sender_type'] ?? '';
   const createTime = payload.meta['create_time'] ?? '';
   const senderName = extractSenderName(raw);
@@ -263,6 +271,7 @@ function normalizeInboundEvent(raw: unknown): FeishuInboundEvent | null {
     chatId,
     chatType,
     senderId,
+    senderUnionId,
     senderType,
     senderName,
     messageType,

--- a/packages/dreamux/src/server.ts
+++ b/packages/dreamux/src/server.ts
@@ -454,6 +454,7 @@ export class Server {
               : undefined;
           const gate = dreamuxFeishuGate({
             senderId: event.senderId,
+            ...(event.senderUnionId !== '' ? { senderUnionId: event.senderUnionId } : {}),
             senderType: event.senderType,
             chatId: event.chatId,
             chatType: event.chatType,
@@ -474,6 +475,11 @@ export class Server {
                 chat_id: event.chatId,
                 chat_type: event.chatType,
                 sender_id: event.senderId,
+                // Surfaced so a `bot sender type` drop right after an
+                // `introduce consumed` is self-diagnosing: an introduced peer
+                // whose send-time open_id differs from its mention open_id is
+                // matched by union_id, and seeing it here pins that case down.
+                ...(event.senderUnionId !== '' ? { sender_union_id: event.senderUnionId } : {}),
                 message_id: event.messageId,
                 reason: gate.reason,
               },

--- a/packages/dreamux/tests/codex-live.test.ts
+++ b/packages/dreamux/tests/codex-live.test.ts
@@ -171,6 +171,7 @@ function fakeInbound(
     chatId,
     chatType: 'group',
     senderId: 'sender-live',
+    senderUnionId: '',
     senderType: 'user',
     senderName: 'Live Tester',
     messageType: 'text',

--- a/packages/dreamux/tests/e2e.test.ts
+++ b/packages/dreamux/tests/e2e.test.ts
@@ -139,6 +139,7 @@ function fakeInbound(
     chatId,
     chatType: 'group',
     senderId: 'sender-test',
+    senderUnionId: '',
     senderType: 'user',
     senderName: 'Ada',
     messageType: 'text',

--- a/packages/dreamux/tests/feishu-gate.test.ts
+++ b/packages/dreamux/tests/feishu-gate.test.ts
@@ -178,6 +178,49 @@ describe('dreamuxFeishuGate', () => {
         gate({ ...botBase, mentions: [], trustedBotIds: new Set(['peer-bot']) }, access),
       ).toMatchObject({ action: 'deliver' });
     });
+
+    // A peer bot's open_id is app-scoped: it can be introduced under the open_id
+    // resolved in a mention but later send under a different open_id. The trust
+    // set carries its (stable) union_id, so the gate must match on the sender's
+    // union_id even when the open_id does not.
+    it('delivers a trusted bot whose send-time open_id differs but union_id matches', () => {
+      const access = state({
+        allow_users: ['sender-allowed'],
+        group: { policy: 'follow-user', allow_chats: [], require_mention: true },
+      });
+      const trustedBotIds = new Set(['peer-open-mentioned', 'peer-union']);
+      expect(
+        gate(
+          {
+            senderId: 'peer-open-sent',
+            senderUnionId: 'peer-union',
+            senderType: 'bot',
+            mentions: [],
+            trustedBotIds,
+          },
+          access,
+        ),
+      ).toMatchObject({ action: 'deliver' });
+    });
+
+    it('still drops a bot when neither its open_id nor union_id is trusted', () => {
+      const access = state({
+        allow_users: ['sender-allowed'],
+        group: { policy: 'follow-user', allow_chats: [], require_mention: true },
+      });
+      expect(
+        gate(
+          {
+            senderId: 'peer-open-sent',
+            senderUnionId: 'peer-union-other',
+            senderType: 'bot',
+            mentions: [],
+            trustedBotIds: new Set(['peer-open-mentioned', 'peer-union']),
+          },
+          access,
+        ),
+      ).toMatchObject({ action: 'drop', reason: 'bot sender type: bot' });
+    });
   });
 
   it('shares one global list across direct and follow-user group delivery', () => {

--- a/packages/dreamux/tests/feishu-introduce.test.ts
+++ b/packages/dreamux/tests/feishu-introduce.test.ts
@@ -394,6 +394,26 @@ describe('introducedPeers', () => {
       { openId: 'peer-b' },
     ]);
   });
+
+  it('records a distinct union_id so a later send under another open_id matches', () => {
+    const mentions: Mention[] = [
+      { key: '@_user_1', id: { open_id: 'peer-open', union_id: 'peer-union' }, name: 'Peer' },
+    ];
+    expect(introducedPeers(mentions, 'self-bot')).toEqual([
+      { openId: 'peer-open', name: 'Peer', unionId: 'peer-union' },
+    ]);
+  });
+
+  it('omits union_id when it duplicates the open_id we keyed on', () => {
+    const mentions: Mention[] = [
+      { key: '@_user_1', id: { open_id: 'peer-open', union_id: 'peer-open' } },
+      { key: '@_user_2', id: { union_id: 'peer-union-only' } },
+    ];
+    expect(introducedPeers(mentions, 'self-bot')).toEqual([
+      { openId: 'peer-open' },
+      { openId: 'peer-union-only' },
+    ]);
+  });
 });
 
 describe('introduceAckText', () => {
@@ -475,6 +495,22 @@ describe('chat-bots store — awareness vs trust are separate', () => {
     expect(entry?.trusted).toEqual(['peer-a']);
     expect(entry?.known).toEqual(['peer-a']);
     expect((await trustedBotIds('d1', 'chat-a')).has('peer-a')).toBe(true);
+  });
+
+  it("folds a peer's union_id into the gate trust set without polluting display", async () => {
+    await trustIntroducedBots('d1', 'chat-a', [
+      { openId: 'peer-open', unionId: 'peer-union', name: 'Peer' },
+    ]);
+    const set = await trustedBotIds('d1', 'chat-a');
+    // The gate matches a sender by either its open_id or its union_id.
+    expect(set.has('peer-open')).toBe(true);
+    expect(set.has('peer-union')).toBe(true);
+    // Display surfaces stay open_id-only — the union_id never leaks into them.
+    const entry = (await loadChatBots('d1')).chats['chat-a'];
+    expect(entry?.trusted).toEqual(['peer-open']);
+    expect((await listChatBots('d1', 'chat-a')).trusted).toEqual([
+      { openId: 'peer-open', name: 'Peer' },
+    ]);
   });
 
   it('recordBotAdded is idempotent by event id and flags a baseline', async () => {

--- a/packages/dreamux/tests/smoke.test.ts
+++ b/packages/dreamux/tests/smoke.test.ts
@@ -178,6 +178,7 @@ function fakeInbound(
     chatId,
     chatType: 'group',
     senderId: 'sender-test',
+    senderUnionId: '',
     senderType: 'user',
     senderName: '',
     messageType: 'text',

--- a/packages/dreamux/tests/smoke.test.ts
+++ b/packages/dreamux/tests/smoke.test.ts
@@ -353,6 +353,51 @@ describe('dreamux MVP smoke', () => {
     expect(d?.status).toBe('ready');
   });
 
+  it('bridges a peer bot whose send-time open_id differs from its introduce open_id via union_id', async () => {
+    // End-to-end wiring regression for the union_id bridge: an allowlisted
+    // human `/introduce`s a peer bot (mention carries open_id A + union_id U);
+    // the peer later sends under a *different* app-scoped open_id B but the same
+    // union_id U. open_id-only trust would drop it as `bot sender type: bot`;
+    // the union_id match must carry it through server.ts → trust store → gate.
+    server = buildServer({ runtimeDir, fake, bot });
+    server.repos.dispatchers.create({
+      dispatcher_id: 'flow',
+      bot_app_id: 'app-smoke',
+      bot_secret_ref: 'env:UNUSED',
+    });
+    await server.start();
+
+    // 1) Allowlisted human introduces the peer bot. Consumed, never a turn.
+    await bot.inject(
+      fakeInbound('chat-group-a', '/introduce', 'msg-introduce', {
+        senderId: 'sender-test',
+        senderType: 'user',
+        mentions: [
+          {
+            key: '@_user_1',
+            id: { open_id: 'peer-open-mentioned', union_id: 'peer-union' },
+            name: 'Peer',
+          },
+        ],
+      }),
+    );
+
+    // 2) The peer bot sends under a different open_id but the same union_id,
+    //    with no mention (a bot cannot @-mention us).
+    await bot.inject(
+      fakeInbound('chat-group-a', 'hello from the peer bot', 'msg-peer', {
+        senderId: 'peer-open-sent',
+        senderUnionId: 'peer-union',
+        senderType: 'bot',
+        senderName: 'Peer',
+        mentions: [],
+      }),
+    );
+
+    await waitFor(() => codexInputs.length === 1);
+    expect(codexInputs[0]).toContain('hello from the peer bot');
+  });
+
   it('starts the dispatcher app-server with global default Codex home and tm on PATH', async () => {
     const capturedCodexOptions: CodexProcessOptions[] = [];
     server = buildServer({ runtimeDir, fake, bot, capturedCodexOptions });


### PR DESCRIPTION
## 背景

群内 `/introduce` 把被 @ 的 peer bot 记为受信任时，记录的是 **mention 解析出的 open_id**。但投递门禁 `dreamuxFeishuGate` 对 bot 发件人只按 **发件 open_id** 匹配受信集合。

Feishu 的 `open_id` 是 **按 app 隔离** 的：同一个 bot 在「被 mention」与「作为发件人」两种上下文里可能解析出不同的 open_id。于是仅按 open_id 匹配时，刚被 introduce 的 bot 反而会以 `bot sender type: bot` 被丢弃。

这与一次观察到的现象一致：某次 `introduce consumed` 之后紧接着出现同群的 `bot sender type: bot` 丢弃，且被丢弃发件人的 open_id 与受信（mention）open_id 不一致。当前日志未采集 `union_id`，因此**无法在离线条件下确证这两个 open_id 属于同一个 bot 且共享同一 `union_id`**；但「app 隔离导致 open_id 不一致」是最自洽的解释，而 `union_id` 是官方文档给出的跨 app 稳定桥接标识。

## 改动

用 `union_id`（同一开发者多 app 下对同一实体稳定）桥接两种上下文：

- transport `narrowMetaFromEvent` 额外输出发件人 `union_id`（`sender_union_id`）；`FeishuInboundEvent` 新增 `senderUnionId`。
- `introducedPeers` 在 mention 的 `union_id` 与 `open_id` 不同的情况下记录该 `union_id`；`chat-bots-store` 用独立的 `trustedUnionIds` 列表保存，`trustedBotIds()` 把两类 id 合并进门禁的匹配集合。
- `dreamuxFeishuGate` 对 bot 发件人，open_id **或** union_id 命中受信集合即放行。
- `feishu inbound dropped` 诊断日志补充 `sender_union_id`，使下一次复现可自证。

桥接是**尽力而为且不回退**的：仅当 introduce 的 mention 与入站发件人**都**暴露 `union_id` 时生效，原 open_id 路径保持不变。`trustedUnionIds` 不进入展示面（`<group_bots>`、`list_chat_bots`），展示仍只用 open_id。

## 测试

- `dreamuxFeishuGate`：发件 open_id 不同但 union_id 命中 → 放行；两者都不命中 → 仍丢弃（`bot sender type: bot`）。
- `introducedPeers` / chat-bots store：union_id 记录与回读；展示面不被污染。
- transport `narrowMetaFromEvent`：提取 `sender_union_id`。

`rush build`（含类型检查）、`rush lint`、dreamux 全量用例（315 通过 / 1 skip）、feishu-transport 全量用例（179 通过）均通过。

## 残留风险

若该次事件的两个 open_id 实为**两个不同的 bot**，则原丢弃是正确行为、本 PR 对该次事件无效（但仍不会引入回退）；或两上下文中任一未暴露 `union_id` 时桥接不生效。新增的 `sender_union_id` 诊断字段可在下一次复现时一次性确证。