### PR TITLE
feat(runtime): 统一持久化文件版本读取策略（#98 PR2）

### DIFF
--- a/.agents/decisions/top-level-design.md
+++ b/.agents/decisions/top-level-design.md
@@ -218,9 +218,11 @@ and the legacy v1 shape (`dm.allow_users` + a separate `group.follow_users`) is
 no longer read, merged, or inferred. dreamux 0.x does not auto-migrate this file
 because it holds access authorization — silently inferring old permissions could
 relax or revoke access. An absent `group.policy` on a v2 file defaults to the
-secure `follow-user`; it is not inferred from other fields. To move past an
-incompatible file the operator deletes it (returning to the secure default — no
-one is authorized until reconfigured) and re-authorizes access.
+secure `follow-user`; it is not inferred from other fields. `access.json` is
+operator-edited directly (there is no grant command, and `dreamux onboard` does
+not touch it), so the recovery path for an incompatible file is: delete it
+(returning to the secure default — no one is authorized) and recreate it in the
+v2 shape with `allow_users` and `group.policy`.
 
 It must not contain credentials, queued inbound messages, dedupe state, or a
 reaction ledger.

--- a/.agents/decisions/top-level-design.md
+++ b/.agents/decisions/top-level-design.md
@@ -172,7 +172,12 @@ time, admin socket path, and last error.
 
 `status.json` stores dispatcher process status, last-known Codex thread id,
 child process status, and diagnostic timestamps. It must not contain Feishu
