### PR TITLE
feat(teammate): TeamMate MCP parity PR2 — worker provider seam + fake provider (#126)

### DIFF
--- a/.agents/decisions/server-hosted-teammate.md
+++ b/.agents/decisions/server-hosted-teammate.md
@@ -166,6 +166,61 @@ worker provider seam; `cancel_task`/`resume_task`/`get_logs`; standalone
 `history`/`get_status` and `list_tasks` filters; startup redelivery/orphan
 reconciliation; log redaction layer.
 
+## Issue #126: TeamMate MCP parity — PR2 (worker provider seam + fake provider)
+
+PR2 lands the **worker provider seam** PR1 deferred, plus an in-memory fake
+provider that proves the Dispatcher Service execution orchestration end-to-end.
+It still does **not** implement a real Codex/Claude Code worker and does **not**
+wrap or shell out to `tm`.
+
+Worker seam (`/packages/dreamux/src/teammate/worker/`):
+
+- `TeamMateWorkerProvider` runs ONE task as a steerable, multi-input session
+  against a local target. It is a different abstraction from the dispatcher's
+  long-lived `AgentRuntimeProvider` (`/packages/dreamux/src/agent-runtime/`):
+  that one models the dispatcher's own persistent runtime; a worker session is
+  per-task. The seam carries no Codex-only assumptions — a Claude Code worker
+  (still in epic scope) implements the same interface.
+- A provider **never writes the ledger**. It drives lifecycle through callbacks
+  (`onRunning`/`onCompleted`/`onFailed`/`onCancelled`); the execution service is
+  the sole ledger writer, so the server-owned ledger stays the single source of
+  truth.
+- `TeamMateWorkerProviderCatalog` is a deliberately separate, permissive
+  registry — NOT the agent-runtime catalog, which validates refs against the
+  builtin capability registry and would reject an injected fake ref. Resolution
+  never throws; an unknown ref maps to a retryable `provider_unavailable`.
+- The fake provider (`FakeTeamMateWorkerProvider`, ref `fake`) is deterministic
+  and timer-free: a test injects it and drives the lifecycle with explicit
+  controls (`emitCompleted`/`emitFailed`/`emitCancelled`).
+
+Execution service (`/packages/dreamux/src/teammate/worker-execution.ts`):
+
+- Maps worker callbacks onto ledger transitions plus wait-broker notifies:
+  `onRunning → markRunning`, `onCompleted/onFailed → reportCompletion` (the PR1
+  delivery path — record-before-deliver, retain, pull fallback), `onCancelled →
+  recordClose('cancelled')`. A provider-reported failure still lands a durable,
+  pull-able `failed` result.
+- Idempotent: a live session short-circuits a second `execute` (no double
+  start); a terminal task is never re-executed.
+
+Server wiring (`/packages/dreamux/src/server.ts`):
+
+- A new injectable `teamMateWorkerProviders` catalog (empty by default).
+  `run_task`/`execute_task` now go through the execution service; `send_input`
+  records the input (`queued`) then routes it to a live session, promoting it to
+  `submitted` on an accepted disposition (new `ledger.markInputSubmitted`).
+- `get_capabilities` makes the worker catalog the source of truth:
+  `execution_available` and each provider's `worker_available` come from it.
+  **Production behaviour is unchanged from PR1** — with the default empty
+  catalog every provider is worker-unavailable and `execution_available` is
+  false; only an injected catalog (the fake in tests) flips them.
+
+Deferred to later #126 slices (unchanged from PR1, plus): real Codex/Claude
+worker execution; worker runtime-handle persistence on the task record; process
+death / orphan reconciliation (PR2 proves "source of truth after failure" via a
+provider-reported failure, not a real crash); `cancel_task`/`resume_task`/
+`get_logs` MCP tools.
+
 ## Consequences
 
 - The old "Dreamux never owns teammate state" decision is superseded.

--- a/common/changes/@excitedjs/dreamux/issue126-teammate-mcp-pr2-worker-provider_2026-06-07-20-00.json
+++ b/common/changes/@excitedjs/dreamux/issue126-teammate-mcp-pr2-worker-provider_2026-06-07-20-00.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "TeamMate MCP parity PR2 (issue #126): add the worker provider seam and an in-memory fake provider, with no real Codex/Claude Code worker yet and no tm wrapping. Introduce a runtime-agnostic TeamMateWorkerProvider (per-task steerable session, distinct from the dispatcher's long-lived AgentRuntimeProvider) plus a permissive worker catalog; a provider drives lifecycle through callbacks and never writes the ledger. Add a TeamMateWorkerExecutionService that maps onRunning/onCompleted/onFailed/onCancelled onto ledger transitions (markRunning, the PR1 record-before-deliver completion path, and a cancelled close) with wait-broker notifications, idempotent execution, and no re-execution of terminal tasks. Wire run_task/execute_task through the service, route send_input to a live worker session (promoting a queued input to submitted via the new ledger.markInputSubmitted), and make the worker catalog the source of truth for get_capabilities. Production behaviour is unchanged from PR1: with the default empty worker catalog every provider is worker-unavailable and execution tools still report provider_unavailable; only an injected fake catalog (tests) runs a session.",
+      "type": "minor",
+      "packageName": "@excitedjs/dreamux"
+    }
+  ],
+  "packageName": "@excitedjs/dreamux",
+  "email": "053700@gmail.com"
+}

