### PR TITLE
refactor(runtime): 删除 0.x 死兼容垫片与旧 runtime_dir 残留（#98 PR3）

### DIFF
--- a/.agents/components/dispatcher-skill.md
+++ b/.agents/components/dispatcher-skill.md
@@ -57,10 +57,10 @@ The runtime installer is intentionally symlink-only:
 
 - correct symlinks are left unchanged
 - stale or broken symlinks are replaced
-- a legacy copied `dispatcher` directory whose `SKILL.md` exactly matches a
-  known Dreamux-managed fingerprint is migrated to a symlink
 - real user files/directories are not overwritten; startup logs a diagnostic
-  and onboard reports the path as `skipped`
+  and onboard reports the path as `skipped`. This includes an old hand-copied
+  `dispatcher` directory — Dreamux no longer fingerprints and migrates it
+  (issue #98); remove or rename it to let startup recreate the bundled symlink
 - custom symlinks in these bundled skill slots are treated as replaceable
   Dreamux-managed links; use a real file or directory to opt out
 - missing `.codex/skills` directories are created

--- a/.agents/decisions/dispatcher-tm-packaging.md
+++ b/.agents/decisions/dispatcher-tm-packaging.md
@@ -73,10 +73,11 @@ workspaces during a global uninstall.
   A machine with multiple dispatchers may have multiple workspace-local
   symlink sets.
 - Correct symlinks are left unchanged. Stale or broken symlinks are replaced.
-  A legacy copied `dispatcher` directory whose `SKILL.md` matches a known
-  Dreamux-managed fingerprint is migrated to a symlink. Real user files or
-  directories are not overwritten; startup logs a diagnostic and onboard reports
-  the path as `skipped`.
+  Real user files or directories are not overwritten; startup logs a diagnostic
+  and onboard reports the path as `skipped`. This includes an old hand-copied
+  `dispatcher` directory — Dreamux no longer fingerprints and migrates it
+  (issue #98); the operator removes or renames it to let startup recreate the
+  bundled symlink.
 - Custom symlinks at bundled skill paths are treated as Dreamux-managed links
   and may be replaced. Operators who intentionally opt out should use a real
   file or directory at that skill path.

--- a/.agents/decisions/top-level-design.md
+++ b/.agents/decisions/top-level-design.md
@@ -469,12 +469,13 @@ directory into:
 
 The workspace-local skills are intentionally not installed into the operator's
 global `~/.codex/skills`. The installer creates a missing `.codex/skills`
-parent, replaces stale or broken symlinks, and migrates a legacy copied
-`dispatcher` directory only when its `SKILL.md` exactly matches a known
-Dreamux-managed fingerprint. Other real user files or directories are left
-untouched with a startup diagnostic and an onboard `skipped` ledger entry.
-Custom symlinks in these bundled skill slots are treated as Dreamux-managed
-links and may be replaced; use a real file or directory to opt out.
+parent and replaces stale or broken symlinks. Real user files or directories
+are left untouched with a startup diagnostic and an onboard `skipped` ledger
+entry — including an old hand-copied `dispatcher` directory, which Dreamux no
+longer fingerprints and migrates (issue #98); the operator removes or renames
+it to let startup recreate the bundled symlink. Custom symlinks in these
+bundled skill slots are treated as Dreamux-managed links and may be replaced;
+use a real file or directory to opt out.
 
 `uninstall` removes dreamux-owned config, state, logs, and service integration
 by default. It reports workspace-local bundled skill paths, but it does not

--- a/.agents/decisions/top-level-design.md
+++ b/.agents/decisions/top-level-design.md
@@ -246,7 +246,10 @@ validated as stable path segments and length-checked so derived `admin.sock` and
 `codex.sock` paths stay within Linux and macOS `sun_path` limits.
 
 There is no `runtime_dir`, no SQLite database, no persisted inbound message
-queue, and no persisted reaction ledger.
+queue, and no persisted reaction ledger. `stateRoot()` is the single state root;
+the last `runtime_dir` leftovers — the `runtimeRoot()` alias, the onboard
+`runtimeDir` answer/field, and the `--runtime-dir` CLI option — were deleted in
+issue #98 (the option now fails loud as an unknown argument).
 
 ## Dispatcher Lifecycle
 

--- a/common/changes/@excitedjs/dreamux/issue98-remove-compat_2026-06-06-00-00.json
+++ b/common/changes/@excitedjs/dreamux/issue98-remove-compat_2026-06-06-00-00.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Remove dead 0.x compatibility shims (issue #98). Delete the old copied-dispatcher-skill -> bundled-symlink fingerprint migration: a real directory at a bundled skill path is now always left untouched ('skipped'). Rebuild: if a dispatcher workspace still has an old hand-copied skill directory under .codex/skills/, remove or rename it so startup recreates the bundled symlink. Also delete the dead runtime_dir leftovers: the runtimeRoot() alias, the onboard runtimeDir answer, and the CLI --runtime-dir option, which previously was accepted-and-ignored and now fails loud as an unknown argument. No change to bundled-skill install/update, service unit re-registration, or service Node path selection.",
+      "type": "patch",
+      "packageName": "@excitedjs/dreamux"
+    }
+  ],
+  "packageName": "@excitedjs/dreamux",
+  "email": "053700@gmail.com"
+}

--- a/packages/dreamux/src/cli/dreamux.ts
+++ b/packages/dreamux/src/cli/dreamux.ts
@@ -191,10 +191,6 @@ function buildOnboardCommand(y: Argv): Argv {
       type: 'string',
       describe: 'dreamux global config directory',
     })
