### PR TITLE
fix(feishu): 受信 peer bot 需 @ 本 bot；仅按 mention open_id 信任（#102）

### DIFF
--- a/.agents/domains/feishu-introduce.md
+++ b/.agents/domains/feishu-introduce.md
@@ -133,12 +133,25 @@ unchanged.
 - **trusted** — bots introduced by an allowlisted `/introduce`. Only this set
   lets a peer bot's group message through the gate.
 
-`dreamuxFeishuGate` drops every bot sender except one whose open_id is in the
-chat's trusted set (passed as `trustedBotIds`); a trusted bot is delivered
-without an `@`-mention because a bot cannot mention us. When `trustedBotIds` is
-omitted, no bot sender is ever delivered — preserving prior behavior. Recording
-a human open_id as "trusted" is harmless: the gate only bypasses for a bot
-*sender*, so a human entry never widens access.
+Trust identity is **strictly the mention `open_id`** (`introducedPeers`): a
+mention with no `open_id` is skipped, with no fallback to `union_id`/`user_id`
+(issue #102). Within one receiving app a peer bot's `open_id` is the same in the
+"mentioned" and "sender" contexts, so the mention `open_id` recorded here is
+exactly what the gate later matches against the bot's sender `open_id`.
+
+`dreamuxFeishuGate` drops every bot sender unless **both** hold: its sender
+`open_id` is in the chat's trusted set (passed as `trustedBotIds`) **and** the
+message `@`-mentions this bot. Trust is a precondition for entry, not a bypass of
+the mention gate (issue #102, aligned with the upstream lineage where peer-bot
+messages must address the bot before entering the conversation). When
+`trustedBotIds` is omitted, no bot sender is ever delivered. Recording a human
+open_id as "trusted" is harmless: the gate only consults the trusted set for a
+bot *sender*, so a human entry never widens access.
+
+`union_id` is never used for trust matching or persistence. A `sender_union_id`
+field may appear in the `feishu inbound dropped` diagnostic log only — it helps
+an operator tell "same bot, different app-scoped open_id" from "different
+entity" after a drop, and is never consulted by the gate.
 
 ## One-shot trusted-bot context (issue #69)
 

--- a/common/changes/@excitedjs/dreamux/feishu-trusted-bot-mention_2026-06-05-22-00.json
+++ b/common/changes/@excitedjs/dreamux/feishu-trusted-bot-mention_2026-06-05-22-00.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Trusted peer-bot inbound now requires both a trusted sender open_id and an @-mention of this bot; introduce trusts only mention open_id (no union_id/user_id fallback); add diagnostic-only sender_union_id to inbound-drop logs (issue #102)",
+      "type": "patch",
+      "packageName": "@excitedjs/dreamux"
+    }
+  ],
+  "packageName": "@excitedjs/dreamux",
+  "email": "053700@gmail.com"
+}

--- a/common/changes/@excitedjs/feishu-transport/feishu-trusted-bot-mention_2026-06-05-22-00.json
+++ b/common/changes/@excitedjs/feishu-transport/feishu-trusted-bot-mention_2026-06-05-22-00.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "narrowMetaFromEvent surfaces a diagnostic sender_union_id from the inbound event; it is observability-only and never used for access matching (issue #102)",
+      "type": "patch",
+      "packageName": "@excitedjs/feishu-transport"
+    }
+  ],
+  "packageName": "@excitedjs/feishu-transport",
+  "email": "053700@gmail.com"
+}

--- a/packages/channel/feishu-transport/src/parse/content.ts
+++ b/packages/channel/feishu-transport/src/parse/content.ts
@@ -116,6 +116,10 @@ export function narrowMetaFromEvent(rawEvent: unknown): Record<string, unknown> 
     chat_id: asString(message.chat_id),
     chat_type: asString(message.chat_type),
     sender_id: asString(senderId?.open_id),
+    // Diagnostic only. A bot's open_id is app-scoped, so a dropped peer-bot
+    // message's union_id helps an operator tell "same bot, different scope" from
+    // "different entity" after the fact. It is never used for access matching.
+    sender_union_id: asString(senderId?.union_id),
     sender_type: asString(sender.sender_type),
     root_id: asString(message.root_id),
     parent_id: asString(message.parent_id),