--- a/packages/dreamux/src/server.ts
+++ b/packages/dreamux/src/server.ts
@@ -94,6 +94,12 @@ import {
   type TeamMateDeliveryReport,
 } from './teammate/delivery.js';
 import {
+  TeamMateWorkerExecutionService,
+  type TeamMateExecutionOutcome,
+} from './teammate/worker-execution.js';
+import { TeamMateWorkerProviderCatalog } from './teammate/worker/catalog.js';
+import type { TeamMateWorkerProvider } from './teammate/worker/types.js';
+import {
   awaitTeamMateCompletion,
   clampWaitTimeout,
   isWaitToken,
@@ -144,6 +150,13 @@ export interface ServerOptions {
   codexRestartBackoffMaxMs?: number;
   /** Override runtime provider catalog (tests / future provider composition). */
   agentRuntimeProviderCatalog?: AgentRuntimeProviderCatalog;
+  /**
+   * TeamMate worker provider catalog (issue #126 PR2). Empty by default — the
+   * MVP wires no real worker, so execution tools report `provider_unavailable`
+   * exactly as PR1. Tests inject a fake worker catalog to drive the full
+   * accepted → running → completed/failed/cancelled orchestration.
+   */
+  teamMateWorkerProviders?: TeamMateWorkerProviderCatalog;
   /** Max TeamMate completion delivery attempts before delivery_failed (tests). */
   teamMateDeliveryMaxAttempts?: number;
   /** TeamMate delivery backoff per attempt, ms (tests pass 0). */
@@ -355,12 +368,19 @@ export interface ServerMcpAwaitTeamMateCompletionInput {
   timeoutMs?: number;
 }
 
-/** Execution attempt outcome — no worker is wired in PR1, so always unavailable. */
+/**
+ * Execution attempt outcome (issue #126). With no worker wired (production MVP)
+ * this is always `provider_unavailable`, exactly as PR1; an injected worker
+ * catalog produces `running`/`completed`/`failed`/`cancelled` with the resolved
+ * `provider_ref`. The `reason`/`code`/`retryable` fields are present only for
+ * `provider_unavailable`.
+ */
 export interface ServerTeamMateExecutionResult {
-  status: 'provider_unavailable';
-  reason: string;
-  code: string;
-  retryable: boolean;
+  status: 'running' | 'completed' | 'failed' | 'cancelled' | 'provider_unavailable';
+  provider_ref?: string;
+  reason?: string;
+  code?: string;
+  retryable?: boolean;
 }
 
 export interface ServerMcpRunTeamMateTaskResult {
@@ -371,7 +391,12 @@ export interface ServerMcpRunTeamMateTaskResult {
 export interface ServerMcpSendTeamMateInputResult {
   input_id: string;
   mode: TeamMateInputMode;
-  status: 'queued';
+  /**
+   * `submitted` when a live worker session accepted the input, `queued`
+   * otherwise (no worker, or the worker rejected it) — the input is still
+   * durably recorded either way (issue #126 PR2).
+   */
+  status: 'queued' | 'submitted';
   after_event_id: number;
   task: ServerTeamMateTaskSummary;
 }
@@ -427,6 +452,8 @@ export class Server {
   private readonly channelProviderResolver: (ref: string) => ChannelProvider;
   private readonly agentRuntimeProviders: AgentRuntimeProviderCatalog;
   private readonly teamMateDelivery: TeamMateDeliveryService;
+  private readonly teamMateWorkers: TeamMateWorkerProviderCatalog;
+  private readonly teamMateWorkerExecution: TeamMateWorkerExecutionService;
 
   constructor(opts: ServerOptions = {}) {
     this.opts = opts;
@@ -478,6 +505,17 @@ export class Server {
       ...(opts.teamMateDeliveryBackoffMs !== undefined
         ? { backoffMs: opts.teamMateDeliveryBackoffMs }
         : {}),
+    });
+    this.teamMateWorkers =
+      opts.teamMateWorkerProviders ?? new TeamMateWorkerProviderCatalog();
+    this.teamMateWorkerExecution = new TeamMateWorkerExecutionService({
+      ledger: (dispatcherId) => this.teamMateLedger(dispatcherId),
+      workers: () => this.teamMateWorkers,
+      reportCompletion: (report) =>
+        this.teamMateDelivery.reportCompletion(report),
+      notifyEvent: (dispatcherId, taskId) =>
+        this.teamMateWaitBroker.notify(dispatcherId, taskId),
+      log: (level, message, fields) => this.log[level](fields ?? {}, message),
     });
     this.repos = {
       dispatchers: new DispatcherStore(opts.config ?? BUILT_IN_DEFAULTS),
@@ -1036,9 +1074,10 @@ export class Server {
 
   /**
    * Primary create-and-execute tool (`run_task`, issue #126). Creates a v2 task
-   * with a resolved local target, then attempts execution. No worker is wired in
-   * PR1, so the task is created durably and the execution sub-result reports
-   * `provider_unavailable`; the worker provider seam lands in a later slice.
+   * with a resolved local target, then attempts execution through the worker
+   * provider seam. With no worker wired (production MVP) the task is created
+   * durably and the execution sub-result reports `provider_unavailable`; an
+   * injected worker catalog starts a live session and drives the lifecycle.
    */
   async runTeamMateTaskFromMcp(
     input: ServerMcpRunTeamMateTaskInput,
@@ -1048,7 +1087,7 @@ export class Server {
       input.targetPath,
       this.mustDispatcherDir(input.dispatcherId),
     );
-    const task = await this.teamMateLedger(input.dispatcherId).acceptTask({
+    const accepted = await this.teamMateLedger(input.dispatcherId).acceptTask({
       title: input.title,
       prompt: input.prompt,
       callerKind: input.callerKind,
@@ -1064,26 +1103,28 @@ export class Server {
         ? { operationId: input.operationId }
         : {}),
     });
-    this.teamMateWaitBroker.notify(input.dispatcherId, task.task_id);
+    this.teamMateWaitBroker.notify(input.dispatcherId, accepted.task_id);
     this.log.info(
       {
         dispatcher_id: input.dispatcherId,
-        task_id: task.task_id,
+        task_id: accepted.task_id,
         caller_kind: input.callerKind,
       },
       'teammate task run requested',
     );
-    return {
-      task: toTeamMateTaskSummary(task),
-      execution: teamMateProviderUnavailable(),
-    };
+    const execution = await this.teamMateWorkerExecution.execute({
+      dispatcherId: input.dispatcherId,
+      taskId: accepted.task_id,
+      ...(input.providerRef !== undefined ? { providerRef: input.providerRef } : {}),
+    });
+    return this.teamMateExecutionResult(input.dispatcherId, accepted, execution);
   }
 
   /**
    * Start or retry execution for an already-accepted task (`execute_task`,
-   * issue #126). No worker is wired in PR1, so this is a read-only stub that
-   * returns `provider_unavailable` with the current snapshot — it does not fake
-   * a running worker.
+   * issue #126). With no worker wired this returns `provider_unavailable` with
+   * the current snapshot (it never fakes a running worker); an injected worker
+   * catalog starts/retries a live session.
    */
   async executeTeamMateTaskFromMcp(
     input: ServerMcpExecuteTeamMateTaskInput,
@@ -1094,9 +1135,30 @@ export class Server {
     if (task === null) {
       throw new Error(`TeamMate task ${JSON.stringify(input.taskId)} does not exist`);
     }
+    const execution = await this.teamMateWorkerExecution.execute({
+      dispatcherId: input.dispatcherId,
+      taskId: input.taskId,
+      ...(input.providerRef !== undefined ? { providerRef: input.providerRef } : {}),
+    });
+    return this.teamMateExecutionResult(input.dispatcherId, task, execution);
+  }
+
+  /**
+   * Build the `{ task, execution }` wire result. The task summary is re-read so
+   * it reflects any lifecycle transition the worker's `onRunning`/terminal
+   * callbacks landed during execution; the local target path stays out of it.
+   */
+  private async teamMateExecutionResult(
+    dispatcherId: string,
+    fallback: TeamMateTaskRecord,
+    execution: TeamMateExecutionOutcome,
+  ): Promise<ServerMcpRunTeamMateTaskResult> {
+    const latest =
+      (await this.teamMateLedger(dispatcherId).getTask(fallback.task_id)) ??
+      fallback;
     return {
-      task: toTeamMateTaskSummary(task),
-      execution: teamMateProviderUnavailable(),
+      task: toTeamMateTaskSummary(latest),
+      execution: toExecutionResult(execution),
     };
   }
 
@@ -1110,17 +1172,35 @@ export class Server {
     input: ServerMcpSendTeamMateInputInput,
   ): Promise<ServerMcpSendTeamMateInputResult> {
     const ledger = this.teamMateLedger(input.dispatcherId);
+    // Record the input durably first (`queued` + an `input_queued` event), so it
+    // survives even if no worker is live.
     const { task, input: recorded } = await ledger.appendInput(input.taskId, {
       text: input.prompt,
       mode: input.mode ?? 'steer',
     });
     this.teamMateWaitBroker.notify(input.dispatcherId, task.task_id);
+    // Route to a live worker session, if any. An accepted disposition promotes
+    // the input to `submitted`; with no live worker it stays `queued`.
+    const routed = await this.teamMateWorkerExecution.sendInput({
+      dispatcherId: input.dispatcherId,
+      taskId: input.taskId,
+      inputId: recorded.input_id,
+      text: recorded.text,
+      mode: recorded.mode,
+    });
+    let status: 'queued' | 'submitted' = 'queued';
+    let latest = task;
+    if (routed.delivered && routed.disposition?.status === 'accepted') {
+      latest = await ledger.markInputSubmitted(input.taskId, recorded.input_id);
+      this.teamMateWaitBroker.notify(input.dispatcherId, input.taskId);
+      status = 'submitted';
+    }
     return {
       input_id: recorded.input_id,
       mode: recorded.mode,
-      status: 'queued',
-      after_event_id: lastEventId(task),
-      task: toTeamMateTaskSummary(task),
+      status,
+      after_event_id: lastEventId(latest),
+      task: toTeamMateTaskSummary(latest),
     };
   }
 
@@ -1177,23 +1257,32 @@ export class Server {
   }
 
   /**
-   * Read-only capability advertisement (`get_capabilities`, issue #126). Lists
-   * both built-in runtimes truthfully — worker execution is not implemented yet,
-   * so every provider reports `worker_available: false`.
+   * Read-only capability advertisement (`get_capabilities`, issue #126). The
+   * worker catalog is the source of truth: each built-in runtime is reported
+   * with its worker capability looked up from the catalog (unavailable when the
+   * catalog has no worker for it — the production MVP), and any worker provider
+   * not also an agent runtime (e.g. an injected fake) is appended. With the
+   * default empty catalog, every provider is `worker_available: false` and
+   * `execution_available` is false, exactly as PR1.
    */
   getTeamMateCapabilitiesFromMcp(): ServerTeamMateCapabilities {
-    const providers: ServerTeamMateProviderCapability[] =
-      this.agentRuntimeProviders.list().map((provider) => ({
-        provider_ref: provider.ref,
-        worker_available: false,
-        unsupported_reason:
-          'TeamMate worker execution is not implemented yet (issue #126)',
-        modes: { steer: false, queue: false, interrupt: false },
-        resume: false,
-        logs: false,
-      }));
+    const workers = this.teamMateWorkers;
+    const workerByRef = new Map(
+      workers.list().map((worker) => [worker.ref, worker] as const),
+    );
+    const providers: ServerTeamMateProviderCapability[] = [];
+    const seen = new Set<string>();
+    for (const runtime of this.agentRuntimeProviders.list()) {
+      providers.push(toProviderCapability(runtime.ref, workerByRef.get(runtime.ref)));
+      seen.add(runtime.ref);
+    }
+    for (const worker of workers.list()) {
+      if (seen.has(worker.ref)) continue;
+      providers.push(toProviderCapability(worker.ref, worker));
+      seen.add(worker.ref);
+    }
     return {
-      execution_available: false,
+      execution_available: workers.hasAvailableProvider(),
       wait: { default_ms: TEAMMATE_WAIT_DEFAULT_MS, max_ms: TEAMMATE_WAIT_MAX_MS },
       target_modes: [...TEAMMATE_TARGET_MODES],
       input_modes: [...TEAMMATE_INPUT_MODES],
@@ -1396,13 +1485,52 @@ function toTeamMatePullResult(
   };
 }
 
-/** The execution sub-result while no worker provider is wired (issue #126). */
-function teamMateProviderUnavailable(): ServerTeamMateExecutionResult {
+/** Map the execution service outcome onto the public `execution` sub-result. */
+function toExecutionResult(
+  outcome: TeamMateExecutionOutcome,
+): ServerTeamMateExecutionResult {
+  if (outcome.status === 'provider_unavailable') {
+    return {
+      status: 'provider_unavailable',
+      reason: outcome.reason,
+      code: outcome.code,
+      retryable: outcome.retryable,
+    };
+  }
   return {
-    status: 'provider_unavailable',
-    reason: 'TeamMate worker execution is not implemented yet (issue #126)',
-    code: 'TEAMMATE_PROVIDER_UNAVAILABLE',
-    retryable: true,
+    status: outcome.status,
+    ...(outcome.provider_ref !== '' ? { provider_ref: outcome.provider_ref } : {}),
+  };
+}
+
+/**
+ * Build a provider capability row for `get_capabilities`. When the catalog has a
+ * worker for the ref, its capabilities are reported; otherwise the ref is listed
+ * as worker-unavailable (the production MVP for both built-in runtimes).
+ */
+function toProviderCapability(
+  ref: string,
+  worker: TeamMateWorkerProvider | undefined,
+): ServerTeamMateProviderCapability {
+  if (worker === undefined) {
+    return {
+      provider_ref: ref,
+      worker_available: false,
+      unsupported_reason:
+        'TeamMate worker execution is not implemented yet (issue #126)',
+      modes: { steer: false, queue: false, interrupt: false },
+      resume: false,
+      logs: false,
+    };
+  }
+  const caps = worker.capabilities();
+  return {
+    provider_ref: ref,
+    worker_available: caps.worker_available,
+    unsupported_reason: caps.unsupported_reason,
+    modes: { ...caps.modes },
+    resume: caps.resume,
+    logs: caps.logs,
   };
 }
 

--- a/packages/dreamux/src/teammate/ledger.ts
+++ b/packages/dreamux/src/teammate/ledger.ts
@@ -623,6 +623,37 @@ export class TeamMateTaskLedger {
   }
 
   /**
+   * Mark a previously-queued follow-up input as `submitted` once a live worker
+   * session has accepted it (issue #126 PR2). Idempotent: a no-op if the input
+   * is already submitted. Without a live worker the input stays `queued`. This
+   * is an input-status change only; it adds no new event to the stream.
+   */
+  async markInputSubmitted(
+    taskId: string,
+    inputId: string,
+    options: { now?: number } = {},
+  ): Promise<TeamMateTaskRecord> {
+    const existing = await this.mustGetTask(taskId);
+    const index = existing.inputs.findIndex(
+      (input) => input.input_id === inputId,
+    );
+    if (index === -1) {
+      throw new Error(
+        `TeamMate task ${JSON.stringify(taskId)} has no input ` +
+          JSON.stringify(inputId),
+      );
+    }
+    if (existing.inputs[index]!.status === 'submitted') {
+      return cloneTask(existing);
+    }
+    const now = options.now ?? Date.now();
+    const inputs = existing.inputs.map((input, i) =>
+      i === index ? { ...input, status: 'submitted' as const } : input,
+    );
+    return this.writeTask({ ...existing, inputs, updated_at: now });
+  }
+
+  /**
    * Record a task's final result. The result is persisted durably here, BEFORE
    * any delivery attempt — so a crash or a downed runtime can never lose it; a
    * later delivery only transitions an already-saved result to

--- a/packages/dreamux/src/teammate/worker-execution.ts
+++ b/packages/dreamux/src/teammate/worker-execution.ts
@@ -1,0 +1,299 @@
+/**
+ * TeamMate worker execution orchestration (issue #126 PR2).
+ *
+ * This service is the sole bridge between a {@link TeamMateWorkerProvider} and
+ * the server-owned ledger. It resolves a provider, starts a per-task session,
+ * and maps the provider's lifecycle callbacks onto ledger transitions plus
+ * wait-broker notifications:
+ *
+ *   onRunning   → ledger.markRunning              (accepted/queued → running)
+ *   onCompleted → reportCompletion('completed')   (record result + deliver + notify)
+ *   onFailed    → reportCompletion('failed')      (record result + deliver + notify)
+ *   onCancelled → ledger.recordClose('cancelled') (live → cancelled close)
+ *
+ * The ledger stays the single source of truth: a provider never writes it, and a
+ * provider-reported failure still lands a durable, pull-able `failed` result.
+ * The completion path reuses the PR1 delivery service (`reportCompletion`), so
+ * completion notification and delivery retry are unchanged.
+ *
+ * Production wires no worker for the MVP (an empty catalog), so `execute`
+ * returns `provider_unavailable` exactly as PR1 did; only an injected catalog
+ * (the fake worker in tests) actually runs a session.
+ */
+
+import {
+  TeamMateTaskTransitionError,
+  type TeamMateInputMode,
+  type TeamMateLifecycleStatus,
+  type TeamMateTaskLedger,
+} from './ledger.js';
+import type { TeamMateWorkerProviderCatalog } from './worker/catalog.js';
+import type {
+  TeamMateWorkerCallbacks,
+  TeamMateWorkerInputDisposition,
+  TeamMateWorkerSession,
+} from './worker/types.js';
+
+export const TEAMMATE_PROVIDER_UNAVAILABLE_CODE = 'TEAMMATE_PROVIDER_UNAVAILABLE';
+
+const PROVIDER_UNAVAILABLE_DEFAULT_REASON =
+  'TeamMate worker execution is not available';
+
+/** Execution outcome the server maps onto the wire `execution` sub-result. */
+export type TeamMateExecutionOutcome =
+  | { status: 'running'; provider_ref: string }
+  | { status: 'completed'; provider_ref: string }
+  | { status: 'failed'; provider_ref: string }
+  | { status: 'cancelled'; provider_ref: string }
+  | {
+      status: 'provider_unavailable';
+      reason: string;
+      code: string;
+      retryable: boolean;
+    };
+
+export interface TeamMateWorkerCompletionReport {
+  dispatcherId: string;
+  taskId: string;
+  outcome: 'completed' | 'failed';
+  finalText: string;
+}
+
+export interface TeamMateWorkerExecutionDeps {
+  ledger: (dispatcherId: string) => TeamMateTaskLedger;
+  /** Resolve the active worker catalog (empty in production for the MVP). */
+  workers: () => TeamMateWorkerProviderCatalog;
+  /**
+   * Record a worker-reported completion/failure. Wired to the PR1 delivery
+   * service so completion is persisted before delivery and waiters wake at once.
+   */
+  reportCompletion: (report: TeamMateWorkerCompletionReport) => Promise<unknown>;
+  /** Wake the wait broker after a ledger transition the service owns. */
+  notifyEvent?: (dispatcherId: string, taskId: string) => void;
+  log?: (
+    level: 'info' | 'warn' | 'error',
+    message: string,
+    fields?: Record<string, unknown>,
+  ) => void;
+}
+
+export interface ExecuteTeamMateTaskInput {
+  dispatcherId: string;
+  taskId: string;
+  /** Explicit provider ref override; falls back to the task's pinned ref. */
+  providerRef?: string;
+}
+
+export interface SendTeamMateWorkerInputInput {
+  dispatcherId: string;
+  taskId: string;
+  inputId: string;
+  text: string;
+  mode: TeamMateInputMode;
+}
+
+export interface SendTeamMateWorkerInputResult {
+  /** Whether a live worker session received the input. */
+  delivered: boolean;
+  disposition?: TeamMateWorkerInputDisposition;
+}
+
+export class TeamMateWorkerExecutionService {
+  private readonly sessions = new Map<string, TeamMateWorkerSession>();
+
+  constructor(private readonly deps: TeamMateWorkerExecutionDeps) {}
+
+  hasLiveSession(dispatcherId: string, taskId: string): boolean {
+    return this.sessions.has(key(dispatcherId, taskId));
+  }
+
+  /**
+   * Start (or no-op retry) worker execution for an accepted task. Returns the
+   * execution outcome; the lifecycle transition itself flows through the
+   * provider's `onRunning` callback. A missing/unavailable provider leaves the
+   * task `accepted` (retryable). A terminal task is never re-executed.
+   */
+  async execute(
+    input: ExecuteTeamMateTaskInput,
+  ): Promise<TeamMateExecutionOutcome> {
+    const ledger = this.deps.ledger(input.dispatcherId);
+    const task = await ledger.getTask(input.taskId);
+    if (task === null) {
+      throw new Error(
+        `TeamMate task ${JSON.stringify(input.taskId)} does not exist`,
+      );
+    }
+
+    const sessionKey = key(input.dispatcherId, input.taskId);
+    // Idempotent: a live session means the worker is already running; never
+    // start a second one for the same task.
+    const live = this.sessions.get(sessionKey);
+    if (live !== undefined) {
+      return { status: 'running', provider_ref: live.handle.providerRef };
+    }
+
+    if (isTerminalLifecycle(task.lifecycle_status)) {
+      // A finished task is not re-executed; surface its terminal status.
+      return {
+        status: task.lifecycle_status,
+        provider_ref: task.provider_ref ?? '',
+      };
+    }
+
+    if (task.lifecycle_status === 'running') {
+      // Running with no live session in THIS process means a prior run is still
+      // owned elsewhere or predates a restart. Do not start a second worker for
+      // the same task; surface it as running. Resume / orphan reconciliation of
+      // such a task is deferred (issue #126).
+      return { status: 'running', provider_ref: task.provider_ref ?? '' };
+    }
+
+    const provider = this.deps
+      .workers()
+      .resolve(input.providerRef ?? task.provider_ref);
+    if (provider === null) {
+      return providerUnavailable(PROVIDER_UNAVAILABLE_DEFAULT_REASON);
+    }
+    const caps = provider.capabilities();
+    if (!caps.worker_available) {
+      return providerUnavailable(
+        caps.unsupported_reason || PROVIDER_UNAVAILABLE_DEFAULT_REASON,
+      );
+    }
+
+    const callbacks = this.buildCallbacks(input.dispatcherId, input.taskId);
+    const outcome = await provider.startSession(
+      {
+        dispatcherId: input.dispatcherId,
+        taskId: input.taskId,
+        teammateId: task.teammate_id,
+        title: task.title,
+        prompt: task.prompt,
+        target: task.target,
+        targetMode: task.target_mode,
+      },
+      callbacks,
+    );
+    if (outcome.status === 'unavailable') {
+      // The task stays accepted/queued so execute_task can retry later.
+      return {
+        status: 'provider_unavailable',
+        reason: outcome.reason,
+        code: outcome.code,
+        retryable: outcome.retryable,
+      };
+    }
+    this.deps.log?.('info', 'teammate worker session started', {
+      dispatcher_id: input.dispatcherId,
+      task_id: input.taskId,
+      provider_ref: provider.ref,
+    });
+    // A provider that completes/fails/cancels synchronously inside startSession
+    // already drove the terminal callback; re-read the ledger and only retain a
+    // session that is still live, so the idempotent live-session check stays
+    // accurate and we never store a torn-down session.
+    const after = await ledger.getTask(input.taskId);
+    const lifecycle = after?.lifecycle_status ?? 'running';
+    if (after !== null && isTerminalLifecycle(lifecycle)) {
+      return { status: lifecycle, provider_ref: provider.ref };
+    }
+    this.sessions.set(sessionKey, outcome.session);
+    return { status: 'running', provider_ref: provider.ref };
+  }
+
+  /**
+   * Route a follow-up input to a live worker session, if any. The caller records
+   * the input in the ledger first (durable, `queued`); on an accepted
+   * disposition it transitions the input to `submitted`. With no live session
+   * the input simply stays `queued` for a future worker — PR1 behaviour.
+   */
+  async sendInput(
+    input: SendTeamMateWorkerInputInput,
+  ): Promise<SendTeamMateWorkerInputResult> {
+    const session = this.sessions.get(key(input.dispatcherId, input.taskId));
+    if (session === undefined) return { delivered: false };
+    const disposition = await session.sendInput({
+      inputId: input.inputId,
+      text: input.text,
+      mode: input.mode,
+    });
+    return { delivered: true, disposition };
+  }
+
+  private buildCallbacks(
+    dispatcherId: string,
+    taskId: string,
+  ): TeamMateWorkerCallbacks {
+    const ledger = this.deps.ledger(dispatcherId);
+    const sessionKey = key(dispatcherId, taskId);
+    return {
+      onRunning: async () => {
+        const task = await ledger.getTask(taskId);
+        if (task === null) return;
+        if (
+          task.lifecycle_status !== 'accepted' &&
+          task.lifecycle_status !== 'queued'
+        ) {
+          return; // already running/terminal — running is idempotent.
+        }
+        try {
+          await ledger.markRunning(taskId);
+        } catch (err) {
+          if (!(err instanceof TeamMateTaskTransitionError)) throw err;
+          return;
+        }
+        this.deps.notifyEvent?.(dispatcherId, taskId);
+      },
+      onCompleted: async (finalText) => {
+        this.sessions.delete(sessionKey);
+        await this.deps.reportCompletion({
+          dispatcherId,
+          taskId,
+          outcome: 'completed',
+          finalText,
+        });
+      },
+      onFailed: async (errorText) => {
+        this.sessions.delete(sessionKey);
+        await this.deps.reportCompletion({
+          dispatcherId,
+          taskId,
+          outcome: 'failed',
+          finalText: errorText,
+        });
+      },
+      onCancelled: async (reason) => {
+        this.sessions.delete(sessionKey);
+        try {
+          await ledger.recordClose(taskId, {
+            status: 'cancelled',
+            ...(reason !== null && reason !== '' ? { note: reason } : {}),
+          });
+        } catch (err) {
+          if (!(err instanceof TeamMateTaskTransitionError)) throw err;
+          return;
+        }
+        this.deps.notifyEvent?.(dispatcherId, taskId);
+      },
+    };
+  }
+}
+
+function providerUnavailable(reason: string): TeamMateExecutionOutcome {
+  return {
+    status: 'provider_unavailable',
+    reason,
+    code: TEAMMATE_PROVIDER_UNAVAILABLE_CODE,
+    retryable: true,
+  };
+}
+
+function isTerminalLifecycle(
+  status: TeamMateLifecycleStatus,
+): status is 'completed' | 'failed' | 'cancelled' {
+  return status === 'completed' || status === 'failed' || status === 'cancelled';
+}
+
+function key(dispatcherId: string, taskId: string): string {
+  return `${dispatcherId} ${taskId}`;
+}

--- a/packages/dreamux/src/teammate/worker-execution.ts
+++ b/packages/dreamux/src/teammate/worker-execution.ts
@@ -295,5 +295,5 @@ function isTerminalLifecycle(
 }
 
 function key(dispatcherId: string, taskId: string): string {
-  return `${dispatcherId} ${taskId}`;
+  return `${dispatcherId}\u0000${taskId}`;
 }

--- a/packages/dreamux/src/teammate/worker/catalog.ts
+++ b/packages/dreamux/src/teammate/worker/catalog.ts
@@ -1,0 +1,55 @@
+import type { TeamMateWorkerProvider } from './types.js';
+
+export interface TeamMateWorkerProviderCatalogOptions {
+  providers?: readonly TeamMateWorkerProvider[];
+  /** Provider ref used when a task does not pin one; defaults to the first. */
+  defaultRef?: string;
+}
+
+/**
+ * Lightweight registry of TeamMate worker providers, keyed by ref (issue #126
+ * PR2). Deliberately NOT the agent-runtime catalog: that one validates refs
+ * against the builtin capability registry and rejects unknown/reserved refs,
+ * which would fight an injected test/fake worker. Worker providers are wired by
+ * the server (empty in production for the MVP — no real worker yet) or injected
+ * by tests. Resolution never throws; an unknown ref maps to `null`, which the
+ * caller turns into a retryable `provider_unavailable`.
+ */
+export class TeamMateWorkerProviderCatalog {
+  private readonly providers = new Map<string, TeamMateWorkerProvider>();
+  private readonly defaultRef: string | null;
+
+  constructor(options: TeamMateWorkerProviderCatalogOptions = {}) {
+    const list = options.providers ?? [];
+    for (const provider of list) {
+      this.providers.set(provider.ref, provider);
+    }
+    this.defaultRef =
+      options.defaultRef ?? (list.length > 0 ? list[0]!.ref : null);
+  }
+
+  list(): TeamMateWorkerProvider[] {
+    return [...this.providers.values()];
+  }
+
+  isEmpty(): boolean {
+    return this.providers.size === 0;
+  }
+
+  /** Whether any registered provider currently advertises worker execution. */
+  hasAvailableProvider(): boolean {
+    return this.list().some((p) => p.capabilities().worker_available);
+  }
+
+  /**
+   * Resolve a provider by ref, or the default when ref is null/undefined/empty.
+   * Returns null when nothing matches.
+   */
+  resolve(ref: string | null | undefined): TeamMateWorkerProvider | null {
+    if (typeof ref === 'string' && ref !== '') {
+      return this.providers.get(ref) ?? null;
+    }
+    if (this.defaultRef === null) return null;
+    return this.providers.get(this.defaultRef) ?? null;
+  }
+}

--- a/packages/dreamux/src/teammate/worker/fake-provider.ts
+++ b/packages/dreamux/src/teammate/worker/fake-provider.ts
@@ -1,0 +1,198 @@
+/**
+ * Deterministic in-memory TeamMate worker provider (issue #126 PR2).
+ *
+ * It implements the worker seam without launching any CLI, so the execution
+ * service's orchestration can be proved end-to-end: a test injects this provider
+ * via the worker catalog, runs a task, then drives the lifecycle with explicit
+ * controls (`emitCompleted`/`emitFailed`/`emitCancelled`) — no timers, no
+ * `sleep`. It is a TEST/seam-proving provider; production wires no worker for the
+ * MVP, so capabilities still report real built-in runtimes as unavailable.
+ */
+
+import type { TeamMateInputMode } from '../ledger.js';
+import type {
+  TeamMateWorkerCallbacks,
+  TeamMateWorkerCapabilities,
+  TeamMateWorkerHandle,
+  TeamMateWorkerInputDisposition,
+  TeamMateWorkerProvider,
+  TeamMateWorkerSession,
+  TeamMateWorkerStartContext,
+  TeamMateWorkerStartOutcome,
+} from './types.js';
+
+/** The canonical ref for the in-memory fake worker (neutral, not Codex-only). */
+export const FAKE_TEAMMATE_WORKER_REF = 'fake';
+
+export interface FakeTeamMateWorkerInput {
+  inputId: string;
+  text: string;
+  mode: TeamMateInputMode;
+}
+
+interface FakeSessionState {
+  context: TeamMateWorkerStartContext;
+  callbacks: TeamMateWorkerCallbacks;
+  handle: TeamMateWorkerHandle;
+  inputs: FakeTeamMateWorkerInput[];
+  closed: boolean;
+}
+
+export interface FakeTeamMateWorkerProviderOptions {
+  ref?: string;
+  /** When false, startSession returns `unavailable` (simulate a downed worker). */
+  available?: boolean;
+  unavailableReason?: string;
+  capabilities?: Partial<Omit<TeamMateWorkerCapabilities, 'worker_available'>>;
+  /**
+   * Auto-emit `onRunning` during startSession so the event stream is
+   * accepted → running before any terminal transition (default true).
+   */
+  autoRunning?: boolean;
+  /** Decide a follow-up input's disposition; default accepts every mode. */
+  inputDisposition?: (
+    input: FakeTeamMateWorkerInput,
+  ) => TeamMateWorkerInputDisposition;
+}
+
+export class FakeTeamMateWorkerProvider implements TeamMateWorkerProvider {
+  readonly ref: string;
+  private readonly available: boolean;
+  private readonly unavailableReason: string;
+  private readonly caps: TeamMateWorkerCapabilities;
+  private readonly autoRunning: boolean;
+  private readonly inputDisposition: (
+    input: FakeTeamMateWorkerInput,
+  ) => TeamMateWorkerInputDisposition;
+  private readonly sessions = new Map<string, FakeSessionState>();
+
+  constructor(options: FakeTeamMateWorkerProviderOptions = {}) {
+    this.ref = options.ref ?? FAKE_TEAMMATE_WORKER_REF;
+    this.available = options.available ?? true;
+    this.unavailableReason =
+      options.unavailableReason ?? 'fake worker is unavailable';
+    this.caps = {
+      worker_available: this.available,
+      unsupported_reason: this.available ? '' : this.unavailableReason,
+      modes: { steer: true, queue: true, interrupt: true },
+      resume: false,
+      logs: false,
+      ...options.capabilities,
+    };
+    this.autoRunning = options.autoRunning ?? true;
+    this.inputDisposition =
+      options.inputDisposition ?? (() => ({ status: 'accepted' }));
+  }
+
+  capabilities(): TeamMateWorkerCapabilities {
+    return { ...this.caps, modes: { ...this.caps.modes } };
+  }
+
+  async startSession(
+    context: TeamMateWorkerStartContext,
+    callbacks: TeamMateWorkerCallbacks,
+  ): Promise<TeamMateWorkerStartOutcome> {
+    if (!this.available) {
+      return {
+        status: 'unavailable',
+        reason: this.unavailableReason,
+        code: 'TEAMMATE_WORKER_UNAVAILABLE',
+        retryable: true,
+      };
+    }
+    const handle: TeamMateWorkerHandle = {
+      providerRef: this.ref,
+      sessionId: `fake-session-${context.taskId}`,
+      threadId: null,
+    };
+    const state: FakeSessionState = {
+      context,
+      callbacks,
+      handle,
+      inputs: [],
+      closed: false,
+    };
+    this.sessions.set(context.taskId, state);
+    const session: TeamMateWorkerSession = {
+      handle,
+      sendInput: (input) => this.handleInput(context.taskId, input),
+      cancel: (reason) => this.handleCancel(context.taskId, reason),
+    };
+    if (this.autoRunning) {
+      await callbacks.onRunning(handle);
+    }
+    return { status: 'started', session };
+  }
+
+  /** Test control: drive a live session to completion. */
+  async emitCompleted(taskId: string, finalText: string): Promise<void> {
+    const state = this.mustLive(taskId);
+    state.closed = true;
+    await state.callbacks.onCompleted(finalText);
+  }
+
+  /** Test control: drive a live session to a reported failure. */
+  async emitFailed(taskId: string, errorText: string): Promise<void> {
+    const state = this.mustLive(taskId);
+    state.closed = true;
+    await state.callbacks.onFailed(errorText);
+  }
+
+  /** Test control: drive a live session to a cancelled close. */
+  async emitCancelled(
+    taskId: string,
+    reason: string | null = null,
+  ): Promise<void> {
+    const state = this.mustLive(taskId);
+    state.closed = true;
+    await state.callbacks.onCancelled(reason);
+  }
+
+  /** Test control: emit an extra running event (e.g. to assert idempotency). */
+  async emitRunning(taskId: string): Promise<void> {
+    const state = this.mustLive(taskId);
+    await state.callbacks.onRunning(state.handle);
+  }
+
+  /** The follow-up inputs the fake observed for a task (assertion helper). */
+  inputsFor(taskId: string): FakeTeamMateWorkerInput[] {
+    return [...(this.sessions.get(taskId)?.inputs ?? [])];
+  }
+
+  hasLiveSession(taskId: string): boolean {
+    const state = this.sessions.get(taskId);
+    return state !== undefined && !state.closed;
+  }
+
+  private async handleInput(
+    taskId: string,
+    input: FakeTeamMateWorkerInput,
+  ): Promise<TeamMateWorkerInputDisposition> {
+    const state = this.mustLive(taskId);
+    const disposition = this.inputDisposition(input);
+    if (disposition.status === 'accepted') {
+      state.inputs.push({ ...input });
+    }
+    return disposition;
+  }
+
+  private async handleCancel(
+    taskId: string,
+    reason: string | null,
+  ): Promise<void> {
+    const state = this.sessions.get(taskId);
+    if (state === undefined || state.closed) return;
+    state.closed = true;
+    await state.callbacks.onCancelled(reason);
+  }
+
+  private mustLive(taskId: string): FakeSessionState {
+    const state = this.sessions.get(taskId);
+    if (state === undefined) {
+      throw new Error(
+        `fake worker has no session for task ${JSON.stringify(taskId)}`,
+      );
+    }
+    return state;
+  }
+}

--- a/packages/dreamux/src/teammate/worker/index.ts
+++ b/packages/dreamux/src/teammate/worker/index.ts
@@ -1,0 +1,3 @@
+export * from './types.js';
+export * from './catalog.js';
+export * from './fake-provider.js';

--- a/packages/dreamux/src/teammate/worker/types.ts
+++ b/packages/dreamux/src/teammate/worker/types.ts
@@ -1,0 +1,110 @@
+/**
+ * TeamMate worker provider seam (issue #126 PR2).
+ *
+ * A worker provider runs ONE TeamMate task as a steerable, multi-input session
+ * against a local target. This is deliberately a different abstraction from the
+ * dispatcher's long-lived `AgentRuntimeProvider` (`src/agent-runtime/`): that one
+ * models the dispatcher's own persistent runtime, whereas a worker session is
+ * per-task and terminates when the task does.
+ *
+ * The provider never writes the ledger. It only emits lifecycle through the
+ * {@link TeamMateWorkerCallbacks}; the execution service is the sole ledger
+ * writer, so the server-owned ledger stays the single source of truth. The
+ * contract carries no Codex-only assumptions — a Claude Code worker (still in
+ * epic scope) implements the same seam.
+ */
+
+import type {
+  TeamMateInputMode,
+  TeamMateTargetMode,
+  TeamMateTaskTarget,
+} from '../ledger.js';
+
+/** Per-task worker capabilities a provider advertises (read by get_capabilities). */
+export interface TeamMateWorkerCapabilities {
+  worker_available: boolean;
+  /** Why execution is unavailable; empty when `worker_available` is true. */
+  unsupported_reason: string;
+  modes: { steer: boolean; queue: boolean; interrupt: boolean };
+  resume: boolean;
+  logs: boolean;
+}
+
+/**
+ * Immutable context handed to a provider when a task starts. The target path is
+ * local state already resolved/confined by the ledger; the provider receives it
+ * but the server keeps it out of public artifacts.
+ */
+export interface TeamMateWorkerStartContext {
+  dispatcherId: string;
+  taskId: string;
+  teammateId: string | null;
+  title: string;
+  prompt: string;
+  target: TeamMateTaskTarget | null;
+  targetMode: TeamMateTargetMode | null;
+  // Team Mode reservation (issue #126): a future Team leader/Epic identity may be
+  // threaded here additively. PR2 adds no Team fields and no Codex-only fields.
+}
+
+/** Opaque runtime handle a provider returns once a session is live. */
+export interface TeamMateWorkerHandle {
+  providerRef: string;
+  sessionId: string | null;
+  threadId: string | null;
+}
+
+/** Disposition of a follow-up input routed to a live worker session. */
+export type TeamMateWorkerInputDisposition =
+  | { status: 'accepted' }
+  | { status: 'rejected'; reason: string };
+
+/**
+ * Service-side callbacks a provider drives to map worker lifecycle onto the
+ * server-owned ledger. A provider MUST NOT touch the ledger directly; it only
+ * emits these, and the execution service performs the ledger transition plus the
+ * wait-broker notify.
+ */
+export interface TeamMateWorkerCallbacks {
+  /** The worker has started turning; maps to `markRunning`. */
+  onRunning(handle: TeamMateWorkerHandle): Promise<void>;
+  /** The task finished successfully with a final result. */
+  onCompleted(finalText: string): Promise<void>;
+  /** The task failed; `errorText` is retained as the failure result. */
+  onFailed(errorText: string): Promise<void>;
+  /** The task was cancelled by the worker; maps to a `cancelled` close. */
+  onCancelled(reason: string | null): Promise<void>;
+}
+
+/** A live, steerable worker session for one task. */
+export interface TeamMateWorkerSession {
+  readonly handle: TeamMateWorkerHandle;
+  /** Deliver a follow-up input to the live session. */
+  sendInput(input: {
+    inputId: string;
+    text: string;
+    mode: TeamMateInputMode;
+  }): Promise<TeamMateWorkerInputDisposition>;
+  /** Request cancellation; the provider drives `onCancelled` when it lands. */
+  cancel(reason: string | null): Promise<void>;
+}
+
+/** Outcome of attempting to start a worker session. */
+export type TeamMateWorkerStartOutcome =
+  | { status: 'started'; session: TeamMateWorkerSession }
+  | {
+      status: 'unavailable';
+      reason: string;
+      code: string;
+      retryable: boolean;
+    };
+
+/** A pluggable TeamMate worker runtime. */
+export interface TeamMateWorkerProvider {
+  readonly ref: string;
+  capabilities(): TeamMateWorkerCapabilities;
+  startSession(
+    context: TeamMateWorkerStartContext,
+    callbacks: TeamMateWorkerCallbacks,
+  ): Promise<TeamMateWorkerStartOutcome>;
+}

--- a/packages/dreamux/tests/smoke.test.ts
+++ b/packages/dreamux/tests/smoke.test.ts
@@ -61,6 +61,11 @@ import { writeRestartIntent } from '../src/daemon/restart-intent.js';
 import { dreamuxBinPath } from '../src/runtime/package-bin.js';
 import { createLogger, type DreamuxLogger } from '../src/runtime/logger.js';
 import { DREAMUX_DISPATCHER_BASE_INSTRUCTIONS } from '../src/dispatcher/base-prompt.js';
+import { TeamMateWorkerProviderCatalog } from '../src/teammate/worker/catalog.js';
+import {
+  FakeTeamMateWorkerProvider,
+  FAKE_TEAMMATE_WORKER_REF,
+} from '../src/teammate/worker/fake-provider.js';
 import { startFakeCodex, type FakeCodex } from './fake-codex.js';
 import { testDispatcherConfig } from './helpers/config.js';
 import { Writable } from 'node:stream';
@@ -119,11 +124,19 @@ function buildServer(opts: {
   codexRestartBackoffBaseMs?: number;
   codexRestartBackoffMaxMs?: number;
   channelLoggerFactory?: (dispatcherId: string) => DreamuxLogger;
+  teamMateWorkerProviders?: TeamMateWorkerProviderCatalog;
+  teamMateDeliveryBackoffMs?: (attempt: number) => number;
 }): Server {
   return new Server({
     config: opts.config ?? BUILT_IN_DEFAULTS,
     adminSocketPath: join(opts.runtimeDir, 'admin.sock'),
     skipBotSecret: opts.skipBotSecret ?? true,
+    ...(opts.teamMateWorkerProviders !== undefined
+      ? { teamMateWorkerProviders: opts.teamMateWorkerProviders }
+      : {}),
+    ...(opts.teamMateDeliveryBackoffMs !== undefined
+      ? { teamMateDeliveryBackoffMs: opts.teamMateDeliveryBackoffMs }
+      : {}),
     ...(opts.channelLoggerFactory !== undefined
       ? { channelLoggerFactory: opts.channelLoggerFactory }
       : {}),
@@ -1680,6 +1693,212 @@ describe('dreamux MVP smoke', () => {
     expect(refs).toContain('builtin:codex');
     expect(refs).toContain('builtin:claude-code');
     expect(caps.providers.every((p) => p.worker_available === false)).toBe(true);
+  });
+
+  it('mcp.teammate.capabilities reflects an injected worker provider as available', async () => {
+    server = buildServer({
+      runtimeDir,
+      fake,
+      bot,
+      config: configWithDispatcher({ cwd: runtimeDir }),
+      teamMateWorkerProviders: new TeamMateWorkerProviderCatalog({
+        providers: [new FakeTeamMateWorkerProvider()],
+      }),
+    });
+    await server.start();
+
+    const caps = (await sendAdminRequest(
+      'mcp.teammate.capabilities',
+      { dispatcher_id: 'flow' },
+      { socketPath: join(runtimeDir, 'admin.sock') },
+    )) as {
+      execution_available: boolean;
+      providers: Array<{
+        provider_ref: string;
+        worker_available: boolean;
+        modes: { steer: boolean };
+      }>;
+    };
+
+    // Injecting an available worker flips execution_available and appends the
+    // worker ref alongside the (still worker-unavailable) built-in runtimes.
+    expect(caps.execution_available).toBe(true);
+    const fakeRow = caps.providers.find(
+      (p) => p.provider_ref === FAKE_TEAMMATE_WORKER_REF,
+    );
+    expect(fakeRow?.worker_available).toBe(true);
+    expect(fakeRow?.modes.steer).toBe(true);
+    const builtinCodex = caps.providers.find(
+      (p) => p.provider_ref === 'builtin:codex',
+    );
+    expect(builtinCodex?.worker_available).toBe(false);
+  });
+
+  it('run_task executes through an injected worker and await/pull collect the result', async () => {
+    const fakeWorker = new FakeTeamMateWorkerProvider();
+    server = buildServer({
+      runtimeDir,
+      fake,
+      bot,
+      config: configWithDispatcher({ cwd: runtimeDir }),
+      teamMateWorkerProviders: new TeamMateWorkerProviderCatalog({
+        providers: [fakeWorker],
+      }),
+      teamMateDeliveryBackoffMs: () => 0,
+    });
+    await server.start();
+    const socketPath = join(runtimeDir, 'admin.sock');
+
+    const created = (await sendAdminRequest(
+      'mcp.teammate.run',
+      {
+        dispatcher_id: 'flow',
+        caller_kind: 'dispatcher',
+        title: 'Run task',
+        prompt: 'Investigate the failing test.',
+        target_path: '.',
+      },
+      { socketPath },
+    )) as {
+      task: { task_id: string; lifecycle_status: string; last_event_id: number };
+      execution: { status: string; provider_ref?: string };
+    };
+
+    // With a worker wired, run_task starts a live session: the task is running
+    // (not provider_unavailable) and the execution names the resolved provider.
+    expect(created.execution).toMatchObject({
+      status: 'running',
+      provider_ref: FAKE_TEAMMATE_WORKER_REF,
+    });
+    expect(created.task.lifecycle_status).toBe('running');
+    // The local target path is still kept out of the public summary.
+    expect(JSON.stringify(created.task)).not.toContain(runtimeDir);
+    const taskId = created.task.task_id;
+
+    // Register the wait, then drive the fake worker to completion; the waiter
+    // must wake from the recorded completion event, not its timeout.
+    const awaiting = sendAdminRequest(
+      'mcp.teammate.await',
+      {
+        dispatcher_id: 'flow',
+        task_id: taskId,
+        after_event_id: created.task.last_event_id,
+        timeout_ms: 3000,
+      },
+      { socketPath, timeoutMs: 9000 },
+    ) as Promise<{ status: string; result: { outcome: string; text: string } | null }>;
+
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    await fakeWorker.emitCompleted(taskId, 'the worker finished the job');
+
+    const awaited = await awaiting;
+    expect(awaited.status).toBe('completed');
+    expect(awaited.result?.outcome).toBe('completed');
+
+    // Pull returns the retained result regardless of delivery (no runtime up).
+    const pulled = (await sendAdminRequest(
+      'mcp.teammate.pull',
+      { dispatcher_id: 'flow', task_id: taskId },
+      { socketPath },
+    )) as { result: { outcome: string; text: string } };
+    expect(pulled.result.text).toBe('the worker finished the job');
+  });
+
+  it('send_input promotes a queued input to submitted when a worker session is live', async () => {
+    const fakeWorker = new FakeTeamMateWorkerProvider();
+    server = buildServer({
+      runtimeDir,
+      fake,
+      bot,
+      config: configWithDispatcher({ cwd: runtimeDir }),
+      teamMateWorkerProviders: new TeamMateWorkerProviderCatalog({
+        providers: [fakeWorker],
+      }),
+      teamMateDeliveryBackoffMs: () => 0,
+    });
+    await server.start();
+    const socketPath = join(runtimeDir, 'admin.sock');
+
+    const created = (await sendAdminRequest(
+      'mcp.teammate.run',
+      {
+        dispatcher_id: 'flow',
+        caller_kind: 'dispatcher',
+        title: 'Steerable task',
+        prompt: 'Start working and await steering.',
+        target_path: '.',
+      },
+      { socketPath },
+    )) as { task: { task_id: string } };
+    const taskId = created.task.task_id;
+
+    const sent = (await sendAdminRequest(
+      'mcp.teammate.send_input',
+      {
+        dispatcher_id: 'flow',
+        task_id: taskId,
+        prompt: 'also check the integration tests',
+      },
+      { socketPath },
+    )) as { status: string; mode: string; input_id: string };
+    // Default mode is steer, and the live worker accepted it -> submitted.
+    expect(sent.mode).toBe('steer');
+    expect(sent.status).toBe('submitted');
+    expect(fakeWorker.inputsFor(taskId)).toHaveLength(1);
+
+    const task = (await sendAdminRequest(
+      'mcp.teammate.get',
+      { dispatcher_id: 'flow', task_id: taskId },
+      { socketPath },
+    )) as { task: { inputs: Array<{ input_id: string; status: string }> } };
+    expect(task.task.inputs[0]).toMatchObject({
+      input_id: sent.input_id,
+      status: 'submitted',
+    });
+  });
+
+  it('run_task drives the task to cancelled when the worker cancels', async () => {
+    const fakeWorker = new FakeTeamMateWorkerProvider();
+    server = buildServer({
+      runtimeDir,
+      fake,
+      bot,
+      config: configWithDispatcher({ cwd: runtimeDir }),
+      teamMateWorkerProviders: new TeamMateWorkerProviderCatalog({
+        providers: [fakeWorker],
+      }),
+      teamMateDeliveryBackoffMs: () => 0,
+    });
+    await server.start();
+    const socketPath = join(runtimeDir, 'admin.sock');
+
+    const created = (await sendAdminRequest(
+      'mcp.teammate.run',
+      {
+        dispatcher_id: 'flow',
+        caller_kind: 'dispatcher',
+        title: 'Cancellable task',
+        prompt: 'Begin work.',
+        target_path: '.',
+      },
+      { socketPath },
+    )) as { task: { task_id: string } };
+    const taskId = created.task.task_id;
+
+    await fakeWorker.emitCancelled(taskId, 'superseded by a newer task');
+
+    const task = (await sendAdminRequest(
+      'mcp.teammate.get',
+      { dispatcher_id: 'flow', task_id: taskId },
+      { socketPath },
+    )) as {
+      task: { lifecycle_status: string; close: { status: string; note: string } };
+    };
+    expect(task.task.lifecycle_status).toBe('cancelled');
+    expect(task.task.close).toMatchObject({
+      status: 'cancelled',
+      note: 'superseded by a newer task',
+    });
   });
 
   it('await_completion wakes promptly when a completion is recorded mid-wait', async () => {

--- a/packages/dreamux/tests/teammate-worker.test.ts
+++ b/packages/dreamux/tests/teammate-worker.test.ts
@@ -1,0 +1,350 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+
+import { TeamMateTaskLedger } from '../src/teammate/ledger.js';
+import { TeamMateDeliveryService } from '../src/teammate/delivery.js';
+import {
+  TeamMateWorkerExecutionService,
+  type TeamMateExecutionOutcome,
+} from '../src/teammate/worker-execution.js';
+import { TeamMateWorkerProviderCatalog } from '../src/teammate/worker/catalog.js';
+import {
+  FakeTeamMateWorkerProvider,
+  FAKE_TEAMMATE_WORKER_REF,
+} from '../src/teammate/worker/fake-provider.js';
+import { TeamMateWaitBroker } from '../src/teammate/wait-broker.js';
+import { resetRuntimeConfig } from '../src/runtime/paths.js';
+
+const DISPATCHER = 'flow';
+
+interface Harness {
+  ledger: TeamMateTaskLedger;
+  broker: TeamMateWaitBroker;
+  execution: TeamMateWorkerExecutionService;
+  notifications: number;
+}
+
+/**
+ * Build an execution service over a real ledger and the PR1 delivery service
+ * (with no runtime, so delivery ends `delivery_failed` while the result stays
+ * pull-able — exactly the "result is the source of truth" guarantee we assert).
+ */
+function buildHarness(
+  workers: TeamMateWorkerProviderCatalog,
+): Harness {
+  const ledger = new TeamMateTaskLedger(DISPATCHER);
+  const broker = new TeamMateWaitBroker();
+  const state = { notifications: 0 };
+  const delivery = new TeamMateDeliveryService({
+    ledger: () => ledger,
+    resolveRuntime: () => null,
+    backoffMs: () => 0,
+    notifyEvent: (d, t) => broker.notify(d, t),
+  });
+  const execution = new TeamMateWorkerExecutionService({
+    ledger: () => ledger,
+    workers: () => workers,
+    reportCompletion: (report) => delivery.reportCompletion(report),
+    notifyEvent: (d, t) => {
+      state.notifications++;
+      broker.notify(d, t);
+    },
+  });
+  return {
+    ledger,
+    broker,
+    execution,
+    get notifications() {
+      return state.notifications;
+    },
+  } as Harness;
+}
+
+async function acceptTask(
+  ledger: TeamMateTaskLedger,
+  overrides: Partial<{ providerRef: string; taskId: string }> = {},
+): Promise<string> {
+  const task = await ledger.acceptTask({
+    title: 'Run task',
+    prompt: 'Investigate the failing test.',
+    callerKind: 'dispatcher',
+    target: { kind: 'path', path: '/tmp/work' },
+    ...(overrides.providerRef !== undefined
+      ? { providerRef: overrides.providerRef }
+      : {}),
+    ...(overrides.taskId !== undefined ? { taskId: overrides.taskId } : {}),
+  });
+  return task.task_id;
+}
+
+describe('TeamMate worker execution', () => {
+  let root: string;
+  let previousHome: string | undefined;
+
+  beforeEach(() => {
+    root = mkdtempSync(join(tmpdir(), 'dreamux-teammate-worker-'));
+    previousHome = process.env['HOME'];
+    process.env['HOME'] = join(root, 'home');
+    resetRuntimeConfig();
+  });
+
+  afterEach(() => {
+    if (previousHome === undefined) delete process.env['HOME'];
+    else process.env['HOME'] = previousHome;
+    resetRuntimeConfig();
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  it('drives accepted -> running -> completed with a pull-able result', async () => {
+    const fake = new FakeTeamMateWorkerProvider();
+    const { ledger, execution } = buildHarness(
+      new TeamMateWorkerProviderCatalog({ providers: [fake] }),
+    );
+    const taskId = await acceptTask(ledger);
+
+    const started = await execution.execute({ dispatcherId: DISPATCHER, taskId });
+    expect(started).toEqual({
+      status: 'running',
+      provider_ref: FAKE_TEAMMATE_WORKER_REF,
+    });
+
+    // onRunning landed during startSession, so the event stream is accepted ->
+    // running with no terminal event yet.
+    let task = await ledger.getTask(taskId);
+    expect(task?.lifecycle_status).toBe('running');
+    expect(task?.events.map((e) => e.type)).toEqual(['accepted', 'running']);
+
+    await fake.emitCompleted(taskId, 'the work is done');
+
+    task = await ledger.getTask(taskId);
+    expect(task?.lifecycle_status).toBe('completed');
+    expect(task?.result).toMatchObject({
+      outcome: 'completed',
+      text: 'the work is done',
+    });
+    // The ledger is the source of truth: the result is retained and pull-able
+    // even though delivery failed (no runtime to deliver into).
+    expect(task?.delivery_status).toBe('delivery_failed');
+    const latest = await ledger.latestResultTask();
+    expect(latest?.task_id).toBe(taskId);
+    expect(latest?.result?.text).toBe('the work is done');
+    expect(execution.hasLiveSession(DISPATCHER, taskId)).toBe(false);
+  });
+
+  it('reports provider_unavailable and leaves the task accepted when no worker is wired', async () => {
+    const { ledger, execution } = buildHarness(
+      new TeamMateWorkerProviderCatalog(),
+    );
+    const taskId = await acceptTask(ledger);
+
+    const outcome = await execution.execute({ dispatcherId: DISPATCHER, taskId });
+    expect(outcome).toEqual({
+      status: 'provider_unavailable',
+      reason: expect.any(String),
+      code: 'TEAMMATE_PROVIDER_UNAVAILABLE',
+      retryable: true,
+    });
+
+    const task = await ledger.getTask(taskId);
+    // The task stays accepted so execute_task can retry once a worker exists.
+    expect(task?.lifecycle_status).toBe('accepted');
+    expect(task?.events.map((e) => e.type)).toEqual(['accepted']);
+  });
+
+  it('reports provider_unavailable when the worker advertises itself unavailable', async () => {
+    const fake = new FakeTeamMateWorkerProvider({
+      available: false,
+      unavailableReason: 'fake worker is down',
+    });
+    const { ledger, execution } = buildHarness(
+      new TeamMateWorkerProviderCatalog({ providers: [fake] }),
+    );
+    const taskId = await acceptTask(ledger);
+
+    const outcome = await execution.execute({ dispatcherId: DISPATCHER, taskId });
+    expect(outcome.status).toBe('provider_unavailable');
+
+    expect((await ledger.getTask(taskId))?.lifecycle_status).toBe('accepted');
+  });
+
+  it('records a worker-reported failure as a pull-able failed result', async () => {
+    const fake = new FakeTeamMateWorkerProvider();
+    const { ledger, execution } = buildHarness(
+      new TeamMateWorkerProviderCatalog({ providers: [fake] }),
+    );
+    const taskId = await acceptTask(ledger);
+    await execution.execute({ dispatcherId: DISPATCHER, taskId });
+
+    await fake.emitFailed(taskId, 'the worker hit an unrecoverable error');
+
+    const task = await ledger.getTask(taskId);
+    expect(task?.lifecycle_status).toBe('failed');
+    expect(task?.result).toMatchObject({
+      outcome: 'failed',
+      text: 'the worker hit an unrecoverable error',
+    });
+    // Source of truth after failure: the result is retained and pull-able.
+    const latest = await ledger.latestResultTask();
+    expect(latest?.task_id).toBe(taskId);
+    expect(execution.hasLiveSession(DISPATCHER, taskId)).toBe(false);
+  });
+
+  it('closes the task as cancelled when the worker cancels', async () => {
+    const fake = new FakeTeamMateWorkerProvider();
+    const { ledger, execution } = buildHarness(
+      new TeamMateWorkerProviderCatalog({ providers: [fake] }),
+    );
+    const taskId = await acceptTask(ledger);
+    await execution.execute({ dispatcherId: DISPATCHER, taskId });
+
+    await fake.emitCancelled(taskId, 'operator asked to stop');
+
+    const task = await ledger.getTask(taskId);
+    expect(task?.lifecycle_status).toBe('cancelled');
+    expect(task?.close).toMatchObject({
+      status: 'cancelled',
+      note: 'operator asked to stop',
+    });
+    expect(task?.events.map((e) => e.type)).toContain('closed');
+  });
+
+  it('is idempotent: a second execute does not start a second session', async () => {
+    const fake = new FakeTeamMateWorkerProvider();
+    const { ledger, execution } = buildHarness(
+      new TeamMateWorkerProviderCatalog({ providers: [fake] }),
+    );
+    const taskId = await acceptTask(ledger);
+
+    const first = await execution.execute({ dispatcherId: DISPATCHER, taskId });
+    const second = await execution.execute({ dispatcherId: DISPATCHER, taskId });
+    expect(first).toEqual(second);
+
+    // Only one running event — the second execute short-circuited on the live
+    // session instead of re-running the worker.
+    const task = await ledger.getTask(taskId);
+    expect(task?.events.filter((e) => e.type === 'running')).toHaveLength(1);
+  });
+
+  it('does not re-execute a terminal task', async () => {
+    const fake = new FakeTeamMateWorkerProvider();
+    const { ledger, execution } = buildHarness(
+      new TeamMateWorkerProviderCatalog({ providers: [fake] }),
+    );
+    const taskId = await acceptTask(ledger);
+    await execution.execute({ dispatcherId: DISPATCHER, taskId });
+    await fake.emitCompleted(taskId, 'done');
+
+    const outcome = await execution.execute({ dispatcherId: DISPATCHER, taskId });
+    expect(outcome).toMatchObject({ status: 'completed' });
+    // No second running transition was attempted.
+    const task = await ledger.getTask(taskId);
+    expect(task?.events.filter((e) => e.type === 'running')).toHaveLength(1);
+  });
+
+  it('routes follow-up input to a live session and leaves it queued without one', async () => {
+    const fake = new FakeTeamMateWorkerProvider();
+    const workers = new TeamMateWorkerProviderCatalog({ providers: [fake] });
+    const { ledger, execution } = buildHarness(workers);
+    const taskId = await acceptTask(ledger);
+
+    // No session yet: the input is not delivered to a worker.
+    const beforeStart = await execution.sendInput({
+      dispatcherId: DISPATCHER,
+      taskId,
+      inputId: 'input_1',
+      text: 'early steer',
+      mode: 'steer',
+    });
+    expect(beforeStart.delivered).toBe(false);
+
+    await execution.execute({ dispatcherId: DISPATCHER, taskId });
+    const delivered = await execution.sendInput({
+      dispatcherId: DISPATCHER,
+      taskId,
+      inputId: 'input_2',
+      text: 'steer the worker',
+      mode: 'steer',
+    });
+    expect(delivered).toEqual({
+      delivered: true,
+      disposition: { status: 'accepted' },
+    });
+    expect(fake.inputsFor(taskId)).toEqual([
+      { inputId: 'input_2', text: 'steer the worker', mode: 'steer' },
+    ]);
+  });
+
+  it('surfaces a worker input rejection disposition', async () => {
+    const fake = new FakeTeamMateWorkerProvider({
+      inputDisposition: (input) =>
+        input.mode === 'interrupt'
+          ? { status: 'rejected', reason: 'interrupt not supported mid-turn' }
+          : { status: 'accepted' },
+    });
+    const { ledger, execution } = buildHarness(
+      new TeamMateWorkerProviderCatalog({ providers: [fake] }),
+    );
+    const taskId = await acceptTask(ledger);
+    await execution.execute({ dispatcherId: DISPATCHER, taskId });
+
+    const rejected = await execution.sendInput({
+      dispatcherId: DISPATCHER,
+      taskId,
+      inputId: 'input_1',
+      text: 'stop now',
+      mode: 'interrupt',
+    });
+    expect(rejected).toEqual({
+      delivered: true,
+      disposition: { status: 'rejected', reason: 'interrupt not supported mid-turn' },
+    });
+    // A rejected input is not recorded by the fake worker.
+    expect(fake.inputsFor(taskId)).toEqual([]);
+  });
+
+  it('selects the provider pinned on the task', async () => {
+    const codexLike = new FakeTeamMateWorkerProvider({ ref: 'builtin:codex' });
+    const other = new FakeTeamMateWorkerProvider({ ref: FAKE_TEAMMATE_WORKER_REF });
+    const { ledger, execution } = buildHarness(
+      new TeamMateWorkerProviderCatalog({
+        providers: [other, codexLike],
+        defaultRef: FAKE_TEAMMATE_WORKER_REF,
+      }),
+    );
+    const taskId = await acceptTask(ledger, { providerRef: 'builtin:codex' });
+
+    const outcome = (await execution.execute({
+      dispatcherId: DISPATCHER,
+      taskId,
+    })) as Extract<TeamMateExecutionOutcome, { status: 'running' }>;
+    expect(outcome.provider_ref).toBe('builtin:codex');
+  });
+
+  it('wakes a waiter when the worker completes mid-wait', async () => {
+    const fake = new FakeTeamMateWorkerProvider();
+    const { ledger, broker, execution } = buildHarness(
+      new TeamMateWorkerProviderCatalog({ providers: [fake] }),
+    );
+    const { awaitTeamMateCompletion } = await import(
+      '../src/teammate/wait-broker.js'
+    );
+    const taskId = await acceptTask(ledger);
+    await execution.execute({ dispatcherId: DISPATCHER, taskId });
+    const running = await ledger.getTask(taskId);
+
+    const waiting = awaitTeamMateCompletion(broker, {
+      dispatcherId: DISPATCHER,
+      taskId,
+      afterEventId: running!.events[running!.events.length - 1]!.event_id,
+      until: new Set(['completed', 'failed', 'cancelled'] as const),
+      timeoutMs: 3000,
+      loadTask: () => ledger.getTask(taskId),
+    });
+
+    await fake.emitCompleted(taskId, 'finished while waiting');
+    const outcome = await waiting;
+    expect(outcome.status).toBe('reached');
+  });
+});


### PR DESCRIPTION
## TeamMate MCP parity — PR2(worker provider seam + fake provider)

承接 PR1(#127,已并入 `next`,merge commit `df1433871effd01a3108eceb420a8b0cf4caf723`)的 ledger v2 + 事件/等待地基。本 PR 接入 **worker provider 接缝与 in-memory fake provider**,证明 Dispatcher Service 的执行编排链路。**仍不**实现真实 Codex/Claude Code worker,**不**在 MCP 后包/调 `tm`。Base:`next`。

关联 issue:#126(公开 PR2 计划见该 issue 评论:https://github.com/excitedjs/dreamux/issues/126#issuecomment-4642307217)。

### 范围内

**Worker provider 接缝(新)** —— `packages/dreamux/src/teammate/worker/`
- `TeamMateWorkerProvider`:把**单个任务**作为可 steer 的多输入会话跑在本地 target 上 —— 与既有 `AgentRuntimeProvider`(`packages/dreamux/src/agent-runtime/`,dispatcher 自身常驻 runtime)是**不同抽象**,生命周期按任务而非常驻。接缝不内置 Codex-only 假设,Claude Code worker(仍在 epic 范围)可实现同一接口。
- provider **永不直接写 ledger**:只通过 `onRunning`/`onCompleted`/`onFailed`/`onCancelled` 回调驱动生命周期;`TeamMateWorkerExecutionService` 是**唯一 ledger 写入者**,ledger 仍是唯一真相。
- `TeamMateWorkerProviderCatalog` 是独立、宽松的注册表(**不复用** agent-runtime catalog —— 后者按 builtin 能力注册表校验 ref,会拒绝注入的 fake ref);解析永不抛错,未知 ref 映射为可重试的 `provider_unavailable`。
- `FakeTeamMateWorkerProvider`(ref `fake`)确定且无定时器:测试注入后用显式控制(`emitCompleted`/`emitFailed`/`emitCancelled`)驱动生命周期。

**编排服务** —— `packages/dreamux/src/teammate/worker-execution.ts`
- 回调到 ledger 转移 + 等待 broker 唤醒:`onRunning → markRunning`、`onCompleted/onFailed → reportCompletion`(复用 PR1 的 record-before-deliver 完成路径:落盘、保留、pull 兜底)、`onCancelled → recordClose('cancelled')`。**provider 主动上报失败**仍落 durable、可 pull 的 `failed` 结果。
- 幂等:已有 live session 的任务再次 execute 直接短路返回 running(不重复启动);终态任务不再执行;`running` 但本进程无 session(进程重启遗留)也不再启动第二个 worker。

**Server 接线** —— `packages/dreamux/src/server.ts`
- 新增可注入的 `teamMateWorkerProviders` catalog(**默认空**)。`run_task`/`execute_task` 经执行服务;`send_input` 先入 ledger(`queued`)再路由到 live session,被接受时经新增 `ledger.markInputSubmitted` 升为 `submitted`。
- `get_capabilities` 以 worker catalog 为真相:`execution_available` 与每个 provider 的 `worker_available` 均来自 catalog。

### PR1 兼容(生产行为不变)
- 默认空 catalog → 所有 provider `worker_available:false`、`execution_available:false`;执行类工具仍报 `provider_unavailable`。**仅注入 fake catalog(测试)时**才真正起 session。
- `schedule` 仍仅入 ledger;MCP `tools/list` 工具集与 PR1 完全一致(未新增 `cancel_task`/`resume_task`/`get_logs`)。
- 嵌套派发边界不变:`run_task`/`schedule` 仍经 `assertTeamMateSchedulingAuthority`,普通 TeamMate 不可嵌套派发。

### 测试
- 单元(`tests/teammate-worker.test.ts`,11 例):`accepted→running→completed` 且结果可 pull;provider 不可用(空 catalog / worker 自报不可用)且任务停在 `accepted`;worker 上报失败落 `failed` 可 pull;cancelled close;幂等无重复启动;终态不再执行;input 路由(无 session 不投递 / live session accepted / rejected disposition);按任务 pin 的 provider 选择;完成中途唤醒 waiter。
- server e2e(`tests/smoke.test.ts`,新增 4 例):注入 worker 后 `get_capabilities` 翻 available;`run_task → await_completion → pull` 全链路;`send_input` 升 `submitted`;worker 取消驱动 `cancelled` close。
- 全量:516 passed / 2 skipped(opt-in live codex)。`rush build` / `rush lint` / `.agents` check 均通过;附 rush change 文件。

### 残留风险(已知、未阻塞,留待后续切片)
- **`execute_task` / `send_input` 无调度权限门**:仅 `run_task`/`schedule` 过 `assertTeamMateSchedulingAuthority`。PR1 中 `execute_task` 是 `provider_unavailable` no-op 故无碍;PR2 起它会**真正启动 worker**。当前仍安全(生产 catalog 为空,且未接 `teammate`-kind caller)。语义上:对已 accepted、dispatcher 自有任务的执行/steer **刻意不算调度操作**,故不设权限门。
- **`task.provider_ref` 不回写实际运行的 provider**(`markRunning` 未改):默认选 provider 跑完后记录仍可能为 null;worker runtime-handle 持久化延后。
- **真实异步 worker 的 session 竞态(仅前瞻)**:执行服务假定终态回调在 `startSession` 返回**之后**触发(同步 fake 成立)。真实异步 worker 若在 `startSession` 返回与 `sessions.set` 之间完成,会留下陈旧 session 项 —— 留作 worker 切片加固,本 PR 不修(无真实异步 provider 不可测,提前改属过早优化)。
- "崩溃后真相一致"以 **provider 主动上报失败** 验证;进程真实死亡的 orphan 对账与启动恢复重投按 epic 延后。
- 词法目标 containment / realpath 加固延续 PR1 口径(worker 真正用到路径的切片再加固)。

> 作者实现,Codex 评审。