-credentials.
+credentials. It is server-owned, rebuildable recovery state: on an
+incompatible/unknown version, malformed JSON, or a dispatcher-id mismatch,
+`hydrate()` warns and rebuilds the row from config defaults (a saved thread_id
+may not be resumed) — it never silently discards and never hard-fatals the
+server (issue #98). Likewise the one-shot `restart-intent.json` marker: a
+malformed or unknown-version marker is warned and dropped, not silently ignored.
 
 `access.json` stores dispatcher-local access state. The shape is:
 
@@ -207,12 +212,15 @@ is no separate per-group sender list.
   authorization (`allow_chats` is ignored), a message is always mention-gated,
   and the sender must be on the global `allow_users` list.
 
-The legacy v1 shape (`dm.allow_users` + a separate `group.follow_users`) is read
-and migrated forward by `readDispatcherAccess`: the two legacy sender lists are
-merged into `allow_users`, the policy is inferred (a non-empty `follow_users` →
-`follow-user`, else a non-empty `allow_chats` → `allowlist`, else the default
-`follow-user`), and the first save rewrites the file to the v2 shape. The legacy
-fields are never written back.
+`access.json` is **v2-only** (issue #98). `readDispatcherAccess` requires
+`version === 2`; any other or missing version fails loud with rebuild guidance,
+and the legacy v1 shape (`dm.allow_users` + a separate `group.follow_users`) is
+no longer read, merged, or inferred. dreamux 0.x does not auto-migrate this file
+because it holds access authorization — silently inferring old permissions could
+relax or revoke access. An absent `group.policy` on a v2 file defaults to the
+secure `follow-user`; it is not inferred from other fields. To move past an
+incompatible file the operator deletes it (returning to the secure default — no
+one is authorized until reconfigured) and re-authorizes access.
 
 It must not contain credentials, queued inbound messages, dedupe state, or a
 reaction ledger.

--- a/common/changes/@excitedjs/dreamux/issue98-version-policy_2026-06-05-13-00.json
+++ b/common/changes/@excitedjs/dreamux/issue98-version-policy_2026-06-05-13-00.json
@@ -1,7 +1,7 @@
 {
   "changes": [
     {
-      "comment": "Unify persisted-file version policy (issue #98). BREAKING: dispatcher access.json is now v2-only; the legacy v1 shape (dm.allow_users + group.follow_users) is no longer auto-migrated and an unsupported/missing version fails loud. Rebuild: delete the dispatcher's access.json to return to the secure default (no one authorized until reconfigured), then re-authorize access (e.g. re-run onboard / re-issue grants) and restart. status.json and restart-intent.json now warn-and-rebuild / warn-and-drop on incompatible or malformed content instead of silently discarding; neither hard-fatals the server.",
+      "comment": "Unify persisted-file version policy (issue #98). BREAKING: dispatcher access.json is now v2-only; the legacy v1 shape (dm.allow_users + group.follow_users) is no longer auto-migrated and an unsupported/missing version fails loud. Rebuild: delete the dispatcher's access.json to return to the secure default (no one authorized), then recreate it as a v2 access.json with allow_users and group.policy (see the access.json section in the dreamux README) and restart; note that `dreamux onboard` does not restore access grants. status.json and restart-intent.json now warn-and-rebuild / warn-and-drop on incompatible, malformed, or invalid-field content instead of silently discarding or misreading; neither hard-fatals the server.",
       "type": "minor",
       "packageName": "@excitedjs/dreamux"
     }

--- a/common/changes/@excitedjs/dreamux/issue98-version-policy_2026-06-05-13-00.json
+++ b/common/changes/@excitedjs/dreamux/issue98-version-policy_2026-06-05-13-00.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Unify persisted-file version policy (issue #98). BREAKING: dispatcher access.json is now v2-only; the legacy v1 shape (dm.allow_users + group.follow_users) is no longer auto-migrated and an unsupported/missing version fails loud. Rebuild: delete the dispatcher's access.json to return to the secure default (no one authorized until reconfigured), then re-authorize access (e.g. re-run onboard / re-issue grants) and restart. status.json and restart-intent.json now warn-and-rebuild / warn-and-drop on incompatible or malformed content instead of silently discarding; neither hard-fatals the server.",
+      "type": "minor",
+      "packageName": "@excitedjs/dreamux"
+    }
+  ],
+  "packageName": "@excitedjs/dreamux",
+  "email": "053700@gmail.com"
+}

--- a/packages/dreamux/README.md
+++ b/packages/dreamux/README.md
@@ -144,13 +144,11 @@ Access-gate allowlists are not part of `config.json`. Configure them in
 
 ```json
 {
-  "version": 1,
-  "dm": {
-    "allow_users": ["<USER_ID>"]
-  },
+  "version": 2,
+  "allow_users": ["<USER_ID>"],
   "group": {
+    "policy": "follow-user",
     "allow_chats": ["<CHAT_ID>"],
-    "follow_users": ["<USER_ID>"],
     "require_mention": true
   },
   "observed_chats": [],
@@ -158,6 +156,15 @@ Access-gate allowlists are not part of `config.json`. Configure them in
   "last_gate": null
 }
 ```
+
+`access.json` is v2-only. `allow_users` is the single global allowlist of
+sender open_ids, shared by direct messages and the group `follow-user` policy.
+`group.policy` is one of `block`, `allowlist`, or `follow-user`; under
+`allowlist` the gate consults `allow_chats`, under `follow-user` it ignores
+`allow_chats` and gates on `allow_users`. dreamux 0.x does not migrate older
+shapes: an unsupported or missing `version` fails loud at startup. To reset,
+delete the file (secure default: no one authorized) and recreate it in this v2
+shape.
 
 The server reads `access.json` directly at runtime and preserves runtime
 observations and warnings in the same file.

--- a/packages/dreamux/src/channel/feishu-gate.ts
+++ b/packages/dreamux/src/channel/feishu-gate.ts
@@ -28,11 +28,11 @@ export type GroupPolicy = 'block' | 'allowlist' | 'follow-user';
 
 export interface DispatcherAccessState {
   /**
-   * Schema version. `1` was the legacy two-list shape (`dm.allow_users` +
-   * `group.follow_users`); `2` unifies them into the top-level `allow_users`
-   * and adds the explicit `group.policy`. `readDispatcherAccess` migrates a v1
-   * file forward by field presence; the marker just records that the rewrite
-   * happened.
+   * Schema version. The only supported value is `2`: a single top-level
+   * `allow_users` list plus an explicit `group.policy`. Per issue #98, dreamux
+   * 0.x does not auto-migrate older shapes — `readDispatcherAccess` fails loud
+   * on any other (or missing) version and tells the operator to recreate the
+   * file, since it holds access authorization and cannot be inferred safely.
    */
   version: 2;
   /**
@@ -288,23 +288,25 @@ function readDispatcherAccess(
   if (!isRecord(raw)) {
     throw new Error(`dispatcher access error in ${path}: top-level must be an object`);
   }
+  // v2-only: the legacy v1 shape (`dm.allow_users` + `group.follow_users`) is no
+  // longer read or inferred. An unsupported or missing version fails loud — this
+  // file holds access authorization, so dreamux refuses to guess old permissions.
+  if (raw['version'] !== 2) {
+    const found =
+      raw['version'] === undefined ? 'missing' : JSON.stringify(raw['version']);
+    throw new Error(
+      `dispatcher access error in ${path}: unsupported schema version (found ${found}, expected 2).\n` +
+        'dreamux 0.x does not migrate old access state. This file controls access ' +
+        'authorization and old permissions will not be inferred. Delete it to return ' +
+        'to the secure default (no one is authorized until reconfigured), then ' +
+        're-authorize access (e.g. re-run onboard / re-issue grants) and restart.',
+    );
+  }
   const defaults = defaultDispatcherAccessState();
-  const dm = isRecord(raw['dm']) ? raw['dm'] : {};
   const group = isRecord(raw['group']) ? raw['group'] : {};
   const lastGate = raw['last_gate'];
 
-  // v2 unifies three possible sources of allowed senders into one list:
-  //   - top-level `allow_users` (v2),
-  //   - legacy `dm.allow_users` (v1 direct allowlist),
-  //   - legacy `group.follow_users` (v1 group sender allowlist).
-  // They are merged and de-duplicated; the legacy fields are read but never
-  // written back, so the first save collapses the file to the v2 shape. The
-  // union means DM access becomes `dm.allow_users ∪ group.follow_users` — for
-  // the common case (the two were equal, or dm ⊇ follow) DM is unchanged.
-  const topAllow = readStringArray(raw, 'allow_users', [], path);
-  const legacyDmAllow = readStringArray(dm, 'allow_users', [], path);
-  const legacyFollow = readStringArray(group, 'follow_users', [], path);
-  const allowUsers = [...new Set([...topAllow, ...legacyDmAllow, ...legacyFollow])];
+  const allowUsers = readStringArray(raw, 'allow_users', [], path);
   const allowChats = readStringArray(
     group,
     'allow_chats',
@@ -312,19 +314,10 @@ function readDispatcherAccess(
     path,
   );
 
-  // Group policy: an explicit value always wins. Otherwise infer from the
-  // legacy shape — a non-empty `follow_users` is the strongest signal the
-  // operator wanted sender-scoped gating, so preserve it as `follow-user`
-  // (never silently relax it to chat-only `allowlist`); then a non-empty
-  // `allow_chats` means chat-scoped gating; else the secure default.
-  const explicitPolicy = readGroupPolicy(group['policy'], path);
+  // Group policy: an explicit value wins; an absent field falls back to the
+  // secure default. No inference from other fields — that was the v1 migration.
   const policy: GroupPolicy =
-    explicitPolicy ??
-    (legacyFollow.length > 0
-      ? 'follow-user'
-      : allowChats.length > 0
-        ? 'allowlist'
-        : defaults.group.policy);
+    readGroupPolicy(group['policy'], path) ?? defaults.group.policy;
 
   return {
     version: 2,

--- a/packages/dreamux/src/channel/feishu-gate.ts
+++ b/packages/dreamux/src/channel/feishu-gate.ts
@@ -298,8 +298,9 @@ function readDispatcherAccess(
       `dispatcher access error in ${path}: unsupported schema version (found ${found}, expected 2).\n` +
         'dreamux 0.x does not migrate old access state. This file controls access ' +
         'authorization and old permissions will not be inferred. Delete it to return ' +
-        'to the secure default (no one is authorized until reconfigured), then ' +
-        're-authorize access (e.g. re-run onboard / re-issue grants) and restart.',
+        'to the secure default (no one is authorized), then recreate it as a v2 ' +
+        'access.json — set `allow_users` and `group.policy` — and restart. See the ' +
+        'access.json section in the dreamux README for the v2 shape.',
     );
   }
   const defaults = defaultDispatcherAccessState();

--- a/packages/dreamux/src/daemon/restart-intent.ts
+++ b/packages/dreamux/src/daemon/restart-intent.ts
@@ -149,19 +149,32 @@ export class RestartIntentConsumer {
 
   /**
    * Read the marker (if any), delete it from disk, and return a consumer. A
-   * missing / malformed / expired marker yields an empty consumer (and the
-   * stale file is removed). This is the only reader of the marker file.
+   * missing or expired marker yields an empty consumer quietly. A malformed or
+   * unknown-version marker also yields an empty consumer, but is reported via
+   * `warn` (issue #98): a bad marker is dropped, not silently ignored, because a
+   * restart notice the operator explicitly requested would otherwise vanish
+   * without a trace. The file is removed regardless of validity (single reader,
+   * never replays). This is the only reader of the marker file.
    */
   static async load(
-    options: { now: number; path?: string } = { now: 0 },
+    options: { now: number; path?: string; warn?: (message: string) => void } = {
+      now: 0,
+    },
   ): Promise<RestartIntentConsumer> {
     const path = options.path ?? restartIntentPath();
+    const warn = options.warn ?? ((message) => console.warn(message));
     const empty = new RestartIntentConsumer('', 0, new Set());
-    let parsed: RestartIntentFile | null = null;
+
+    let text: string | null = null;
     try {
-      parsed = JSON.parse(await readFile(path, 'utf8')) as RestartIntentFile;
-    } catch {
-      parsed = null;
+      text = await readFile(path, 'utf8');
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code !== 'ENOENT') {
+        warn(
+          `restart marker ${path} could not be read ` +
+            `(${err instanceof Error ? err.message : String(err)}); dropping it.`,
+        );
+      }
     }
     // Single reader: drop the file regardless of validity so it never replays.
     try {
@@ -169,7 +182,31 @@ export class RestartIntentConsumer {
     } catch {
       /* best effort */
     }
-    if (parsed === null || parsed.version !== 1) return empty;
+    if (text === null) return empty;
+
+    let parsed: RestartIntentFile | null = null;
+    try {
+      parsed = JSON.parse(text) as RestartIntentFile;
+    } catch (err) {
+      warn(
+        `restart marker ${path} is not valid JSON ` +
+          `(${err instanceof Error ? err.message : String(err)}); dropped it. ` +
+          'A requested restart notice will not be delivered.',
+      );
+      return empty;
+    }
+    if (parsed === null || parsed.version !== 1) {
+      const found =
+        parsed === null || parsed.version === undefined
+          ? 'missing'
+          : JSON.stringify(parsed.version);
+      warn(
+        `restart marker ${path} ignored: unsupported version ` +
+          `(found ${found}, expected 1); dropped it. ` +
+          'A requested restart notice will not be delivered.',
+      );
+      return empty;
+    }
     const expiresAtMs = parsed.created_at_ms + parsed.ttl_ms;
     if (options.now > expiresAtMs) return empty;
     const announce =

--- a/packages/dreamux/src/daemon/restart-intent.ts
+++ b/packages/dreamux/src/daemon/restart-intent.ts
@@ -207,6 +207,23 @@ export class RestartIntentConsumer {
       );
       return empty;
     }
+    // A correctly-versioned marker can still carry malformed fields. Treat that
+    // like any other corrupt marker: warn + drop, never throw or misread. A
+    // non-array `targets` would otherwise crash `dedupeNonEmpty`, and a
+    // non-numeric `created_at_ms`/`ttl_ms` would produce a NaN expiry.
+    if (
+      !Number.isFinite(parsed.created_at_ms) ||
+      !Number.isFinite(parsed.ttl_ms) ||
+      !Array.isArray(parsed.targets) ||
+      !parsed.targets.every((target) => typeof target === 'string')
+    ) {
+      warn(
+        `restart marker ${path} ignored: malformed fields ` +
+          '(created_at_ms/ttl_ms must be finite numbers, targets a string array); ' +
+          'dropped it. A requested restart notice will not be delivered.',
+      );
+      return empty;
+    }
     const expiresAtMs = parsed.created_at_ms + parsed.ttl_ms;
     if (options.now > expiresAtMs) return empty;
     const announce =
@@ -216,7 +233,7 @@ export class RestartIntentConsumer {
     return new RestartIntentConsumer(
       announce,
       expiresAtMs,
-      new Set(dedupeNonEmpty(parsed.targets ?? [])),
+      new Set(dedupeNonEmpty(parsed.targets)),
     );
   }
 

--- a/packages/dreamux/src/runtime/config.ts
+++ b/packages/dreamux/src/runtime/config.ts
@@ -169,8 +169,10 @@ export async function assertNoLegacyTomlOnly(
   if ((await pathExists(jsonFile)) || !(await pathExists(tomlFile))) return;
   throw new Error(
     `legacy dreamux config detected at ${tomlFile}, but ${jsonFile} does not exist.\n` +
-      'dreamux no longer reads TOML config and will not create default JSON over an existing install.\n' +
-      `Create ${jsonFile} manually with a dispatchers array, then move ${tomlFile} aside.`,
+      'dreamux 0.x does not migrate TOML config; it will not read it or write default ' +
+      'JSON over an existing install.\n' +
+      `Recreate the config as JSON (run \`dreamux onboard\`, or write ${jsonFile} with a ` +
+      `dispatchers array), then move ${tomlFile} aside.`,
   );
 }
 

--- a/packages/dreamux/src/runtime/dispatcher-store.ts
+++ b/packages/dreamux/src/runtime/dispatcher-store.ts
@@ -326,24 +326,58 @@ async function readStatusFile(
     return null;
   }
 
+  // A correctly-versioned, id-matched file can still carry malformed key
+  // fields. Silently coercing them (a numeric thread_id → null, a bad status →
+  // 'declared', a non-finite updated_at → now) would lose a resumable thread or
+  // change status without a trace. Treat a wrong-typed field as a corrupt file:
+  // warn + rebuild. An *absent* nullable field is benign and defaults to null;
+  // the required `status` / `updated_at` must be present and well-typed.
+  if (
+    !isNullableString(raw.thread_id) ||
+    !isDispatcherStatus(raw.status) ||
+    !(typeof raw.updated_at === 'number' && Number.isFinite(raw.updated_at)) ||
+    !isNullableNumber(raw.last_started_at) ||
+    !isNullableNumber(raw.last_ready_at) ||
+    !isNullableString(raw.last_error) ||
+    !isNullableString(raw.last_lost_thread_id)
+  ) {
+    warn(
+      `dispatcher '${id}' status file ${path} ignored: malformed v1 fields; ` +
+        'rebuilding dispatcher status from config defaults; ' +
+        'a saved thread_id will not be resumed.',
+    );
+    return null;
+  }
+
   return {
     version: 1,
     dispatcher_id: id,
-    thread_id: typeof raw.thread_id === 'string' ? raw.thread_id : null,
-    status: isDispatcherStatus(raw.status) ? raw.status : 'declared',
-    updated_at:
-      typeof raw.updated_at === 'number' && Number.isFinite(raw.updated_at)
-        ? raw.updated_at
-        : Date.now(),
-    last_started_at: numberOrNull(raw.last_started_at),
-    last_ready_at: numberOrNull(raw.last_ready_at),
-    last_error: stringOrNull(raw.last_error),
-    last_lost_thread_id: stringOrNull(raw.last_lost_thread_id),
+    thread_id: raw.thread_id ?? null,
+    status: raw.status,
+    updated_at: raw.updated_at,
+    last_started_at: raw.last_started_at ?? null,
+    last_ready_at: raw.last_ready_at ?? null,
+    last_error: raw.last_error ?? null,
+    last_lost_thread_id: raw.last_lost_thread_id ?? null,
   };
 }
 
 function errMessage(err: unknown): string {
   return err instanceof Error ? err.message : String(err);
+}
+
+/** Accept an absent (defaults to null), explicit null, or string field. */
+function isNullableString(value: unknown): boolean {
+  return value === undefined || value === null || typeof value === 'string';
+}
+
+/** Accept an absent (defaults to null), explicit null, or finite-number field. */
+function isNullableNumber(value: unknown): boolean {
+  return (
+    value === undefined ||
+    value === null ||
+    (typeof value === 'number' && Number.isFinite(value))
+  );
 }
 
 function isDispatcherStatus(value: unknown): value is DispatcherStatus {
@@ -353,14 +387,6 @@ function isDispatcherStatus(value: unknown): value is DispatcherStatus {
     value === 'degraded' ||
     value === 'stopping' ||
     value === 'stopped';
-}
-
-function numberOrNull(value: unknown): number | null {
-  return typeof value === 'number' && Number.isFinite(value) ? value : null;
-}
-
-function stringOrNull(value: unknown): string | null {
-  return typeof value === 'string' ? value : null;
 }
 
 function normalizeEnabled(value: 0 | 1 | boolean): 0 | 1 {

--- a/packages/dreamux/src/runtime/dispatcher-store.ts
+++ b/packages/dreamux/src/runtime/dispatcher-store.ts
@@ -4,6 +4,16 @@ import { dirname } from 'node:path';
 import type { DispatcherConfig, DreamuxConfig } from './config.js';
 import { dispatcherStatusPath } from './paths.js';
 
+/**
+ * Warn sink for non-fatal recovery problems. `status.json` is server-owned,
+ * rebuildable recovery state (issue #98): an incompatible/corrupt file must not
+ * hard-fatal the server, but it must not be discarded silently either — the
+ * loss of a resumable thread_id is observable. Defaults to `console.warn` so
+ * direct callers and tests still surface it; the server passes its logger.
+ */
+export type StatusWarnLog = (message: string) => void;
+const defaultStatusWarn: StatusWarnLog = (message) => console.warn(message);
+
 export type DispatcherStatus =
   | 'declared'
   | 'starting'
@@ -70,10 +80,10 @@ export class DispatcherStore {
    * Restores thread_id / status / timestamps across restarts. The server calls
    * this once during `start()`, before any dispatcher is launched. Idempotent.
    */
-  async hydrate(): Promise<void> {
+  async hydrate(warn: StatusWarnLog = defaultStatusWarn): Promise<void> {
     const now = Date.now();
     for (const dispatcher of this.seedDispatchers) {
-      this.rows.set(dispatcher.id, await rowFromConfig(dispatcher, now));
+      this.rows.set(dispatcher.id, await rowFromConfig(dispatcher, now, warn));
     }
   }
 
@@ -241,8 +251,9 @@ function rowDefaults(config: DispatcherConfig, now: number): DispatcherRow {
 async function rowFromConfig(
   config: DispatcherConfig,
   now: number,
+  warn: StatusWarnLog,
 ): Promise<DispatcherRow> {
-  const status = await readStatusFile(config.id);
+  const status = await readStatusFile(config.id, warn);
   return {
     ...rowDefaults(config, now),
     thread_id: status?.thread_id ?? null,
@@ -274,30 +285,65 @@ function dispatcherCodexArgsJson(config: DispatcherConfig): string {
 
 async function readStatusFile(
   id: string,
+  warn: StatusWarnLog,
 ): Promise<DispatcherStatusFile | null> {
   const path = dispatcherStatusPath(id);
+  let text: string;
   try {
-    const raw = JSON.parse(
-      await readFile(path, 'utf8'),
-    ) as Partial<DispatcherStatusFile>;
-    if (raw.version !== 1 || raw.dispatcher_id !== id) return null;
-    return {
-      version: 1,
-      dispatcher_id: id,
-      thread_id: typeof raw.thread_id === 'string' ? raw.thread_id : null,
-      status: isDispatcherStatus(raw.status) ? raw.status : 'declared',
-      updated_at:
-        typeof raw.updated_at === 'number' && Number.isFinite(raw.updated_at)
-          ? raw.updated_at
-          : Date.now(),
-      last_started_at: numberOrNull(raw.last_started_at),
-      last_ready_at: numberOrNull(raw.last_ready_at),
-      last_error: stringOrNull(raw.last_error),
-      last_lost_thread_id: stringOrNull(raw.last_lost_thread_id),
-    };
-  } catch {
+    text = await readFile(path, 'utf8');
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === 'ENOENT') return null;
+    // A readable file that fails for any other reason: rebuild, but say so.
+    warn(
+      `dispatcher '${id}' status file ${path} could not be read ` +
+        `(${errMessage(err)}); rebuilding dispatcher status from config defaults.`,
+    );
     return null;
   }
+
+  let raw: Partial<DispatcherStatusFile>;
+  try {
+    raw = JSON.parse(text) as Partial<DispatcherStatusFile>;
+  } catch (err) {
+    warn(
+      `dispatcher '${id}' status file ${path} is not valid JSON ` +
+        `(${errMessage(err)}); rebuilding dispatcher status; ` +
+        'a saved thread_id may not be resumed.',
+    );
+    return null;
+  }
+
+  if (raw.version !== 1 || raw.dispatcher_id !== id) {
+    const reason =
+      raw.version !== 1
+        ? `unsupported version (found ${raw.version === undefined ? 'missing' : JSON.stringify(raw.version)}, expected 1)`
+        : `dispatcher id mismatch (file recorded ${JSON.stringify(raw.dispatcher_id)})`;
+    warn(
+      `dispatcher '${id}' status file ${path} ignored: ${reason}; ` +
+        'rebuilding dispatcher status from config defaults; ' +
+        'a saved thread_id will not be resumed.',
+    );
+    return null;
+  }
+
+  return {
+    version: 1,
+    dispatcher_id: id,
+    thread_id: typeof raw.thread_id === 'string' ? raw.thread_id : null,
+    status: isDispatcherStatus(raw.status) ? raw.status : 'declared',
+    updated_at:
+      typeof raw.updated_at === 'number' && Number.isFinite(raw.updated_at)
+        ? raw.updated_at
+        : Date.now(),
+    last_started_at: numberOrNull(raw.last_started_at),
+    last_ready_at: numberOrNull(raw.last_ready_at),
+    last_error: stringOrNull(raw.last_error),
+    last_lost_thread_id: stringOrNull(raw.last_lost_thread_id),
+  };
+}
+
+function errMessage(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
 }
 
 function isDispatcherStatus(value: unknown): value is DispatcherStatus {

--- a/packages/dreamux/src/runtime/dispatcher-store.ts
+++ b/packages/dreamux/src/runtime/dispatcher-store.ts
@@ -301,9 +301,9 @@ async function readStatusFile(
     return null;
   }
 
-  let raw: Partial<DispatcherStatusFile>;
+  let parsed: unknown;
   try {
-    raw = JSON.parse(text) as Partial<DispatcherStatusFile>;
+    parsed = JSON.parse(text);
   } catch (err) {
     warn(
       `dispatcher '${id}' status file ${path} is not valid JSON ` +
@@ -312,6 +312,18 @@ async function readStatusFile(
     );
     return null;
   }
+
+  // Valid JSON that is not an object (e.g. `null`) would crash the field reads
+  // below; treat it like any other corrupt status file.
+  if (parsed === null || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    warn(
+      `dispatcher '${id}' status file ${path} ignored: top-level must be an ` +
+        'object; rebuilding dispatcher status from config defaults; ' +
+        'a saved thread_id will not be resumed.',
+    );
+    return null;
+  }
+  const raw = parsed as Partial<DispatcherStatusFile>;
 
   if (raw.version !== 1 || raw.dispatcher_id !== id) {
     const reason =

--- a/packages/dreamux/src/server.ts
+++ b/packages/dreamux/src/server.ts
@@ -272,10 +272,13 @@ export class Server {
     // Restore each dispatcher's persisted status.json into the in-memory store
     // before any row is listed or launched (the constructor only seeded
     // config-derived defaults — the status read is async).
-    await this.repos.dispatchers.hydrate();
+    await this.repos.dispatchers.hydrate((message) => this.log.warn(message));
     // Load (and delete) any restart marker before bringing dispatchers up, so
     // the snapshot is in memory when each resumed dispatcher claims its notice.
-    this.restartIntent = await RestartIntentConsumer.load({ now: Date.now() });
+    this.restartIntent = await RestartIntentConsumer.load({
+      now: Date.now(),
+      warn: (message) => this.log.warn(message),
+    });
 
     this.admin = createAdminSocketServer(
       this,

--- a/packages/dreamux/tests/dispatcher-store.test.ts
+++ b/packages/dreamux/tests/dispatcher-store.test.ts
@@ -139,4 +139,56 @@ describe('dispatcher status hydration (issue #98: warn + rebuild)', () => {
     expect(warnings).toHaveLength(1);
     expect(warnings[0]).toMatch(/dispatcher id mismatch/);
   });
+
+  it('warns and rebuilds when v1/id match but key fields are malformed', async () => {
+    // A numeric thread_id / bad status / non-finite updated_at must not be
+    // silently coerced (that would drop a resumable thread or change status).
+    for (const bad of [
+      { thread_id: 123 },
+      { status: 'bogus' },
+      { updated_at: 'nope' },
+      { last_started_at: 'soon' },
+    ]) {
+      writeRawStatus('flow', {
+        version: 1,
+        dispatcher_id: 'flow',
+        thread_id: 'thread-x',
+        status: 'ready',
+        updated_at: 123,
+        last_started_at: 100,
+        last_ready_at: null,
+        last_error: null,
+        last_lost_thread_id: null,
+        ...bad,
+      });
+      const store = new DispatcherStore(configWith());
+      const warnings: string[] = [];
+      await store.hydrate((m) => warnings.push(m));
+
+      const row = store.get('flow');
+      expect(row?.status).toBe('declared');
+      expect(row?.thread_id).toBeNull();
+      expect(warnings).toHaveLength(1);
+      expect(warnings[0]).toMatch(/malformed v1 fields/);
+    }
+  });
+
+  it('treats an absent nullable field as a benign null (no warn)', async () => {
+    // Omitted diagnostic fields default to null; a valid thread still resumes.
+    writeRawStatus('flow', {
+      version: 1,
+      dispatcher_id: 'flow',
+      thread_id: 'thread-x',
+      status: 'ready',
+      updated_at: 123,
+    });
+    const store = new DispatcherStore(configWith());
+    const warnings: string[] = [];
+    await store.hydrate((m) => warnings.push(m));
+
+    const row = store.get('flow');
+    expect(row?.thread_id).toBe('thread-x');
+    expect(row?.last_started_at).toBeNull();
+    expect(warnings).toEqual([]);
+  });
 });

--- a/packages/dreamux/tests/dispatcher-store.test.ts
+++ b/packages/dreamux/tests/dispatcher-store.test.ts
@@ -1,0 +1,142 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+
+import type { DreamuxConfig } from '../src/runtime/config.js';
+import { DispatcherStore } from '../src/runtime/dispatcher-store.js';
+import { dispatcherStatusPath, resetRuntimeConfig } from '../src/runtime/paths.js';
+
+function configWith(id = 'flow'): DreamuxConfig {
+  return {
+    codex: {
+      bin: 'codex',
+      approval_policy: 'never',
+      sandbox_mode: 'workspace-write',
+      extra_args: [],
+      initialize_timeout_ms: 10_000,
+    },
+    dispatchers: [
+      {
+        id,
+        cwd: null,
+        enabled: true,
+        feishu: { app_id: 'app-x', app_secret: 'secret' },
+        codex: {
+          approval_policy: null,
+          sandbox_mode: null,
+          extra_args: [],
+          extra_env: {},
+        },
+      },
+    ],
+  };
+}
+
+function writeRawStatus(id: string, raw: unknown): void {
+  const path = dispatcherStatusPath(id);
+  mkdirSync(dirname(path), { recursive: true });
+  writeFileSync(path, JSON.stringify(raw), { mode: 0o600 });
+}
+
+describe('dispatcher status hydration (issue #98: warn + rebuild)', () => {
+  let root: string;
+  let previousHome: string | undefined;
+
+  beforeEach(() => {
+    root = mkdtempSync(join(tmpdir(), 'dreamux-store-'));
+    previousHome = process.env['HOME'];
+    process.env['HOME'] = join(root, 'home');
+    resetRuntimeConfig();
+  });
+
+  afterEach(() => {
+    if (previousHome === undefined) delete process.env['HOME'];
+    else process.env['HOME'] = previousHome;
+    resetRuntimeConfig();
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  it('restores a valid v1 status file without warning', async () => {
+    writeRawStatus('flow', {
+      version: 1,
+      dispatcher_id: 'flow',
+      thread_id: 'thread-x',
+      status: 'ready',
+      updated_at: 123,
+      last_started_at: 100,
+      last_ready_at: 110,
+      last_error: null,
+      last_lost_thread_id: null,
+    });
+    const store = new DispatcherStore(configWith());
+    const warnings: string[] = [];
+    await store.hydrate((m) => warnings.push(m));
+
+    const row = store.get('flow');
+    expect(row?.thread_id).toBe('thread-x');
+    expect(row?.status).toBe('ready');
+    expect(warnings).toEqual([]);
+  });
+
+  it('rebuilds (declared) without warning when no status file exists', async () => {
+    const store = new DispatcherStore(configWith());
+    const warnings: string[] = [];
+    await store.hydrate((m) => warnings.push(m));
+
+    const row = store.get('flow');
+    expect(row?.status).toBe('declared');
+    expect(row?.thread_id).toBeNull();
+    expect(warnings).toEqual([]);
+  });
+
+  it('warns and rebuilds on an unknown version, not silently discarding', async () => {
+    writeRawStatus('flow', {
+      version: 2,
+      dispatcher_id: 'flow',
+      thread_id: 'thread-x',
+      status: 'ready',
+      updated_at: 123,
+    });
+    const store = new DispatcherStore(configWith());
+    const warnings: string[] = [];
+    await store.hydrate((m) => warnings.push(m));
+
+    const row = store.get('flow');
+    expect(row?.status).toBe('declared');
+    expect(row?.thread_id).toBeNull();
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]).toMatch(/unsupported version/);
+    expect(warnings[0]).toMatch(/thread_id will not be resumed/);
+  });
+
+  it('warns and rebuilds on malformed JSON', async () => {
+    const path = dispatcherStatusPath('flow');
+    mkdirSync(dirname(path), { recursive: true });
+    writeFileSync(path, 'not json', { mode: 0o600 });
+    const store = new DispatcherStore(configWith());
+    const warnings: string[] = [];
+    await store.hydrate((m) => warnings.push(m));
+
+    expect(store.get('flow')?.status).toBe('declared');
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]).toMatch(/not valid JSON/);
+  });
+
+  it('warns and rebuilds on a dispatcher id mismatch', async () => {
+    writeRawStatus('flow', {
+      version: 1,
+      dispatcher_id: 'other',
+      thread_id: 'thread-x',
+      status: 'ready',
+      updated_at: 123,
+    });
+    const store = new DispatcherStore(configWith());
+    const warnings: string[] = [];
+    await store.hydrate((m) => warnings.push(m));
+
+    expect(store.get('flow')?.thread_id).toBeNull();
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]).toMatch(/dispatcher id mismatch/);
+  });
+});

--- a/packages/dreamux/tests/dispatcher-store.test.ts
+++ b/packages/dreamux/tests/dispatcher-store.test.ts
@@ -123,6 +123,33 @@ describe('dispatcher status hydration (issue #98: warn + rebuild)', () => {
     expect(warnings[0]).toMatch(/not valid JSON/);
   });
 
+  it('warns and rebuilds when the status file is JSON null', async () => {
+    // `null` parses as valid JSON; reading raw.version off it would otherwise
+    // throw and hard-fatal hydrate() instead of warn + rebuild.
+    const path = dispatcherStatusPath('flow');
+    mkdirSync(dirname(path), { recursive: true });
+    writeFileSync(path, 'null', { mode: 0o600 });
+    const store = new DispatcherStore(configWith());
+    const warnings: string[] = [];
+    await store.hydrate((m) => warnings.push(m));
+
+    expect(store.get('flow')?.status).toBe('declared');
+    expect(store.get('flow')?.thread_id).toBeNull();
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]).toMatch(/top-level must be an object/);
+  });
+
+  it('warns and rebuilds when the status file is a non-object JSON value', async () => {
+    writeRawStatus('flow', 123);
+    const store = new DispatcherStore(configWith());
+    const warnings: string[] = [];
+    await store.hydrate((m) => warnings.push(m));
+
+    expect(store.get('flow')?.status).toBe('declared');
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]).toMatch(/top-level must be an object/);
+  });
+
   it('warns and rebuilds on a dispatcher id mismatch', async () => {
     writeRawStatus('flow', {
       version: 1,

--- a/packages/dreamux/tests/feishu-gate.test.ts
+++ b/packages/dreamux/tests/feishu-gate.test.ts
@@ -288,68 +288,69 @@ describe('dispatcher access state files', () => {
     expect(await loadDispatcherAccess('flow')).toEqual(access);
   });
 
-  describe('v1 → v2 migration', () => {
-    it('lifts legacy dm.allow_users into the global list (follow-user)', async () => {
+  describe('v2-only access schema (issue #98: no migration)', () => {
+    it('fails loud on a legacy v1 file instead of migrating it', async () => {
       writeRawAccess('flow', {
         version: 1,
         dm: { allow_users: ['user-a'] },
-        group: { allow_chats: [], follow_users: [], require_mention: true },
-      });
-      const access = await loadDispatcherAccess('flow');
-      expect(access.version).toBe(2);
-      expect(access.allow_users).toEqual(['user-a']);
-      expect(access.group.policy).toBe('follow-user');
-    });
-
-    it('preserves a legacy follow_users restriction as follow-user, not allowlist', async () => {
-      // Both lists set: the sender restriction must NOT be silently relaxed to
-      // chat-only allowlist gating (that would let any chat member talk).
-      writeRawAccess('flow', {
-        version: 1,
-        dm: { allow_users: [] },
-        group: {
-          allow_chats: ['chat-group-a'],
-          follow_users: ['user-a'],
-          require_mention: true,
-        },
-      });
-      const access = await loadDispatcherAccess('flow');
-      expect(access.allow_users).toEqual(['user-a']);
-      expect(access.group.policy).toBe('follow-user');
-      expect(access.group.allow_chats).toEqual(['chat-group-a']);
-    });
-
-    it('infers allowlist when only a chat allowlist is configured', async () => {
-      writeRawAccess('flow', {
-        version: 1,
-        dm: { allow_users: [] },
-        group: {
-          allow_chats: ['chat-group-a'],
-          follow_users: [],
-          require_mention: true,
-        },
-      });
-      expect((await loadDispatcherAccess('flow')).group.policy).toBe('allowlist');
-    });
-
-    it('merges and de-duplicates dm.allow_users and group.follow_users', async () => {
-      writeRawAccess('flow', {
-        version: 1,
-        dm: { allow_users: ['user-a', 'user-b'] },
         group: {
           allow_chats: [],
-          follow_users: ['user-b', 'user-c'],
+          follow_users: ['user-b'],
           require_mention: true,
         },
       });
-      expect((await loadDispatcherAccess('flow')).allow_users).toEqual([
-        'user-a',
-        'user-b',
-        'user-c',
-      ]);
+      await expect(loadDispatcherAccess('flow')).rejects.toThrow(
+        /unsupported schema version.*expected 2/s,
+      );
     });
 
-    it('honors an explicit group.policy over inference', async () => {
+    it('error names the action: delete to reset, then re-authorize', async () => {
+      writeRawAccess('flow', { version: 1, dm: { allow_users: ['user-a'] } });
+      await expect(loadDispatcherAccess('flow')).rejects.toThrow(
+        /Delete it.*re-authorize/s,
+      );
+    });
+
+    it('fails loud when the version field is missing', async () => {
+      writeRawAccess('flow', {
+        allow_users: ['user-a'],
+        group: { policy: 'follow-user', allow_chats: [], require_mention: true },
+      });
+      await expect(loadDispatcherAccess('flow')).rejects.toThrow(
+        /unsupported schema version \(found missing/,
+      );
+    });
+
+    it('does not infer from legacy fields present on a v2 file', async () => {
+      // Legacy-only fields carry no meaning anymore: dm.* and group.follow_users
+      // are ignored, and a present allow_chats does NOT infer an allowlist policy.
+      writeRawAccess('flow', {
+        version: 2,
+        allow_users: ['user-a'],
+        dm: { allow_users: ['ignored'] },
+        group: {
+          allow_chats: ['chat-group-a'],
+          follow_users: ['ignored'],
+          require_mention: true,
+        },
+      });
+      const access = await loadDispatcherAccess('flow');
+      expect(access.allow_users).toEqual(['user-a']);
+      expect(access.group.policy).toBe('follow-user');
+    });
+
+    it('defaults an absent group.policy on a v2 file to secure follow-user', async () => {
+      writeRawAccess('flow', {
+        version: 2,
+        allow_users: [],
+        group: { allow_chats: ['chat-group-a'], require_mention: true },
+      });
+      expect((await loadDispatcherAccess('flow')).group.policy).toBe(
+        'follow-user',
+      );
+    });
+
+    it('honors an explicit group.policy on a v2 file', async () => {
       writeRawAccess('flow', {
         version: 2,
         allow_users: ['user-a'],
@@ -362,7 +363,7 @@ describe('dispatcher access state files', () => {
       expect((await loadDispatcherAccess('flow')).group.policy).toBe('allowlist');
     });
 
-    it('rejects an invalid group.policy', async () => {
+    it('rejects an invalid group.policy on a v2 file', async () => {
       writeRawAccess('flow', {
         version: 2,
         allow_users: [],

--- a/packages/dreamux/tests/feishu-gate.test.ts
+++ b/packages/dreamux/tests/feishu-gate.test.ts
@@ -304,10 +304,10 @@ describe('dispatcher access state files', () => {
       );
     });
 
-    it('error names the action: delete to reset, then re-authorize', async () => {
+    it('error names the action: delete to reset, then recreate a v2 file', async () => {
       writeRawAccess('flow', { version: 1, dm: { allow_users: ['user-a'] } });
       await expect(loadDispatcherAccess('flow')).rejects.toThrow(
-        /Delete it.*re-authorize/s,
+        /Delete it.*recreate it as a v2 access\.json/s,
       );
     });
 

--- a/packages/dreamux/tests/restart-intent.test.ts
+++ b/packages/dreamux/tests/restart-intent.test.ts
@@ -106,14 +106,53 @@ describe('restart intent marker', () => {
     expect(existsSync(path)).toBe(false);
   });
 
-  it('yields an empty consumer for a missing or malformed marker', async () => {
-    expect(
-      (await RestartIntentConsumer.load({ now: 0, path })).claim('flow', 0),
-    ).toBeNull();
+  it('yields an empty consumer for a missing marker without warning', async () => {
+    const warnings: string[] = [];
+    const consumer = await RestartIntentConsumer.load({
+      now: 0,
+      path,
+      warn: (m) => warnings.push(m),
+    });
+    expect(consumer.claim('flow', 0)).toBeNull();
+    // Missing marker is the common case (no restart notice requested): quiet.
+    expect(warnings).toEqual([]);
+  });
 
+  it('warns and drops a malformed marker (issue #98: not silent)', async () => {
     writeFileSync(path, 'not json', { mode: 0o600 });
-    const consumer = await RestartIntentConsumer.load({ now: 0, path });
+    const warnings: string[] = [];
+    const consumer = await RestartIntentConsumer.load({
+      now: 0,
+      path,
+      warn: (m) => warnings.push(m),
+    });
     expect(existsSync(path)).toBe(false);
     expect(consumer.claim('flow', 0)).toBeNull();
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]).toMatch(/not valid JSON/);
+  });
+
+  it('warns and drops a marker with an unknown version', async () => {
+    writeFileSync(
+      path,
+      JSON.stringify({
+        version: 2,
+        created_at_ms: 0,
+        ttl_ms: DEFAULT_RESTART_INTENT_TTL_MS,
+        announce: 'x',
+        targets: ['flow'],
+      }),
+      { mode: 0o600 },
+    );
+    const warnings: string[] = [];
+    const consumer = await RestartIntentConsumer.load({
+      now: 0,
+      path,
+      warn: (m) => warnings.push(m),
+    });
+    expect(existsSync(path)).toBe(false);
+    expect(consumer.claim('flow', 0)).toBeNull();
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]).toMatch(/unsupported version/);
   });
 });

--- a/packages/dreamux/tests/restart-intent.test.ts
+++ b/packages/dreamux/tests/restart-intent.test.ts
@@ -155,4 +155,53 @@ describe('restart intent marker', () => {
     expect(warnings).toHaveLength(1);
     expect(warnings[0]).toMatch(/unsupported version/);
   });
+
+  it('warns and drops a v1 marker whose targets is not a string array', async () => {
+    // A non-array targets would otherwise crash dedupeNonEmpty at server start.
+    writeFileSync(
+      path,
+      JSON.stringify({
+        version: 1,
+        created_at_ms: 0,
+        ttl_ms: DEFAULT_RESTART_INTENT_TTL_MS,
+        announce: 'x',
+        targets: { flow: true },
+      }),
+      { mode: 0o600 },
+    );
+    const warnings: string[] = [];
+    const consumer = await RestartIntentConsumer.load({
+      now: 0,
+      path,
+      warn: (m) => warnings.push(m),
+    });
+    expect(existsSync(path)).toBe(false);
+    expect(consumer.claim('flow', 0)).toBeNull();
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]).toMatch(/malformed fields/);
+  });
+
+  it('warns and drops a v1 marker with non-numeric created_at_ms/ttl_ms', async () => {
+    writeFileSync(
+      path,
+      JSON.stringify({
+        version: 1,
+        created_at_ms: 'soon',
+        ttl_ms: null,
+        announce: 'x',
+        targets: ['flow'],
+      }),
+      { mode: 0o600 },
+    );
+    const warnings: string[] = [];
+    const consumer = await RestartIntentConsumer.load({
+      now: 0,
+      path,
+      warn: (m) => warnings.push(m),
+    });
+    expect(existsSync(path)).toBe(false);
+    expect(consumer.claim('flow', 0)).toBeNull();
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]).toMatch(/malformed fields/);
+  });
 });


### PR DESCRIPTION
## 背景

issue #98 PR2（共 3 个 PR：①changelog 基础设施 ✅ #104 → **②版本读取策略统一（本 PR）** → ③旧兼容删除）。本 PR 收敛 0.x 阶段对各类带版本持久化文件的不一致处理，落到「按对象类别一条规则」：安全/操作者状态 fail-loud，可重建状态 warn+重建/丢弃，绝不静默误读、绝不 hard-fatal 整个服务。

## 改动

| 对象 | 处置 |
|---|---|
| `access.json` | **v2-only**：删除 v1/v2 字段推断与 `dm.allow_users`/`group.follow_users` 合并；版本不支持/缺失 → **fail-loud + 重建指引**（含三段式文案：文件原因 / 不会推断旧权限 / 删除回到安全默认但需重新授权）。v2 文件缺 `group.policy` → 回退安全默认 `follow-user`，不再从其它字段推断。 |
| `status.json` | 服务端可重建恢复状态：版本不符 / 损坏 JSON / dispatcher id 不符 → **warn + 重建**（saved thread_id 可能不恢复），不静默丢弃、不 hard-fatal。通过 `DispatcherStore.hydrate()` 注入 warn sink。 |
| `restart-intent.json` | 一次性 marker：损坏 / 未知版本 → **warn + drop**（明确说明请求的 restart notice 不会送达）；missing/expired 保持安静；不 hard-fatal。 |
| TOML config 守卫 | 保留 fail-loud，仅按 0.x 重建语义改文案并指向 `dreamux onboard`。 |

## 范围边界（明确不在本 PR）

旧 skill 指纹迁移删除、`runtimeRoot`/`runtime_dir`/`--runtime-dir` 清理（→ PR3）；onboard config upsert clobber（follow-up）；不新增 `config.version`；不重设计 `chat-bots.json`；不改环境兼容（service node path）。

## 测试 / 检查

- `rush build` ✅、`rush lint` ✅、`.agents/scripts/check.sh` ✅
- 全量 `vitest`：**329 passed / 1 skipped**（live codex）
- **反转**：`feishu-gate.test.ts` 原 v1→v2 迁移用例改为 fail-loud 断言（含「删除后需重新授权」文案断言、缺 version 断言、v2 文件不再从 legacy 字段推断断言）。
- **新增**：`dispatcher-store.test.ts`（status warn+rebuild：合法恢复无 warn / 缺文件无 warn / 未知版本 warn+重建 / 损坏 JSON / id 不符）；`restart-intent.test.ts` 增加 missing 无 warn、malformed warn+drop、未知版本 warn+drop。
- 兼容性：`global-config.test.ts` / `uninstall.test.ts` 对 TOML 守卫的断言（`/legacy dreamux config/`、`/dispatchers array/`）措辞改后仍通过。

## 破坏性变更

线上存量 `access.json` v1 文件升级后会 **fail-loud**：操作者需删除该文件（回到安全默认，重配前不授权任何人）并重新授权。已通过 rush change file 记录（`BREAKING:` + `Rebuild:`），PR1 的 `dreamux changelog` 提供读取入口。

## 残留风险

- access.json fail-loud 爆炸半径：v2 自 #82 落地，pre-#82 安装存在 v1 文件 → 升级即报错（#98 明确接受的代价，已配 changelog 指引）。
- warn sink 默认 `console.warn`，服务路径注入 pino logger；非服务直接调用方（如测试）走 console 默认，可观察。

Refs #98