--- a/packages/channel/feishu-transport/tests/content.test.ts
+++ b/packages/channel/feishu-transport/tests/content.test.ts
@@ -134,6 +134,27 @@ describe('narrowMetaFromEvent', () => {
     })
   })
 
+  test('extracts the sender union_id (diagnostic) when present', () => {
+    expect(
+      narrowMetaFromEvent({
+        event: {
+          sender: {
+            sender_type: 'bot',
+            sender_id: { open_id: 'ou_sender', union_id: 'on_union' },
+          },
+          message: { message_id: 'om_3', chat_id: 'oc_3', chat_type: 'group' },
+        },
+      }),
+    ).toEqual({
+      message_id: 'om_3',
+      chat_id: 'oc_3',
+      chat_type: 'group',
+      sender_id: 'ou_sender',
+      sender_union_id: 'on_union',
+      sender_type: 'bot',
+    })
+  })
+
   test('extracts metadata from already-unwrapped event payloads', () => {
     expect(
       narrowMetaFromEvent({

--- a/packages/dreamux/src/channel/feishu-gate.ts
+++ b/packages/dreamux/src/channel/feishu-gate.ts
@@ -71,10 +71,11 @@ export interface DreamuxFeishuGateInput {
   now?: number;
   /**
    * Peer-bot open_ids trusted in this chat via an allowlisted `/introduce`
-   * (issue #62). A bot sender is normally dropped; a trusted bot's group
-   * message is delivered without an @-mention (bots cannot @-mention us).
-   * `undefined` for direct messages and for callers that do not track trust,
-   * in which case no bot sender is ever delivered — preserving prior behavior.
+   * (issue #62, #102). A bot sender is dropped unless its open_id is in this
+   * set AND the message @-mentions this bot — trust is a precondition, not a
+   * bypass of the mention gate. `undefined` for direct messages and for callers
+   * that do not track trust, in which case no bot sender is ever delivered —
+   * preserving prior behavior.
    */
   trustedBotIds?: ReadonlySet<string>;
 }
@@ -184,14 +185,21 @@ export function dreamuxFeishuGate(
 
   if (senderIsBot) {
     // A peer bot speaks only if it was introduced (trusted) for this chat by an
-    // allowlisted `/introduce`. Trusted bots bypass the mention gate because a
-    // bot cannot @-mention us; untrusted bots are dropped as before. This is
-    // per-chat trust (`trustedBotIds` is scoped to this chat by the caller) and
-    // is never reached through the human `allow_users` list.
-    if (input.trustedBotIds?.has(input.senderId) ?? false) {
-      return deliver(access, input, now);
+    // allowlisted `/introduce` AND it @-mentions this bot (issue #102, aligned
+    // with upstream lineage): trust is a precondition for entry, not a bypass of
+    // the mention gate. Untrusted bots are dropped regardless of mention. This
+    // is per-chat trust (`trustedBotIds` is scoped to this chat by the caller)
+    // and is never reached through the human `allow_users` list.
+    if (!(input.trustedBotIds?.has(input.senderId) ?? false)) {
+      return drop(`bot sender type: ${input.senderType}`);
     }
-    return drop(`bot sender type: ${input.senderType}`);
+    if (input.botOpenId === undefined) {
+      return drop('group message requires a bot mention but bot open_id is unknown');
+    }
+    if (!isBotMentioned(input.mentions, input.botOpenId)) {
+      return drop('bot not mentioned');
+    }
+    return deliver(access, input, now);
   }
 
   if (policy === 'follow-user') {

--- a/packages/dreamux/src/channel/introduce.ts
+++ b/packages/dreamux/src/channel/introduce.ts
@@ -170,8 +170,15 @@ export function detectIntroduce(
 
 /**
  * The peer bots an `/introduce` names — every @-mention except our own bot.
- * The sender-type check in the gate is what actually scopes trust to bots, so
- * a stray human mention recorded here can never widen access.
+ *
+ * Trust identity is **only** a mention's `open_id`. A mention that lacks
+ * `open_id` is skipped — we never fall back to `union_id` or `user_id` (issue
+ * #102). Within one receiving app a peer bot's `open_id` is stable across the
+ * "mentioned" and "sender" contexts, so the mention `open_id` recorded here is
+ * exactly what the inbound gate later matches against the bot's sender
+ * `open_id`; a `union_id`/`user_id` would not. The sender-type check in the
+ * gate is what actually scopes trust to bots, so a stray human mention recorded
+ * here can never widen access.
  */
 export function introducedPeers(
   mentions: Mention[],
@@ -180,7 +187,7 @@ export function introducedPeers(
   const peers: PeerBot[] = [];
   const seen = new Set<string>();
   for (const m of mentions) {
-    const openId = m.id?.open_id ?? m.id?.union_id ?? '';
+    const openId = m.id?.open_id ?? '';
     if (openId === '' || openId === selfOpenId || seen.has(openId)) continue;
     seen.add(openId);
     peers.push(m.name !== undefined ? { openId, name: m.name } : { openId });

--- a/packages/dreamux/src/feishu/bot.ts
+++ b/packages/dreamux/src/feishu/bot.ts
@@ -46,6 +46,13 @@ export interface FeishuInboundEvent {
   chatId: string;
   chatType: string; // 'p2p' | 'group' | ...
   senderId: string;
+  /**
+   * The sender's `union_id`, when Feishu provides it. Diagnostic only — it is
+   * surfaced in inbound-drop logs to help tell "same bot, different app-scoped
+   * open_id" apart from "different entity", and is never used for access
+   * gating. Absent when Feishu omits it.
+   */
+  senderUnionId?: string;
   senderType: string;
   /**
    * Best-effort display name seam for future enrichers. Feishu
@@ -252,6 +259,7 @@ function normalizeInboundEvent(raw: unknown): FeishuInboundEvent | null {
   const chatId = payload.meta['chat_id'] ?? '';
   const chatType = payload.meta['chat_type'] ?? '';
   const senderId = payload.meta['sender_id'] ?? '';
+  const senderUnionId = payload.meta['sender_union_id'] ?? '';
   const senderType = payload.meta['sender_type'] ?? '';
   const createTime = payload.meta['create_time'] ?? '';
   const senderName = extractSenderName(raw);
@@ -263,6 +271,7 @@ function normalizeInboundEvent(raw: unknown): FeishuInboundEvent | null {
     chatId,
     chatType,
     senderId,
+    ...(senderUnionId !== '' ? { senderUnionId } : {}),
     senderType,
     senderName,
     messageType,

--- a/packages/dreamux/src/server.ts
+++ b/packages/dreamux/src/server.ts
@@ -474,6 +474,13 @@ export class Server {
                 chat_id: event.chatId,
                 chat_type: event.chatType,
                 sender_id: event.senderId,
+                // Diagnostic only (issue #102): when a peer-bot message is
+                // dropped, its union_id helps tell "same bot, different
+                // app-scoped open_id" from "different entity". Not used for
+                // gating.
+                ...(event.senderUnionId !== undefined && event.senderUnionId !== ''
+                  ? { sender_union_id: event.senderUnionId }
+                  : {}),
                 message_id: event.messageId,
                 reason: gate.reason,
               },

--- a/packages/dreamux/tests/feishu-gate.test.ts
+++ b/packages/dreamux/tests/feishu-gate.test.ts
@@ -163,20 +163,46 @@ describe('dreamuxFeishuGate', () => {
 
   describe('peer-bot trust is per-chat and never reached through allow_users', () => {
     const botBase = { senderId: 'peer-bot', senderType: 'bot' };
+    // The default `gate` helper mention list @-mentions `bot-open-id`, the bot's
+    // own open_id, so a bot message that keeps it counts as "@-mentions us".
+    const mentionUs = [{ key: '@_bot', id: { open_id: 'bot-open-id' } }];
 
     it('drops an un-introduced bot sender', () => {
       const access = state({ group: { policy: 'allowlist', allow_chats: ['chat-group-a'], require_mention: true } });
       expect(gate(botBase, access)).toMatchObject({ action: 'drop' });
     });
 
-    it('delivers an introduced (trusted) bot sender without a mention, under follow-user', () => {
+    it('delivers a trusted bot that @-mentions us, under follow-user', () => {
+      const access = state({
+        allow_users: ['sender-allowed'],
+        group: { policy: 'follow-user', allow_chats: [], require_mention: true },
+      });
+      expect(
+        gate(
+          { ...botBase, mentions: mentionUs, trustedBotIds: new Set(['peer-bot']) },
+          access,
+        ),
+      ).toMatchObject({ action: 'deliver' });
+    });
+
+    it('drops a trusted bot that does NOT @-mention us (#102: trust is not a mention bypass)', () => {
       const access = state({
         allow_users: ['sender-allowed'],
         group: { policy: 'follow-user', allow_chats: [], require_mention: true },
       });
       expect(
         gate({ ...botBase, mentions: [], trustedBotIds: new Set(['peer-bot']) }, access),
-      ).toMatchObject({ action: 'deliver' });
+      ).toMatchObject({ action: 'drop', reason: 'bot not mentioned' });
+    });
+
+    it('drops an untrusted bot even when it @-mentions us', () => {
+      const access = state({
+        allow_users: ['sender-allowed'],
+        group: { policy: 'follow-user', allow_chats: [], require_mention: true },
+      });
+      expect(
+        gate({ ...botBase, mentions: mentionUs, trustedBotIds: new Set() }, access),
+      ).toMatchObject({ action: 'drop', reason: 'bot sender type: bot' });
     });
   });
 

--- a/packages/dreamux/tests/feishu-introduce.test.ts
+++ b/packages/dreamux/tests/feishu-introduce.test.ts
@@ -387,11 +387,34 @@ describe('introducedPeers', () => {
       { key: '@_user_1', id: { open_id: 'self-bot' }, name: 'Us' },
       { key: '@_user_2', id: { open_id: 'peer-a' }, name: 'Peer A' },
       { key: '@_user_3', id: { open_id: 'peer-a' }, name: 'Peer A again' },
-      { key: '@_user_4', id: { union_id: 'peer-b' } },
     ];
     expect(introducedPeers(mentions, 'self-bot')).toEqual([
       { openId: 'peer-a', name: 'Peer A' },
-      { openId: 'peer-b' },
+    ]);
+  });
+
+  // #102: trust identity is strictly the mention open_id. A mention with no
+  // open_id is skipped — no union_id / user_id fallback — so the trusted set
+  // only ever holds ids the inbound gate can match against a sender open_id.
+  it('skips a mention that has no open_id (no union_id/user_id fallback)', () => {
+    const mentions: Mention[] = [
+      { key: '@_user_1', id: { union_id: 'peer-union' }, name: 'Union Only' },
+      { key: '@_user_2', id: { user_id: 'peer-user' }, name: 'User Only' },
+      { key: '@_user_3', name: 'No Id' },
+      { key: '@_user_4', id: { open_id: 'peer-a' }, name: 'Peer A' },
+    ];
+    expect(introducedPeers(mentions, 'self-bot')).toEqual([
+      { openId: 'peer-a', name: 'Peer A' },
+    ]);
+  });
+
+  it('keeps only the open_id when a mention carries both open_id and union_id', () => {
+    const mentions: Mention[] = [
+      { key: '@_user_1', id: { open_id: 'peer-a', union_id: 'peer-union' }, name: 'Peer A' },
+    ];
+    // No `unionId` field on the result — union_id never enters trust.
+    expect(introducedPeers(mentions, 'self-bot')).toEqual([
+      { openId: 'peer-a', name: 'Peer A' },
     ]);
   });
 });
@@ -427,16 +450,34 @@ describe('gate trust — only introduced bots may speak in a group', () => {
     now: 1_700_000_000_000,
   };
 
+  // A peer bot @-mentioning us is encoded as a mention resolving to botOpenId.
+  const mentionUs = [{ key: '@_bot', id: { open_id: 'self-bot' } }];
+
   it('drops a bot sender that has not been introduced', () => {
     const access = state({ group: { policy: 'allowlist', allow_chats: ['chat-a'] } });
-    expect(dreamuxFeishuGate(base, access)).toMatchObject({ action: 'drop' });
+    expect(
+      dreamuxFeishuGate({ ...base, mentions: mentionUs }, access),
+    ).toMatchObject({ action: 'drop' });
   });
 
-  it('delivers a bot sender that was introduced (trusted), without a mention', () => {
+  it('delivers a trusted bot that @-mentions us', () => {
     const access = state({ group: { policy: 'allowlist', allow_chats: ['chat-a'] } });
     expect(
-      dreamuxFeishuGate({ ...base, trustedBotIds: new Set(['peer-bot']) }, access),
+      dreamuxFeishuGate(
+        { ...base, mentions: mentionUs, trustedBotIds: new Set(['peer-bot']) },
+        access,
+      ),
     ).toMatchObject({ action: 'deliver' });
+  });
+
+  it('drops a trusted bot that does NOT @-mention us (#102)', () => {
+    const access = state({ group: { policy: 'allowlist', allow_chats: ['chat-a'] } });
+    expect(
+      dreamuxFeishuGate(
+        { ...base, mentions: [], trustedBotIds: new Set(['peer-bot']) },
+        access,
+      ),
+    ).toMatchObject({ action: 'drop', reason: 'bot not mentioned' });
   });
 });
 
@@ -558,6 +599,16 @@ describe('chat-bots store — one-shot pending context (issue #69)', () => {
       { openId: 'peer-a', name: 'Peer A' },
     ]);
     expect(listing.trusted).toEqual([{ openId: 'peer-a', name: 'Peer A' }]);
+  });
+
+  // #102: a peer introduced without a name still trusts its open_id; the
+  // listing omits `name` entirely rather than echoing the raw open_id as a name.
+  it('trusts an open_id with no name and omits name in the listing', async () => {
+    await trustIntroducedBots('d1', 'chat-a', [{ openId: 'peer-noname' }]);
+    expect((await trustedBotIds('d1', 'chat-a')).has('peer-noname')).toBe(true);
+    const listing = await listChatBots('d1', 'chat-a');
+    expect(listing.trusted).toEqual([{ openId: 'peer-noname' }]);
+    expect(listing.trusted[0]).not.toHaveProperty('name');
   });
 
   it('returns empty listings/baseline for an unknown chat', async () => {

--- a/packages/dreamux/tests/smoke.test.ts
+++ b/packages/dreamux/tests/smoke.test.ts
@@ -352,6 +352,73 @@ describe('dreamux MVP smoke', () => {
     expect(d?.status).toBe('ready');
   });
 
+  it('introduce (no @ to us) trusts peer bots; trusted bot inbound requires @ (issue #102)', async () => {
+    const self = 'fake-open-id-app-smoke'; // the fake bot's own open_id
+    const atUs = [{ key: '@_bot', id: { open_id: self }, name: 'Dispatcher' }];
+    server = buildServer({ runtimeDir, fake, bot });
+    server.repos.dispatchers.create({
+      dispatcher_id: 'flow',
+      bot_app_id: 'app-smoke',
+      bot_secret_ref: 'env:UNUSED',
+    });
+    await server.start();
+
+    // 1) Allow-listed human runs /introduce mentioning two peer bots WITHOUT
+    //    @-mentioning us. Both peers are trusted by their mention open_id.
+    await bot.inject(
+      fakeInbound('chat-group-a', '/introduce', 'msg-intro', {
+        senderId: 'sender-test',
+        senderType: 'user',
+        mentions: [
+          { key: '@_user_1', id: { open_id: 'peer-bee' }, name: 'Bee' },
+          { key: '@_user_2', id: { open_id: 'peer-cee' } }, // no name
+        ],
+      }),
+    );
+
+    // list_chat_bots exposes trusted as { open_id, name? }; missing name omitted.
+    const listing = await server.listChatBotsFromMcp({
+      dispatcherId: 'flow',
+      chatId: 'chat-group-a',
+    });
+    expect(listing.chat_id).toBe('chat-group-a');
+    expect(listing.trusted).toEqual([
+      { open_id: 'peer-bee', name: 'Bee' },
+      { open_id: 'peer-cee' },
+    ]);
+
+    // 2) Trusted bot that @-mentions us → delivered to Codex.
+    await bot.inject(
+      fakeInbound('chat-group-a', 'hello from bee', 'msg-bee', {
+        senderId: 'peer-bee',
+        senderType: 'bot',
+        senderName: 'Bee',
+        mentions: atUs,
+      }),
+    );
+    await waitFor(() => codexInputs.length === 1);
+    expect(codexInputs[0]).toContain('hello from bee');
+
+    // 3) Trusted bot WITHOUT an @ → dropped (no new Codex turn).
+    await bot.inject(
+      fakeInbound('chat-group-a', 'no at here', 'msg-bee-noat', {
+        senderId: 'peer-bee',
+        senderType: 'bot',
+        mentions: [],
+      }),
+    );
+    // 4) Untrusted bot WITH an @ → dropped.
+    await bot.inject(
+      fakeInbound('chat-group-a', 'stranger', 'msg-dee', {
+        senderId: 'peer-dee',
+        senderType: 'bot',
+        mentions: atUs,
+      }),
+    );
+    await sleep(120);
+    expect(codexInputs).toHaveLength(1);
+  });
+
   it('starts the dispatcher app-server with global default Codex home and tm on PATH', async () => {
     const capturedCodexOptions: CodexProcessOptions[] = [];
     server = buildServer({ runtimeDir, fake, bot, capturedCodexOptions });


### PR DESCRIPTION
实现 #102 的修正版受信 peer bot 设计，取代已关闭的 #101（union_id 方案）。Closes #102。

## 改动

- **信任身份仅取 mention open_id**：`introducedPeers` 只认 `mentions[].id.open_id`；缺 open_id 的 mention 直接跳过，**不回退 union_id/user_id**。同一接收 app 内 peer bot 的 open_id 在「被 @」与「作为发件人」两种上下文一致，故记录的 mention open_id 正是入站 gate 用来匹配 sender open_id 的值。
- **入站放行要求 @**：bot 发件人仅当「sender open_id ∈ trusted」**且**「消息 @ 了本 bot」时才投递。信任是准入前提、非 mention 旁路（与上游血缘一致：peer bot 消息需先 @ 本 bot 才进入会话）。受信但未 @ → 丢弃；未受信即便 @ → 丢弃。
- **不再用 union_id 做信任**：信任匹配与持久化均无 union_id。仅新增**纯诊断**字段 `sender_union_id`（transport 透出、入站 drop 日志记录），用于事后区分「同一 bot 不同 app 作用域 open_id」与「不同实体」，**不参与 gate**。
- **known / trusted 保持分离**；`list_chat_bots` 仍返回 `{ chat_id, known: [{ open_id, name? }], trusted: [{ open_id, name? }] }`，名字未知则省略 name（绝不用 raw id 充当展示名）。
- **introduce 无需 @ 本 bot**：allow-list 人类用户 @ 多个 peer bot 并发 `/introduce` 即可逐个授信（前提：bot 订阅「接收群内全部消息」，属平台配置）。

## 测试

- introduce 不 @ 本 bot → 两个 peer 进入 trusted；`list_chat_bots` 返回 `{open_id, name?}`（缺名省略）。
- 受信 + @ → 投递；受信 + 未 @ → 丢弃；未受信 + @ → 丢弃。
- union 反回归：仅 union_id / 仅 user_id / 无 id 的 mention 被跳过；open_id+union_id 只存 open_id。
- 无名字仍按 open_id 授信且列表省略 name。
- transport `narrowMetaFromEvent` 提取诊断 `sender_union_id`。

## 验证

`rush build`（含类型检查）✅、`rush lint`✅、`.agents` KB 校验✅、`rush change --verify` ✅。
dreamux 全量 317 通过 / 1 skip；feishu-transport 全量 179 通过。

## 残留风险

- 「introduce 不 @ 本 bot 也能到达 Dreamux」依赖 bot 的群消息订阅范围为「接收全部」，属平台配置而非代码。
- 若历史失配源于「@ 到的并非真正发件实体」，则按本设计属正确丢弃；新增的 `sender_union_id` 诊断可在下次复现时确认根因。