### PR TITLE
feat(cli): 新增 dreamux changelog 命令并随包发布 changelog（#98 PR1）

### DIFF
--- a/.agents/decisions/cli-and-package-naming.md
+++ b/.agents/decisions/cli-and-package-naming.md
@@ -45,7 +45,16 @@ delegation; that wrapper is not a dreamux admin CLI.
   dreamux dispatcher stop
   dreamux config path
   dreamux config show
+  dreamux changelog
+  dreamux changelog --json
   ```
+
+- `dreamux changelog` prints the installed package's rush-generated
+  `CHANGELOG.md` (`--json` prints `CHANGELOG.json`). It is an offline,
+  deterministic read of the *installed* version — the upgrade-time information
+  entry point for the 0.x fail-loud + rebuild policy (issue #98). Both changelog
+  files must stay in `packages/dreamux/package.json` `files` or the command
+  reads nothing after publish.
 
 - `dreamux serve` is the foreground server entry point. Service managers also
   invoke `dreamux serve`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,8 +55,12 @@ two-paths consequence of `.agents/decisions/rush-pnpm-monorepo.md`).
 The user-facing CLI is the single global bin `dreamux`. Current command tree:
 `onboard`, `uninstall`, `serve`, `status`, `doctor`,
 `daemon install|uninstall|start|stop|restart`,
-`dispatcher add|remove|list|status|start|stop`, `feishu-mcp`, and
-`config path|show`. `dreamux serve` is the foreground server entry point. The
+`dispatcher add|remove|list|status|start|stop`, `feishu-mcp`,
+`config path|show`, and `changelog [--json]`. `dreamux changelog` prints the
+installed package's rush-generated `CHANGELOG.md` (or `CHANGELOG.json` with
+`--json`) — an offline read of the installed version, the upgrade-time
+information entry point for the 0.x fail-loud + rebuild policy (issue #98).
+`dreamux serve` is the foreground server entry point. The
 `daemon` group wraps the native user-level service manager (Linux
 `systemctl --user`, macOS `launchctl`); `daemon uninstall` removes only the
 service unit, whereas top-level `dreamux uninstall` removes config/state/logs
@@ -146,6 +150,36 @@ explicitly supersedes the top-level design.
 - **Tests that depend on a real codex install fail loudly when codex is
   missing**, not silent skip. Opt-in skip via `DREAMUX_SKIP_LIVE_CODEX=1`
   (see `tests/codex-0135-live.test.ts`'s docstring).
+
+## Changelog responsibility (user-visible upgrade blockers)
+
+In 0.x dreamux does **not** ship automatic schema migrations: incompatible
+config/state is handled by fail-loud + an explicit rebuild (issue #98). The
+changelog is the only upgrade-time information channel, so any change that can
+block or break a user's upgrade **must** ship a rush change file describing it.
+
+A change is an upgrade blocker if it touches any of:
+
+- config file schema or field semantics;
+- user directory structure or runtime/state/cache paths;
+- `access` / `state` / `status` / `restart-intent` (and similar) persisted file
+  formats;
+- `onboard` / `daemon` / service-unit behavior;
+- bundled skills, dispatcher working directory, or `.codex/skills` structure;
+- anything a user or an LLM must manually rebuild, delete, or migrate across the
+  upgrade.
+
+Rules:
+
+- Write the note via `rush change` (it feeds the rush-generated
+  `packages/dreamux/CHANGELOG.md` / `CHANGELOG.json`). Never hand-edit the
+  generated changelog files — a release regenerates them and the edit is lost.
+- In the change comment, lead breaking notes with a `BREAKING:` line and, when
+  the user must act, a `Rebuild:` line naming the exact file/path to recreate,
+  so a model reading `dreamux changelog --json` can parse the required action.
+- The matching read path is the bundled `dreamux-maintenance` skill's
+  "Upgrade Flow": install new package → `dreamux changelog` → handle
+  breaking/rebuild notes → `daemon restart` / `onboard`.
 
 ## Commits
 

--- a/common/changes/@excitedjs/dreamux/issue98-changelog-command_2026-06-05-12-00.json
+++ b/common/changes/@excitedjs/dreamux/issue98-changelog-command_2026-06-05-12-00.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Add the `dreamux changelog` command (and `--json`) that prints the installed package's bundled CHANGELOG, and ship CHANGELOG.md/CHANGELOG.json in the package files. This is the upgrade-time information entry point for the 0.x fail-loud + rebuild policy (issue #98).",
+      "type": "minor",
+      "packageName": "@excitedjs/dreamux"
+    }
+  ],
+  "packageName": "@excitedjs/dreamux",
+  "email": "053700@gmail.com"
+}

--- a/packages/dreamux/CLAUDE.md
+++ b/packages/dreamux/CLAUDE.md
@@ -6,6 +6,11 @@ app-server orchestration, Feishu MCP shim, state, and logs.
 ## Responsibilities
 
 - Own the `dreamux` and `tm` package bins.
+- Ship `CHANGELOG.md` / `CHANGELOG.json` inside the package (`files`) so
+  `dreamux changelog` can read the installed version's notes offline. Any
+  user-visible upgrade blocker in this package must carry a rush change file —
+  see the root `CLAUDE.md` "Changelog responsibility" rule. Never hand-edit the
+  generated changelog files.
 - Load operator config and server-owned state.
 - Start, stop, and supervise dispatcher Codex app-server processes.
 - Manage Codex threads, turn submission, restart notices, and fail-fast approval

--- a/packages/dreamux/package.json
+++ b/packages/dreamux/package.json
@@ -22,7 +22,9 @@
     "dist",
     "skills",
     "README.md",
-    "LICENSE"
+    "LICENSE",
+    "CHANGELOG.md",
+    "CHANGELOG.json"
   ],
   "scripts": {
     "build": "tsc -p tsconfig.json",

--- a/packages/dreamux/skills/dreamux-maintenance/SKILL.md
+++ b/packages/dreamux/skills/dreamux-maintenance/SKILL.md
@@ -74,6 +74,40 @@ dreamux config show
 For questions about active turns, steering, background commands, and repeated
 responses after compaction, read `references/codex-turns.md`.
 
+## Upgrade Flow
+
+Dreamux is in 0.x and does not ship automatic schema migrations. Incompatible
+config/state is handled by fail-loud + an explicit rebuild, not by silent
+conversion. Before installing or upgrading, read the changelog and resolve any
+breaking changes first; only then restart.
+
+1. Install the new package, then read the changelog it ships:
+
+```bash
+dreamux changelog          # CHANGELOG.md (human-readable)
+dreamux changelog --json   # CHANGELOG.json (machine-readable)
+```
+
+   `dreamux changelog` reads the *installed* package — run it after installing
+   the new version, not before. It cannot show notes for a version you have not
+   installed yet.
+
+2. Act on any breaking/rebuild notes before starting the new version:
+   - Rebuild or move aside config/state files the changelog calls out (for
+     example a Feishu `access.json` that is no longer schema-compatible — it
+     holds access grants and is not auto-migrated, so it must be recreated).
+   - Do not expect old permissions or recovery state to be inferred; the
+     changelog states exactly what to recreate.
+
+3. Only after the changelog actions are done, complete the upgrade:
+
+```bash
+dreamux daemon restart
+# or, for first install / re-registration:
+dreamux onboard
+dreamux daemon install
+```
+
 ## Restart Policy
 
 - If only the service wrapper changed, use `dreamux daemon restart`.

--- a/packages/dreamux/skills/dreamux-maintenance/SKILL.md
+++ b/packages/dreamux/skills/dreamux-maintenance/SKILL.md
@@ -78,8 +78,9 @@ responses after compaction, read `references/codex-turns.md`.
 
 Dreamux is in 0.x and does not ship automatic schema migrations. Incompatible
 config/state is handled by fail-loud + an explicit rebuild, not by silent
-conversion. Before installing or upgrading, read the changelog and resolve any
-breaking changes first; only then restart.
+conversion. `dreamux changelog` reads the *installed* package, so the order is:
+install the new package, run `dreamux changelog`, handle any breaking/rebuild
+notes, and only then restart or re-register.
 
 1. Install the new package, then read the changelog it ships:
 

--- a/packages/dreamux/src/cli/changelog.ts
+++ b/packages/dreamux/src/cli/changelog.ts
@@ -1,0 +1,51 @@
+/**
+ * `dreamux changelog` — offline, deterministic read of the *installed* package's
+ * release notes.
+ *
+ * Per issue #98, the 0.x upgrade policy is fail-loud + rebuild rather than
+ * accumulating automatic migrations. This command is the upgrade-time
+ * information entry point: after installing a new package, an operator (or an
+ * LLM following the `dreamux-maintenance` skill) reads the changelog shipped
+ * inside that new package, handles any breaking changes / rebuilds, and only
+ * then runs `dreamux daemon restart` / `onboard`.
+ *
+ * It reads the rush-generated `CHANGELOG.md` / `CHANGELOG.json` bundled in the
+ * package. It never fetches over the network and never inspects a target
+ * version: it reports the version that is currently installed.
+ */
+
+import { readFile } from 'node:fs/promises';
+
+import {
+  packagedChangelogJsonPath,
+  packagedChangelogMarkdownPath,
+} from '../runtime/paths.js';
+
+export interface ReadChangelogOptions {
+  json?: boolean;
+}
+
+/**
+ * Return the packaged changelog text. Markdown by default; the raw
+ * `CHANGELOG.json` when `json` is set. Fails loud when the file is absent so a
+ * broken package layout (changelog dropped from `package.json` `files`) is
+ * obvious rather than silently printing nothing.
+ */
+export async function readPackagedChangelog(
+  options: ReadChangelogOptions = {},
+): Promise<string> {
+  const path = options.json
+    ? packagedChangelogJsonPath()
+    : packagedChangelogMarkdownPath();
+  try {
+    return await readFile(path, 'utf8');
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === 'ENOENT') {
+      throw new Error(
+        `dreamux changelog is unavailable: ${path} is missing from the installed package.\n` +
+          'This usually means the changelog file was dropped from the package `files` list; reinstall dreamux.',
+      );
+    }
+    throw err;
+  }
+}

--- a/packages/dreamux/src/cli/dreamux.ts
+++ b/packages/dreamux/src/cli/dreamux.ts
@@ -569,7 +569,7 @@ async function main(): Promise<void> {
     .command('config <command>', 'Inspect config', buildConfigCommands)
     .command(
       'changelog',
-      "Print the installed package's changelog (read before upgrading)",
+      "Print the installed package's changelog (run after install, before restart/onboard)",
       (yy) =>
         yy.option('json', {
           type: 'boolean',

--- a/packages/dreamux/src/cli/dreamux.ts
+++ b/packages/dreamux/src/cli/dreamux.ts
@@ -44,6 +44,7 @@ import {
   notifyResumedRestart,
 } from '../daemon/restart-intent.js';
 import { ExecaCommandRunner } from '../onboard/commands.js';
+import { readPackagedChangelog } from './changelog.js';
 import { printDoctorResult, runDreamuxDoctor } from './doctor.js';
 import { runFeishuMcp } from '../mcp/feishu-mcp.js';
 import { createLogger } from '../runtime/logger.js';
@@ -566,6 +567,19 @@ async function main(): Promise<void> {
       },
     )
     .command('config <command>', 'Inspect config', buildConfigCommands)
+    .command(
+      'changelog',
+      "Print the installed package's changelog (read before upgrading)",
+      (yy) =>
+        yy.option('json', {
+          type: 'boolean',
+          describe: 'Print the raw CHANGELOG.json instead of CHANGELOG.md',
+        }),
+      async (argv) => {
+        const text = await readPackagedChangelog({ json: argv.json === true });
+        process.stdout.write(text.endsWith('\n') ? text : `${text}\n`);
+      },
+    )
     .demandCommand(1, 'Choose a command')
     .strict()
     .help()

--- a/packages/dreamux/src/runtime/paths.ts
+++ b/packages/dreamux/src/runtime/paths.ts
@@ -152,6 +152,20 @@ export function bundledSkillDir(skillName: BundledSkillName): string {
   return join(bundledSkillsDir(), skillName);
 }
 
+/**
+ * Packaged changelog files, shipped inside the installed package so that
+ * `dreamux changelog` is an offline, deterministic read of the *installed*
+ * version's release notes. Both files are rush-generated; they must stay in
+ * `package.json` `files` or these paths resolve outside the published tarball.
+ */
+export function packagedChangelogMarkdownPath(): string {
+  return join(PACKAGE_ROOT, 'CHANGELOG.md');
+}
+
+export function packagedChangelogJsonPath(): string {
+  return join(PACKAGE_ROOT, 'CHANGELOG.json');
+}
+
 export function dispatcherAppServerControlDir(id: string): string {
   return dispatcherDir(id);
 }

--- a/packages/dreamux/tests/changelog.test.ts
+++ b/packages/dreamux/tests/changelog.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest';
+import { readFile } from 'node:fs/promises';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { readPackagedChangelog } from '../src/cli/changelog.js';
+import {
+  packagedChangelogJsonPath,
+  packagedChangelogMarkdownPath,
+} from '../src/runtime/paths.js';
+
+const PACKAGE_ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
+
+describe('dreamux changelog', () => {
+  it('resolves the packaged changelog paths to the package root', () => {
+    expect(packagedChangelogMarkdownPath()).toBe(
+      join(PACKAGE_ROOT, 'CHANGELOG.md'),
+    );
+    expect(packagedChangelogJsonPath()).toBe(
+      join(PACKAGE_ROOT, 'CHANGELOG.json'),
+    );
+  });
+
+  it('prints the markdown changelog by default', async () => {
+    const text = await readPackagedChangelog();
+    expect(text).toContain('# Change Log - @excitedjs/dreamux');
+  });
+
+  it('prints the raw JSON changelog with --json', async () => {
+    const text = await readPackagedChangelog({ json: true });
+    const parsed = JSON.parse(text) as { name: string; entries: unknown[] };
+    expect(parsed.name).toBe('@excitedjs/dreamux');
+    expect(Array.isArray(parsed.entries)).toBe(true);
+  });
+
+  // Packaging guard: `dreamux changelog` reads files shipped in the published
+  // tarball. If either changelog is dropped from `package.json` `files`, the
+  // command reads nothing after install. This test fails loud on that
+  // regression so the publish shape stays correct.
+  it('ships both changelog files in package.json files', async () => {
+    const pkg = JSON.parse(
+      await readFile(join(PACKAGE_ROOT, 'package.json'), 'utf8'),
+    ) as { files: string[] };
+    expect(pkg.files).toContain('CHANGELOG.md');
+    expect(pkg.files).toContain('CHANGELOG.json');
+  });
+});


### PR DESCRIPTION
## 背景

issue #98 收敛后的 PR1（共 3 个 PR：①changelog 基础设施+文档 → ②版本读取策略统一 → ③旧兼容删除）。本 PR 只做 changelog 基础设施与文档，是 0.x「fail-loud + 重建」升级策略的信息入口，**不改动任何迁移行为**。

## 改动

- 新增 `dreamux changelog` / `dreamux changelog --json`：离线、确定地读取**已安装包内**的 rush 生成 `CHANGELOG.md` / `CHANGELOG.json`，缺文件时 fail-loud。
- `packages/dreamux/package.json` 的 `files` 加入 `CHANGELOG.md`、`CHANGELOG.json`（此前未包含，否则发布后命令读不到）。
- 路径构造器放入 `src/runtime/paths.ts`（`packagedChangelogMarkdownPath` / `packagedChangelogJsonPath`），遵守仓库「路径只在 paths.ts 构造」规则。
- `dreamux-maintenance` skill 新增 **Upgrade Flow** 章节：安装新包 → `dreamux changelog` → 按 breaking/rebuild 说明处理 config/state → 再 `daemon restart` / `onboard`；并说明命令读的是已安装版本、不能预览未安装版本。
- root `CLAUDE.md` + `packages/dreamux/CLAUDE.md` 固化 changelog 写入责任：用户侧升级阻塞点变更必须写 `rush change`（禁止手改生成物），breaking 用 `BREAKING:` 行、需操作时加 `Rebuild:` 行，便于 `--json` 消费方解析。
- KB `.agents/decisions/cli-and-package-naming.md` 命令树补充 `changelog`。
- 配套 `rush change`（minor）。

## 范围边界

明确**不在本 PR**：access/status/restart-intent 迁移行为变更、`runtimeRoot`/`--runtime-dir`/旧 skill 迁移删除、onboard upsert clobber follow-up。这些属于 PR2/PR3。

## 测试 / 检查

- `rush build`、`rush lint`、`.agents/scripts/check.sh` 全绿。
- 全量 `vitest`：314 passed / 1 skipped（live codex）。
- 新增 `tests/changelog.test.ts`：路径解析、md/json 输出、**`package.json files` 含两个 changelog 的发布形态守卫**。
- 构建产物端到端冒烟：`dreamux changelog` / `--json` / `--help` 均正常。

## 残留风险

- changelog 内容由 rush 在发布时生成，本 PR 仅消费现有文件，不改生成链路。
- `--json` 的 `BREAKING:`/`Rebuild:` 约定是文档约定，尚无强制校验（如需 lint 校验可后续另开）。

Refs #98