### PR TITLE
fix(skills): 修复 team-dev-workflow frontmatter YAML 解析

### DIFF
--- a/common/changes/@excitedjs/dreamux/worktree-skill-colon-pr_2026-06-06-08-52.json
+++ b/common/changes/@excitedjs/dreamux/worktree-skill-colon-pr_2026-06-06-08-52.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Fix team-dev-workflow skill frontmatter so Codex can parse it. The description had an unquoted colon-space (\"dispatcher: adversarial ...\"), which strict YAML reads as a nested mapping and rejects with \"mapping values are not allowed here\", making the bundled skill silently invisible in Codex. Reworded the description to drop the colon; the skill now lists and parses.",
+      "type": "patch",
+      "packageName": "@excitedjs/dreamux"
+    }
+  ],
+  "packageName": "@excitedjs/dreamux",
+  "email": "053700@gmail.com"
+}

--- a/packages/dreamux/skills/team-dev-workflow/SKILL.md
+++ b/packages/dreamux/skills/team-dev-workflow/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: team-dev-workflow
-description: Coordinate multi-teammate software development workflows from a Dreamux dispatcher: adversarial MR/PR review, design negotiation, merge readiness checks, cleanup, and unblocking a teammate. Use for coordination cycles, not ordinary single-repo edits.
+description: Coordinate multi-teammate software development workflows from a Dreamux dispatcher, covering adversarial MR/PR review, design negotiation, merge readiness checks, cleanup, and unblocking a teammate. Use for coordination cycles, not ordinary single-repo edits.
 ---
 
 # Team Development Workflow

--- a/packages/dreamux/tests/bundled-skills.test.ts
+++ b/packages/dreamux/tests/bundled-skills.test.ts
@@ -152,6 +152,55 @@ describe('bundled workspace skill installer', () => {
       installBundledWorkspaceSkills({ dispatcherCwd, platform: 'win32' }),
     ).rejects.toThrow('directory symlinks');
   });
+
+  // Codex parses each SKILL.md frontmatter as strict YAML. An unquoted
+  // (plain) scalar that contains a colon-space (`: `) is read as a nested
+  // mapping indicator and the whole frontmatter fails with "mapping values
+  // are not allowed here", which makes the skill silently invisible. This is
+  // exactly how `team-dev-workflow` once broke ("...dispatcher: adversarial
+  // ..."). Guard every bundled skill against reintroducing that pitfall
+  // without pulling in a YAML parser dependency just for the test.
+  it('keeps every bundled skill frontmatter free of YAML colon-space pitfalls', () => {
+    for (const skillName of BUNDLED_SKILL_NAMES) {
+      const skillFile = join(bundledSkillDir(skillName), 'SKILL.md');
+      const lines = readFileSync(skillFile, 'utf8').split('\n');
+
+      expect(lines[0], `${skillName} SKILL.md must open with frontmatter`).toBe(
+        '---',
+      );
+      const end = lines.indexOf('---', 1);
+      expect(end, `${skillName} frontmatter must be closed`).toBeGreaterThan(0);
+
+      const frontmatter: Record<string, string> = {};
+      for (const line of lines.slice(1, end)) {
+        if (line.trim() === '') continue;
+        const separator = line.indexOf(': ');
+        expect(
+          separator,
+          `${skillName} frontmatter line is not a "key: value" pair: ${line}`,
+        ).toBeGreaterThan(0);
+        const key = line.slice(0, separator);
+        const value = line.slice(separator + 2);
+        frontmatter[key] = value;
+
+        const quoted =
+          (value.startsWith('"') && value.endsWith('"')) ||
+          (value.startsWith("'") && value.endsWith("'"));
+        if (!quoted) {
+          expect(
+            value.includes(': '),
+            `${skillName} frontmatter value for "${key}" has an unquoted colon-space that breaks YAML parsing: ${value}`,
+          ).toBe(false);
+        }
+      }
+
+      expect(frontmatter.name, `${skillName} must declare a name`).toBe(skillName);
+      expect(
+        (frontmatter.description ?? '').length,
+        `${skillName} must declare a description`,
+      ).toBeGreaterThan(0);
+    }
+  });
 });
 
 const LEGACY_COPIED_DISPATCHER_SKILL = `---


### PR DESCRIPTION
## 背景

用户反馈 `team-dev-workflow` skill 在 Codex 里不可见。

## 根因

不是"多个冒号",而是 description 里**唯一一处** `: `(冒号+空格):

> ...from a Dreamux dispatcher**: **adversarial MR/PR review...

Codex 按严格 YAML 解析 frontmatter,plain scalar 里的 `: ` 被当成嵌套 mapping 指示符,整段 frontmatter 报 `mapping values are not allowed here` 而解析失败,skill 因此被静默丢弃、不出现在列表里。`MR/PR` 是斜杠、无关;不带空格的冒号也不会触发。

PyYAML 复现:旧描述 `FAIL (ScannerError)`,改后 `OK`。

## 修复

- 改写 description,去掉那处冒号(保留全部触发关键词,且与 `dispatcher`、`dreamux-maintenance` 两个兄弟 skill 的无引号风格一致)。
- 新增一个**无依赖**回归守卫:遍历所有 bundled skill 的 frontmatter,对未加引号的 value 断言不含 `: `,防止该坑复现(不为此引入 YAML 解析依赖)。
- 补 rush change file(改动落在已发布包的 bundled skills)。

## 验证

- `vitest run bundled-skills` — 10 passed(含新守卫测试)。
- 守卫对旧值会失败、对新值通过(双向确认)。
- `rush change --verify` 通过。