### PR TITLE
feat(runtime): builtin:claude-code 常驻 stream-json 进程 (#120)

### DIFF
--- a/.agents/decisions/agent-runtime-provider.md
+++ b/.agents/decisions/agent-runtime-provider.md
@@ -80,8 +80,13 @@ Implementation status:
     binary fails loudly at `start()` (degraded + throw, Codex-aligned); an
     unexpected child exit marks the runtime degraded and the next turn re-spawns
     with `--resume <session_id>` (lazy restart bound to the serial turn queue, no
-    background backoff timer). A live contract test is opt-in via
-    `DREAMUX_RUN_LIVE_CLAUDE_CODE` (loud skip otherwise, never silent).
+    background backoff timer). A per-turn deadline
+    (`turn_timeout_ms`, default 600000) bounds every turn at the session layer:
+    if a still-alive child never emits a terminal `result`, the turn fails and
+    the child is reaped, so a stall becomes a normal degraded / `failed`-delivery
+    outcome instead of wedging the serial queue (and TeamMate delivery behind
+    it). A live contract test is opt-in via `DREAMUX_RUN_LIVE_CLAUDE_CODE` (loud
+    skip otherwise, never silent).
   - The resident protocol model and process-supervision shape are adapted from
     the Claudemux `next` implementation; the AgentRuntime provider seam,
     runtime-owned MCP injection, degraded/`last_error` status, and TeamMate

--- a/.agents/decisions/agent-runtime-provider.md
+++ b/.agents/decisions/agent-runtime-provider.md
@@ -63,13 +63,29 @@ Implementation status:
   the Codex-backed dispatcher runtime.
 - `builtin:claude-code` is wired through the same `AgentRuntimeProvider`
   catalog (#110 PR6). It is a real second runtime, not a Codex rename: it owns
-  its own config shape (`DispatcherClaudeCodeConfig`), translates the
+  its own config shape (`DispatcherClaudeCodeConfig`) and translates the
   Dreamux-owned MCP descriptors into Claude Code's JSON MCP config
-  (`--mcp-config`) rather than Codex `mcp_servers.*` TOML flags, and runs a turn
-  per headless `claude --print` invocation (no app-server, handshake, or restart
-  loop). Process spawning is behind an injectable turn-runner seam; a missing
-  `claude` binary fails loudly on the first turn, and a live contract test is
-  opt-in via `DREAMUX_RUN_LIVE_CLAUDE_CODE` (loud skip otherwise, never silent).
+  (`--mcp-config`) rather than Codex `mcp_servers.*` TOML flags.
+  - **Resident stream-json transport (#120).** It runs a single long-lived
+    `claude --print --input-format stream-json --output-format stream-json
+    --verbose` child for the dispatcher's lifetime — replacing the original
+    one-shot `claude --print <prompt>` per turn. Turns are NDJSON `user` lines
+    on stdin; `init` / `assistant` / `result` envelopes are read off stdout.
+    Unlike Codex there is no `initialize` handshake: the child emits `init`
+    lazily with the first turn, so readiness is "child spawned", not "handshake
+    completed". The wire protocol is modelled by a pure, forward-tolerant parser
+    (`runtime/claude-code-stream.ts`) and the resident child is supervised by an
+    injectable session seam (`agent-runtime/claude-code-session.ts`); a fake
+    session keeps the lifecycle fully unit-testable. A missing/broken `claude`
+    binary fails loudly at `start()` (degraded + throw, Codex-aligned); an
+    unexpected child exit marks the runtime degraded and the next turn re-spawns
+    with `--resume <session_id>` (lazy restart bound to the serial turn queue, no
+    background backoff timer). A live contract test is opt-in via
+    `DREAMUX_RUN_LIVE_CLAUDE_CODE` (loud skip otherwise, never silent).
+  - The resident protocol model and process-supervision shape are adapted from
+    the Claudemux `next` implementation; the AgentRuntime provider seam,
+    runtime-owned MCP injection, degraded/`last_error` status, and TeamMate
+    delivery result contract are Dreamux's own.
 - The shared interface already includes both confirmed TeamMate completion
   delivery shapes: Codex inbox-and-turn delivery and Claude Code task
   notification delivery. PR6 declares the `claudeCodeTaskNotification`

--- a/common/changes/@excitedjs/dreamux/issue120-claude-code-resident_2026-06-07-12-00.json
+++ b/common/changes/@excitedjs/dreamux/issue120-claude-code-resident_2026-06-07-12-00.json
@@ -1,7 +1,7 @@
 {
   "changes": [
     {
-      "comment": "Run builtin:claude-code as a resident stream-json process (one long-lived `claude --print --input-format stream-json` child per dispatcher) instead of a one-shot `claude --print` per turn, for issue #120. Adds the logs/claude-code/ stderr log directory; config and persisted state schemas are unchanged.",
+      "comment": "Run builtin:claude-code as a resident stream-json process (one long-lived `claude --print --input-format stream-json` child per dispatcher) instead of a one-shot `claude --print` per turn, for issue #120. Adds an optional `dispatchers[].runtime.config.turn_timeout_ms` (default 600000) bounding a single resident turn, and the logs/claude-code/ stderr log directory; persisted state schemas are unchanged and the new config field is optional with a default.",
       "type": "patch",
       "packageName": "@excitedjs/dreamux"
     }

--- a/common/changes/@excitedjs/dreamux/issue120-claude-code-resident_2026-06-07-12-00.json
+++ b/common/changes/@excitedjs/dreamux/issue120-claude-code-resident_2026-06-07-12-00.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Run builtin:claude-code as a resident stream-json process (one long-lived `claude --print --input-format stream-json` child per dispatcher) instead of a one-shot `claude --print` per turn, for issue #120. Adds the logs/claude-code/ stderr log directory; config and persisted state schemas are unchanged.",
+      "type": "patch",
+      "packageName": "@excitedjs/dreamux"
+    }
+  ],
+  "packageName": "@excitedjs/dreamux",
+  "email": "053700@gmail.com"
+}

--- a/packages/dreamux/src/agent-runtime/claude-code-session.ts
+++ b/packages/dreamux/src/agent-runtime/claude-code-session.ts
@@ -57,6 +57,13 @@ export interface ClaudeCodeSessionSpec {
   env: NodeJS.ProcessEnv;
   /** Where to append the child's stderr (its stdout is the in-process data plane). */
   stderrLogPath: string;
+  /**
+   * Per-turn deadline (ms). If the still-alive child never emits a terminal
+   * `result` within this window, the turn is failed and the child is reaped so
+   * the serial turn queue (and TeamMate completion delivery behind it) cannot
+   * wedge forever. Must be > 0.
+   */
+  turnTimeoutMs: number;
   /** Diagnostic logger for protocol-level events (parse errors, control answers). */
   log?: (level: 'info' | 'warn' | 'error', msg: string, err?: unknown) => void;
 }
@@ -90,6 +97,7 @@ interface PendingTurn {
   resolve: (outcome: TurnOutcome) => void;
   reject: (err: Error) => void;
   aggregator: TurnAggregator;
+  timer: NodeJS.Timeout | null;
 }
 
 /** The live session: spawns and supervises the real `claude` child. */
@@ -178,16 +186,54 @@ class LiveClaudeCodeSession implements ClaudeCodeSession {
         resolve,
         reject,
         aggregator: new TurnAggregator(),
+        timer: null,
       };
+      // Per-turn deadline: a still-alive child that never emits a terminal
+      // `result` (e.g. it stalls waiting on input, or only streams
+      // `init`/`assistant`/control envelopes) must not pend forever. On the
+      // deadline, fail this turn and reap the child — `isAlive()` then goes
+      // false, so the runtime re-spawns (with `--resume`) on the next turn
+      // rather than reusing a child with half a turn's output buffered.
+      pending.timer = setTimeout(() => {
+        if (this.pending !== pending) return;
+        this.pending = null;
+        this.spec.log?.(
+          'error',
+          `claude turn timed out after ${this.spec.turnTimeoutMs}ms; reaping resident child`,
+        );
+        reject(
+          new Error(
+            `claude resident turn timed out after ${this.spec.turnTimeoutMs}ms without a result`,
+          ),
+        );
+        // Reap is fire-and-forget: the turn has already been rejected, and the
+        // next turn will re-spawn a fresh child.
+        void this.stop().catch(() => {
+          /* reap is best-effort */
+        });
+      }, this.spec.turnTimeoutMs);
       this.pending = pending;
       // A failed stdin write must fail the turn (and not leave it dangling).
       stdin.write(`${buildUserMessage(prompt)}\n`, (err) => {
         if (err != null && this.pending === pending) {
-          this.pending = null;
-          reject(err instanceof Error ? err : new Error(String(err)));
+          this.settlePending()?.reject(
+            err instanceof Error ? err : new Error(String(err)),
+          );
         }
       });
     });
