### PR TITLE
ci(release): 新增 sanctioned 的 next beta prerelease 发布通道 (#122)

### DIFF
--- a/.agents/decisions/npm-release-oidc.md
+++ b/.agents/decisions/npm-release-oidc.md
@@ -1,9 +1,9 @@
 # npm release via OIDC trusted publishing
 
 - **Status:** Accepted
-- **Date:** 2026-05-30
+- **Date:** 2026-05-30 (next beta channel added 2026-06-07)
 - **Affects:** npm publishing of every `shouldPublish` package, `/.github/workflows/`, the rush version mechanism
-- **PR / Issue:** infra/feishu-transport-release
+- **PR / Issue:** infra/feishu-transport-release; next beta channel — issue #122
 
 ## Context
 
@@ -65,6 +65,55 @@ So **Rush owns versioning and publish orchestration, pnpm owns the registry
 manifest rewrite, npm owns the OIDC/provenance upload**, and all halves are
 monorepo-wide.
 
+### `next` beta prerelease channel
+
+A sanctioned prerelease channel publishes from `next` to the **`beta`**
+dist-tag without ever moving `latest`, so changes already merged to `next` can
+be install-verified in a real dispatcher environment ahead of a stable release.
+It reuses the same `release.yml` file — and therefore the **same per-package
+npm trusted-publisher entry** (Workflow: `release.yml`) — rather than adding a
+second workflow that would need its own npm registration and reintroduce a
+default-branch dispatch dance:
+
+- A third job, **`beta`**, is gated `if: github.ref_name == 'next'`. The `on:`
+  block is unchanged (`push: [main]` + `workflow_dispatch`), so `beta` is
+  reachable only by dispatching `release.yml` against `next`. `push` fires on
+  main only; the stable `version`/`publish` jobs stay gated to main and never
+  run on next. `concurrency: release-${{ github.ref_name }}` already namespaces
+  next vs main.
+- The dispatch works because `release.yml` already lives on the default branch
+  (main) with `workflow_dispatch`, which is what makes the workflow
+  dispatchable at all; `workflow_dispatch` then **executes the copy of the file
+  from the selected ref**. The beta logic must therefore physically exist on
+  `next`, which is why the change lands on `next` (a strict superset of main),
+  not main. No two-step rollout and no new `workflow_dispatch` inputs (inputs
+  added only on a non-default branch would not render in the dispatch form,
+  which is read from the default branch).
+- The job is **ephemeral and writes nothing back to git**. It bumps an in-tree
+  prerelease version with
+  `rush publish --apply --partial-prerelease --prerelease-name beta.<run_number>`
+  (e.g. `0.12.0` → `0.12.1-beta.<n>`), builds, packs + audits the tarballs, then
+  `rush publish --include-all --publish --tag beta --set-access-level public
+  --registry https://registry.npmjs.org` with `NPM_CONFIG_PROVENANCE=true`. It
+  is a single job because the uncommitted prerelease version must persist across
+  apply → build → pack → publish.
+- **Version uniqueness is structural.** `github.run_number` is monotonic per
+  workflow, so every dispatch produces a distinct `beta.<n>` identifier and can
+  never collide with an already-published prerelease. A repeated/failed run is
+  retried by simply dispatching again (new run number); rush additionally skips
+  any package whose version is already published.
+- **The pending change files survive.** A stable `rush publish --apply` deletes
+  the consumed change files (which is why the stable `version` job commits
+  `common/changes`); prerelease apply (`--prerelease-name`) does **not** delete
+  them. Combined with never committing, this guarantees the eventual stable
+  release on main still consumes the same change files — beta cannot strip the
+  stable release's input.
+- **Manifest hygiene gate before upload.** The job packs with `rush publish
+  --pack --include-all` and scans each tarball for the public-repo red line
+  (internal Feishu identifiers, internal hosts, absolute build paths) and a
+  minimal sanity check (`package/package.json` present), aborting before any
+  registry I/O if a tarball is dirty.
+
 ## Consequences
 
 - **Required setup the npm account owner must do** (per package, cannot be done
@@ -73,6 +122,24 @@ monorepo-wide.
   `excitedjs/dreamux`, workflow **`release.yml`** (the same file for every
   package), environment blank. Adding a package later = a rush.json entry + one
   npm entry; no workflow change.
+- **The beta channel needs no extra npm owner setup — but the owner must
+  confirm one fact.** Because the `beta` job reuses `release.yml`, the existing
+  per-package trusted-publisher entry (Workflow: `release.yml`, environment
+  blank) already authorizes it: npm's trusted publisher matches on
+  repository + workflow filename and does not pin a git ref/branch by default,
+  so a `release.yml` run dispatched against `next` is authorized exactly like a
+  run on `main`. This "no new config" property is the deciding reason to reuse
+  the file; it is owner-verifiable on each package's npmjs.com settings page and
+  is the one external item to confirm before the first beta dispatch. If a
+  package's entry were ever restricted to a specific environment or ref, the
+  beta job would need a matching entry.
+- **How to cut and verify a beta.** Once this lands on `next`: dispatch the
+  `release` workflow (Actions → release → Run workflow) selecting branch
+  `next`. The job publishes `0.12.x-beta.<run_number>` to the `beta` tag.
+  Install-verify with `npm install @excitedjs/dreamux@beta`; inspect tags with
+  `npm dist-tag ls @excitedjs/dreamux` and confirm `latest` is unchanged. A
+  failed/duplicate run is handled by dispatching again — the new run number
+  yields a fresh version and rush skips anything already published.
 - **First publish of any package is a one-time token bootstrap, not OIDC.** npm's
   trusted-publisher config lives on a package's settings page, which exists only
   after the package has been published once — so the *first* publish of each

--- a/.agents/decisions/npm-release-oidc.md
+++ b/.agents/decisions/npm-release-oidc.md
@@ -108,11 +108,22 @@ default-branch dispatch dance:
   them. Combined with never committing, this guarantees the eventual stable
   release on main still consumes the same change files — beta cannot strip the
   stable release's input.
-- **Manifest hygiene gate before upload.** The job packs with `rush publish
-  --pack --include-all` and scans each tarball for the public-repo red line
-  (internal Feishu identifiers, internal hosts, absolute build paths) and a
-  minimal sanity check (`package/package.json` present), aborting before any
-  registry I/O if a tarball is dirty.
+- **Manifest hygiene gate before upload.** The job packs **real** tarballs with
+  `rush publish --include-all --publish --pack --release-folder …` and scans
+  each one before the upload step runs. The `--publish` flag is load-bearing:
+  `rush publish --pack` under Rush's default read-only mode only prints
+  `DRYRUN: pnpm pack` and writes no tarball, so a pack step without `--publish`
+  is a silent no-op gate. `--pack` still suppresses the registry upload (and,
+  without `--apply-git-tags-on-pack`, applies no git tags), so this remains a
+  no-I/O pre-check. Zero tarballs is treated as a hard failure (a gate that
+  scans nothing is not a gate). Each tarball is scanned for the public-repo red
+  line (internal Feishu identifiers, the internal `/data00` mount, an absolute
+  `/home/<user>/` builder/developer path) plus a `package/package.json` sanity
+  check. The known **public** example `/home/volta/` (documented in
+  `onboard/service.ts` and compiled into dist) is allow-listed so it cannot
+  false-fail the gate; any other home path still fails. The audited tarball is
+  representative of the upload because both come from the same deterministic
+  `dist` and `files` allow-list.
 
 ## Consequences
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -271,8 +271,14 @@ jobs:
           fail=0
           for tgz in "${tarballs[@]}"; do
             echo "== $tgz =="
-            tar tzf "$tgz"
-            if ! tar tzf "$tgz" | grep -q 'package/package\.json'; then
+            listing="$(tar tzf "$tgz")"
+            printf '%s\n' "$listing"
+            # Existence check via a here-string, NOT `tar tzf | grep -q`: under
+            # `set -o pipefail`, grep -q exits on the first match, the upstream
+            # tar takes SIGPIPE and exits 141, and pipefail propagates 141 —
+            # false-failing this check as "missing package.json" purely on pipe
+            # timing. A here-string has no upstream process to signal.
+            if ! grep -qxF 'package/package.json' <<<"$listing"; then
               echo "Tarball $tgz is missing package.json" >&2
               fail=1
             fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,13 +31,25 @@
 # before setting shouldPublish=true, because npm package settings only exist
 # after the package has been created.
 #
-# Manual dispatch is a retry hook for main only; npm publishes must not come
-# from feature branches.
+# Manual dispatch against main is a retry hook for stable only; stable npm
+# publishes must not come from feature branches.
 #
 # When a version bump is needed, the release job pushes the generated
 # package.json / CHANGELOG commit back to main with the workflow GITHUB_TOKEN.
 # This repository's main protection must continue to allow that bot push, or a
 # future stricter protection rule must grant github-actions[bot] a bypass.
+#
+# The `next` beta channel reuses this same file (and therefore the same npm
+# trusted-publisher entry, Workflow: release.yml). The `beta` job below runs
+# ONLY when this workflow is dispatched against the `next` branch
+# (github.ref_name == 'next'); the stable version/publish jobs are gated to
+# main and never run on next. Beta publishes a prerelease to the `beta`
+# dist-tag and never moves `latest`. It is ephemeral: it bumps an in-tree
+# prerelease version with `--prerelease-name beta.<run_number>` and publishes,
+# but commits and pushes NOTHING back to next. Crucially, prerelease apply does
+# NOT delete the pending Rush change files (a stable `rush publish --apply`
+# does), so the eventual stable release on main still consumes them. See
+# .agents/decisions/npm-release-oidc.md ("next beta prerelease channel").
 
 name: release
 
@@ -171,3 +183,118 @@ jobs:
             --publish \
             --set-access-level public \
             --registry https://registry.npmjs.org
+
+  beta:
+    name: publish next prerelease to npm beta dist-tag (OIDC)
+    # Beta runs only when release.yml is dispatched against `next`. The `on:`
+    # block fires `push` on main only, so this job never runs on a push; it is
+    # reachable solely via `workflow_dispatch` with ref=next. Dispatching
+    # against main runs the stable jobs above and skips this one. Single job by
+    # design: the prerelease version lives in an uncommitted working tree that
+    # must persist across apply -> build -> pack -> publish, so it cannot be
+    # split the way the stable version/publish jobs are.
+    if: github.ref_name == 'next'
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.ref_name }}
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
+      - name: Upgrade npm for OIDC trusted publishing
+        # Same requirement as the stable publish job: tokenless trusted
+        # publishing needs npm 11.5.1+ so the final npm process can exchange
+        # the GitHub OIDC id-token for a short-lived publish token.
+        run: npm install -g npm@11.5.1
+
+      - name: Build (rush, monorepo-aware)
+        run: |
+          node common/scripts/install-run-rush.js install
+          node common/scripts/install-run-rush.js build
+
+      - name: Apply prerelease version (ephemeral, never committed)
+        # github.run_number gives every dispatch a unique, monotonic prerelease
+        # id, so re-dispatching never collides with an already-published beta.
+        # --partial-prerelease bumps only packages that have pending change
+        # files (e.g. 0.12.0 -> 0.12.1-beta.<n>); packages without changes stay
+        # at their published version and the publish step skips them. Unlike a
+        # stable `rush publish --apply`, prerelease apply does NOT delete the
+        # change files, so the eventual stable release on main still sees them.
+        # This working tree is throwaway CI state: NOTHING is committed/pushed.
+        env:
+          RUN_NUMBER: ${{ github.run_number }}
+        run: |
+          set -euo pipefail
+          node common/scripts/install-run-rush.js publish \
+            --apply \
+            --partial-prerelease \
+            --prerelease-name "beta.${RUN_NUMBER}"
+          echo "Resulting package versions:"
+          git --no-pager diff -- '*/package.json' | grep -E '^\+.*"version"' || \
+            echo "  (no package had pending change files; nothing to prerelease)"
+
+      - name: Pack and verify manifest (no registry I/O)
+        # Pack the would-be tarballs locally and audit their contents before any
+        # registry upload. Two checks: (1) the public-repo red line — no
+        # internal Feishu identifiers, internal hosts, or absolute build paths
+        # may leak into a published artifact; (2) each publishable tarball
+        # carries dist/ and package.json.
+        run: |
+          set -euo pipefail
+          rm -rf common/temp/beta-tarballs
+          node common/scripts/install-run-rush.js publish \
+            --pack \
+            --include-all \
+            --release-folder common/temp/beta-tarballs
+          shopt -s nullglob
+          tarballs=(common/temp/beta-tarballs/*.tgz)
+          if [ ${#tarballs[@]} -eq 0 ]; then
+            echo "No tarballs packed (no publishable package changed); nothing to verify."
+            exit 0
+          fi
+          fail=0
+          for tgz in "${tarballs[@]}"; do
+            echo "== $tgz =="
+            tar tzf "$tgz"
+            contents="$(tar xzO -f "$tgz" 2>/dev/null || true)"
+            if printf '%s' "$contents" | grep -aoE '(ou_[A-Za-z0-9]{20}|oc_[A-Za-z0-9]{20}|cli_[A-Za-z0-9]{16}|/data00/|/home/[a-z][a-z0-9_-]+/)' ; then
+              echo "FORBIDDEN internal content found in $tgz" >&2
+              fail=1
+            fi
+            if ! tar tzf "$tgz" | grep -q 'package/package.json'; then
+              echo "Tarball $tgz is missing package.json" >&2
+              fail=1
+            fi
+          done
+          [ "$fail" -eq 0 ] || { echo "Manifest verification failed; aborting before publish." >&2; exit 1; }
+
+      - name: Publish prerelease to npm beta dist-tag (rush native, OIDC)
+        # Same proven stable invocation, plus `--tag beta`: rush invokes
+        # `pnpm publish --tag beta`, pnpm rewrites workspace:* deps to registry
+        # versions, and npm uploads to the `beta` dist-tag — `latest` is never
+        # touched. --include-all republishes only versions newer than what npm
+        # already has, so an unchanged dep (feishu-transport at its published
+        # version) is skipped. --registry suppresses git tagging (same as the
+        # stable publish job, which runs with contents: read and never pushes).
+        env:
+          NPM_CONFIG_PROVENANCE: 'true'
+        run: |
+          node common/scripts/install-run-rush.js publish \
+            --include-all \
+            --publish \
+            --tag beta \
+            --set-access-level public \
+            --registry https://registry.npmjs.org
+
+      - name: Print install-verify hint
+        run: |
+          echo "Beta prerelease published to the 'beta' dist-tag."
+          echo "Verify with: npm install @excitedjs/dreamux@beta"
+          echo "Inspect tags: npm dist-tag ls @excitedjs/dreamux"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -193,7 +193,10 @@ jobs:
     # design: the prerelease version lives in an uncommitted working tree that
     # must persist across apply -> build -> pack -> publish, so it cannot be
     # split the way the stable version/publish jobs are.
-    if: github.ref_name == 'next'
+    #
+    # Gate on the fully-qualified ref (refs/heads/next), not github.ref_name, so
+    # a future tag named `next` can never satisfy it — only the next branch can.
+    if: github.ref == 'refs/heads/next'
     runs-on: ubuntu-latest
     timeout-minutes: 20
     permissions:
@@ -240,36 +243,56 @@ jobs:
           git --no-pager diff -- '*/package.json' | grep -E '^\+.*"version"' || \
             echo "  (no package had pending change files; nothing to prerelease)"
 
-      - name: Pack and verify manifest (no registry I/O)
-        # Pack the would-be tarballs locally and audit their contents before any
-        # registry upload. Two checks: (1) the public-repo red line — no
-        # internal Feishu identifiers, internal hosts, or absolute build paths
-        # may leak into a published artifact; (2) each publishable tarball
-        # carries dist/ and package.json.
+      - name: Pack and verify manifest (no registry upload)
+        # IMPORTANT: `rush publish --pack` is a no-op under Rush's default
+        # read-only mode — it only prints `DRYRUN: pnpm pack` and writes nothing.
+        # Real tarballs are produced only with `--publish`, where `--pack` still
+        # suppresses the registry upload (and, without --apply-git-tags-on-pack,
+        # applies no git tags). So we pack with --include-all --publish --pack
+        # into a release folder, then audit every tarball BEFORE the real
+        # publish step uploads anything. --include-all packs every
+        # shouldPublish=true package (dreamux + feishu-transport), so the audit
+        # always has artifacts; zero tarballs means pack failed -> fail hard.
         run: |
           set -euo pipefail
           rm -rf common/temp/beta-tarballs
           node common/scripts/install-run-rush.js publish \
-            --pack \
             --include-all \
+            --publish \
+            --pack \
             --release-folder common/temp/beta-tarballs
           shopt -s nullglob
           tarballs=(common/temp/beta-tarballs/*.tgz)
           if [ ${#tarballs[@]} -eq 0 ]; then
-            echo "No tarballs packed (no publishable package changed); nothing to verify."
-            exit 0
+            echo "Expected packed tarballs under common/temp/beta-tarballs but found none." >&2
+            echo "A manifest gate that scans nothing is not a gate; aborting before publish." >&2
+            exit 1
           fi
           fail=0
           for tgz in "${tarballs[@]}"; do
             echo "== $tgz =="
             tar tzf "$tgz"
-            contents="$(tar xzO -f "$tgz" 2>/dev/null || true)"
-            if printf '%s' "$contents" | grep -aoE '(ou_[A-Za-z0-9]{20}|oc_[A-Za-z0-9]{20}|cli_[A-Za-z0-9]{16}|/data00/|/home/[a-z][a-z0-9_-]+/)' ; then
-              echo "FORBIDDEN internal content found in $tgz" >&2
+            if ! tar tzf "$tgz" | grep -q 'package/package\.json'; then
+              echo "Tarball $tgz is missing package.json" >&2
               fail=1
             fi
-            if ! tar tzf "$tgz" | grep -q 'package/package.json'; then
-              echo "Tarball $tgz is missing package.json" >&2
+            # Public-repo red line: a published artifact must not carry internal
+            # Feishu identifiers, the internal /data00 mount, or an absolute
+            # builder/developer home path. `/home/volta/` is an intentional
+            # PUBLIC example in onboard/service.ts (it documents Volta's home
+            # layout and is compiled into dist), so that exact token is
+            # allow-listed; any other /home/<user>/ is treated as a leaked path.
+            # Extend the allow-list (grep -vxE alternation) only with reviewed,
+            # provably-public example paths.
+            leaks="$(
+              tar xzO -f "$tgz" 2>/dev/null \
+                | grep -aoE '(ou_[A-Za-z0-9]{20}|oc_[A-Za-z0-9]{20}|cli_[A-Za-z0-9]{16}|/data00/|/home/[a-z][a-z0-9_-]+/)' \
+                | grep -vxE '/home/volta/' \
+                | sort -u || true
+            )"
+            if [ -n "$leaks" ]; then
+              echo "FORBIDDEN internal content in $tgz:" >&2
+              printf '  %s\n' "$leaks" >&2
               fail=1
             fi
           done


### PR DESCRIPTION
## 方案概述

为 issue #122 补一个正式、可审计的 `next` beta 发布通道:从 `next` 发布 prerelease 到 npm `beta` dist-tag,**绝不移动 `latest`**,用于在真实 dispatcher 环境安装验证已合入 `next` 的变更。

在 `release.yml` 中新增第三个 job `beta`,**复用同一个 workflow 文件**(因此复用每个包已有的 npm trusted-publisher 条目 `Workflow: release.yml`),无需新增 npm 外部配置。

## 设计要点

- **触发**:`beta` job 以 `if: github.ref_name == 'next'` 门控。`on:` 块保持不变(`push: [main]` + `workflow_dispatch`),因此 beta 只能通过对 `next` 分支 `workflow_dispatch` 触发;stable 的 `version`/`publish` job 仍门控到 main,绝不在 next 上运行。`concurrency: release-${{ github.ref_name }}` 已天然隔离 next/main。
- **为什么 target `next` 而非 main**:`workflow_dispatch` 执行的是**所选 ref 上的 workflow 副本**,所以 beta 逻辑必须物理存在于 `next`;default 分支(main)上已有的 `release.yml` 负责让 workflow 可被 dispatch。`next` 是 `main` 的严格超集(divergence `0 10`),所以一个 PR 即可,无需两步。
- **完全 ephemeral,不向 git 写任何东西**:用 `rush publish --apply --partial-prerelease --prerelease-name beta.<run_number>` 在 CI 工作树里临时 bump(`0.12.0` → `0.12.1-beta.<n>`),build → pack+审计 → 用 `--tag beta` 发布。不 commit、不 push。
- **版本号可预测且天然防冲突**:`github.run_number` 单调递增,每次 dispatch 产生唯一 `beta.<n>`,重跑也不会撞已发布版本;rush 还会跳过任何已发布的版本。
- **stable 输入不会被破坏**:prerelease apply(`--prerelease-name`)**不会删除** pending Rush change files(stable 的 `rush publish --apply` 才会删,所以 stable version job 要 `git add common/changes`)。叠加"绝不 commit",保证 main 上后续 stable 发布仍能消费同一批 change files。
- **发布前 manifest 校验**:用 `rush publish --pack --include-all` 打包后扫描每个 tarball,拦截公开仓库红线内容(内部 Feishu 标识 / 内部 host / 绝对构建路径)并检查 `package.json` 存在,任何脏 tarball 在 registry I/O 之前 abort。
- **workspace:\* 重写**:beta 的 `@excitedjs/dreamux` 会把 `feishu-transport` 依赖 pin 到当前 in-tree `0.2.3`(已在 `latest`),可正常安装,因此**不需要 beta 发布 transport**;`--include-all` 对已发布的 `0.2.3` 会自动 `Skip`。推论:若某个可发布依赖未来带了 pending changes,必须在同一次 run 里一起 beta 发布,否则被重写的依赖无法解析。

## ⚠️ Owner 需确认的外部配置(一项)

- npm trusted publisher 按 `repository + workflow 文件名` 匹配,**默认不 pin git ref/branch**,因此对 `next` dispatch 的 `release.yml` run 与对 `main` 的 run 被同等授权 → **无需新增 npm 配置**。这是复用文件方案的决定性优势。请 owner 在每个可发布包的 npmjs.com 设置页确认其 trusted-publisher 条目**未**被限制到特定 environment 或 ref。若被限制,beta job 需要补一条匹配条目。

## 如何发布与验证

合入 `next` 后:Actions → release → Run workflow,选择分支 `next` 触发。发布完成后:
- 安装验证:`npm install @excitedjs/dreamux@beta`
- 检查 dist-tags:`npm dist-tag ls @excitedjs/dreamux`,确认 `latest` 未变
- 失败/重复:直接重新 dispatch,新 run number 产生新版本,rush 跳过已发布的

## 本地验证

- `rush publish --help` 确认 flag:`--tag`、`--prerelease-name`、`--partial-prerelease`、`--pack` 均存在。
- dry-run 实测 `rush publish --apply --partial-prerelease --prerelease-name beta.999`:`@excitedjs/dreamux` → `0.12.1-beta.999`,`feishu-transport` 保持 `0.2.3`,change files **保留未删**。
- dry-run 实测 `rush publish --include-all --tag beta`:输出 `pnpm publish --tag beta --access public`(dreamux)+ `Skip @excitedjs/feishu-transport. Not updated.`,确认只发 beta tag、不动 latest。
- `actionlint`(含 shellcheck)对 `release.yml` 全绿;`python yaml` parse OK;`.agents/scripts/check.sh` → `KB OK`;gitleaks pre-commit 通过。
- **未在本地实跑发布**:发布需 OIDC + npm auth,只能在 GitHub Actions 内进行(符合非目标,不是缺口)。

## 剩余风险

- 上述 owner 需确认的 trusted-publisher ref/environment 限制问题(无法从仓库内核实)。
- manifest 扫描为 fail-safe 方向(宁可误杀也不泄漏);若误报会让 beta run 失败并打印清晰原因,由 owner 调整。

Refs #122