-    .option('runtime-dir', {
-      type: 'string',
-      describe: 'dreamux runtime directory',
-    })
     .option('dispatcher-id', {
       type: 'string',
       describe: 'Dispatcher id to create or update',
@@ -244,10 +240,6 @@ function buildUninstallCommand(y: Argv): Argv {
     .option('config-dir', {
       type: 'string',
       describe: 'dreamux global config directory',
-    })
-    .option('runtime-dir', {
-      type: 'string',
-      describe: 'Legacy option ignored; uninstall removes dreamux state/log paths',
     });
 }
 
@@ -255,12 +247,10 @@ async function handleUninstall(argv: unknown): Promise<void> {
   const args = argv as {
     dryRun?: boolean;
     configDir?: string;
-    runtimeDir?: string;
   };
   const result = await runUninstall({
     dryRun: args.dryRun,
     configDir: args.configDir,
-    runtimeDir: args.runtimeDir,
   });
   printUninstallResult(result);
 }

--- a/packages/dreamux/src/daemon/install.ts
+++ b/packages/dreamux/src/daemon/install.ts
@@ -25,7 +25,7 @@ import { TransparentFileLedger } from '../onboard/ledger.js';
 import type { CommandRunner, OnboardFileLedgerEntry } from '../onboard/types.js';
 import { globalConfigDir, loadConfig } from '../runtime/config.js';
 import { dreamuxBinPath } from '../runtime/package-bin.js';
-import { setRuntimeConfig, stateRoot } from '../runtime/paths.js';
+import { setRuntimeConfig } from '../runtime/paths.js';
 
 export interface DaemonInstallOptions {
   startService?: boolean;
@@ -73,7 +73,6 @@ export async function runDaemonInstall(
       });
   const answers: ServiceInstallAnswers = {
     configDir: globalConfigDir(),
-    runtimeDir: stateRoot(),
     codexBin,
     dreamuxBin: dreamuxBinPath(env),
     nodeBin,

--- a/packages/dreamux/src/onboard/run.ts
+++ b/packages/dreamux/src/onboard/run.ts
@@ -82,7 +82,6 @@ export async function runOnboard(
     : process.execPath;
   const effectiveAnswers = {
     ...answers,
-    runtimeDir: stateRoot(),
     codexBin: serviceCodexBin,
     nodeBin: serviceNodeBin,
   };

--- a/packages/dreamux/src/onboard/service.ts
+++ b/packages/dreamux/src/onboard/service.ts
@@ -35,7 +35,6 @@ export const SERVICE_PATH_DEFAULTS = ['/usr/local/bin', '/usr/bin', '/bin'];
 
 export interface ServiceInstallAnswers {
   configDir: string;
-  runtimeDir: string;
   codexBin: string;
   dreamuxBin: string;
   nodeBin: string;

--- a/packages/dreamux/src/onboard/types.ts
+++ b/packages/dreamux/src/onboard/types.ts
@@ -17,7 +17,6 @@ export type ServicePlatform = 'launchd' | 'systemd';
 
 export interface OnboardAnswers {
   configDir: string;
-  runtimeDir: string;
   dispatcherId: string;
   dispatcherCwd: string;
   codexBin: string;

--- a/packages/dreamux/src/onboard/uninstall.ts
+++ b/packages/dreamux/src/onboard/uninstall.ts
@@ -39,7 +39,6 @@ export interface UninstallEntry {
 
 export interface RunUninstallOptions {
   configDir?: string;
-  runtimeDir?: string;
   runner?: CommandRunner;
   platform?: NodeJS.Platform;
   homeDir?: string;

--- a/packages/dreamux/src/onboard/wizard.ts
+++ b/packages/dreamux/src/onboard/wizard.ts
@@ -18,7 +18,6 @@ export interface OnboardCliOptions {
   yes?: boolean;
   dryRun?: boolean;
   configDir?: string;
-  runtimeDir?: string;
   dispatcherId?: string;
   dispatcherCwd?: string;
   codexBin?: string;
@@ -41,10 +40,6 @@ export async function collectOnboardAnswers(
   const configDir = await promptText(
     'dreamux config directory',
     defaultConfigDir(options),
-  );
-  const runtimeDir = await promptText(
-    'dreamux runtime directory',
-    defaultRuntimeDir(options),
   );
   const dispatcherId = await promptText(
     'dispatcher id',
@@ -76,7 +71,6 @@ export async function collectOnboardAnswers(
     {
       ...options,
       configDir,
-      runtimeDir,
       dispatcherId,
       dispatcherCwd,
       codexBin,
@@ -102,7 +96,6 @@ export function answersFromOptions(
   const dispatcherCwd = options.dispatcherCwd ?? process.cwd();
   return {
     configDir: normalizePath(options.configDir ?? defaultConfigDir(options)),
-    runtimeDir: normalizePath(options.runtimeDir ?? defaultRuntimeDir(options)),
     dispatcherId: validateDispatcherId(
       options.dispatcherId ?? DEFAULT_DISPATCHER_ID,
     ),
@@ -121,10 +114,6 @@ export function answersFromOptions(
 
 function defaultConfigDir(options: OnboardCliOptions): string {
   return options.configDir ?? join(homedir(), '.dreamux');
-}
-
-function defaultRuntimeDir(options: OnboardCliOptions): string {
-  return options.runtimeDir ?? join(homedir(), '.dreamux', 'runtime');
 }
 
 async function promptText(label: string, initialValue?: string): Promise<string> {

--- a/packages/dreamux/src/runtime/bundled-skills.ts
+++ b/packages/dreamux/src/runtime/bundled-skills.ts
@@ -238,4 +238,3 @@ async function replaceSkillSymlink(
     );
   }
 }
-

--- a/packages/dreamux/src/runtime/bundled-skills.ts
+++ b/packages/dreamux/src/runtime/bundled-skills.ts
@@ -1,10 +1,8 @@
-import { createHash, randomUUID } from 'node:crypto';
+import { randomUUID } from 'node:crypto';
 import {
   access,
   lstat,
   mkdir,
-  readFile,
-  readdir,
   realpath,
   rename,
   rm,
@@ -36,12 +34,6 @@ export type BundledSkillInstallStatus =
   | 'replaced'
   | 'unchanged'
   | 'skipped';
-
-const LEGACY_COPIED_DISPATCHER_SKILL_SHA256 = new Set([
-  // Pre-symlink Dreamux wrote exactly this dispatcher SKILL.md copy.
-  // Only exact unmodified copies are migrated automatically.
-  '4dca0986d2e7ecde171ac3436718eaa1fefe599dacfdc2d20c90d2cf1d443be1',
-]);
 
 export interface BundledSkillInstallResult {
   skillName: BundledSkillName;
@@ -138,28 +130,9 @@ async function installOneSkill(options: {
   }
 
   if (!targetInfo.isSymbolicLink()) {
-    const legacyCopiedSkill = await isLegacyCopiedDispatcherSkill({
-      skillName: options.skillName,
-      targetPath,
-      targetInfo,
-    });
-    if (legacyCopiedSkill) {
-      if (!options.dryRun) {
-        await replaceLegacyCopiedDirectoryWithSymlink(
-          sourcePath,
-          targetPath,
-          options.skillName,
-        );
-      }
-      return {
-        skillName: options.skillName,
-        sourcePath,
-        targetPath,
-        status: 'replaced',
-        reason:
-          'migrated a legacy Dreamux-copied dispatcher skill directory to the bundled symlink',
-      };
-    }
+    // A real file or directory at the skill path is left untouched. dreamux 0.x
+    // does not migrate old hand-copied skill directories (issue #98); the
+    // operator removes or renames it to opt back into the bundled symlink.
     return {
       skillName: options.skillName,
       sourcePath,
@@ -216,28 +189,6 @@ async function assertBundledSkillSource(
   }
 }
 
-async function isLegacyCopiedDispatcherSkill(options: {
-  skillName: BundledSkillName;
-  targetPath: string;
-  targetInfo: Awaited<ReturnType<typeof lstat>>;
-}): Promise<boolean> {
-  if (options.skillName !== 'dispatcher' || !options.targetInfo.isDirectory()) {
-    return false;
-  }
-  try {
-    const entries = await readdir(options.targetPath);
-    if (entries.length !== 1 || entries[0] !== 'SKILL.md') return false;
-    const skillFile = resolve(options.targetPath, 'SKILL.md');
-    const skillInfo = await stat(skillFile);
-    if (!skillInfo.isFile()) return false;
-    const content = await readFile(skillFile);
-    const hash = createHash('sha256').update(content).digest('hex');
-    return LEGACY_COPIED_DISPATCHER_SKILL_SHA256.has(hash);
-  } catch {
-    return false;
-  }
-}
-
 async function resolvedSymlinkTarget(path: string): Promise<string | null> {
   try {
     return await realpath(path);
@@ -288,30 +239,3 @@ async function replaceSkillSymlink(
   }
 }
 
-async function replaceLegacyCopiedDirectoryWithSymlink(
-  sourcePath: string,
-  targetPath: string,
-  skillName: BundledSkillName,
-): Promise<void> {
-  const parent = dirname(targetPath);
-  const suffix = randomUUID();
-  const temporaryLink = resolve(parent, `.${skillName}.dreamux-next-${suffix}`);
-  const backupPath = resolve(parent, `.${skillName}.dreamux-legacy-${suffix}`);
-  let backupCreated = false;
-  try {
-    await createSkillSymlink(sourcePath, temporaryLink, skillName);
-    await rename(targetPath, backupPath);
-    backupCreated = true;
-    await rename(temporaryLink, targetPath);
-    await rm(backupPath, { recursive: true });
-  } catch (err) {
-    await rm(temporaryLink, { force: true, recursive: false }).catch(() => {});
-    if (backupCreated && !(await pathExists(targetPath))) {
-      await rename(backupPath, targetPath).catch(() => {});
-    }
-    const detail = err instanceof Error ? err.message : String(err);
-    throw new Error(
-      `failed to migrate legacy copied bundled skill '${skillName}' at ${targetPath}: ${detail}`,
-    );
-  }
-}

--- a/packages/dreamux/src/runtime/paths.ts
+++ b/packages/dreamux/src/runtime/paths.ts
@@ -15,9 +15,8 @@
  *       codex-app-server/
  *         <dispatcher-id>.log
  *
- * `runtime_dir` is not an effective runtime contract. The legacy runtimeRoot()
- * function remains as a compatibility alias for stateRoot() while older call
- * sites are retired.
+ * `stateRoot()` is the single root for dreamux-owned state. The old
+ * `runtime_dir` concept (and its `runtimeRoot()` alias) was retired in issue #98.
  */
 
 import { homedir } from 'node:os';
@@ -86,13 +85,6 @@ export function restartIntentPath(): string {
 
 export function logsRoot(): string {
   return join(dreamuxRoot(), 'logs');
-}
-
-/**
- * Legacy compatibility alias. New code should call stateRoot().
- */
-export function runtimeRoot(): string {
-  return stateRoot();
 }
 
 export function adminSocketPath(): string {

--- a/packages/dreamux/src/server.ts
+++ b/packages/dreamux/src/server.ts
@@ -233,7 +233,7 @@ export class Server {
   constructor(opts: ServerOptions = {}) {
     this.opts = opts;
     // Install the config snapshot before any paths.* / runtime.* lookup
-    // happens. paths.runtimeRoot / adminSocketPath / etc. consult this
+    // happens. paths.stateRoot / adminSocketPath / etc. consult this
     // snapshot for non-env defaults (env vars still win).
     setRuntimeConfig(opts.config ?? BUILT_IN_DEFAULTS);
     // Default loggers are stderr-only (zero files opened) so tests that

--- a/packages/dreamux/tests/bundled-skills.test.ts
+++ b/packages/dreamux/tests/bundled-skills.test.ts
@@ -76,7 +76,11 @@ describe('bundled workspace skill installer', () => {
     expect(realpathSync(target)).toBe(realpathSync(bundledSkillDir('dispatcher')));
   });
 
-  it('migrates the legacy copied dispatcher skill directory to a symlink', async () => {
+  it('leaves an old hand-copied dispatcher skill directory untouched (no migration)', async () => {
+    // issue #98: dreamux no longer fingerprints and migrates a previously
+    // copied dispatcher skill directory. A real directory at the skill path is
+    // left as-is; the operator removes or renames it to opt back into the
+    // bundled symlink.
     const target = dispatcherWorkspaceSkillDir(dispatcherCwd, 'dispatcher');
     mkdirSync(target, { recursive: true });
     writeFileSync(join(target, 'SKILL.md'), LEGACY_COPIED_DISPATCHER_SKILL);
@@ -86,29 +90,10 @@ describe('bundled workspace skill installer', () => {
       result.skillName === 'dispatcher'
     );
 
-    expect(dispatcherResult?.status).toBe('replaced');
-    expect(dispatcherResult?.reason).toContain('legacy Dreamux-copied');
-    expect(lstatSync(target).isSymbolicLink()).toBe(true);
-    expect(realpathSync(target)).toBe(realpathSync(bundledSkillDir('dispatcher')));
-  });
-
-  it('does not migrate a modified legacy dispatcher skill directory', async () => {
-    const target = dispatcherWorkspaceSkillDir(dispatcherCwd, 'dispatcher');
-    mkdirSync(target, { recursive: true });
-    writeFileSync(
-      join(target, 'SKILL.md'),
-      `${LEGACY_COPIED_DISPATCHER_SKILL}\n# local edit\n`,
-    );
-
-    const results = await installBundledWorkspaceSkills({ dispatcherCwd });
-    const dispatcherResult = results.find((result) =>
-      result.skillName === 'dispatcher'
-    );
-
     expect(dispatcherResult?.status).toBe('skipped');
     expect(lstatSync(target).isSymbolicLink()).toBe(false);
-    expect(readFileSync(join(target, 'SKILL.md'), 'utf8')).toContain(
-      '# local edit',
+    expect(readFileSync(join(target, 'SKILL.md'), 'utf8')).toBe(
+      LEGACY_COPIED_DISPATCHER_SKILL,
     );
   });
 

--- a/packages/dreamux/tests/global-config.test.ts
+++ b/packages/dreamux/tests/global-config.test.ts
@@ -25,7 +25,6 @@ import {
 import {
   adminSocketPath,
   resetRuntimeConfig,
-  runtimeRoot,
   serverJsonPath,
   setRuntimeConfig,
   stateRoot,
@@ -478,14 +477,6 @@ describe('runtime path precedence', () => {
     }
     rmSync(configDir, { recursive: true, force: true });
     resetRuntimeConfig();
-  });
-
-  it('runtimeRoot aliases stateRoot and ignores legacy env overrides', async () => {
-    writeConfigObjectAt(configDir, {});
-    const { config } = await loadOrInitConfig({ configDir });
-    setRuntimeConfig(config);
-    process.env['CODEX_HOST_RUNTIME_DIR'] = '/tmp/from-env';
-    expect(runtimeRoot()).toBe(stateRoot());
   });
 
   it('adminSocketPath is fixed under stateRoot', async () => {

--- a/packages/dreamux/tests/onboard.test.ts
+++ b/packages/dreamux/tests/onboard.test.ts
@@ -149,9 +149,7 @@ describe('dreamux onboard', () => {
   it('writes dispatcher state, records subprocess files, and passes the serve doctor', async () => {
     const runner = new FakeRunner();
     const answers = testAnswers({
-      configDir: join(root, 'config'),
-      runtimeDir: join(root, 'runtime'),
-      dreamuxBin: '/usr/local/bin/dreamux',
+      configDir: join(root, 'config'),      dreamuxBin: '/usr/local/bin/dreamux',
       botAppId: 'app-test',
       botAppSecret: 'secret-test',
     });
@@ -243,9 +241,7 @@ describe('dreamux onboard', () => {
   it('reports skipped bundled skill conflicts during onboard', async () => {
     const runner = new FakeRunner();
     const answers = testAnswers({
-      configDir: join(root, 'config'),
-      runtimeDir: join(root, 'runtime'),
-      registerService: false,
+      configDir: join(root, 'config'),      registerService: false,
       startService: false,
     });
     writeGlobalCodexAuth(answers);
@@ -276,9 +272,7 @@ describe('dreamux onboard', () => {
   it('pins the service to a stable system Node and leads PATH with its directory', async () => {
     const runner = new FakeRunner();
     const answers = testAnswers({
-      configDir: join(root, 'config'),
-      runtimeDir: join(root, 'runtime'),
-      dreamuxBin: '/usr/local/bin/dreamux',
+      configDir: join(root, 'config'),      dreamuxBin: '/usr/local/bin/dreamux',
     });
     writeGlobalCodexAuth(answers);
     // /usr/local/bin/node exists, is not version-manager-bound, satisfies the
@@ -311,9 +305,7 @@ describe('dreamux onboard', () => {
   it('excludes a version-manager-bound candidate and falls back to the current Node', async () => {
     const runner = new FakeRunner();
     const answers = testAnswers({
-      configDir: join(root, 'config'),
-      runtimeDir: join(root, 'runtime'),
-      dreamuxBin: '/usr/local/bin/dreamux',
+      configDir: join(root, 'config'),      dreamuxBin: '/usr/local/bin/dreamux',
     });
     writeGlobalCodexAuth(answers);
     // /usr/local/bin/node is executable but realpaths into an nvm install, so
@@ -351,9 +343,7 @@ describe('dreamux onboard', () => {
     const runner = new FakeRunner();
     runner.lingerEnableOk = false;
     const answers = testAnswers({
-      configDir: join(root, 'config'),
-      runtimeDir: join(root, 'runtime'),
-      registerService: true,
+      configDir: join(root, 'config'),      registerService: true,
     });
     writeGlobalCodexAuth(answers);
 
@@ -382,9 +372,7 @@ describe('dreamux onboard', () => {
   it('does not let an interactive shell token satisfy the managed service doctor', async () => {
     const runner = new FakeRunner();
     const answers = testAnswers({
-      configDir: join(root, 'config'),
-      runtimeDir: join(root, 'runtime'),
-      registerService: true,
+      configDir: join(root, 'config'),      registerService: true,
     });
 
     await expect(
@@ -403,9 +391,7 @@ describe('dreamux onboard', () => {
   it('fails before systemd registration when the service cannot execute the launcher', async () => {
     const runner = new FakeRunner();
     const answers = testAnswers({
-      configDir: join(root, 'config'),
-      runtimeDir: join(root, 'runtime'),
-      registerService: true,
+      configDir: join(root, 'config'),      registerService: true,
       dreamuxBin: '/usr/local/bin/dreamux',
     });
     writeGlobalCodexAuth(answers);
@@ -428,9 +414,7 @@ describe('dreamux onboard', () => {
   it('rewrites workspace dispatcher skills and skips already-loaded launchd services on rerun', async () => {
     const runner = new FakeRunner();
     const answers = testAnswers({
-      configDir: join(root, 'config'),
-      runtimeDir: join(root, 'runtime'),
-      registerService: true,
+      configDir: join(root, 'config'),      registerService: true,
       startService: true,
     });
     writeGlobalCodexAuth(answers);
@@ -478,7 +462,6 @@ describe('dreamux onboard', () => {
 
   it('preserves existing codex globals and other dispatchers on rerun', async () => {
     const runner = new FakeRunner();
-    const ignoredRuntimeDir = join(root, 'ignored-runtime');
     const configDir = join(root, 'config');
     mkdirSync(configDir, { recursive: true });
     writeFileSync(
@@ -511,7 +494,6 @@ describe('dreamux onboard', () => {
     );
     const answers = testAnswers({
       configDir,
-      runtimeDir: ignoredRuntimeDir,
       dispatcherId: 'docs',
       dispatcherCwd: join(root, 'docs-cwd'),
       registerService: false,
@@ -572,7 +554,6 @@ describe('dreamux onboard', () => {
         },
       },
     ]);
-    expect(existsSync(ignoredRuntimeDir)).toBe(false);
   });
 
   it('rejects a new dispatcher that reuses an existing Feishu app_id', async () => {
@@ -632,9 +613,7 @@ describe('dreamux onboard', () => {
   it('fails non-interactive setup when required channel inputs are missing', () => {
     const options: OnboardCliOptions = {
       yes: true,
-      configDir: join(root, 'config'),
-      runtimeDir: join(root, 'runtime'),
-    };
+      configDir: join(root, 'config'),    };
 
     expect(() => answersFromOptions(options, false)).toThrow(
       'non-interactive onboard requires --bot-app-id',
@@ -645,9 +624,7 @@ describe('dreamux onboard', () => {
     const answers = answersFromOptions(
       {
         yes: true,
-        configDir: join(root, 'config'),
-        runtimeDir: join(root, 'runtime'),
-        botAppId: 'app-test',
+        configDir: join(root, 'config'),        botAppId: 'app-test',
         botAppSecret: 'secret-test',
       },
       false,
@@ -660,7 +637,6 @@ describe('dreamux onboard', () => {
 function testAnswers(overrides: Partial<OnboardAnswers>): OnboardAnswers {
   return {
     configDir: join(rootForTest(overrides), 'config'),
-    runtimeDir: join(rootForTest(overrides), 'runtime'),
     dispatcherId: 'flow',
     dispatcherCwd: join(rootForTest(overrides), 'dispatcher-cwd'),
     codexBin: process.execPath,

--- a/packages/dreamux/tests/runtime-paths.test.ts
+++ b/packages/dreamux/tests/runtime-paths.test.ts
@@ -25,7 +25,6 @@ import {
   dreamuxRoot,
   logsRoot,
   resetRuntimeConfig,
-  runtimeRoot,
   serverJsonPath,
   serverLogPath,
   stateRoot,
@@ -56,7 +55,6 @@ describe('runtime paths', () => {
     expect(dreamuxRoot()).toBe(join(homedir(), '.dreamux'));
     expect(stateRoot()).toBe(join(dreamuxRoot(), 'state'));
     expect(logsRoot()).toBe(join(dreamuxRoot(), 'logs'));
-    expect(runtimeRoot()).toBe(stateRoot());
     expect(serverJsonPath()).toBe(join(stateRoot(), 'server.json'));
     expect(adminSocketPath()).toBe(join(stateRoot(), 'admin.sock'));
 


### PR DESCRIPTION
## 背景

issue #98 PR3（共 3 个 PR：①changelog 基础设施 ✅ #104 → ②版本读取策略统一 ✅ #105 → **③删除旧兼容垫片 / 死概念（本 PR）**）。纯删除，无新行为。

## 改动

**bundled skills — 删除旧拷贝→symlink 指纹迁移**
- 删除 `LEGACY_COPIED_DISPATCHER_SKILL_SHA256`、`isLegacyCopiedDispatcherSkill()`、`replaceLegacyCopiedDirectoryWithSymlink()`。
- skill 路径若是真实目录，统一走既有 `'skipped'` 分支（提示 remove/rename），不再做指纹匹配迁移。
- **保留**正常的 link / unchanged / replace-stale-or-broken-symlink 行为。

**runtime_dir 死概念全链路清理**
- `paths.ts`：删除 `runtimeRoot()` 别名（`stateRoot()` 为唯一 state root），更新模块 doc 与 `server.ts` 注释。
- CLI：删除 onboard / uninstall 的 `--runtime-dir` 选项（此前 accept-and-ignored），现传入即 fail-loud（yargs strict：`Unknown arguments: runtime-dir`）。
- onboard 管线：从 `OnboardAnswers` / `OnboardCliOptions` / `ServiceInstallAnswers` / `RunUninstallOptions` 删除死字段 `runtimeDir`；删除 wizard 的 runtime-dir 提示与 `defaultRuntimeDir()`；删除 `run.ts` / `daemon/install.ts` 中对 `stateRoot()` 的冗余赋值（及由此产生的未用 import）。

**确认死亡依据**：`service.ts` 的 `ServiceInstallAnswers.runtimeDir` 仅声明、不参与 unit 渲染；`run.ts` 早已用 `runtimeDir: stateRoot()` 覆盖向导收集值；`uninstall.ts` 的 `runtimeDir?` 从不读取（直接用 `stateRoot()`/`logsRoot()`）。

## 范围边界（明确不在本 PR）

不改 service Node 路径稳定化 / Homebrew 兼容、service unit 重注册、onboard config upsert（follow-up）、PR2 已处理的 access/status/restart 策略;不新增任何迁移行为。

## 测试 / 检查

- `rush build` ✅、`rush lint` ✅、`.agents/scripts/check.sh` ✅
- 全量 `vitest`：**333 passed / 1 skipped**（live codex）
- **反转/更新**：`bundled-skills.test.ts` 原「migrates legacy copied dir → replaced」改为「leaves old hand-copied dir untouched → skipped」；删除 `global-config.test.ts` / `runtime-paths.test.ts` 的 `runtimeRoot aliases stateRoot` 断言;清理 `onboard.test.ts` 的 `runtimeDir` 残留与对 ignored runtime-dir 的断言。
- 既有 `onboard.test.ts` 的 `not.toHaveProperty('runtime_dir')` 断言保留（证明 config 不写 runtime_dir）。
- 构建产物端到端冒烟：`onboard --help` 不再含 runtime;`uninstall --runtime-dir` → fail-loud。

## 残留风险

- 行为变更（已记入 change file）：曾依赖 `--runtime-dir` 的脚本现会报错;曾依赖旧拷贝 skill 目录自动迁移的工作区，现需手动 remove/rename 该目录以重建 symlink（升级窗口内多数已是 symlink，属边缘场景）。
- 测试内仍存在大量名为 `runtimeDir` 的**测试本地临时目录变量 / `buildServer` 选项**（用于拼 admin socket 路径），与被删的生产 `runtime_dir` 概念无关，按范围不改名。

Refs #98