+  }
+
+  /**
+   * Detach the in-flight turn: clear its deadline timer and null `pending`,
+   * returning it so the caller can resolve or reject it exactly once.
+   */
+  private settlePending(): PendingTurn | null {
+    const pending = this.pending;
+    if (pending === null) return null;
+    if (pending.timer !== null) clearTimeout(pending.timer);
+    this.pending = null;
+    return pending;
   }
 
   async stop(): Promise<void> {
@@ -224,11 +270,11 @@ class LiveClaudeCodeSession implements ClaudeCodeSession {
         this.pending?.aggregator.accept(line);
         break;
       case 'result': {
-        const pending = this.pending;
+        if (this.pending === null) break;
+        this.pending.aggregator.accept(line);
+        const outcome = this.pending.aggregator.outcome();
+        const pending = this.settlePending();
         if (pending === null) break;
-        pending.aggregator.accept(line);
-        const outcome = pending.aggregator.outcome();
-        this.pending = null;
         if (outcome !== null) pending.resolve(outcome);
         else pending.reject(new Error('claude turn ended without a result'));
         break;
@@ -276,10 +322,7 @@ class LiveClaudeCodeSession implements ClaudeCodeSession {
   }
 
   private failPending(err: Error): void {
-    const pending = this.pending;
-    if (pending === null) return;
-    this.pending = null;
-    pending.reject(err);
+    this.settlePending()?.reject(err);
   }
 
   private onExitHandler: (() => void) | null = null;

--- a/packages/dreamux/src/agent-runtime/claude-code-session.ts
+++ b/packages/dreamux/src/agent-runtime/claude-code-session.ts
@@ -1,0 +1,301 @@
+/**
+ * The resident Claude Code stream-json session (issue #120).
+ *
+ * This is the process-supervision seam for `builtin:claude-code`. It replaces
+ * the retired one-shot `claude --print <prompt>` model — where every turn paid a
+ * fresh process cold-start and there was no session continuity beyond
+ * `--resume` — with a single long-lived `claude --print --input-format
+ * stream-json` child that holds stdin/stdout open and serves many turns.
+ *
+ * Responsibilities (mirrors the role `codex/supervisor.ts` plays for Codex):
+ *
+ *  - **Spawn + hold.** `start()` spawns the child in its own process group
+ *    (so a leaked grandchild can be group-killed on reap) and resolves once the
+ *    child is up. The child does NOT emit `init` until the first user message
+ *    arrives, so readiness must not wait on it — the session id is captured from
+ *    the first turn's `init` / `result`.
+ *  - **Serialize turns.** `submitTurn()` writes one `user` message line to
+ *    stdin and resolves with the aggregated `TurnOutcome` when the terminal
+ *    `result` lands. Callers MUST serialize (the runtime's turn queue does);
+ *    a second concurrent `submitTurn` is rejected rather than interleaving two
+ *    turns on one stdin.
+ *  - **Demux stdout.** Each NDJSON line is parsed by the pure
+ *    `runtime/claude-code-stream.ts` model; data-plane envelopes feed the
+ *    in-flight aggregator, control requests are answered defensively so an
+ *    unattended turn never wedges on a permission callback.
+ *  - **Surface exit.** A child exit mid-turn rejects the in-flight turn; an
+ *    exit at any time fires `onExit` so the runtime can mark itself degraded and
+ *    re-spawn (with `--resume`) on the next turn.
+ *
+ * The seam is injectable ({@link ClaudeCodeSessionFactory}) so the runtime
+ * lifecycle is unit-testable with a fake session and no live `claude` binary.
+ */
+
+import { spawn, type ChildProcess, type SpawnOptions } from 'node:child_process';
+import { mkdir, open } from 'node:fs/promises';
+import { dirname } from 'node:path';
+
+import { isProcessAlive, killProcessGroup } from '../codex/supervisor.js';
+import {
+  buildCanUseToolAllow,
+  buildControlAck,
+  buildUserMessage,
+  LineBuffer,
+  parseLine,
+  TurnAggregator,
+  type ParsedLine,
+  type TurnOutcome,
+} from '../runtime/claude-code-stream.js';
+
+export type { TurnOutcome } from '../runtime/claude-code-stream.js';
+
+/** Everything needed to spawn one resident `claude` stream-json child. */
+export interface ClaudeCodeSessionSpec {
+  bin: string;
+  args: string[];
+  cwd: string;
+  env: NodeJS.ProcessEnv;
+  /** Where to append the child's stderr (its stdout is the in-process data plane). */
+  stderrLogPath: string;
+  /** Diagnostic logger for protocol-level events (parse errors, control answers). */
+  log?: (level: 'info' | 'warn' | 'error', msg: string, err?: unknown) => void;
+}
+
+/**
+ * A resident Claude Code session. Turns are serialized by the caller; the
+ * session itself rejects a concurrent `submitTurn` defensively.
+ */
+export interface ClaudeCodeSession {
+  /** Spawn the child and resolve once it is up (reject on spawn error). */
+  start(): Promise<void>;
+  /** Submit one user turn; resolve with the outcome when `result` lands. */
+  submitTurn(prompt: string): Promise<TurnOutcome>;
+  /** Whether the child is currently alive. */
+  isAlive(): boolean;
+  /**
+   * Register a one-shot handler fired when the child exits unexpectedly (not via
+   * {@link stop}). The runtime uses it to mark itself degraded and re-spawn on
+   * the next turn. Register before {@link start}.
+   */
+  setOnExit(handler: () => void): void;
+  /** Reap the child (SIGTERM → SIGKILL group). Idempotent. */
+  stop(): Promise<void>;
+}
+
+export type ClaudeCodeSessionFactory = (
+  spec: ClaudeCodeSessionSpec,
+) => ClaudeCodeSession;
+
+interface PendingTurn {
+  resolve: (outcome: TurnOutcome) => void;
+  reject: (err: Error) => void;
+  aggregator: TurnAggregator;
+}
+
+/** The live session: spawns and supervises the real `claude` child. */
+class LiveClaudeCodeSession implements ClaudeCodeSession {
+  private child: ChildProcess | null = null;
+  private pid: number | null = null;
+  private exited = false;
+  private stopped = false;
+  private readonly lineBuf = new LineBuffer();
+  private pending: PendingTurn | null = null;
+
+  constructor(private readonly spec: ClaudeCodeSessionSpec) {}
+
+  isAlive(): boolean {
+    return this.child !== null && !this.exited;
+  }
+
+  async start(): Promise<void> {
+    if (this.child !== null) {
+      throw new Error('ClaudeCodeSession.start: already started');
+    }
+    await mkdir(this.spec.cwd, { recursive: true });
+    await mkdir(dirname(this.spec.stderrLogPath), { recursive: true });
+    // Open the stderr log as a FileHandle and hand its fd to the child. The
+    // handle is closed once the child owns the inherited fd (the finally),
+    // matching the timing discipline in codex/supervisor.ts.
+    const stderrHandle = await open(this.spec.stderrLogPath, 'a', 0o600);
+    const spawnOpts: SpawnOptions = {
+      cwd: this.spec.cwd,
+      env: this.spec.env,
+      // Own process group so a leaked grandchild (the rust/node split a CLI may
+      // fork) is group-killable on reap, never a leak.
+      detached: true,
+      stdio: ['pipe', 'pipe', stderrHandle.fd],
+    };
+    let child: ChildProcess;
+    try {
+      child = await new Promise<ChildProcess>((resolve, reject) => {
+        let settled = false;
+        const c = spawn(this.spec.bin, this.spec.args, spawnOpts);
+        c.once('error', (e) => {
+          if (settled) return;
+          settled = true;
+          reject(e instanceof Error ? e : new Error(String(e)));
+        });
+        c.once('spawn', () => {
+          if (settled) return;
+          settled = true;
+          resolve(c);
+        });
+      });
+    } finally {
+      await stderrHandle.close();
+    }
+    if (child.pid === undefined) {
+      throw new Error('claude resident child spawned without a pid');
+    }
+    this.child = child;
+    this.pid = child.pid;
+    // Post-spawn `error` must not crash the host event loop.
+    child.on('error', (err) => {
+      this.spec.log?.('warn', 'claude resident child error', err);
+    });
+    child.stdout?.setEncoding('utf8');
+    child.stdout?.on('data', (chunk: string) => {
+      for (const line of this.lineBuf.push(chunk)) this.onLine(parseLine(line));
+    });
+    child.once('exit', () => this.onChildExit());
+  }
+
+  async submitTurn(prompt: string): Promise<TurnOutcome> {
+    if (this.stopped) {
+      return Promise.reject(new Error('claude resident session is stopped'));
+    }
+    const stdin = this.child?.stdin;
+    if (this.child === null || this.exited || stdin == null || !stdin.writable) {
+      return Promise.reject(new Error('claude resident child is not running'));
+    }
+    if (this.pending !== null) {
+      return Promise.reject(
+        new Error('claude resident session is already mid-turn'),
+      );
+    }
+    return new Promise<TurnOutcome>((resolve, reject) => {
+      const pending: PendingTurn = {
+        resolve,
+        reject,
+        aggregator: new TurnAggregator(),
+      };
+      this.pending = pending;
+      // A failed stdin write must fail the turn (and not leave it dangling).
+      stdin.write(`${buildUserMessage(prompt)}\n`, (err) => {
+        if (err != null && this.pending === pending) {
+          this.pending = null;
+          reject(err instanceof Error ? err : new Error(String(err)));
+        }
+      });
+    });
+  }
+
+  async stop(): Promise<void> {
+    if (this.stopped) return;
+    this.stopped = true;
+    // Mark exited up front so the child's own `exit` event (fired by the kill
+    // below) is treated as a deliberate stop, never an unexpected exit that
+    // would fire `onExit` → degrade the runtime we are intentionally tearing
+    // down.
+    this.exited = true;
+    this.failPending(new Error('claude resident session stopped mid-turn'));
+    const pid = this.pid;
+    if (pid !== null) {
+      if (isProcessAlive(pid)) {
+        killProcessGroup(pid, 'SIGTERM');
+        const deadline = Date.now() + 1000;
+        while (Date.now() < deadline) {
+          if (!isProcessAlive(pid)) break;
+          await new Promise<void>((r) => setTimeout(r, 25));
+        }
+      }
+      // Always SIGKILL the group — a reparented grandchild outliving its leader
+      // is the exact leak this guards against.
+      killProcessGroup(pid, 'SIGKILL');
+    }
+    this.exited = true;
+    this.child = null;
+  }
+
+  private onLine(line: ParsedLine): void {
+    switch (line.kind) {
+      case 'init':
+      case 'assistant':
+        this.pending?.aggregator.accept(line);
+        break;
+      case 'result': {
+        const pending = this.pending;
+        if (pending === null) break;
+        pending.aggregator.accept(line);
+        const outcome = pending.aggregator.outcome();
+        this.pending = null;
+        if (outcome !== null) pending.resolve(outcome);
+        else pending.reject(new Error('claude turn ended without a result'));
+        break;
+      }
+      case 'control_request':
+        this.onControlRequest(line.requestId, line.subtype, line.request);
+        break;
+      case 'parse_error':
+        this.spec.log?.('warn', `claude stream-json parse error: ${line.raw}`);
+        break;
+      default:
+        break;
+    }
+  }
+
+  private onControlRequest(
+    requestId: string | null,
+    subtype: string | null,
+    request: Record<string, unknown>,
+  ): void {
+    const stdin = this.child?.stdin;
+    if (requestId === null || stdin == null || !stdin.writable) return;
+    // Unattended posture: answer permission callbacks so a turn never wedges
+    // waiting on a human. Under a bypassing permission mode the CLI does not
+    // ask, but answering defensively is harmless and crash-proof.
+    let reply: string;
+    if (subtype === 'can_use_tool') {
+      const rawInput = request['input'];
+      const input =
+        typeof rawInput === 'object' && rawInput !== null && !Array.isArray(rawInput)
+          ? (rawInput as Record<string, unknown>)
+          : {};
+      reply = buildCanUseToolAllow(requestId, input);
+    } else {
+      reply = buildControlAck(requestId);
+    }
+    stdin.write(`${reply}\n`);
+  }
+
+  private onChildExit(): void {
+    if (this.exited) return;
+    this.exited = true;
+    this.failPending(new Error('claude resident child exited mid-turn'));
+    this.onExitHandler?.();
+  }
+
+  private failPending(err: Error): void {
+    const pending = this.pending;
+    if (pending === null) return;
+    this.pending = null;
+    pending.reject(err);
+  }
+
+  private onExitHandler: (() => void) | null = null;
+
+  setOnExit(handler: () => void): void {
+    this.onExitHandler = handler;
+  }
+}
+
+/**
+ * The default factory: spawns the real `claude` binary. The returned session
+ * exposes a `setOnExit` registration the runtime uses to react to an unexpected
+ * child death (degrade + re-spawn next turn).
+ */
+export function createDefaultClaudeCodeSession(
+  spec: ClaudeCodeSessionSpec,
+): ClaudeCodeSession {
+  return new LiveClaudeCodeSession(spec);
+}

--- a/packages/dreamux/src/agent-runtime/claude-code.ts
+++ b/packages/dreamux/src/agent-runtime/claude-code.ts
@@ -1,42 +1,52 @@
 /**
- * `builtin:claude-code` AgentRuntimeProvider (issue #110 PR6).
+ * `builtin:claude-code` AgentRuntimeProvider (issue #110 PR6, resident
+ * stream-json transport since issue #120).
  *
  * A real second agent runtime that proves the AgentRuntimeProvider abstraction
- * is not "Codex renamed". It differs from `builtin:codex` in every
+ * is not "Codex renamed". Like Codex it now runs a **resident child process**
+ * supervised for the dispatcher's lifetime — but it differs in every
  * runtime-specific dimension:
  *
- * - **No persistent app-server / handshake / WebSocket.** Claude Code runs a
- *   turn per headless `claude --print` invocation, so there is no long-lived
- *   child to supervise, no restart/backoff loop, and no initialize timeout.
+ * - **Stream-json over stdio, not an app-server WebSocket.** The resident child
+ *   is `claude --print --input-format stream-json --output-format stream-json`
+ *   (see `runtime/claude-code-args.ts`); turns are NDJSON `user` lines on stdin
+ *   and `init`/`assistant`/`result` envelopes on stdout (see
+ *   `runtime/claude-code-stream.ts`). There is no `initialize` handshake — the
+ *   child emits `init` lazily with the first turn — so readiness is "child
+ *   spawned", not "handshake completed".
  * - **MCP injection is a JSON config document** (`--mcp-config <file>`), not
- *   Codex's `-c mcp_servers.*` TOML CLI flags. See `runtime/claude-code-args.ts`.
+ *   Codex's `-c mcp_servers.*` TOML CLI flags.
  * - **Runtime-owned config** is `DispatcherClaudeCodeConfig` (bin / model /
  *   permission_mode / extra_args / extra_env), distinct from the Codex config.
  * - **Completion delivery** is the Claude Code task-notification path, not the
  *   Codex inbox-then-trigger path.
  *
- * Process spawning goes through an injectable {@link ClaudeCodeTurnRunner} seam
- * (mirroring Codex's process-factory seam), so the lifecycle contract is fully
- * unit-testable with a fake runner. A live `claude` binary is exercised only by
- * the opt-in live test.
+ * Process spawning goes through an injectable {@link ClaudeCodeSessionFactory}
+ * seam (mirroring Codex's process-factory seam), so the lifecycle contract is
+ * fully unit-testable with a fake session. A live `claude` binary is exercised
+ * only by the opt-in live test.
  *
- * Failure contract: a turn failure (missing binary, spawn error, non-zero exit)
- * is never swallowed. For inbound/restart turns it drives the runtime to
- * `degraded` with a persisted `last_error` (observable via status/doctor). For
- * `deliverTeamMateCompletion` it surfaces as a `failed` result the caller can
- * act on (PR8 delivery retry). `enqueueInbound` still returns after accept
- * (submit != completion) so the channel can ack promptly.
+ * Failure contract (unchanged by #120): a turn failure (spawn error, child
+ * exit, error `result`) is never swallowed. For inbound/restart turns it drives
+ * the runtime to `degraded` with a persisted `last_error` (observable via
+ * status/doctor). For `deliverTeamMateCompletion` it surfaces as a `failed`
+ * result the caller can act on (PR8 delivery retry). `enqueueInbound` still
+ * returns after accept (submit != completion) so the channel can ack promptly.
  *
- * Scope note: this PR declares the task-notification delivery capability and
- * provides the runtime's delivery entry point. The executable TeamMate delivery
- * loop (ledger, retry, pull fallback) belongs to the server-hosted TeamMate PRs
- * (#110 PR7/PR8), per `.agents/decisions/agent-runtime-provider.md`.
+ * Restart: an unexpected child exit marks the runtime `degraded`; the next turn
+ * re-spawns the resident child with `--resume <session_id>`, restoring the
+ * conversation. There is no background backoff timer — re-spawn is lazy and
+ * bound to the (serialized) turn queue, so it stays deterministic.
+ *
+ * Reference: the resident stream-json protocol model and process-supervision
+ * shape are adapted from the Claudemux `next` implementation; the AgentRuntime /
+ * Channel / DispatcherService boundaries (provider seam, runtime-owned MCP
+ * injection, degraded/last_error status, TeamMate delivery result contract) are
+ * Dreamux's own, per `.agents/decisions/agent-runtime-provider.md`.
  */
 
-import { execFile } from 'node:child_process';
 import { mkdir, writeFile } from 'node:fs/promises';
 import { dirname } from 'node:path';
-import { promisify } from 'node:util';
 
 import { createBuiltinRegistry } from '../registry/index.js';
 import {
@@ -47,13 +57,19 @@ import {
 } from '../runtime/config.js';
 import {
   dispatcherClaudeCodeMcpConfigPath,
+  dispatcherClaudeCodeStreamLogPath,
   dispatcherCodexCwd,
 } from '../runtime/paths.js';
 import { dispatcherProcessEnv } from '../runtime/package-bin.js';
 import {
-  claudeCodeTurnArgs,
+  claudeCodeResidentArgs,
   stringifyClaudeCodeMcpConfig,
 } from '../runtime/claude-code-args.js';
+import {
+  createDefaultClaudeCodeSession,
+  type ClaudeCodeSession,
+  type ClaudeCodeSessionFactory,
+} from './claude-code-session.js';
 import type {
   InboundDeliveryHooks,
   InboundDeliveryResult,
@@ -68,69 +84,15 @@ import type {
   TeamMateCompletionEnvelope,
 } from './types.js';
 
-const execFileAsync = promisify(execFile);
-
-/** One headless Claude Code turn invocation. */
-export interface ClaudeCodeTurnRequest {
-  bin: string;
-  args: string[];
-  cwd: string;
-  env: NodeJS.ProcessEnv;
-}
-
-/** The result of one turn: the (possibly new) session id and the final text. */
-export interface ClaudeCodeTurnResult {
-  sessionId: string | null;
-  result: string;
-}
-
-/** Injectable seam for running a Claude Code turn (tests inject a fake). */
-export interface ClaudeCodeTurnRunner {
-  runTurn(request: ClaudeCodeTurnRequest): Promise<ClaudeCodeTurnResult>;
-}
-
-/** Parse the `claude --output-format json` result envelope, defensively. */
-export function parseClaudeCodeJsonResult(stdout: string): ClaudeCodeTurnResult {
-  const trimmed = stdout.trim();
-  let parsed: unknown;
-  try {
-    parsed = JSON.parse(trimmed);
-  } catch {
-    return { sessionId: null, result: trimmed };
-  }
-  if (parsed !== null && typeof parsed === 'object' && !Array.isArray(parsed)) {
-    const obj = parsed as Record<string, unknown>;
-    const sessionId =
-      typeof obj['session_id'] === 'string' ? obj['session_id'] : null;
-    const result = typeof obj['result'] === 'string' ? obj['result'] : trimmed;
-    return { sessionId, result };
-  }
-  return { sessionId: null, result: trimmed };
-}
-
-/** The live turn runner: spawns the real `claude` binary. */
-export function createDefaultClaudeCodeTurnRunner(): ClaudeCodeTurnRunner {
-  return {
-    async runTurn(request: ClaudeCodeTurnRequest): Promise<ClaudeCodeTurnResult> {
-      const { stdout } = await execFileAsync(request.bin, request.args, {
-        cwd: request.cwd,
-        env: request.env,
-        maxBuffer: 64 * 1024 * 1024,
-      });
-      return parseClaudeCodeJsonResult(stdout);
-    },
-  };
-}
-
 export interface ClaudeCodeAgentRuntimeProviderOptions {
   /** Optional host-level bin resolver (default: identity on the config bin). */
   resolveBinPath?: (bin: string) => string;
-  /** Override the turn runner (tests inject a fake). */
-  turnRunner?: ClaudeCodeTurnRunner;
+  /** Override the resident-session factory (tests inject a fake). */
+  sessionFactory?: ClaudeCodeSessionFactory;
 }
 
 interface ClaudeCodeRuntimeDeps {
-  turnRunner: ClaudeCodeTurnRunner;
+  sessionFactory: ClaudeCodeSessionFactory;
   resolveBinPath: (bin: string) => string;
 }
 
@@ -149,10 +111,10 @@ function errMessage(err: unknown): string {
 }
 
 /**
- * The Claude Code agent runtime for one dispatcher. Turns run serially (one at a
- * time) and `enqueueInbound` returns after the message is accepted — not after
- * the turn completes — matching the Codex runtime's submit-then-serialize
- * contract.
+ * The Claude Code agent runtime for one dispatcher. A single resident
+ * stream-json child serves every turn. Turns run serially (one at a time) and
+ * `enqueueInbound` returns after the message is accepted — not after the turn
+ * completes — matching the Codex runtime's submit-then-serialize contract.
  */
 export class ClaudeCodeRuntime implements AgentRuntime {
   readonly providerRef = BUILTIN_CLAUDE_CODE_PROVIDER_REF;
@@ -163,6 +125,7 @@ export class ClaudeCodeRuntime implements AgentRuntime {
   private readonly cwd: string;
   private readonly mcpConfigPath: string;
   private readonly mcpConfigDoc: string;
+  private readonly stderrLogPath: string;
   private status: DispatcherStatus = 'declared';
   private threadId: string | null;
   private readonly resumed: boolean;
@@ -170,6 +133,7 @@ export class ClaudeCodeRuntime implements AgentRuntime {
   private readonly seen = new Set<string>();
   private queue: Promise<void> = Promise.resolve();
   private turnCounter = 0;
+  private session: ClaudeCodeSession | null = null;
 
   constructor(
     private readonly context: AgentRuntimeCreateContext,
@@ -184,6 +148,7 @@ export class ClaudeCodeRuntime implements AgentRuntime {
     this.cwd = context.row.codex_cwd ?? dispatcherCodexCwd(this.dispatcherId);
     this.mcpConfigPath = dispatcherClaudeCodeMcpConfigPath(this.dispatcherId);
     this.mcpConfigDoc = stringifyClaudeCodeMcpConfig(context.mcpServers);
+    this.stderrLogPath = dispatcherClaudeCodeStreamLogPath(this.dispatcherId);
     this.threadId = context.row.thread_id;
     this.resumed = context.row.thread_id !== null;
   }
@@ -205,15 +170,14 @@ export class ClaudeCodeRuntime implements AgentRuntime {
     try {
       await mkdir(dirname(this.mcpConfigPath), { recursive: true });
       await writeFile(this.mcpConfigPath, this.mcpConfigDoc, { mode: 0o600 });
+      // Spawn the resident child up front so the runtime is truly resident
+      // (Codex-aligned). A missing/broken `claude` binary fails here and drives
+      // the runtime to degraded + throws, rather than a silent no-op.
+      await this.ensureSession();
     } catch (err) {
       await this.setStatus('degraded', err);
       throw err;
     }
-    // No persistent app-server: a healthy "started" Claude Code runtime is one
-    // whose MCP config is materialized and which is ready to accept per-turn
-    // invocations. A missing `claude` binary surfaces on the first turn as a
-    // degraded runtime status + persisted last_error (see the failure contract
-    // in the file header), not a silent no-op.
     await this.setStatus('ready');
   }
 
@@ -221,6 +185,15 @@ export class ClaudeCodeRuntime implements AgentRuntime {
     if (this.stopped) return;
     this.stopped = true;
     await this.setStatus('stopping');
+    const session = this.session;
+    this.session = null;
+    if (session !== null) {
+      try {
+        await session.stop();
+      } catch (err) {
+        this.log('warn', 'claude-code session stop errored', err);
+      }
+    }
     await this.setStatus('stopped');
   }
 
@@ -241,12 +214,10 @@ export class ClaudeCodeRuntime implements AgentRuntime {
     }
     const turnId = `claude-turn-${++this.turnCounter}`;
     // Submit-then-serialize: return after accept (so the channel can ack
-    // promptly), run the turn on the serial queue. Unlike Codex there is no
-    // separate submit-ack before execution, so a turn failure cannot be
+    // promptly), run the turn on the serial queue. A turn failure cannot be
     // returned to this caller without blocking the channel ack on full turn
     // completion. Instead, a failed turn drives the runtime to `degraded` with a
-    // persisted `last_error` (visible via status/doctor) — the failure is never
-    // swallowed. See the PR6 review thread / the agent-runtime decision record.
+    // persisted `last_error` (visible via status/doctor) — never swallowed.
     void this.runTurnOnQueue(input.parsed_text, turnId).then(
       () => this.markTurnSucceeded(),
       (err) => this.markTurnFailed(turnId, err),
@@ -315,29 +286,63 @@ export class ClaudeCodeRuntime implements AgentRuntime {
     await this.setStatus('degraded', err);
   }
 
-  private async runTurn(prompt: string, turnId: string): Promise<void> {
-    const args = claudeCodeTurnArgs({
+  /**
+   * Ensure a live resident session exists, spawning (or re-spawning after an
+   * unexpected exit) as needed. Re-spawn resumes the persisted session id so the
+   * conversation survives a crash.
+   */
+  private async ensureSession(): Promise<ClaudeCodeSession> {
+    if (this.session !== null && this.session.isAlive()) return this.session;
+    const args = claudeCodeResidentArgs({
       config: this.config,
       mcpConfigPath: this.mcpConfigPath,
-      prompt,
       resumeSessionId: this.threadId,
     });
-    const result = await this.deps.turnRunner.runTurn({
+    const session = this.deps.sessionFactory({
       bin: this.bin,
       args,
       cwd: this.cwd,
       env: dispatcherProcessEnv(globalThis.process.env, this.config.extra_env),
+      stderrLogPath: this.stderrLogPath,
+      log: (level, msg, err) => this.log(level, msg, err),
     });
+    session.setOnExit(() => {
+      void this.onSessionExit(session);
+    });
+    await session.start();
+    this.session = session;
+    return session;
+  }
+
+  /** React to an unexpected resident-child exit: degrade and drop the session. */
+  private async onSessionExit(session: ClaudeCodeSession): Promise<void> {
+    if (this.session !== session) return; // already replaced/stopped
+    this.session = null;
+    if (this.stopped) return;
+    this.log('error', 'claude-code resident child exited unexpectedly');
+    await this.setStatus('degraded', new Error('claude resident child exited'));
+  }
+
+  private async runTurn(prompt: string, turnId: string): Promise<void> {
+    const session = await this.ensureSession();
+    const outcome = await session.submitTurn(prompt);
     if (
-      result.sessionId !== null &&
-      result.sessionId !== '' &&
-      result.sessionId !== this.threadId
+      outcome.sessionId !== null &&
+      outcome.sessionId !== '' &&
+      outcome.sessionId !== this.threadId
     ) {
-      this.threadId = result.sessionId;
+      this.threadId = outcome.sessionId;
       await this.context.dispatchers.setThreadId(
         this.dispatcherId,
-        result.sessionId,
+        outcome.sessionId,
       );
+    }
+    if (outcome.isError) {
+      const detail =
+        outcome.errors.length > 0
+          ? outcome.errors.join('; ')
+          : (outcome.subtype ?? 'unknown error');
+      throw new Error(`claude turn ${turnId} returned an error result: ${detail}`);
     }
     this.log('info', `claude-code turn ${turnId} completed`);
   }
@@ -370,7 +375,8 @@ export function createClaudeCodeAgentRuntimeProvider(
   const descriptor = createBuiltinRegistry().resolve(
     BUILTIN_CLAUDE_CODE_PROVIDER_REF,
   );
-  const turnRunner = options.turnRunner ?? createDefaultClaudeCodeTurnRunner();
+  const sessionFactory =
+    options.sessionFactory ?? createDefaultClaudeCodeSession;
   const resolveBinPath = options.resolveBinPath ?? ((bin: string) => bin);
   return {
     ref: BUILTIN_CLAUDE_CODE_PROVIDER_REF,
@@ -385,7 +391,7 @@ export function createClaudeCodeAgentRuntimeProvider(
       ],
     },
     createRuntime(context: AgentRuntimeCreateContext): AgentRuntime {
-      return new ClaudeCodeRuntime(context, { turnRunner, resolveBinPath });
+      return new ClaudeCodeRuntime(context, { sessionFactory, resolveBinPath });
     },
   };
 }

--- a/packages/dreamux/src/agent-runtime/claude-code.ts
+++ b/packages/dreamux/src/agent-runtime/claude-code.ts
@@ -38,6 +38,14 @@
  * conversation. There is no background backoff timer — re-spawn is lazy and
  * bound to the (serialized) turn queue, so it stays deterministic.
  *
+ * Per-turn deadline: a turn whose still-alive child never emits a terminal
+ * `result` (a stall, or a wait on input the runtime cannot satisfy) would
+ * otherwise pend forever and wedge the serial queue — and, behind it, TeamMate
+ * completion delivery, which awaits this runtime. `turn_timeout_ms` bounds every
+ * turn at the session layer: on the deadline the turn fails and the child is
+ * reaped (so the next turn re-spawns), turning an infinite hang into a normal
+ * degraded + `last_error` (inbound) or `failed` delivery result.
+ *
  * Reference: the resident stream-json protocol model and process-supervision
  * shape are adapted from the Claudemux `next` implementation; the AgentRuntime /
  * Channel / DispatcherService boundaries (provider seam, runtime-owned MCP
@@ -304,6 +312,7 @@ export class ClaudeCodeRuntime implements AgentRuntime {
       cwd: this.cwd,
       env: dispatcherProcessEnv(globalThis.process.env, this.config.extra_env),
       stderrLogPath: this.stderrLogPath,
+      turnTimeoutMs: this.config.turn_timeout_ms,
       log: (level, msg, err) => this.log(level, msg, err),
     });
     session.setOnExit(() => {

--- a/packages/dreamux/src/agent-runtime/index.ts
+++ b/packages/dreamux/src/agent-runtime/index.ts
@@ -1,4 +1,5 @@
 export * from './catalog.js';
 export * from './codex.js';
 export * from './claude-code.js';
+export * from './claude-code-session.js';
 export * from './types.js';

--- a/packages/dreamux/src/runtime/claude-code-args.ts
+++ b/packages/dreamux/src/runtime/claude-code-args.ts
@@ -41,27 +41,37 @@ export function stringifyClaudeCodeMcpConfig(
   return `${JSON.stringify(claudeCodeMcpConfig(servers), null, 2)}\n`;
 }
 
-export interface ClaudeCodeTurnArgsInput {
+export interface ClaudeCodeResidentArgsInput {
   config: DispatcherClaudeCodeConfig;
   /** Path to the generated Claude Code MCP config document. */
   mcpConfigPath: string;
-  /** The turn prompt (the inbound text or a delivery notification). */
-  prompt: string;
-  /** Resume an existing Claude Code session, when one is known. */
+  /** Resume an existing Claude Code session, when one is known (spawn-time). */
   resumeSessionId?: string | null;
 }
 
 /**
- * Build the `claude` CLI args for one headless turn. Claude Code runs a turn
- * per non-interactive `--print` invocation (no persistent app-server), reads
- * its MCP servers from the JSON config, optionally resumes a prior session, and
- * emits a single JSON result (`--output-format json`) carrying the session id.
+ * Build the `claude` CLI args for the *resident* stream-json transport (issue
+ * #120). Unlike the retired one-shot `claude --print <prompt>`, this launches a
+ * long-lived process that keeps stdin/stdout open: `--input-format stream-json`
+ * consumes NDJSON `user` messages on stdin (one per turn) until EOF, and
+ * `--output-format stream-json --verbose` streams `init` / `assistant` /
+ * `result` envelopes on stdout. The prompt is therefore NOT a CLI argument —
+ * each turn is written to stdin as a `user` message line (see
+ * `runtime/claude-code-stream.ts`).
+ *
+ * It reads its MCP servers from the JSON config (`--mcp-config`), optionally
+ * resumes a prior session at spawn time (`--resume`, used both for operator
+ * resume and for re-spawn after an unexpected exit), and threads the operator's
+ * model / permission mode / extra args through.
  */
-export function claudeCodeTurnArgs(input: ClaudeCodeTurnArgsInput): string[] {
+export function claudeCodeResidentArgs(input: ClaudeCodeResidentArgsInput): string[] {
   const args = [
     '--print',
+    '--input-format',
+    'stream-json',
     '--output-format',
-    'json',
+    'stream-json',
+    '--verbose',
     '--mcp-config',
     input.mcpConfigPath,
   ];
@@ -79,7 +89,5 @@ export function claudeCodeTurnArgs(input: ClaudeCodeTurnArgsInput): string[] {
     args.push('--resume', input.resumeSessionId);
   }
   args.push(...input.config.extra_args);
-  // The prompt is the trailing positional argument under `--print`.
-  args.push(input.prompt);
   return args;
 }

--- a/packages/dreamux/src/runtime/claude-code-stream.ts
+++ b/packages/dreamux/src/runtime/claude-code-stream.ts
@@ -1,0 +1,330 @@
+/**
+ * The Claude Code stream-json wire protocol (issue #120).
+ *
+ * A clean-room model of the NDJSON envelopes the `claude` CLI emits and accepts
+ * on stdio under `--input-format stream-json --output-format stream-json`. This
+ * is what makes the `builtin:claude-code` runtime *resident*: one long-lived
+ * `claude --print` process consumes user-message lines on stdin and streams
+ * `init` / `assistant` / `result` envelopes on stdout, instead of a fresh
+ * one-shot process per turn.
+ *
+ * Two design rules, both load-bearing:
+ *
+ *  - **Forward-tolerant by construction.** The CLI's real envelope set is much
+ *    wider than anything Dreamux consumes (extra `system` subtypes, rate-limit
+ *    events, hook lifecycle, streamlined variants, and extra `result` fields).
+ *    This parser never validates a closed schema and never throws on an unknown
+ *    `type` / `subtype`; it reads only the fields the runtime needs and ignores
+ *    the rest. A wider or newer CLI build cannot break a turn.
+ *
+ *  - **Pure, no IO.** No process, no clock, no filesystem — so the line framer,
+ *    the line parser, and the turn aggregator are unit-tested against synthetic
+ *    envelope sequences (hand-authored to the real wire shapes) with no live
+ *    `claude` binary.
+ *
+ * Public-safety note: this module is a generic protocol model. It carries no
+ * Feishu identifiers, tokens, private paths, or environment-specific details.
+ */
+
+/** A parsed JSON object, or `null` for anything that is not a JSON object. */
+export type JsonObject = Record<string, unknown>;
+
+function isObject(v: unknown): v is JsonObject {
+  return typeof v === 'object' && v !== null && !Array.isArray(v);
+}
+
+function str(v: unknown): string | null {
+  return typeof v === 'string' ? v : null;
+}
+
+// ─── Line framing ───────────────────────────────────────────────────────────
+
+/**
+ * Incremental newline framer. The child's stdout is NDJSON but arrives in
+ * arbitrary chunks; `push` returns the complete lines so far and buffers a
+ * trailing partial line until its newline lands. Blank lines are dropped.
+ */
+export class LineBuffer {
+  private buf = '';
+
+  push(chunk: string): string[] {
+    this.buf += chunk;
+    const out: string[] = [];
+    let nl = this.buf.indexOf('\n');
+    while (nl >= 0) {
+      const line = this.buf.slice(0, nl);
+      this.buf = this.buf.slice(nl + 1);
+      const trimmed = line.endsWith('\r') ? line.slice(0, -1) : line;
+      if (trimmed.length > 0) out.push(trimmed);
+      nl = this.buf.indexOf('\n');
+    }
+    return out;
+  }
+
+  /** Any buffered bytes with no trailing newline (e.g. at stream end). */
+  flush(): string | null {
+    const rest = this.buf.trim();
+    this.buf = '';
+    return rest.length > 0 ? rest : null;
+  }
+}
+
+// ─── Parsed envelope ────────────────────────────────────────────────────────
+
+/**
+ * One decoded stdout line. `kind` is Dreamux's coarse classification, not the
+ * CLI's `type` — it groups the wire types by how the runtime reacts:
+ *
+ *  - `init` / `assistant` / `result` — the data-plane envelopes the turn
+ *    aggregator consumes.
+ *  - `control_request` / `control_response` — the control plane (permission
+ *    callbacks the runtime answers defensively).
+ *  - `other` — a valid JSON object the runtime does not act on (rate-limit
+ *    events, hook lifecycle, streamlined text, …). Carried, never dropped.
+ *  - `parse_error` — the line was not JSON; surfaced for logging, never thrown.
+ */
+export type ParsedLine =
+  | {
+      kind: 'init';
+      sessionId: string | null;
+      model: string | null;
+      raw: JsonObject;
+    }
+  | {
+      kind: 'assistant';
+      text: string;
+      sessionId: string | null;
+      raw: JsonObject;
+    }
+  | { kind: 'result'; outcome: ResultEnvelope; raw: JsonObject }
+  | {
+      kind: 'control_request';
+      requestId: string | null;
+      subtype: string | null;
+      request: JsonObject;
+      raw: JsonObject;
+    }
+  | {
+      kind: 'control_response';
+      requestId: string | null;
+      ok: boolean;
+      raw: JsonObject;
+    }
+  | { kind: 'other'; type: string | null; subtype: string | null; raw: JsonObject }
+  | { kind: 'parse_error'; raw: string };
+
+/** The terminal `result` envelope, reduced to what the runtime records per turn. */
+export interface ResultEnvelope {
+  /** `success` or one of the `error_*` subtypes. Unknown subtypes pass through. */
+  readonly subtype: string | null;
+  readonly isError: boolean;
+  /** The success-path final text (`result`); `null` for error subtypes. */
+  readonly text: string | null;
+  readonly sessionId: string | null;
+  /** Error subtypes may carry a message list; empty otherwise. */
+  readonly errors: readonly string[];
+}
+
+/**
+ * Join the text blocks of an Anthropic assistant `message.content` array.
+ * `thinking` and `tool_use` blocks contribute no visible text and are skipped.
+ */
+export function assistantText(message: unknown): string {
+  if (!isObject(message)) return '';
+  const content = message['content'];
+  if (typeof content === 'string') return content;
+  if (!Array.isArray(content)) return '';
+  const parts: string[] = [];
+  for (const block of content) {
+    if (!isObject(block)) continue;
+    if (block['type'] === 'text') {
+      const t = str(block['text']);
+      if (t !== null) parts.push(t);
+    }
+  }
+  return parts.join('');
+}
+
+function parseResult(o: JsonObject): ResultEnvelope {
+  const subtype = str(o['subtype']);
+  const errorsRaw = o['errors'];
+  const errors = Array.isArray(errorsRaw)
+    ? errorsRaw.filter((e): e is string => typeof e === 'string')
+    : [];
+  return {
+    subtype,
+    isError: o['is_error'] === true || (subtype !== null && subtype !== 'success'),
+    text: str(o['result']),
+    sessionId: str(o['session_id']),
+    errors,
+  };
+}
+
+/**
+ * Decode one stdout line. Never throws: a non-JSON line becomes `parse_error`,
+ * and a JSON object of an unmodelled type becomes `other`.
+ */
+export function parseLine(line: string): ParsedLine {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(line);
+  } catch {
+    return { kind: 'parse_error', raw: line };
+  }
+  if (!isObject(parsed)) return { kind: 'parse_error', raw: line };
+  const type = str(parsed['type']);
+  const subtype = str(parsed['subtype']);
+
+  switch (type) {
+    case 'system':
+      if (subtype === 'init') {
+        return {
+          kind: 'init',
+          sessionId: str(parsed['session_id']),
+          model: str(parsed['model']),
+          raw: parsed,
+        };
+      }
+      return { kind: 'other', type, subtype, raw: parsed };
+    case 'assistant':
+      return {
+        kind: 'assistant',
+        text: assistantText(parsed['message']),
+        sessionId: str(parsed['session_id']),
+        raw: parsed,
+      };
+    case 'result':
+      return { kind: 'result', outcome: parseResult(parsed), raw: parsed };
+    case 'control_request': {
+      const request = parsed['request'];
+      return {
+        kind: 'control_request',
+        requestId: str(parsed['request_id']),
+        subtype: isObject(request) ? str(request['subtype']) : null,
+        request: isObject(request) ? request : {},
+        raw: parsed,
+      };
+    }
+    case 'control_response': {
+      const response = parsed['response'];
+      if (isObject(response)) {
+        return {
+          kind: 'control_response',
+          requestId: str(response['request_id']),
+          ok: response['subtype'] === 'success',
+          raw: parsed,
+        };
+      }
+      return { kind: 'control_response', requestId: null, ok: false, raw: parsed };
+    }
+    default:
+      return { kind: 'other', type, subtype, raw: parsed };
+  }
+}
+
+// ─── Outbound message builders (stdin) ──────────────────────────────────────
+
+/** One user turn as a stream-json `user` message line (no trailing newline). */
+export function buildUserMessage(text: string): string {
+  return JSON.stringify({
+    type: 'user',
+    message: { role: 'user', content: [{ type: 'text', text }] },
+  });
+}
+
+/**
+ * Answer a `can_use_tool` control request with `allow`. A Dreamux dispatcher
+ * runs unattended, so the answer for a runtime that has no human to consult is
+ * "allow"; `updatedInput` echoes the tool's original input back unchanged.
+ *
+ * This is a defensive path: under a bypassing permission mode the CLI does not
+ * gate tools, so `can_use_tool` is not normally emitted. It is wired so that if
+ * a build or mode does emit one, the runtime answers it rather than leaving the
+ * turn waiting on an unanswered control request.
+ */
+export function buildCanUseToolAllow(requestId: string, input: JsonObject): string {
+  return JSON.stringify({
+    type: 'control_response',
+    response: {
+      subtype: 'success',
+      request_id: requestId,
+      response: { behavior: 'allow', updatedInput: input },
+    },
+  });
+}
+
+/** Acknowledge any other control request with a bare success so the CLI proceeds. */
+export function buildControlAck(requestId: string): string {
+  return JSON.stringify({
+    type: 'control_response',
+    response: { subtype: 'success', request_id: requestId, response: {} },
+  });
+}
+
+// ─── Turn aggregation ───────────────────────────────────────────────────────
+
+/** The reduced outcome of one assistant turn, terminated by a `result`. */
+export interface TurnOutcome {
+  readonly isError: boolean;
+  /** Final reply text: the `result.result`, falling back to the last assistant snapshot. */
+  readonly text: string;
+  readonly sessionId: string | null;
+  readonly subtype: string | null;
+  readonly errors: readonly string[];
+}
+
+/**
+ * Accumulates the envelopes of a single turn and resolves a `TurnOutcome` when
+ * the `result` lands. One aggregator per turn: feed every `ParsedLine`, then
+ * read `outcome()` once `done` is true.
+ *
+ * The final text prefers the `result.result` (the CLI's own canonical answer)
+ * and falls back to the latest `assistant` snapshot — so a turn that ends
+ * tool-only or whose result text is empty still surfaces whatever the model
+ * last said.
+ */
+export class TurnAggregator {
+  private lastAssistantText = '';
+  private result: ResultEnvelope | null = null;
+  private initSessionId: string | null = null;
+
+  /** Returns `true` once the terminal `result` has been seen. */
+  get done(): boolean {
+    return this.result !== null;
+  }
+
+  /** The session id from `init` (or the result), once known. */
+  get sessionId(): string | null {
+    return this.result?.sessionId ?? this.initSessionId;
+  }
+
+  accept(line: ParsedLine): void {
+    switch (line.kind) {
+      case 'init':
+        if (line.sessionId !== null) this.initSessionId = line.sessionId;
+        break;
+      case 'assistant':
+        if (line.text.length > 0) this.lastAssistantText = line.text;
+        break;
+      case 'result':
+        this.result = line.outcome;
+        break;
+      default:
+        break;
+    }
+  }
+
+  outcome(): TurnOutcome | null {
+    const r = this.result;
+    if (r === null) return null;
+    const text =
+      r.text !== null && r.text.length > 0 ? r.text : this.lastAssistantText;
+    return {
+      isError: r.isError,
+      text,
+      sessionId: r.sessionId ?? this.initSessionId,
+      subtype: r.subtype,
+      errors: r.errors,
+    };
+  }
+}

--- a/packages/dreamux/src/runtime/config.ts
+++ b/packages/dreamux/src/runtime/config.ts
@@ -92,7 +92,10 @@ export interface DispatcherCodexConfig {
  * Code binary; `model` / `permission_mode` map to `--model` / `--permission-mode`;
  * `extra_args` / `extra_env` are passed through. `model` and `permission_mode`
  * are `null` when the operator does not pin them (Claude Code's own defaults
- * apply).
+ * apply). `turn_timeout_ms` bounds a single resident turn (issue #120): if the
+ * still-alive child never emits a terminal `result` for a turn, the runtime
+ * fails that turn and reaps/re-spawns the child rather than wedging the serial
+ * turn queue (and, behind it, TeamMate completion delivery) forever.
  */
 export interface DispatcherClaudeCodeConfig {
   bin: string;
@@ -100,6 +103,7 @@ export interface DispatcherClaudeCodeConfig {
   permission_mode: string | null;
   extra_args: string[];
   extra_env: Record<string, string>;
+  turn_timeout_ms: number;
 }
 
 /**
@@ -111,6 +115,15 @@ export const DEFAULT_CODEX_BIN = 'codex';
 
 /** Default `dispatchers[].runtime.config.bin` for `builtin:claude-code`. */
 export const DEFAULT_CLAUDE_CODE_BIN = 'claude';
+
+/**
+ * Default per-turn deadline for the resident `builtin:claude-code` child (ms).
+ * Generous enough not to interrupt a legitimately long tool-using turn, but
+ * finite so a child that stalls without a terminal `result` cannot wedge the
+ * dispatcher (issue #120). Operators can override via
+ * `dispatchers[].runtime.config.turn_timeout_ms`.
+ */
+export const DEFAULT_CLAUDE_CODE_TURN_TIMEOUT_MS = 600_000;
 
 /** Permission modes accepted for `builtin:claude-code` (Claude Code `--permission-mode`). */
 export const ALLOWED_CLAUDE_CODE_PERMISSION_MODES = new Set([
@@ -593,6 +606,7 @@ export function defaultDispatcherClaudeCodeConfig(): DispatcherClaudeCodeConfig 
     permission_mode: null,
     extra_args: [],
     extra_env: {},
+    turn_timeout_ms: DEFAULT_CLAUDE_CODE_TURN_TIMEOUT_MS,
   };
 }
 
@@ -603,7 +617,14 @@ function readDispatcherClaudeCodeConfig(
 ): DispatcherClaudeCodeConfig {
   rejectUnknownKeys(
     rawClaude,
-    new Set(['bin', 'model', 'permission_mode', 'extra_args', 'extra_env']),
+    new Set([
+      'bin',
+      'model',
+      'permission_mode',
+      'extra_args',
+      'extra_env',
+      'turn_timeout_ms',
+    ]),
     file,
     prefix,
   );
@@ -638,6 +659,13 @@ function readDispatcherClaudeCodeConfig(
       rawClaude,
       'extra_env',
       defaults.extra_env,
+      file,
+      prefix,
+    ),
+    turn_timeout_ms: requirePositiveInt(
+      rawClaude,
+      'turn_timeout_ms',
+      defaults.turn_timeout_ms,
       file,
       prefix,
     ),

--- a/packages/dreamux/src/runtime/config.ts
+++ b/packages/dreamux/src/runtime/config.ts
@@ -85,10 +85,11 @@ export interface DispatcherCodexConfig {
  * Builtin Claude Code runtime settings under `dispatchers[].runtime.config`
  * when `runtime.provider` is `builtin:claude-code` (issue #110 PR6).
  *
- * Deliberately distinct from {@link DispatcherCodexConfig}: Claude Code is a
- * headless per-turn CLI (`claude --print`), so there is no app-server handshake
- * timeout, approval policy, or sandbox mode here. `bin` is the Claude Code
- * binary; `model` / `permission_mode` map to `--model` / `--permission-mode`;
+ * Deliberately distinct from {@link DispatcherCodexConfig}: Claude Code runs as
+ * a resident headless stream-json process (`claude --print --input-format
+ * stream-json …`, issue #120) with no `initialize` handshake, so there is no
+ * handshake timeout, approval policy, or sandbox mode here. `bin` is the Claude
+ * Code binary; `model` / `permission_mode` map to `--model` / `--permission-mode`;
  * `extra_args` / `extra_env` are passed through. `model` and `permission_mode`
  * are `null` when the operator does not pin them (Claude Code's own defaults
  * apply).

--- a/packages/dreamux/src/runtime/paths.ts
+++ b/packages/dreamux/src/runtime/paths.ts
@@ -230,6 +230,19 @@ export function teammateMcpLogPath(id: string): string {
   return join(teammateMcpLogDir(), `${dispatcherPathSegment(id)}.log`);
 }
 
+export function claudeCodeLogDir(): string {
+  return join(logsRoot(), 'claude-code');
+}
+
+/**
+ * Per-dispatcher Claude Code resident stream-json child diagnostics (issue
+ * #120). The child's stdout is the NDJSON data plane (consumed in-process by the
+ * runtime), so only its stderr is logged here for crash diagnosis.
+ */
+export function dispatcherClaudeCodeStreamLogPath(id: string): string {
+  return join(claudeCodeLogDir(), `${dispatcherPathSegment(id)}.stderr.log`);
+}
+
 export function dispatcherCodexAppServerLogPath(id: string): string {
   return join(codexAppServerLogDir(), `${dispatcherPathSegment(id)}.log`);
 }

--- a/packages/dreamux/tests/claude-code-live.test.ts
+++ b/packages/dreamux/tests/claude-code-live.test.ts
@@ -8,8 +8,8 @@
  * gated and how to enable it.
  *
  * When opted in, the test FAILS LOUDLY if `claude` is missing on PATH (it does
- * not skip), then exercises one real headless turn through the default turn
- * runner and asserts the runtime captures a session id.
+ * not skip), then exercises two real turns over ONE resident stream-json process
+ * and asserts the runtime captures a session id and reuses it across turns.
  */
 
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
@@ -74,7 +74,7 @@ describe('claude-code live integration (opt-in)', () => {
     ).toBe(true);
   });
 
-  it('runs one real headless turn and captures a session id', async () => {
+  it('runs two real turns over one resident process and reuses the session', async () => {
     const dispatcher = testDispatcherConfig({
       id: 'live',
       runtime: {
@@ -107,18 +107,39 @@ describe('claude-code live integration (opt-in)', () => {
     await runtime.start();
     expect(runtime.getStatus()).toBe('ready');
 
-    const result = await runtime.enqueueInbound({
+    const first = await runtime.enqueueInbound({
       source_chat_id: 'c',
       source_message_id: 'live-1',
       sender_id: 'u',
       parsed_text: 'Reply with the single word: pong',
     });
-    expect(result.status).toBe('submitted');
+    expect(first.status).toBe('submitted');
 
     const deadline = Date.now() + 120_000;
     while (runtime.getThreadId() === null && Date.now() < deadline) {
       await new Promise((resolve) => setTimeout(resolve, 250));
     }
-    expect(runtime.getThreadId()).not.toBeNull();
+    const sessionId = runtime.getThreadId();
+    expect(sessionId).not.toBeNull();
+
+    // Second turn over the SAME resident process: the runtime must stay ready
+    // and keep the same session id (no re-spawn, no new session).
+    const second = await runtime.enqueueInbound({
+      source_chat_id: 'c',
+      source_message_id: 'live-2',
+      sender_id: 'u',
+      parsed_text: 'Reply with the single word: ping',
+    });
+    expect(second.status).toBe('submitted');
+
+    const deadline2 = Date.now() + 120_000;
+    while (runtime.getStatus() !== 'ready' && Date.now() < deadline2) {
+      await new Promise((resolve) => setTimeout(resolve, 250));
+    }
+    expect(runtime.getStatus()).toBe('ready');
+    expect(runtime.getThreadId()).toBe(sessionId);
+
+    await runtime.stop();
+    expect(runtime.getStatus()).toBe('stopped');
   });
 });

--- a/packages/dreamux/tests/claude-code-live.test.ts
+++ b/packages/dreamux/tests/claude-code-live.test.ts
@@ -87,6 +87,7 @@ describe('claude-code live integration (opt-in)', () => {
           permission_mode: 'acceptEdits',
           extra_args: [],
           extra_env: {},
+          turn_timeout_ms: 120_000,
         },
       },
     });

--- a/packages/dreamux/tests/claude-code-runtime.test.ts
+++ b/packages/dreamux/tests/claude-code-runtime.test.ts
@@ -3,12 +3,16 @@ import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
+import { dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
 import { createClaudeCodeAgentRuntimeProvider } from '../src/agent-runtime/claude-code.js';
-import type {
-  ClaudeCodeSession,
-  ClaudeCodeSessionFactory,
-  ClaudeCodeSessionSpec,
-  TurnOutcome,
+import {
+  createDefaultClaudeCodeSession,
+  type ClaudeCodeSession,
+  type ClaudeCodeSessionFactory,
+  type ClaudeCodeSessionSpec,
+  type TurnOutcome,
 } from '../src/agent-runtime/claude-code-session.js';
 import {
   claudeCodeMcpConfig,
@@ -41,6 +45,7 @@ function claudeDispatcher(id = 'flow') {
         permission_mode: 'acceptEdits',
         extra_args: [],
         extra_env: {},
+        turn_timeout_ms: 600_000,
       },
     },
   });
@@ -468,6 +473,60 @@ describe('ClaudeCodeRuntime resident lifecycle (fake session)', () => {
       respawn.spec.args.indexOf('--resume') + 2,
     )).toEqual(['--resume', 'session-abc']);
     await waitFor(() => runtime.getStatus() === 'ready');
+  });
+
+  it('a stalled child (alive, no result) degrades the runtime and fails delivery instead of wedging', async () => {
+    // Real resident session against the stall fixture: the child stays alive but
+    // never emits a terminal `result`. The per-turn deadline must fail the turn
+    // so neither inbound nor TeamMate delivery hangs forever.
+    const fixture = join(
+      dirname(fileURLToPath(import.meta.url)),
+      'fixtures',
+      'fake-claude-stream.mjs',
+    );
+    const stallFactory: ClaudeCodeSessionFactory = (spec) =>
+      createDefaultClaudeCodeSession({
+        ...spec,
+        bin: process.execPath,
+        args: [fixture, 'stall'],
+        turnTimeoutMs: 250,
+      });
+    const dispatcher = claudeDispatcher('flow');
+    const store = new DispatcherStore(testDreamuxConfig([dispatcher]));
+    const row = store.get('flow');
+    const runtime = createClaudeCodeAgentRuntimeProvider({
+      sessionFactory: stallFactory,
+    }).createRuntime({
+      row: row!,
+      dispatcher,
+      dispatchers: store,
+      mcpServers: [],
+      log: () => {
+        /* test sink */
+      },
+    });
+    await runtime.start();
+
+    await runtime.enqueueInbound({
+      source_chat_id: 'c',
+      source_message_id: 'm1',
+      sender_id: 'u',
+      parsed_text: 'go',
+    });
+    await waitFor(() => runtime.getStatus() === 'degraded', 5000);
+    expect(store.get('flow')?.last_error).toMatch(/timed out/i);
+
+    // Delivery must return a real `failed` result (so PR8 retry can act),
+    // bounded by the same deadline — never an unresolved await.
+    const delivery = await runtime.deliverTeamMateCompletion!({
+      taskId: 'task-stall',
+      teammateId: 'mate-1',
+      status: 'completed',
+      finalText: 'done',
+    });
+    expect(delivery.status).toBe('failed');
+
+    await runtime.stop();
   });
 
   it('returns failed (not accepted) when a TeamMate completion turn fails', async () => {

--- a/packages/dreamux/tests/claude-code-runtime.test.ts
+++ b/packages/dreamux/tests/claude-code-runtime.test.ts
@@ -3,16 +3,16 @@ import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
-import {
-  createClaudeCodeAgentRuntimeProvider,
-  parseClaudeCodeJsonResult,
-  type ClaudeCodeTurnRequest,
-  type ClaudeCodeTurnResult,
-  type ClaudeCodeTurnRunner,
-} from '../src/agent-runtime/claude-code.js';
+import { createClaudeCodeAgentRuntimeProvider } from '../src/agent-runtime/claude-code.js';
+import type {
+  ClaudeCodeSession,
+  ClaudeCodeSessionFactory,
+  ClaudeCodeSessionSpec,
+  TurnOutcome,
+} from '../src/agent-runtime/claude-code-session.js';
 import {
   claudeCodeMcpConfig,
-  claudeCodeTurnArgs,
+  claudeCodeResidentArgs,
 } from '../src/runtime/claude-code-args.js';
 import { codexMcpServerArgs } from '../src/codex/mcp-config.js';
 import { DispatcherStore } from '../src/runtime/dispatcher-store.js';
@@ -46,50 +46,74 @@ function claudeDispatcher(id = 'flow') {
   });
 }
 
-interface RecordingRunner extends ClaudeCodeTurnRunner {
-  readonly calls: ClaudeCodeTurnRequest[];
+function okOutcome(sessionId: string | null = 'session-abc'): TurnOutcome {
+  return { isError: false, text: 'done', sessionId, subtype: 'success', errors: [] };
 }
 
-function recordingRunner(sessionId: string | null = 'session-abc'): RecordingRunner {
-  const calls: ClaudeCodeTurnRequest[] = [];
-  const result: ClaudeCodeTurnResult = { sessionId, result: 'done' };
-  return {
-    calls,
-    async runTurn(request: ClaudeCodeTurnRequest): Promise<ClaudeCodeTurnResult> {
-      calls.push(request);
-      return result;
-    },
-  };
+/** A fake resident session: records turns, plays a scripted outcome sequence. */
+interface FakeSession extends ClaudeCodeSession {
+  readonly spec: ClaudeCodeSessionSpec;
+  readonly prompts: string[];
+  startCount(): number;
+  /** Simulate an unexpected child exit (fires the registered onExit). */
+  triggerExit(): void;
 }
 
-/** A runner whose turns always fail (e.g. missing binary / non-zero exit). */
-function failingRunner(message = 'claude turn failed'): RecordingRunner {
-  const calls: ClaudeCodeTurnRequest[] = [];
-  return {
-    calls,
-    async runTurn(request: ClaudeCodeTurnRequest): Promise<ClaudeCodeTurnResult> {
-      calls.push(request);
-      throw new Error(message);
-    },
-  };
+interface FakeFleet {
+  factory: ClaudeCodeSessionFactory;
+  sessions: FakeSession[];
 }
 
-/** A runner that plays a scripted sequence of outcomes, one per turn. */
-function scriptedRunner(
-  outcomes: ReadonlyArray<Error | ClaudeCodeTurnResult>,
-): RecordingRunner {
-  const calls: ClaudeCodeTurnRequest[] = [];
-  let index = 0;
-  return {
-    calls,
-    async runTurn(request: ClaudeCodeTurnRequest): Promise<ClaudeCodeTurnResult> {
-      calls.push(request);
-      const outcome = outcomes[Math.min(index, outcomes.length - 1)];
-      index += 1;
-      if (outcome instanceof Error) throw outcome;
-      return outcome as ClaudeCodeTurnResult;
-    },
+/**
+ * Build an injectable session factory. `outcomes` is a per-turn script shared
+ * across all (re)spawned sessions; an `Error` entry makes that turn throw.
+ * `startError` makes the *first* spawn fail (missing binary parity).
+ */
+function fakeFleet(
+  outcomes: ReadonlyArray<Error | TurnOutcome> = [okOutcome()],
+  opts: { startError?: Error } = {},
+): FakeFleet {
+  const sessions: FakeSession[] = [];
+  let turnIndex = 0;
+  let spawnIndex = 0;
+  const factory: ClaudeCodeSessionFactory = (spec) => {
+    const mySpawn = spawnIndex++;
+    let alive = false;
+    let starts = 0;
+    let onExit: (() => void) | null = null;
+    const prompts: string[] = [];
+    const session: FakeSession = {
+      spec,
+      prompts,
+      startCount: () => starts,
+      async start() {
+        starts += 1;
+        if (opts.startError !== undefined && mySpawn === 0) throw opts.startError;
+        alive = true;
+      },
+      isAlive: () => alive,
+      setOnExit(handler) {
+        onExit = handler;
+      },
+      async submitTurn(prompt) {
+        prompts.push(prompt);
+        const outcome = outcomes[Math.min(turnIndex, outcomes.length - 1)];
+        turnIndex += 1;
+        if (outcome instanceof Error) throw outcome;
+        return outcome as TurnOutcome;
+      },
+      async stop() {
+        alive = false;
+      },
+      triggerExit() {
+        alive = false;
+        onExit?.();
+      },
+    };
+    sessions.push(session);
+    return session;
   };
+  return { factory, sessions };
 }
 
 async function waitFor(predicate: () => boolean, timeoutMs = 2000): Promise<void> {
@@ -113,26 +137,27 @@ describe('claude-code pure translation (not Codex renamed)', () => {
       },
     });
     // The Codex runtime turns the same descriptor into `-c mcp_servers.*` CLI
-    // flags — a fundamentally different shape. This is the proof the runtimes
-    // are not the same code wearing two names.
+    // flags — a fundamentally different shape.
     const codex = codexMcpServerArgs([FEISHU_MCP]);
     expect(codex[0]).toBe('-c');
     expect(codex.some((a) => a.startsWith('mcp_servers.feishu.command='))).toBe(true);
     expect(Array.isArray(cc)).toBe(false);
   });
 
-  it('builds headless turn args with print/json/mcp-config and resume', () => {
-    const args = claudeCodeTurnArgs({
+  it('builds resident stream-json launch args (no positional prompt), with resume', () => {
+    const args = claudeCodeResidentArgs({
       config: { ...defaultDispatcherClaudeCodeConfig(), model: 'sonnet', permission_mode: 'acceptEdits' },
       mcpConfigPath: '/state/flow/claude-code/mcp.json',
-      prompt: 'hello there',
       resumeSessionId: 'sess-1',
     });
     expect(args).toContain('--print');
-    expect(args.slice(args.indexOf('--output-format'), args.indexOf('--output-format') + 2)).toEqual([
-      '--output-format',
-      'json',
-    ]);
+    expect(
+      args.slice(args.indexOf('--input-format'), args.indexOf('--input-format') + 2),
+    ).toEqual(['--input-format', 'stream-json']);
+    expect(
+      args.slice(args.indexOf('--output-format'), args.indexOf('--output-format') + 2),
+    ).toEqual(['--output-format', 'stream-json']);
+    expect(args).toContain('--verbose');
     expect(args.slice(args.indexOf('--mcp-config'), args.indexOf('--mcp-config') + 2)).toEqual([
       '--mcp-config',
       '/state/flow/claude-code/mcp.json',
@@ -143,35 +168,24 @@ describe('claude-code pure translation (not Codex renamed)', () => {
       '--resume',
       'sess-1',
     ]);
-    // Prompt is the trailing positional.
-    expect(args[args.length - 1]).toBe('hello there');
+    // The prompt is NOT a CLI arg under the resident transport — it is a stdin
+    // `user` message line. Every arg is a flag or flag value.
+    expect(args).not.toContain('hello there');
   });
 
   it('omits --resume when there is no session yet', () => {
-    const args = claudeCodeTurnArgs({
+    const args = claudeCodeResidentArgs({
       config: defaultDispatcherClaudeCodeConfig(),
       mcpConfigPath: '/x.json',
-      prompt: 'p',
       resumeSessionId: null,
     });
     expect(args).not.toContain('--resume');
-  });
-
-  it('parses the claude --output-format json envelope, falling back on non-JSON', () => {
-    expect(parseClaudeCodeJsonResult('{"session_id":"s1","result":"hi"}')).toEqual({
-      sessionId: 's1',
-      result: 'hi',
-    });
-    expect(parseClaudeCodeJsonResult('not json')).toEqual({
-      sessionId: null,
-      result: 'not json',
-    });
   });
 });
 
 describe('builtin:claude-code provider', () => {
   it('exposes the claude-code ref and task-notification delivery shape', () => {
-    const provider = createClaudeCodeAgentRuntimeProvider({ turnRunner: recordingRunner() });
+    const provider = createClaudeCodeAgentRuntimeProvider({ sessionFactory: fakeFleet().factory });
     expect(provider.ref).toBe('builtin:claude-code');
     expect(provider.descriptor.kind).toBe('agentRuntime');
     expect(provider.delivery.teammateCompletion.map((s) => s.kind)).toEqual([
@@ -180,7 +194,7 @@ describe('builtin:claude-code provider', () => {
   });
 });
 
-describe('ClaudeCodeRuntime lifecycle (fake turn runner)', () => {
+describe('ClaudeCodeRuntime resident lifecycle (fake session)', () => {
   let home: string;
   let previousHome: string | undefined;
 
@@ -197,18 +211,19 @@ describe('ClaudeCodeRuntime lifecycle (fake turn runner)', () => {
   });
 
   function makeRuntime(
-    runner: ClaudeCodeTurnRunner,
+    fleet: FakeFleet,
     opts: { resumeSession?: string } = {},
-  ): { runtime: AgentRuntime; store: DispatcherStore } {
+  ): { runtime: AgentRuntime; store: DispatcherStore; fleet: FakeFleet } {
     const dispatcher = claudeDispatcher('flow');
     const store = new DispatcherStore(testDreamuxConfig([dispatcher]));
     if (opts.resumeSession !== undefined) {
-      // Simulate a previously persisted session id on the row.
       void store.setThreadId('flow', opts.resumeSession);
     }
     const row = store.get('flow');
     expect(row).not.toBeNull();
-    const runtime = createClaudeCodeAgentRuntimeProvider({ turnRunner: runner }).createRuntime({
+    const runtime = createClaudeCodeAgentRuntimeProvider({
+      sessionFactory: fleet.factory,
+    }).createRuntime({
       row: row!,
       dispatcher,
       dispatchers: store,
@@ -217,15 +232,22 @@ describe('ClaudeCodeRuntime lifecycle (fake turn runner)', () => {
         /* test sink */
       },
     });
-    return { runtime, store };
+    return { runtime, store, fleet };
   }
 
-  it('start() materializes the MCP config file and reports ready', async () => {
-    const { runtime } = makeRuntime(recordingRunner());
+  it('start() materializes the MCP config, spawns one resident session, and reports ready', async () => {
+    const fleet = fakeFleet();
+    const { runtime } = makeRuntime(fleet);
     expect(runtime.getStatus()).toBe('declared');
     await runtime.start();
     expect(runtime.getStatus()).toBe('ready');
     expect(runtime.providerRef).toBe('builtin:claude-code');
+
+    // Exactly one resident child, started once, launched with stream-json args.
+    expect(fleet.sessions).toHaveLength(1);
+    expect(fleet.sessions[0]?.startCount()).toBe(1);
+    expect(fleet.sessions[0]?.spec.args).toContain('--input-format');
+    expect(fleet.sessions[0]?.spec.args).toContain('stream-json');
 
     const mcpPath = dispatcherClaudeCodeMcpConfigPath('flow');
     const written = JSON.parse(readFileSync(mcpPath, 'utf8')) as unknown;
@@ -236,37 +258,64 @@ describe('ClaudeCodeRuntime lifecycle (fake turn runner)', () => {
     });
   });
 
-  it('reports wasThreadResumed=false on a fresh dispatcher', async () => {
-    const { runtime } = makeRuntime(recordingRunner());
-    expect(runtime.wasThreadResumed()).toBe(false);
-    expect(runtime.getThreadId()).toBeNull();
+  it('start() drives the runtime to degraded and throws when the child cannot spawn', async () => {
+    const fleet = fakeFleet([okOutcome()], { startError: new Error('claude is missing') });
+    const { runtime, store } = makeRuntime(fleet);
+    await expect(runtime.start()).rejects.toThrow('claude is missing');
+    expect(runtime.getStatus()).toBe('degraded');
+    expect(store.get('flow')?.last_error).toContain('claude is missing');
   });
 
-  it('resumes a persisted session and threads --resume into the turn', async () => {
-    const runner = recordingRunner('session-new');
-    const { runtime } = makeRuntime(runner, { resumeSession: 'session-prev' });
-    expect(runtime.wasThreadResumed()).toBe(true);
-    expect(runtime.getThreadId()).toBe('session-prev');
+  it('runs MULTIPLE turns over ONE resident process', async () => {
+    const fleet = fakeFleet([okOutcome('session-abc'), okOutcome('session-abc')]);
+    const { runtime } = makeRuntime(fleet);
     await runtime.start();
+
     await runtime.enqueueInbound({
       source_chat_id: 'c',
       source_message_id: 'm1',
       sender_id: 'u',
-      parsed_text: 'hello',
+      parsed_text: 'first turn',
     });
-    await waitFor(() => runner.calls.length === 1);
-    expect(runner.calls[0]?.args).toContain('--resume');
+    await waitFor(() => fleet.sessions[0]?.prompts.length === 1);
+
+    await runtime.enqueueInbound({
+      source_chat_id: 'c',
+      source_message_id: 'm2',
+      sender_id: 'u',
+      parsed_text: 'second turn',
+    });
+    await waitFor(() => fleet.sessions[0]?.prompts.length === 2);
+
+    // Both turns ran on the SAME session — the resident-process invariant.
+    expect(fleet.sessions).toHaveLength(1);
+    expect(fleet.sessions[0]?.startCount()).toBe(1);
+    expect(fleet.sessions[0]?.prompts).toEqual(['first turn', 'second turn']);
+  });
+
+  it('reports wasThreadResumed=false on a fresh dispatcher', async () => {
+    const { runtime } = makeRuntime(fakeFleet());
+    expect(runtime.wasThreadResumed()).toBe(false);
+    expect(runtime.getThreadId()).toBeNull();
+  });
+
+  it('resumes a persisted session and threads --resume into the launch args', async () => {
+    const fleet = fakeFleet([okOutcome('session-new')]);
+    const { runtime } = makeRuntime(fleet, { resumeSession: 'session-prev' });
+    expect(runtime.wasThreadResumed()).toBe(true);
+    expect(runtime.getThreadId()).toBe('session-prev');
+    await runtime.start();
     expect(
-      runner.calls[0]?.args.slice(
-        runner.calls[0].args.indexOf('--resume'),
-        runner.calls[0].args.indexOf('--resume') + 2,
+      fleet.sessions[0]?.spec.args.slice(
+        fleet.sessions[0].spec.args.indexOf('--resume'),
+        fleet.sessions[0].spec.args.indexOf('--resume') + 2,
       ),
     ).toEqual(['--resume', 'session-prev']);
   });
 
   it('submits an inbound turn (accept -> run), dedupes, and captures the session', async () => {
-    const runner = recordingRunner('session-abc');
-    const { runtime } = makeRuntime(runner);
+    const fleet = fakeFleet([okOutcome('session-abc')]);
+    const { runtime } = makeRuntime(fleet);
     await runtime.start();
 
     const accepted: string[] = [];
@@ -277,11 +326,10 @@ describe('ClaudeCodeRuntime lifecycle (fake turn runner)', () => {
     expect(first.status).toBe('submitted');
     expect(accepted).toEqual(['m1']);
 
-    await waitFor(() => runner.calls.length === 1);
-    expect(runner.calls[0]?.args[runner.calls[0].args.length - 1]).toBe('do it');
+    await waitFor(() => fleet.sessions[0]?.prompts.length === 1);
+    expect(fleet.sessions[0]?.prompts[0]).toBe('do it');
     await waitFor(() => runtime.getThreadId() === 'session-abc');
 
-    // Duplicate message id is rejected without a second turn.
     const dup = await runtime.enqueueInbound({
       source_chat_id: 'c',
       source_message_id: 'm1',
@@ -289,12 +337,12 @@ describe('ClaudeCodeRuntime lifecycle (fake turn runner)', () => {
       parsed_text: 'do it again',
     });
     expect(dup.status).toBe('duplicate');
-    expect(runner.calls).toHaveLength(1);
+    expect(fleet.sessions[0]?.prompts).toHaveLength(1);
   });
 
   it('delivers a TeamMate completion via the task-notification entry', async () => {
-    const runner = recordingRunner('session-abc');
-    const { runtime } = makeRuntime(runner);
+    const fleet = fakeFleet([okOutcome('session-abc')]);
+    const { runtime } = makeRuntime(fleet);
     await runtime.start();
 
     const result = await runtime.deliverTeamMateCompletion!({
@@ -305,20 +353,22 @@ describe('ClaudeCodeRuntime lifecycle (fake turn runner)', () => {
     });
     expect(result).toEqual({ status: 'accepted' });
 
-    await waitFor(() => runner.calls.length === 1);
-    const prompt = runner.calls[0]?.args[runner.calls[0].args.length - 1] ?? '';
+    await waitFor(() => fleet.sessions[0]?.prompts.length === 1);
+    const prompt = fleet.sessions[0]?.prompts[0] ?? '';
     expect(prompt).toContain('<teammate_task_completion');
     expect(prompt).toContain('task_id="task-7"');
     expect(prompt).toContain('status="completed"');
     expect(prompt).toContain('all done');
   });
 
-  it('stop() halts the runtime and refuses further inbound', async () => {
-    const runner = recordingRunner();
-    const { runtime } = makeRuntime(runner);
+  it('stop() reaps the resident session and refuses further inbound', async () => {
+    const fleet = fakeFleet();
+    const { runtime } = makeRuntime(fleet);
     await runtime.start();
+    expect(fleet.sessions[0]?.isAlive()).toBe(true);
     await runtime.stop();
     expect(runtime.getStatus()).toBe('stopped');
+    expect(fleet.sessions[0]?.isAlive()).toBe(false);
     const after = await runtime.enqueueInbound({
       source_chat_id: 'c',
       source_message_id: 'm9',
@@ -326,16 +376,15 @@ describe('ClaudeCodeRuntime lifecycle (fake turn runner)', () => {
       parsed_text: 'late',
     });
     expect(after.status).toBe('stopped');
-    expect(runner.calls).toHaveLength(0);
+    expect(fleet.sessions[0]?.prompts).toHaveLength(0);
   });
 
   it('drives the runtime to degraded + last_error when an inbound turn fails', async () => {
-    const { runtime, store } = makeRuntime(failingRunner('claude is missing'));
+    const fleet = fakeFleet([new Error('turn boom')]);
+    const { runtime, store } = makeRuntime(fleet);
     await runtime.start();
     expect(runtime.getStatus()).toBe('ready');
 
-    // The message is accepted (channel can ack), but the turn failure is not
-    // swallowed: it surfaces as durable degraded state + a persisted last_error.
     const submit = await runtime.enqueueInbound({
       source_chat_id: 'c',
       source_message_id: 'm1',
@@ -345,15 +394,28 @@ describe('ClaudeCodeRuntime lifecycle (fake turn runner)', () => {
     expect(submit.status).toBe('submitted');
 
     await waitFor(() => runtime.getStatus() === 'degraded');
-    expect(store.get('flow')?.last_error).toContain('claude is missing');
+    expect(store.get('flow')?.last_error).toContain('turn boom');
+  });
+
+  it('surfaces an error result envelope as a degraded turn', async () => {
+    const fleet = fakeFleet([
+      { isError: true, text: '', sessionId: 'session-abc', subtype: 'error_during_execution', errors: ['model overloaded'] },
+    ]);
+    const { runtime, store } = makeRuntime(fleet);
+    await runtime.start();
+    await runtime.enqueueInbound({
+      source_chat_id: 'c',
+      source_message_id: 'm1',
+      sender_id: 'u',
+      parsed_text: 'go',
+    });
+    await waitFor(() => runtime.getStatus() === 'degraded');
+    expect(store.get('flow')?.last_error).toContain('model overloaded');
   });
 
   it('recovers to ready after a failed turn is followed by a successful one', async () => {
-    const runner = scriptedRunner([
-      new Error('transient'),
-      { sessionId: 'session-2', result: 'ok' },
-    ]);
-    const { runtime } = makeRuntime(runner);
+    const fleet = fakeFleet([new Error('transient'), okOutcome('session-2')]);
+    const { runtime } = makeRuntime(fleet);
     await runtime.start();
 
     await runtime.enqueueInbound({
@@ -373,8 +435,44 @@ describe('ClaudeCodeRuntime lifecycle (fake turn runner)', () => {
     await waitFor(() => runtime.getStatus() === 'ready');
   });
 
+  it('degrades on an unexpected child exit and re-spawns (with --resume) on the next turn', async () => {
+    const fleet = fakeFleet([okOutcome('session-abc'), okOutcome('session-abc')]);
+    const { runtime, store } = makeRuntime(fleet);
+    await runtime.start();
+
+    // First turn establishes the session id.
+    await runtime.enqueueInbound({
+      source_chat_id: 'c',
+      source_message_id: 'm1',
+      sender_id: 'u',
+      parsed_text: 'first',
+    });
+    await waitFor(() => runtime.getThreadId() === 'session-abc');
+
+    // The resident child dies unexpectedly → degraded.
+    fleet.sessions[0]?.triggerExit();
+    await waitFor(() => runtime.getStatus() === 'degraded');
+    expect(store.get('flow')?.last_error).toContain('exited');
+
+    // Next turn re-spawns a fresh session that resumes the captured session id.
+    await runtime.enqueueInbound({
+      source_chat_id: 'c',
+      source_message_id: 'm2',
+      sender_id: 'u',
+      parsed_text: 'second',
+    });
+    await waitFor(() => fleet.sessions.length === 2);
+    const respawn = fleet.sessions[1]!;
+    expect(respawn.spec.args.slice(
+      respawn.spec.args.indexOf('--resume'),
+      respawn.spec.args.indexOf('--resume') + 2,
+    )).toEqual(['--resume', 'session-abc']);
+    await waitFor(() => runtime.getStatus() === 'ready');
+  });
+
   it('returns failed (not accepted) when a TeamMate completion turn fails', async () => {
-    const { runtime } = makeRuntime(failingRunner('delivery boom'));
+    const fleet = fakeFleet([new Error('delivery boom')]);
+    const { runtime } = makeRuntime(fleet);
     await runtime.start();
 
     const result = await runtime.deliverTeamMateCompletion!({

--- a/packages/dreamux/tests/claude-code-session.test.ts
+++ b/packages/dreamux/tests/claude-code-session.test.ts
@@ -1,0 +1,105 @@
+/**
+ * Resident-session contract tests (issue #120, P1 follow-up).
+ *
+ * These drive the REAL `createDefaultClaudeCodeSession` supervisor over real OS
+ * pipes against a tiny fake `claude` stream-json child (no real `claude` binary
+ * needed — see `fixtures/fake-claude-stream.mjs`). They cover the path the
+ * adversarial review flagged: a child that stays alive but never emits a
+ * terminal `result` must not pend forever — the per-turn deadline fails the turn
+ * and reaps the child so follow-up work cannot wedge.
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import {
+  createDefaultClaudeCodeSession,
+  type ClaudeCodeSession,
+} from '../src/agent-runtime/claude-code-session.js';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const FIXTURE = join(HERE, 'fixtures', 'fake-claude-stream.mjs');
+
+describe('resident claude session (real child, fake stream-json protocol)', () => {
+  let dir: string;
+  let stderrLog: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'dreamux-cc-session-'));
+    stderrLog = join(dir, 'stderr.log');
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  function makeSession(mode: 'echo' | 'stall', turnTimeoutMs: number): ClaudeCodeSession {
+    return createDefaultClaudeCodeSession({
+      bin: process.execPath,
+      args: [FIXTURE, mode],
+      cwd: dir,
+      env: process.env,
+      stderrLogPath: stderrLog,
+      turnTimeoutMs,
+    });
+  }
+
+  it('resolves turns from streamed results and serves them over one process', async () => {
+    const session = makeSession('echo', 5_000);
+    await session.start();
+
+    const first = await session.submitTurn('hello');
+    expect(first.text).toBe('echo:hello');
+    expect(first.sessionId).toBe('fake-sess-1');
+    expect(first.isError).toBe(false);
+
+    // Second turn over the SAME resident child.
+    const second = await session.submitTurn('again');
+    expect(second.text).toBe('echo:again');
+    expect(session.isAlive()).toBe(true);
+
+    await session.stop();
+    expect(session.isAlive()).toBe(false);
+  });
+
+  it('rejects a concurrent submit rather than interleaving two turns', async () => {
+    const session = makeSession('stall', 5_000);
+    await session.start();
+    const first = session.submitTurn('one'); // never completes (stall)
+    await expect(session.submitTurn('two')).rejects.toThrow(/mid-turn/i);
+    void first.catch(() => {
+      /* abandoned when the session is stopped below */
+    });
+    await session.stop();
+  });
+
+  it('fails the turn and reaps the child when the live child never emits a result', async () => {
+    const session = makeSession('stall', 250);
+    await session.start();
+    expect(session.isAlive()).toBe(true);
+
+    await expect(session.submitTurn('hangs forever')).rejects.toThrow(/timed out/i);
+
+    // The deadline reaped the child, so the runtime re-spawns on the next turn
+    // instead of reusing a child with half a turn's output buffered.
+    expect(session.isAlive()).toBe(false);
+
+    await session.stop(); // idempotent
+    expect(session.isAlive()).toBe(false);
+  });
+
+  it('does not wedge follow-up work: a submit after a timeout fails fast, not forever', async () => {
+    const session = makeSession('stall', 200);
+    await session.start();
+    await expect(session.submitTurn('first')).rejects.toThrow(/timed out/i);
+
+    // A follow-up submit returns promptly (rejected) rather than hanging — the
+    // property that keeps the serial queue and TeamMate delivery retry moving.
+    const start = Date.now();
+    await expect(session.submitTurn('second')).rejects.toThrow();
+    expect(Date.now() - start).toBeLessThan(1_000);
+  });
+});

--- a/packages/dreamux/tests/claude-code-stream.test.ts
+++ b/packages/dreamux/tests/claude-code-stream.test.ts
@@ -1,0 +1,222 @@
+/**
+ * Unit tests for the pure Claude Code stream-json protocol model (issue #120).
+ *
+ * Synthetic envelope sequences only — hand-authored to the real wire shapes,
+ * never captured from a live session — so no `claude` binary is needed.
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import {
+  assistantText,
+  buildCanUseToolAllow,
+  buildControlAck,
+  buildUserMessage,
+  LineBuffer,
+  parseLine,
+  TurnAggregator,
+} from '../src/runtime/claude-code-stream.js';
+
+describe('LineBuffer', () => {
+  it('frames NDJSON across arbitrary chunk boundaries', () => {
+    const buf = new LineBuffer();
+    expect(buf.push('{"a":1}\n{"b')).toEqual(['{"a":1}']);
+    expect(buf.push('":2}\n')).toEqual(['{"b":2}']);
+  });
+
+  it('drops blank lines and strips trailing CR', () => {
+    const buf = new LineBuffer();
+    expect(buf.push('one\r\n\n\ntwo\n')).toEqual(['one', 'two']);
+  });
+
+  it('flush returns a trailing partial line once, then nothing', () => {
+    const buf = new LineBuffer();
+    buf.push('partial');
+    expect(buf.flush()).toBe('partial');
+    expect(buf.flush()).toBeNull();
+  });
+});
+
+describe('parseLine', () => {
+  it('parses a system/init envelope', () => {
+    const line = parseLine(
+      JSON.stringify({ type: 'system', subtype: 'init', session_id: 's1', model: 'claude-x' }),
+    );
+    expect(line).toMatchObject({ kind: 'init', sessionId: 's1', model: 'claude-x' });
+  });
+
+  it('parses an assistant envelope, joining text blocks', () => {
+    const line = parseLine(
+      JSON.stringify({
+        type: 'assistant',
+        session_id: 's1',
+        message: {
+          role: 'assistant',
+          content: [
+            { type: 'thinking', thinking: 'hidden' },
+            { type: 'text', text: 'Hello ' },
+            { type: 'tool_use', name: 'Bash', input: {} },
+            { type: 'text', text: 'world' },
+          ],
+        },
+      }),
+    );
+    expect(line.kind).toBe('assistant');
+    if (line.kind === 'assistant') {
+      expect(line.text).toBe('Hello world');
+      expect(line.sessionId).toBe('s1');
+    }
+  });
+
+  it('parses a success result envelope', () => {
+    const line = parseLine(
+      JSON.stringify({ type: 'result', subtype: 'success', result: 'final', session_id: 's1' }),
+    );
+    expect(line.kind).toBe('result');
+    if (line.kind === 'result') {
+      expect(line.outcome).toMatchObject({
+        subtype: 'success',
+        isError: false,
+        text: 'final',
+        sessionId: 's1',
+      });
+    }
+  });
+
+  it('treats any non-success result subtype as an error', () => {
+    const line = parseLine(
+      JSON.stringify({
+        type: 'result',
+        subtype: 'error_during_execution',
+        session_id: 's1',
+        errors: ['boom'],
+      }),
+    );
+    if (line.kind === 'result') {
+      expect(line.outcome.isError).toBe(true);
+      expect(line.outcome.errors).toEqual(['boom']);
+      expect(line.outcome.text).toBeNull();
+    } else {
+      throw new Error('expected result');
+    }
+  });
+
+  it('parses a can_use_tool control_request', () => {
+    const line = parseLine(
+      JSON.stringify({
+        type: 'control_request',
+        request_id: 'r1',
+        request: { subtype: 'can_use_tool', input: { command: 'ls' } },
+      }),
+    );
+    expect(line).toMatchObject({
+      kind: 'control_request',
+      requestId: 'r1',
+      subtype: 'can_use_tool',
+    });
+  });
+
+  it('parses a control_response success', () => {
+    const line = parseLine(
+      JSON.stringify({
+        type: 'control_response',
+        response: { subtype: 'success', request_id: 'r1', response: {} },
+      }),
+    );
+    expect(line).toMatchObject({ kind: 'control_response', requestId: 'r1', ok: true });
+  });
+
+  it('classifies unmodelled JSON as other and non-JSON as parse_error', () => {
+    expect(parseLine(JSON.stringify({ type: 'stream_event', event: {} })).kind).toBe('other');
+    expect(parseLine('not json').kind).toBe('parse_error');
+    expect(parseLine('[1,2,3]').kind).toBe('parse_error');
+  });
+});
+
+describe('TurnAggregator', () => {
+  it('aggregates init + assistant + result into an outcome', () => {
+    const agg = new TurnAggregator();
+    agg.accept(parseLine(JSON.stringify({ type: 'system', subtype: 'init', session_id: 's1' })));
+    agg.accept(
+      parseLine(
+        JSON.stringify({
+          type: 'assistant',
+          message: { role: 'assistant', content: [{ type: 'text', text: 'snapshot' }] },
+        }),
+      ),
+    );
+    expect(agg.done).toBe(false);
+    agg.accept(
+      parseLine(JSON.stringify({ type: 'result', subtype: 'success', result: 'final', session_id: 's1' })),
+    );
+    expect(agg.done).toBe(true);
+    expect(agg.outcome()).toEqual({
+      isError: false,
+      text: 'final',
+      sessionId: 's1',
+      subtype: 'success',
+      errors: [],
+    });
+  });
+
+  it('falls back to the last assistant snapshot when result text is empty', () => {
+    const agg = new TurnAggregator();
+    agg.accept(
+      parseLine(
+        JSON.stringify({
+          type: 'assistant',
+          message: { role: 'assistant', content: [{ type: 'text', text: 'the answer' }] },
+        }),
+      ),
+    );
+    agg.accept(parseLine(JSON.stringify({ type: 'result', subtype: 'success', session_id: 's1' })));
+    expect(agg.outcome()?.text).toBe('the answer');
+  });
+
+  it('uses the init session id when the result omits one', () => {
+    const agg = new TurnAggregator();
+    agg.accept(parseLine(JSON.stringify({ type: 'system', subtype: 'init', session_id: 's-init' })));
+    agg.accept(parseLine(JSON.stringify({ type: 'result', subtype: 'success', result: 'ok' })));
+    expect(agg.outcome()?.sessionId).toBe('s-init');
+  });
+
+  it('returns null outcome before the result lands', () => {
+    const agg = new TurnAggregator();
+    agg.accept(parseLine(JSON.stringify({ type: 'system', subtype: 'init', session_id: 's1' })));
+    expect(agg.outcome()).toBeNull();
+  });
+});
+
+describe('outbound builders', () => {
+  it('buildUserMessage produces a stream-json user line', () => {
+    expect(JSON.parse(buildUserMessage('hi'))).toEqual({
+      type: 'user',
+      message: { role: 'user', content: [{ type: 'text', text: 'hi' }] },
+    });
+  });
+
+  it('buildCanUseToolAllow echoes the tool input back as updatedInput', () => {
+    const parsed = JSON.parse(buildCanUseToolAllow('r1', { command: 'ls' }));
+    expect(parsed).toEqual({
+      type: 'control_response',
+      response: {
+        subtype: 'success',
+        request_id: 'r1',
+        response: { behavior: 'allow', updatedInput: { command: 'ls' } },
+      },
+    });
+  });
+
+  it('buildControlAck acknowledges with a bare success', () => {
+    expect(JSON.parse(buildControlAck('r2'))).toEqual({
+      type: 'control_response',
+      response: { subtype: 'success', request_id: 'r2', response: {} },
+    });
+  });
+
+  it('assistantText handles string content and ignores non-text blocks', () => {
+    expect(assistantText({ content: 'plain' })).toBe('plain');
+    expect(assistantText({ content: [{ type: 'tool_use' }] })).toBe('');
+    expect(assistantText(null)).toBe('');
+  });
+});

--- a/packages/dreamux/tests/fixtures/fake-claude-stream.mjs
+++ b/packages/dreamux/tests/fixtures/fake-claude-stream.mjs
@@ -1,0 +1,49 @@
+/**
+ * A minimal fake `claude --print --input-format stream-json` child for tests.
+ *
+ * It speaks just enough of the stream-json wire protocol to exercise the
+ * resident-session supervisor (`agent-runtime/claude-code-session.ts`) over real
+ * OS pipes, with no real `claude` binary:
+ *
+ *  - reads NDJSON `user` messages on stdin and keeps stdin open (resident);
+ *  - for each turn, emits a `system/init` (once) and an `assistant` snapshot;
+ *  - mode `echo`   → also emits a terminal `result` (a normal, completed turn);
+ *  - mode `stall`  → never emits a `result` (the stuck-turn path the per-turn
+ *    deadline must cover) while the child stays alive.
+ */
+
+import { createInterface } from 'node:readline';
+
+const mode = process.argv[2] ?? 'echo';
+let sentInit = false;
+
+function emit(obj) {
+  process.stdout.write(`${JSON.stringify(obj)}\n`);
+}
+
+const rl = createInterface({ input: process.stdin });
+rl.on('line', (line) => {
+  let msg;
+  try {
+    msg = JSON.parse(line);
+  } catch {
+    return;
+  }
+  // Ignore the session's defensive control acks; only act on user turns.
+  if (msg?.type !== 'user') return;
+  const text = msg?.message?.content?.[0]?.text ?? '';
+
+  if (!sentInit) {
+    emit({ type: 'system', subtype: 'init', session_id: 'fake-sess-1', model: 'fake-model' });
+    sentInit = true;
+  }
+  emit({
+    type: 'assistant',
+    session_id: 'fake-sess-1',
+    message: { role: 'assistant', content: [{ type: 'text', text: `echo:${text}` }] },
+  });
+  if (mode === 'echo') {
+    emit({ type: 'result', subtype: 'success', result: `echo:${text}`, session_id: 'fake-sess-1' });
+  }
+  // mode 'stall': deliberately no `result` — the turn never terminates.
+});


### PR DESCRIPTION
## 背景

跟进 #110：把 `builtin:claude-code` 运行时从「每轮一次性 `claude --print <prompt>`」改为「常驻 stream-json 进程」，对齐 Codex App Server 的常驻风格。每轮新起进程要付冷启动成本、且除 `--resume` 外无会话连续性；常驻子进程保持 stdin/stdout 打开，单进程服务多轮，按事件流读取结果。

Closes #120。基于最新 `origin/next`，head SHA 见下。

## 协议依据（已核对 Claude Code 2.1.88 源码）

`claude --print --input-format stream-json --output-format stream-json --verbose` 会保持 stdin 打开，按 NDJSON 逐条消费 `user` 消息（`src/cli/print.ts` 的 `for await (structuredIO.structuredInput)` 循环），直到 EOF（`inputClosed`）或 `control_request: end_session` 才退出；而裸 `claude --print <prompt>` 是一次性的。

## 改动

- **`runtime/claude-code-stream.ts`**（新增，纯函数）：NDJSON 行框定（`LineBuffer`）、前向兼容的行解析（`parseLine` → `init/assistant/result/control_*/other/parse_error`，永不抛、永不丢未知类型）、单轮聚合（`TurnAggregator`）、出站构造器（user 消息 / `can_use_tool` 放行 / 控制 ack）。无 IO，可对合成 envelope 单测。
- **`agent-runtime/claude-code-session.ts`**（新增）：可注入的常驻会话 seam。子进程独立进程组启动；turn 经 stdin 串行下发；stdout 解复用；防御性应答控制请求（无人值守不卡死）；reap 时按进程组 group-kill。
- **`agent-runtime/claude-code.ts`**（重写）：运行时持有单个会话。`start()` 前置 spawn（spawn 失败 → degraded + 抛，Codex 对齐）；子进程意外退出 → degraded，下一轮按 `--resume <session_id>` 惰性重启（绑定到串行 turn 队列，无后台 backoff 定时器）。
- **`runtime/claude-code-args.ts`**：`claudeCodeResidentArgs` 构造常驻启动参数；prompt 不再是 CLI 位置参数，而是 stdin user 消息行。
- **`runtime/paths.ts`**：新增 `logs/claude-code/<id>.stderr.log`。

## 保持的契约

- #110：provider seam、builtin-only、运行时持有 MCP（`--mcp-config` JSON 注入不变）、不把 user MCP 搬进 core、不放松 TeamMate 嵌套派活保护。
- #98 fail-loud；#116/#118 的 status/degraded + `last_error`、TeamMate 完成投递结果契约（`accepted`/`failed`）、session/thread 持久化。

## 参考 Claudemux next 的部分 vs Dreamux 化调整

> 按用户要求公开说明对照关系。

**直接参考 Claudemux `next` 的设计**：
- stream-json 线协议模型——envelope 分类、前向兼容解析、单轮聚合（result 文本优先、回退到最后一条 assistant 快照）、出站消息形状。
- 进程监管形状——常驻子进程持有 stdin/stdout、按行解复用驱动单轮、对控制请求防御性应答、独立进程组 + group-kill reap（reap 与 `isProcessAlive`/`killProcessGroup` 复用 Dreamux 既有 Codex supervisor 的实现）。

**因 #110 的 AgentRuntime/Channel/DispatcherService 抽象不同而做的 Dreamux 化调整**：
- 无独立 broker 进程、无 per-teammate unix socket：Dreamux 是单服务进程内托管 N 个 dispatcher，常驻子进程由 `ClaudeCodeRuntime` 实例直接持有（类比 Codex 的 `DispatcherRuntime` 持有 app-server），生命周期由 server 的 `runtime.start()/stop()` 驱动。
- 不启用 Remote Control、不写 `/tmp` turn 信号、不做 channel 环境变量剥离——这些是 Claudemux teammate 特性，Dreamux 的 dispatcher 模型不需要。
- MCP 注入沿用 Dreamux 运行时持有的 `--mcp-config` JSON 文档（channel + TeamMate 调度两类 descriptor），而非 Claudemux 的 teammate settings。
- 失败语义对齐 Dreamux 既有契约：turn 失败/进程退出 → degraded + `last_error`；TeamMate 投递 → `accepted`/`failed` 结果，供 PR8 重试。
- 重启策略选择「惰性重启」（绑定串行 turn 队列）而非后台 backoff 定时器：Dreamux claude-code 的所有 turn 都经 `enqueue`/投递/重启通知进入同一队列，无 Claudemux 那样的 RC/channel 自发 turn，故惰性重启已足够且更可确定性测试。

## 验证

- `rush build` ✅ / `rush lint` ✅ / `npx tsc --noEmit` ✅
- `npx vitest run` ✅ 470 passed | 1 skipped（skip 为 opt-in live claude 测试，需 `DREAMUX_RUN_LIVE_CLAUDE_CODE=1`）
- `.agents/scripts/check.sh` ✅（KB OK）
- 重写 `claude-code-runtime.test.ts`（单进程多轮、degraded/恢复、意外退出 → 按 resume 重生、投递、去重、stop）；新增 `claude-code-stream.test.ts`（协议）；live 测试改为断言「单进程两轮 + session 复用」。

## 风险 / 后续

- 无人值守下交互类工具（如 `AskUserQuestion`）若被触发可能阻塞一轮；当前以「防御性应答 `can_use_tool`」覆盖权限类阻塞，交互类工具留给 operator 通过 `extra_args`（如 `--disallowedTools`）控制。可作为后续小改进内置。
