### PR TITLE
收口 provider registry 职责

### DIFF
--- a/common/changes/@excitedjs/dreamux/worktree-dreamux-codex_2026-06-07-20-05.json
+++ b/common/changes/@excitedjs/dreamux/worktree-dreamux-codex_2026-06-07-20-05.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Provider architecture PR A (issue #135): replace the old capability registry with a provider-ref registry that validates builtin refs and provider kind only. Runtime and channel provider factories now receive descriptors resolved from the server-owned registry, and config provider validation uses the injected registry before Phase 1 wired-provider checks. BREAKING: the exported CapabilityRegistry/capability descriptor API is removed; use ProviderRegistry for ref/kind lookup and read capabilities from provider instances.",
+      "type": "minor",
+      "packageName": "@excitedjs/dreamux"
+    }
+  ],
+  "packageName": "@excitedjs/dreamux",
+  "email": "053700@gmail.com"
+}

--- a/packages/dreamux/src/agent-runtime/catalog.ts
+++ b/packages/dreamux/src/agent-runtime/catalog.ts
@@ -1,9 +1,8 @@
 import {
-  createBuiltinRegistry,
   formatProviderRef,
   ReservedExternalProviderError,
-  type CapabilityRegistry,
   type ProviderDescriptor,
+  type ProviderRegistry,
 } from '../registry/index.js';
 import { createCodexAgentRuntimeProvider } from './codex.js';
 import type { CodexAgentRuntimeProviderOptions } from './codex.js';
@@ -32,16 +31,16 @@ export class WrongProviderKindError extends Error {
 }
 
 export interface AgentRuntimeProviderCatalogOptions {
-  registry?: CapabilityRegistry;
+  registry: ProviderRegistry;
   providers: readonly AgentRuntimeProvider[];
 }
 
 export class AgentRuntimeProviderCatalog {
-  private readonly registry: CapabilityRegistry;
+  private readonly registry: ProviderRegistry;
   private readonly providers = new Map<string, AgentRuntimeProvider>();
 
   constructor(options: AgentRuntimeProviderCatalogOptions) {
-    this.registry = options.registry ?? createBuiltinRegistry();
+    this.registry = options.registry;
     for (const provider of options.providers) {
       this.providers.set(provider.ref, provider);
     }
@@ -77,19 +76,27 @@ export class AgentRuntimeProviderCatalog {
 }
 
 export interface BuiltinAgentRuntimeProviderCatalogOptions {
-  registry?: CapabilityRegistry;
-  codex: CodexAgentRuntimeProviderOptions;
-  claudeCode?: ClaudeCodeAgentRuntimeProviderOptions;
+  registry: ProviderRegistry;
+  codex: Omit<CodexAgentRuntimeProviderOptions, 'descriptor'>;
+  claudeCode?: Omit<ClaudeCodeAgentRuntimeProviderOptions, 'descriptor'>;
 }
 
 export function createBuiltinAgentRuntimeProviderCatalog(
   options: BuiltinAgentRuntimeProviderCatalogOptions,
 ): AgentRuntimeProviderCatalog {
+  const codexDescriptor = options.registry.resolve('builtin:codex');
+  const claudeCodeDescriptor = options.registry.resolve('builtin:claude-code');
   return new AgentRuntimeProviderCatalog({
     providers: [
-      createCodexAgentRuntimeProvider(options.codex),
-      createClaudeCodeAgentRuntimeProvider(options.claudeCode ?? {}),
+      createCodexAgentRuntimeProvider({
+        ...options.codex,
+        descriptor: codexDescriptor,
+      }),
+      createClaudeCodeAgentRuntimeProvider({
+        ...(options.claudeCode ?? {}),
+        descriptor: claudeCodeDescriptor,
+      }),
     ],
-    ...(options.registry !== undefined ? { registry: options.registry } : {}),
+    registry: options.registry,
   });
 }

--- a/packages/dreamux/src/agent-runtime/claude-code.ts
+++ b/packages/dreamux/src/agent-runtime/claude-code.ts
@@ -56,7 +56,7 @@
 import { mkdir, writeFile } from 'node:fs/promises';
 import { dirname } from 'node:path';
 
-import { createBuiltinRegistry } from '../registry/index.js';
+import { type ProviderDescriptor } from '../registry/index.js';
 import {
   BUILTIN_CLAUDE_CODE_PROVIDER_REF,
   defaultDispatcherClaudeCodeConfig,
@@ -93,6 +93,7 @@ import type {
 } from './types.js';
 
 export interface ClaudeCodeAgentRuntimeProviderOptions {
+  descriptor: ProviderDescriptor;
   /** Optional host-level bin resolver (default: identity on the config bin). */
   resolveBinPath?: (bin: string) => string;
   /** Override the resident-session factory (tests inject a fake). */
@@ -379,17 +380,14 @@ export class ClaudeCodeRuntime implements AgentRuntime {
 
 /** Build the Phase 1 `builtin:claude-code` agent runtime provider. */
 export function createClaudeCodeAgentRuntimeProvider(
-  options: ClaudeCodeAgentRuntimeProviderOptions = {},
+  options: ClaudeCodeAgentRuntimeProviderOptions,
 ): AgentRuntimeProvider {
-  const descriptor = createBuiltinRegistry().resolve(
-    BUILTIN_CLAUDE_CODE_PROVIDER_REF,
-  );
   const sessionFactory =
     options.sessionFactory ?? createDefaultClaudeCodeSession;
   const resolveBinPath = options.resolveBinPath ?? ((bin: string) => bin);
   return {
     ref: BUILTIN_CLAUDE_CODE_PROVIDER_REF,
-    descriptor,
+    descriptor: options.descriptor,
     delivery: {
       teammateCompletion: [
         {

--- a/packages/dreamux/src/agent-runtime/codex.ts
+++ b/packages/dreamux/src/agent-runtime/codex.ts
@@ -12,7 +12,7 @@ import {
 } from '../runtime/config.js';
 import type { DispatcherCodexHomeDoctor } from '../runtime/dispatcher-codex-home.js';
 import { codexArgsToCli, parseCodexArgs } from '../runtime/codex-args.js';
-import { createBuiltinRegistry } from '../registry/index.js';
+import { type ProviderDescriptor } from '../registry/index.js';
 import type {
   AgentRuntime,
   AgentRuntimeProvider,
@@ -20,6 +20,7 @@ import type {
 } from './types.js';
 
 export interface CodexAgentRuntimeProviderOptions {
+  descriptor: ProviderDescriptor;
   resolveBinPath: (bin: string) => string;
   codexProcessFactory?: (opts: CodexProcessOptions) => CodexProcess;
   codexClientFactory?: (socketPath: string) => CodexWsClient;
@@ -31,10 +32,9 @@ export interface CodexAgentRuntimeProviderOptions {
 export function createCodexAgentRuntimeProvider(
   options: CodexAgentRuntimeProviderOptions,
 ): AgentRuntimeProvider {
-  const descriptor = createBuiltinRegistry().resolve(BUILTIN_CODEX_PROVIDER_REF);
   return {
     ref: BUILTIN_CODEX_PROVIDER_REF,
-    descriptor,
+    descriptor: options.descriptor,
     delivery: {
       teammateCompletion: [
         {

--- a/packages/dreamux/src/channel/channel-providers.ts
+++ b/packages/dreamux/src/channel/channel-providers.ts
@@ -2,13 +2,17 @@
  * Channel provider resolution (issue #110 PR4).
  *
  * Maps a provider ref to its runnable {@link ChannelProvider} implementation.
- * The ref is first validated through the PR2 capability registry, so malformed
+ * The ref is first validated through the provider registry, so malformed
  * refs, reserved `npm:` refs, and unknown builtins fail loudly here and are
  * never loaded or executed — Phase 1 runs only wired builtin channel providers.
- * The registry stays a pure catalog; this module holds the `id -> factory` map.
+ * The registry stays a pure ref/kind catalog; this module holds the runnable
+ * `id -> factory` map.
  */
 
-import { createBuiltinRegistry } from '../registry/index.js';
+import {
+  type ProviderDescriptor,
+  type ProviderRegistry,
+} from '../registry/index.js';
 import { builtinFeishuChannelProvider } from './feishu-provider.js';
 import type { ChannelProvider } from './provider.js';
 
@@ -23,8 +27,15 @@ export class UnsupportedChannelProviderError extends Error {
   }
 }
 
+export interface ResolveChannelProviderOptions {
+  registry: ProviderRegistry;
+}
+
 /** Builtin id -> channel provider factory. Only wired providers appear here. */
-const CHANNEL_PROVIDER_FACTORIES: Record<string, () => ChannelProvider> = {
+const CHANNEL_PROVIDER_FACTORIES: Record<
+  string,
+  (descriptor: ProviderDescriptor) => ChannelProvider
+> = {
   feishu: builtinFeishuChannelProvider,
 };
 
@@ -35,8 +46,11 @@ const CHANNEL_PROVIDER_FACTORIES: Record<string, () => ChannelProvider> = {
  * refs, {@link UnsupportedChannelProviderError} when the ref resolves to a
  * non-channel provider or to a channel builtin that is not wired in this phase.
  */
-export function resolveChannelProvider(ref: string): ChannelProvider {
-  const descriptor = createBuiltinRegistry().resolve(ref);
+export function resolveChannelProvider(
+  ref: string,
+  options: ResolveChannelProviderOptions,
+): ChannelProvider {
+  const descriptor = options.registry.resolve(ref);
   if (descriptor.kind !== 'channel') {
     throw new UnsupportedChannelProviderError(
       ref,
@@ -50,5 +64,5 @@ export function resolveChannelProvider(ref: string): ChannelProvider {
       'is a registered channel builtin but is not runnable in this phase',
     );
   }
-  return factory();
+  return factory(descriptor);
 }

--- a/packages/dreamux/src/channel/feishu-provider.ts
+++ b/packages/dreamux/src/channel/feishu-provider.ts
@@ -7,12 +7,10 @@
  * modules. Behavior is unchanged; the difference is that the server now reaches
  * these through the provider instead of constructing them by hard-coded name.
  *
- * Capabilities are read from the registry descriptor for `builtin:feishu`
- * (`src/registry/builtins.ts`), so the catalog stays the single source of truth
- * for what this provider exposes.
+ * Capabilities are declared by this provider; the registry only validates the
+ * provider ref and kind.
  */
 
-import { createBuiltinRegistry } from '../registry/index.js';
 import { feishuMcpServerDescriptor } from '../codex/mcp-config.js';
 import {
   channelOutboundToFeishuTarget,
@@ -24,6 +22,7 @@ import {
   saveDispatcherAccess,
 } from './feishu-gate.js';
 import { BUILTIN_FEISHU_PROVIDER_REF } from '../runtime/config.js';
+import { type ProviderDescriptor } from '../registry/index.js';
 import type {
   ChannelAccessOps,
   ChannelCapabilityKind,
@@ -35,12 +34,18 @@ import type {
   ChannelConnection,
 } from './provider.js';
 
+export const FEISHU_CHANNEL_CAPABILITIES: readonly ChannelCapabilityKind[] = [
+  'mcpServer',
+  'reply',
+  'react',
+  'access',
+];
+
 /** Build the Phase 1 `builtin:feishu` channel provider. */
-export function builtinFeishuChannelProvider(): ChannelProvider {
-  const descriptor = createBuiltinRegistry().resolve(BUILTIN_FEISHU_PROVIDER_REF);
-  const capabilities = new Set<string>(
-    descriptor.capabilities.map((capability) => capability.kind),
-  );
+export function builtinFeishuChannelProvider(
+  descriptor: ProviderDescriptor,
+): ChannelProvider {
+  const capabilities = new Set<ChannelCapabilityKind>(FEISHU_CHANNEL_CAPABILITIES);
 
   const access: ChannelAccessOps = {
     load: loadDispatcherAccess,

--- a/packages/dreamux/src/channel/provider.ts
+++ b/packages/dreamux/src/channel/provider.ts
@@ -5,8 +5,9 @@
  * lifecycle, the channel-owned MCP surface contributed to the dispatcher
  * runtime, provider-specific access/trust semantics, and outbound capabilities
  * (reply, react) when it chooses to expose them. Dreamux core consumes the
- * capabilities a provider declares; it does not classify channels as one-way or
- * two-way, and it does not own channel access policy. See
+ * capabilities from the provider instance; the registry only validates refs.
+ * It does not classify channels as one-way or two-way, and it does not own
+ * channel access policy. See
  * `.agents/decisions/channel-provider.md`.
  *
  * Reply and react are deliberately optional: a dispatcher can reply only when
@@ -34,12 +35,7 @@ import type {
   FeishuInboundRoutes,
 } from '../feishu/bot.js';
 
-/**
- * Capability kinds a Channel provider can expose. These match the `kind` of the
- * capability descriptors declared on the registry's builtin channel providers
- * (`src/registry/builtins.ts`); the channel-provider test asserts they stay in
- * sync so the two declarations cannot drift.
- */
+/** Capability kinds a Channel provider can expose. */
 export const CHANNEL_CAPABILITY = {
   /** Contributes a channel-owned MCP server to the dispatcher runtime. */
   mcpServer: 'mcpServer',
@@ -125,7 +121,7 @@ export class ChannelCapabilityError extends Error {
 export interface ChannelProvider {
   /** Normalized provider ref, e.g. `builtin:feishu`. */
   readonly ref: string;
-  /** The capability registry descriptor for this provider. */
+  /** Registry descriptor for this provider ref. */
   readonly descriptor: ProviderDescriptor;
   /** Whether the provider declares a given capability. */
   hasCapability(kind: ChannelCapabilityKind): boolean;

--- a/packages/dreamux/src/registry/builtins.ts
+++ b/packages/dreamux/src/registry/builtins.ts
@@ -1,99 +1,27 @@
 /**
- * Phase-1 builtin provider descriptors for issue #110.
+ * Builtin provider descriptors for the provider registry.
  *
- * These register the bundled providers so that `builtin:feishu`,
- * `builtin:codex`, and `builtin:claude-code` resolve through the registry.
- *
- * Capabilities are declared as `CapabilityDescriptor[]` and are the single
- * source of truth for what each provider exposes; the provider implementations
- * read them back from these descriptors:
- *
- * - `builtin:feishu` (#110 PR4) declares its channel capabilities. The `kind`
- *   values match `CHANNEL_CAPABILITY` in `src/channel/provider.ts`, and
- *   `src/channel/feishu-provider.ts` reads them back; the channel-provider test
- *   asserts they stay in sync.
- * - `builtin:codex` (#110 PR5) declares its agent-runtime capabilities, read by
- *   `src/agent-runtime/codex.ts`.
- * - `builtin:claude-code` (#110 PR6) declares its agent-runtime capabilities,
- *   read by `src/agent-runtime/claude-code.ts`.
- *
- * The confirmed builtin set is recorded in
- * `.agents/decisions/provider-references-and-capability-registry.md` and
- * `.agents/decisions/agent-runtime-provider.md`.
+ * The registry validates refs and kind only. Capabilities are declared by the
+ * provider implementations that core actually invokes.
  */
 
 import { parseProviderRef } from './provider-ref.js';
 import {
-  CapabilityRegistry,
-  capabilityId,
-  type CapabilityDescriptor,
   type ProviderDescriptor,
   type ProviderKind,
+  ProviderRegistry,
 } from './registry.js';
 
 interface BuiltinSpec {
   id: string;
   kind: ProviderKind;
-  /** Capabilities this builtin exposes; ids are namespaced by provider id. */
-  capabilities?: readonly CapabilityDescriptor[];
 }
 
-/** The providers Dreamux ships and can run in phase 1. */
+/** The provider refs Dreamux ships and recognizes. */
 export const BUILTIN_PROVIDERS: readonly BuiltinSpec[] = [
-  {
-    id: 'feishu',
-    kind: 'channel',
-    capabilities: [
-      { id: capabilityId('feishu', 'mcpServer'), kind: 'mcpServer' },
-      { id: capabilityId('feishu', 'reply'), kind: 'reply' },
-      { id: capabilityId('feishu', 'react'), kind: 'react' },
-      { id: capabilityId('feishu', 'access'), kind: 'access' },
-    ],
-  },
-  {
-    id: 'codex',
-    kind: 'agentRuntime',
-    capabilities: [
-      { id: capabilityId('codex', 'lifecycle'), kind: 'agentRuntime.lifecycle' },
-      {
-        id: capabilityId('codex', 'mcpInjection'),
-        kind: 'agentRuntime.mcpInjection',
-      },
-      {
-        id: capabilityId('codex', 'inboundTurn'),
-        kind: 'agentRuntime.inboundTurn',
-      },
-      {
-        id: capabilityId('codex', 'teammateCompletion.codexInboxTurn'),
-        kind: 'agentRuntime.teammateCompletionDelivery',
-      },
-    ],
-  },
-  {
-    id: 'claude-code',
-    kind: 'agentRuntime',
-    capabilities: [
-      {
-        id: capabilityId('claude-code', 'lifecycle'),
-        kind: 'agentRuntime.lifecycle',
-      },
-      {
-        id: capabilityId('claude-code', 'mcpInjection'),
-        kind: 'agentRuntime.mcpInjection',
-      },
-      {
-        id: capabilityId('claude-code', 'inboundTurn'),
-        kind: 'agentRuntime.inboundTurn',
-      },
-      {
-        id: capabilityId(
-          'claude-code',
-          'teammateCompletion.claudeCodeTaskNotification',
-        ),
-        kind: 'agentRuntime.teammateCompletionDelivery',
-      },
-    ],
-  },
+  { id: 'feishu', kind: 'channel' },
+  { id: 'codex', kind: 'agentRuntime' },
+  { id: 'claude-code', kind: 'agentRuntime' },
 ];
 
 function builtinDescriptor(spec: BuiltinSpec): ProviderDescriptor {
@@ -101,18 +29,33 @@ function builtinDescriptor(spec: BuiltinSpec): ProviderDescriptor {
     id: spec.id,
     kind: spec.kind,
     ref: parseProviderRef(`builtin:${spec.id}`),
-    capabilities: [...(spec.capabilities ?? [])],
   };
 }
 
-/**
- * Build a registry pre-populated with the phase-1 builtin providers. This does
- * not wire into the server startup path; callers opt in explicitly.
- */
-export function createBuiltinRegistry(): CapabilityRegistry {
-  const registry = new CapabilityRegistry();
+function buildBuiltinProviderRegistry(): ProviderRegistry {
+  const registry = new ProviderRegistry();
   for (const spec of BUILTIN_PROVIDERS) {
     registry.register(builtinDescriptor(spec));
   }
   return registry;
+}
+
+/**
+ * Build a registry pre-populated with the builtin provider descriptors.
+ */
+export function createBuiltinProviderRegistry(): ProviderRegistry {
+  return buildBuiltinProviderRegistry();
+}
+
+let defaultProviderRegistry: ProviderRegistry | null = null;
+
+/**
+ * Shared builtin registry for config parsing paths that do not yet have a
+ * server-owned registry to inject.
+ */
+export function defaultBuiltinProviderRegistry(): ProviderRegistry {
+  if (defaultProviderRegistry === null) {
+    defaultProviderRegistry = buildBuiltinProviderRegistry();
+  }
+  return defaultProviderRegistry;
 }

--- a/packages/dreamux/src/registry/index.ts
+++ b/packages/dreamux/src/registry/index.ts
@@ -1,5 +1,5 @@
 /**
- * Capability Registry + provider references (issue #110 phase 1 skeleton).
+ * Provider registry + provider references.
  *
  * Process-local provider registration/lookup and the public provider-ref
  * grammar. Builtin providers run; external `npm:` refs are reserved syntax that

--- a/packages/dreamux/src/registry/registry.ts
+++ b/packages/dreamux/src/registry/registry.ts
@@ -1,17 +1,10 @@
 /**
- * Capability Registry skeleton for the issue #110 plugin/provider architecture.
+ * Provider registry for the issue #135 architecture realignment.
  *
- * The registry is process-local and server-owned. It records provider
- * descriptors and the capabilities they expose, and resolves provider refs to
- * descriptors, so core consumers read capabilities from one place instead of
- * constructing channel / runtime / MCP surfaces by hard-coded provider-specific
- * names. See
- * `.agents/decisions/provider-references-and-capability-registry.md`.
- *
- * Scope for this PR (issue #110 phase 1): typed registration + lookup only. It
- * does not take over the server startup path, does not build MCP surfaces, and
- * does not load, install, or execute external npm providers — external refs are
- * reserved syntax that resolve to a clear, typed error.
+ * The registry is process-local and server-owned. It validates provider refs and
+ * resolves them to provider descriptors; executable providers own their runtime
+ * capabilities directly. External `npm:` refs remain reserved until the
+ * agentRuntime loader is implemented.
  */
 
 import {
@@ -21,35 +14,14 @@ import {
 } from './provider-ref.js';
 
 /** Kinds of provider the registry can hold. */
-export type ProviderKind = 'channel' | 'agentRuntime' | 'service';
+export type ProviderKind = 'channel' | 'agentRuntime';
 
-/**
- * A capability a provider exposes. The skeleton records the descriptor metadata;
- * the executable surfaces (MCP servers, reply, runtime delivery hooks) are
- * attached by the per-provider PRs (#110 PR4/PR5/PR6+).
- */
-export interface CapabilityDescriptor {
-  /**
-   * Capability id, namespaced by provider id to avoid collisions, e.g.
-   * `feishu:reply`. Build with {@link capabilityId}.
-   */
-  id: string;
-  /** Provider-defined capability kind, e.g. `mcpServer`, `reply`, `runtimeDelivery`. */
-  kind: string;
-}
-
-/** A registered provider and the capabilities it declares. */
+/** A registered provider descriptor. Capabilities live on provider instances. */
 export interface ProviderDescriptor {
   /** Resolved provider id (the builtin id for builtin refs). */
   id: string;
   kind: ProviderKind;
   ref: ProviderRef;
-  capabilities: CapabilityDescriptor[];
-}
-
-/** Namespace a capability name under its provider id. */
-export function capabilityId(providerId: string, name: string): string {
-  return `${providerId}:${name}`;
 }
 
 /** Thrown when registering a provider id that is already registered. */
@@ -57,20 +29,6 @@ export class DuplicateProviderError extends Error {
   constructor(readonly id: string) {
     super(`provider ${JSON.stringify(id)} is already registered`);
     this.name = 'DuplicateProviderError';
-  }
-}
-
-/** Thrown when two capabilities within one provider share an id. */
-export class DuplicateCapabilityError extends Error {
-  constructor(
-    readonly providerId: string,
-    readonly capabilityId: string,
-  ) {
-    super(
-      `provider ${JSON.stringify(providerId)} declares capability ` +
-        `${JSON.stringify(capabilityId)} more than once`,
-    );
-    this.name = 'DuplicateCapabilityError';
   }
 }
 
@@ -98,27 +56,17 @@ export class ReservedExternalProviderError extends Error {
 
 /**
  * In-process registry of provider descriptors. Construct an empty one and
- * register providers, or use {@link createBuiltinRegistry} for the phase-1
- * builtins.
+ * register providers, or use `createBuiltinProviderRegistry` for the builtins.
  */
-export class CapabilityRegistry {
+export class ProviderRegistry {
   private readonly providers = new Map<string, ProviderDescriptor>();
 
   /**
-   * Register a provider. Throws {@link DuplicateProviderError} on a repeated id
-   * and {@link DuplicateCapabilityError} on a repeated capability id within the
-   * provider.
+   * Register a provider. Throws {@link DuplicateProviderError} on a repeated id.
    */
   register(descriptor: ProviderDescriptor): void {
     if (this.providers.has(descriptor.id)) {
       throw new DuplicateProviderError(descriptor.id);
-    }
-    const seen = new Set<string>();
-    for (const capability of descriptor.capabilities) {
-      if (seen.has(capability.id)) {
-        throw new DuplicateCapabilityError(descriptor.id, capability.id);
-      }
-      seen.add(capability.id);
     }
     this.providers.set(descriptor.id, descriptor);
   }

--- a/packages/dreamux/src/runtime/config.ts
+++ b/packages/dreamux/src/runtime/config.ts
@@ -14,9 +14,10 @@ import {
   InvalidProviderRefError,
   ReservedExternalProviderError,
   UnknownBuiltinProviderError,
-  createBuiltinRegistry,
+  defaultBuiltinProviderRegistry,
   formatProviderRef,
   type ProviderDescriptor,
+  type ProviderRegistry,
 } from '../registry/index.js';
 import { validateDispatcherId } from './dispatcher-id.js';
 
@@ -179,9 +180,32 @@ export const ALLOWED_SANDBOX_MODES = new Set([
 
 export const DEFAULT_CONFIG_JSON = `${JSON.stringify(BUILT_IN_DEFAULTS, null, 2)}\n`;
 
+type ChannelConfigReader = (
+  rawConfig: Record<string, unknown>,
+  file: string,
+  prefix: string,
+) => DispatcherProviderConfig | DispatcherFeishuConfig;
+
+type RuntimeConfigReader = (
+  rawConfig: Record<string, unknown>,
+  file: string,
+  prefix: string,
+) => DispatcherProviderConfig | DispatcherCodexConfig | DispatcherClaudeCodeConfig;
+
+const WIRED_CHANNEL_CONFIG_READERS = new Map<string, ChannelConfigReader>([
+  [BUILTIN_FEISHU_PROVIDER_REF, readDispatcherFeishuConfig],
+]);
+
+const WIRED_RUNTIME_CONFIG_READERS = new Map<string, RuntimeConfigReader>([
+  [BUILTIN_CODEX_PROVIDER_REF, readDispatcherCodexConfig],
+  [BUILTIN_CLAUDE_CODE_PROVIDER_REF, readDispatcherClaudeCodeConfig],
+]);
+
 export interface ConfigPathOverrides {
   /** Override the global config dir. Default: ~/.dreamux. */
   configDir?: string;
+  /** Provider registry used to validate config provider refs. */
+  providerRegistry?: ProviderRegistry;
 }
 
 export function globalConfigDir(overrides: ConfigPathOverrides = {}): string {
@@ -211,7 +235,7 @@ export async function loadOrInitConfig(
   await mkdir(dirname(file), { recursive: true });
 
   const createdOnThisBoot = await atomicWriteIfAbsent(file, DEFAULT_CONFIG_JSON);
-  const config = await readConfigFile(file);
+  const config = await readConfigFile(file, providerRegistryFor(overrides));
   return { config, configFile: file, createdOnThisBoot };
 }
 
@@ -220,7 +244,10 @@ export async function loadConfig(
 ): Promise<{ config: DreamuxConfig; configFile: string }> {
   const file = globalConfigFile(overrides);
   await assertNoLegacyTomlOnly(overrides);
-  return { config: await readConfigFile(file), configFile: file };
+  return {
+    config: await readConfigFile(file, providerRegistryFor(overrides)),
+    configFile: file,
+  };
 }
 
 export function stringifyConfig(config: DreamuxConfig): string {
@@ -242,7 +269,10 @@ export function redactConfigForDisplay(raw: string, file: string): string {
   return `${JSON.stringify(parsed, null, 2)}\n`;
 }
 
-async function readConfigFile(file: string): Promise<DreamuxConfig> {
+async function readConfigFile(
+  file: string,
+  providerRegistry: ProviderRegistry,
+): Promise<DreamuxConfig> {
   if (!(await pathExists(file))) {
     throw new Error(
       `dreamux config is missing at ${file}.\n` +
@@ -261,7 +291,7 @@ async function readConfigFile(file: string): Promise<DreamuxConfig> {
         `Fix the JSON syntax in ${file}, then restart. Run \`dreamux onboard\` if you need to recreate the config.`,
     );
   }
-  return mergeWithDefaults(parsed, file);
+  return mergeWithDefaults(parsed, file, providerRegistry);
 }
 
 export async function assertNoLegacyTomlOnly(
@@ -307,7 +337,15 @@ export async function assertConfigFileMode(file: string): Promise<void> {
   );
 }
 
-function mergeWithDefaults(raw: unknown, file: string): DreamuxConfig {
+function providerRegistryFor(overrides: ConfigPathOverrides): ProviderRegistry {
+  return overrides.providerRegistry ?? defaultBuiltinProviderRegistry();
+}
+
+function mergeWithDefaults(
+  raw: unknown,
+  file: string,
+  providerRegistry: ProviderRegistry,
+): DreamuxConfig {
   if (!isPlainObject(raw)) {
     throw new Error(`dreamux config error in ${file}: top-level must be an object`);
   }
@@ -315,7 +353,7 @@ function mergeWithDefaults(raw: unknown, file: string): DreamuxConfig {
   rejectUnknownKeys(raw, new Set(['dispatchers']), file, '');
 
   return {
-    dispatchers: readDispatchers(raw['dispatchers'], file),
+    dispatchers: readDispatchers(raw['dispatchers'], file, providerRegistry),
   };
 }
 
@@ -337,7 +375,11 @@ function rejectTopLevelCodex(raw: Record<string, unknown>, file: string): void {
   );
 }
 
-function readDispatchers(rawDispatchers: unknown, file: string): DispatcherConfig[] {
+function readDispatchers(
+  rawDispatchers: unknown,
+  file: string,
+  providerRegistry: ProviderRegistry,
+): DispatcherConfig[] {
   if (rawDispatchers === undefined) return [];
   if (!Array.isArray(rawDispatchers)) {
     throw new Error(
@@ -372,7 +414,12 @@ function readDispatchers(rawDispatchers: unknown, file: string): DispatcherConfi
     }
     ids.add(id);
 
-    const channels = readDispatcherChannels(raw['channels'], file, prefix);
+    const channels = readDispatcherChannels(
+      raw['channels'],
+      file,
+      prefix,
+      providerRegistry,
+    );
     const feishu = feishuConfigFromChannels(channels, id);
     const app_id = feishu.app_id;
     const existing = appIdToDispatcher.get(app_id);
@@ -389,7 +436,7 @@ function readDispatchers(rawDispatchers: unknown, file: string): DispatcherConfi
       cwd: cwd === null ? null : expandHome(cwd),
       enabled: readOptionalBoolean(raw, 'enabled', true, file, prefix),
       channels,
-      runtime: readDispatcherRuntime(raw['runtime'], file, prefix),
+      runtime: readDispatcherRuntime(raw['runtime'], file, prefix, providerRegistry),
     });
   }
   return out;
@@ -399,6 +446,7 @@ function readDispatcherChannels(
   rawChannels: unknown,
   file: string,
   dispatcherPrefix: string,
+  providerRegistry: ProviderRegistry,
 ): DispatcherChannelConfig[] {
   const prefix = `${dispatcherPrefix}channels`;
   if (!Array.isArray(rawChannels)) {
@@ -427,20 +475,21 @@ function readDispatcherChannels(
     'channel',
     file,
     channelPrefix,
+    providerRegistry,
   );
-  if (provider.ref !== BUILTIN_FEISHU_PROVIDER_REF) {
+  const readChannelConfig = WIRED_CHANNEL_CONFIG_READERS.get(provider.ref);
+  if (readChannelConfig === undefined) {
     throw new Error(
       `dreamux config error in ${file}: ${channelPrefix}provider='${provider.ref}' is registered but not runnable in this phase.\n` +
         'Only channel provider "builtin:feishu" is wired in Phase 1.',
     );
   }
   const config = readProviderConfigObject(raw['config'], file, `${channelPrefix}config`);
-  const feishu = readDispatcherFeishuConfig(config, file, `${channelPrefix}config.`);
   return [
     {
       id,
       provider: provider.ref,
-      config: feishu,
+      config: readChannelConfig(config, file, `${channelPrefix}config.`),
     },
   ];
 }
@@ -464,6 +513,7 @@ function readDispatcherRuntime(
   rawRuntime: unknown,
   file: string,
   dispatcherPrefix: string,
+  providerRegistry: ProviderRegistry,
 ): DispatcherRuntimeConfig {
   const prefix = `${dispatcherPrefix}runtime.`;
   if (!isPlainObject(rawRuntime)) {
@@ -478,20 +528,16 @@ function readDispatcherRuntime(
     'agentRuntime',
     file,
     prefix,
+    providerRegistry,
   );
   const config = readProviderConfigObject(rawRuntime['config'], file, `${prefix}config`, {
     allowMissing: true,
   });
-  if (provider.ref === BUILTIN_CODEX_PROVIDER_REF) {
+  const readRuntimeConfig = WIRED_RUNTIME_CONFIG_READERS.get(provider.ref);
+  if (readRuntimeConfig !== undefined) {
     return {
       provider: provider.ref,
-      config: readDispatcherCodexConfig(config, file, `${prefix}config.`),
-    };
-  }
-  if (provider.ref === BUILTIN_CLAUDE_CODE_PROVIDER_REF) {
-    return {
-      provider: provider.ref,
-      config: readDispatcherClaudeCodeConfig(config, file, `${prefix}config.`),
+      config: readRuntimeConfig(config, file, `${prefix}config.`),
     };
   }
   // A registered agentRuntime builtin with no config parser wired yet. Fail
@@ -712,10 +758,10 @@ function resolveConfigProvider(
   expectedKind: ProviderDescriptor['kind'],
   file: string,
   prefix: string,
+  providerRegistry: ProviderRegistry,
 ): { ref: string; descriptor: ProviderDescriptor } {
-  const registry = createBuiltinRegistry();
   try {
-    const descriptor = registry.resolve(rawProvider);
+    const descriptor = providerRegistry.resolve(rawProvider);
     if (descriptor.kind !== expectedKind) {
       throw new Error(
         `dreamux config error in ${file}: ${prefix}provider='${rawProvider}' is a ${descriptor.kind} provider, expected ${expectedKind}`,

--- a/packages/dreamux/src/server.ts
+++ b/packages/dreamux/src/server.ts
@@ -31,6 +31,10 @@ import {
 } from './channel/provider.js';
 import { resolveChannelProvider } from './channel/channel-providers.js';
 import {
+  createBuiltinProviderRegistry,
+  type ProviderRegistry,
+} from './registry/index.js';
+import {
   detectIntroduce,
   introduceAckText,
   introduceDenyReason,
@@ -155,6 +159,8 @@ export interface ServerOptions {
    * capability-gated outbound paths.
    */
   channelProviderResolver?: (ref: string) => ChannelProvider;
+  /** Provider registry used by runtime/channel composition. */
+  providerRegistry?: ProviderRegistry;
   /** Codex binary path override (tests, highest precedence). */
   codexBinPath?: string;
   /** Inject a CodexProcess factory (tests). */
@@ -542,6 +548,7 @@ export class Server {
   private readonly log: DreamuxLogger;
   private readonly channelLoggerFactory: (dispatcherId: string) => DreamuxLogger;
   private readonly channelProviderResolver: (ref: string) => ChannelProvider;
+  private readonly providerRegistry: ProviderRegistry;
   private readonly agentRuntimeProviders: AgentRuntimeProviderCatalog;
   private readonly teamMateDelivery: TeamMateDeliveryService;
   private readonly teamMateWorkers: TeamMateWorkerProviderCatalog;
@@ -550,8 +557,11 @@ export class Server {
 
   constructor(opts: ServerOptions = {}) {
     this.opts = opts;
+    this.providerRegistry =
+      opts.providerRegistry ?? createBuiltinProviderRegistry();
     this.channelProviderResolver =
-      opts.channelProviderResolver ?? resolveChannelProvider;
+      opts.channelProviderResolver ??
+      ((ref) => resolveChannelProvider(ref, { registry: this.providerRegistry }));
     // Install the config snapshot before any paths.* / runtime.* lookup
     // happens. paths.stateRoot / adminSocketPath / etc. consult this
     // snapshot for non-env defaults (env vars still win).
@@ -584,6 +594,7 @@ export class Server {
     this.agentRuntimeProviders =
       opts.agentRuntimeProviderCatalog ??
       createBuiltinAgentRuntimeProviderCatalog({
+        registry: this.providerRegistry,
         codex: codexProviderOptions,
       });
     this.teamMateDelivery = new TeamMateDeliveryService({
@@ -853,7 +864,7 @@ export class Server {
     // Resolve the dispatcher's channel provider (issue #110 PR4). The server no
     // longer constructs the Feishu MCP surface / bot / gate by hard-coded name;
     // it consumes the capabilities the provider exposes. The ref is validated
-    // through the capability registry, so a reserved/unknown ref fails loudly.
+    // through the provider registry, so a reserved/unknown ref fails loudly.
     const channelRef =
       dispatcherConfig?.channels[0]?.provider ?? BUILTIN_FEISHU_PROVIDER_REF;
     const channelProvider = this.channelProviderResolver(channelRef);

--- a/packages/dreamux/src/teammate/worker/catalog.ts
+++ b/packages/dreamux/src/teammate/worker/catalog.ts
@@ -9,7 +9,7 @@ export interface TeamMateWorkerProviderCatalogOptions {
 /**
  * Lightweight registry of TeamMate worker providers, keyed by ref (issue #126
  * PR2). Deliberately NOT the agent-runtime catalog: that one validates refs
- * against the builtin capability registry and rejects unknown/reserved refs,
+ * against the builtin provider registry and rejects unknown/reserved refs,
  * which would fight an injected test/fake worker. Worker providers are wired by
  * the server (empty in production for the MVP — no real worker yet) or injected
  * by tests. Resolution never throws; an unknown ref maps to `null`, which the

--- a/packages/dreamux/tests/agent-runtime-provider.test.ts
+++ b/packages/dreamux/tests/agent-runtime-provider.test.ts
@@ -8,13 +8,14 @@ import {
 } from '../src/agent-runtime/index.js';
 import {
   UnknownBuiltinProviderError,
-  createBuiltinRegistry,
+  createBuiltinProviderRegistry,
 } from '../src/registry/index.js';
 import { DispatcherStore } from '../src/runtime/dispatcher-store.js';
 import { testDispatcherConfig, testDreamuxConfig } from './helpers/config.js';
 
 function builtinCatalog(): AgentRuntimeProviderCatalog {
   return createBuiltinAgentRuntimeProviderCatalog({
+    registry: createBuiltinProviderRegistry(),
     codex: { resolveBinPath: (bin) => bin },
   });
 }
@@ -84,8 +85,9 @@ describe('AgentRuntimeProviderCatalog', () => {
   });
 
   it('supports registry injection for future provider composition tests', () => {
+    const registry = createBuiltinProviderRegistry();
     const catalog = new AgentRuntimeProviderCatalog({
-      registry: createBuiltinRegistry(),
+      registry,
       providers: [builtinCatalog().resolve('builtin:codex')],
     });
 

--- a/packages/dreamux/tests/channel-provider.test.ts
+++ b/packages/dreamux/tests/channel-provider.test.ts
@@ -18,79 +18,75 @@ import {
   saveDispatcherAccess,
 } from '../src/channel/feishu-gate.js';
 import {
+  createBuiltinProviderRegistry,
   InvalidProviderRefError,
   ReservedExternalProviderError,
   UnknownBuiltinProviderError,
 } from '../src/registry/index.js';
 import { createFakeFeishuBot } from '../src/feishu/bot.js';
 
+function resolveBuiltinChannelProvider(ref: string) {
+  return resolveChannelProvider(ref, {
+    registry: createBuiltinProviderRegistry(),
+  });
+}
+
+function feishuProvider(): ChannelProvider {
+  const registry = createBuiltinProviderRegistry();
+  return builtinFeishuChannelProvider(registry.resolve('builtin:feishu'));
+}
+
 describe('resolveChannelProvider', () => {
   it('resolves the builtin:feishu channel provider', () => {
-    const provider = resolveChannelProvider('builtin:feishu');
+    const provider = resolveBuiltinChannelProvider('builtin:feishu');
     expect(provider.ref).toBe('builtin:feishu');
     expect(provider.descriptor.kind).toBe('channel');
     expect(provider.descriptor.id).toBe('feishu');
   });
 
   it('rejects an agentRuntime ref as a non-channel provider', () => {
-    expect(() => resolveChannelProvider('builtin:codex')).toThrow(
+    expect(() => resolveBuiltinChannelProvider('builtin:codex')).toThrow(
       UnsupportedChannelProviderError,
     );
-    expect(() => resolveChannelProvider('builtin:claude-code')).toThrow(
+    expect(() => resolveBuiltinChannelProvider('builtin:claude-code')).toThrow(
       UnsupportedChannelProviderError,
     );
   });
 
   it('refuses to load a reserved external npm ref', () => {
-    expect(() => resolveChannelProvider('npm:@example/dreamux-channel')).toThrow(
-      ReservedExternalProviderError,
-    );
     expect(() =>
-      resolveChannelProvider('npm:@example/dreamux-channel#provider'),
+      resolveBuiltinChannelProvider('npm:@example/dreamux-channel'),
+    ).toThrow(ReservedExternalProviderError);
+    expect(() =>
+      resolveBuiltinChannelProvider('npm:@example/dreamux-channel#provider'),
     ).toThrow(ReservedExternalProviderError);
   });
 
   it('rejects an unknown builtin ref', () => {
-    expect(() => resolveChannelProvider('builtin:matrix')).toThrow(
+    expect(() => resolveBuiltinChannelProvider('builtin:matrix')).toThrow(
       UnknownBuiltinProviderError,
     );
   });
 
   it('surfaces a malformed ref through the parser', () => {
-    expect(() => resolveChannelProvider('not-a-ref')).toThrow(
+    expect(() => resolveBuiltinChannelProvider('not-a-ref')).toThrow(
       InvalidProviderRefError,
     );
   });
 });
 
 describe('builtin:feishu capability declaration', () => {
-  it('declares exactly the phase-1 channel capabilities, and they stay in sync', () => {
-    const provider = builtinFeishuChannelProvider();
-    const declared = provider.descriptor.capabilities.map((c) => c.kind).sort();
-    const expected = Object.values(CHANNEL_CAPABILITY).sort();
-    // Drift guard: the registry catalog and the CHANNEL_CAPABILITY enum core
-    // queries against must declare the same capability kinds for builtin:feishu.
-    expect(declared).toEqual(expected);
-  });
-
   it('reports each declared capability through hasCapability', () => {
-    const provider = builtinFeishuChannelProvider();
+    const provider = feishuProvider();
     for (const kind of Object.values(CHANNEL_CAPABILITY)) {
       expect(provider.hasCapability(kind)).toBe(true);
     }
-  });
-
-  it('namespaces capability ids under the provider id', () => {
-    const provider = builtinFeishuChannelProvider();
-    const ids = provider.descriptor.capabilities.map((c) => c.id);
-    expect(ids).toContain('feishu:reply');
-    expect(ids).toContain('feishu:mcpServer');
   });
 });
 
 describe('builtin:feishu owns its MCP / access / reply / react surfaces', () => {
   it('contributes runtime-neutral MCP server descriptors (not runtime CLI args)', () => {
-    const provider = builtinFeishuChannelProvider();
+    const provider = feishuProvider();
     const context = { dispatcherId: 'flow', adminSocketPath: '/tmp/admin.sock' };
     expect(provider.mcpServerDescriptors(context)).toEqual([
       feishuMcpServerDescriptor(context),
@@ -98,7 +94,7 @@ describe('builtin:feishu owns its MCP / access / reply / react surfaces', () => 
   });
 
   it('delegates access load/save/gate to the Feishu access module', () => {
-    const provider = builtinFeishuChannelProvider();
+    const provider = feishuProvider();
     // The provider owns access semantics by delegating to the Feishu gate; core
     // no longer imports these directly.
     expect(provider.access.load).toBe(loadDispatcherAccess);
@@ -107,7 +103,7 @@ describe('builtin:feishu owns its MCP / access / reply / react surfaces', () => 
   });
 
   it('gates a direct message from an un-allowed sender as drop', () => {
-    const provider = builtinFeishuChannelProvider();
+    const provider = feishuProvider();
     const result = provider.access.gate(
       { senderId: 'stranger', chatId: 'chat-dm', chatType: 'p2p' },
       defaultDispatcherAccessState(),
@@ -116,7 +112,7 @@ describe('builtin:feishu owns its MCP / access / reply / react surfaces', () => 
   });
 
   it('translates a channel-neutral reply into the transport target', async () => {
-    const provider = builtinFeishuChannelProvider();
+    const provider = feishuProvider();
     const bot = createFakeFeishuBot('app-test');
     const result = await provider.reply?.(bot, {
       chatId: 'chat-1',
@@ -135,7 +131,7 @@ describe('builtin:feishu owns its MCP / access / reply / react surfaces', () => 
   });
 
   it('adds a reaction through the connection', async () => {
-    const provider = builtinFeishuChannelProvider();
+    const provider = feishuProvider();
     const bot = createFakeFeishuBot('app-test');
     const result = await provider.react?.(bot, {
       messageId: 'msg-1',
@@ -156,7 +152,6 @@ describe('ChannelProvider permits inbound-only channels (reply is not core-manda
         id: 'inbound-only',
         kind: 'channel',
         ref: { source: 'builtin', id: 'inbound-only', raw: 'builtin:inbound-only' },
-        capabilities: [{ id: 'inbound-only:mcpServer', kind: 'mcpServer' }],
       },
       hasCapability: (kind) => kind === CHANNEL_CAPABILITY.mcpServer,
       mcpServerDescriptors: () => [],

--- a/packages/dreamux/tests/claude-code-live.test.ts
+++ b/packages/dreamux/tests/claude-code-live.test.ts
@@ -19,8 +19,12 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { promisify } from 'node:util';
 
-import { createClaudeCodeAgentRuntimeProvider } from '../src/agent-runtime/claude-code.js';
+import {
+  createClaudeCodeAgentRuntimeProvider,
+  type ClaudeCodeAgentRuntimeProviderOptions,
+} from '../src/agent-runtime/claude-code.js';
 import { createClaudeCodeTeamMateWorkerProvider } from '../src/teammate/worker/claude-code-provider.js';
+import { createBuiltinProviderRegistry } from '../src/registry/index.js';
 import { DispatcherStore } from '../src/runtime/dispatcher-store.js';
 import type {
   TeamMateWorkerHandle,
@@ -30,6 +34,16 @@ import { testDispatcherConfig, testDreamuxConfig } from './helpers/config.js';
 const execFileAsync = promisify(execFile);
 
 export const RUN_ENV = 'DREAMUX_RUN_LIVE_CLAUDE_CODE';
+
+function claudeCodeProvider(
+  options: Omit<ClaudeCodeAgentRuntimeProviderOptions, 'descriptor'> = {},
+) {
+  const registry = createBuiltinProviderRegistry();
+  return createClaudeCodeAgentRuntimeProvider({
+    ...options,
+    descriptor: registry.resolve('builtin:claude-code'),
+  });
+}
 
 async function claudeOnPath(): Promise<boolean> {
   try {
@@ -99,7 +113,7 @@ describe('claude-code live integration (opt-in)', () => {
     const row = store.get('live');
     expect(row).not.toBeNull();
 
-    const runtime = createClaudeCodeAgentRuntimeProvider().createRuntime({
+    const runtime = claudeCodeProvider().createRuntime({
       row: row!,
       dispatcher,
       dispatchers: store,

--- a/packages/dreamux/tests/claude-code-runtime.test.ts
+++ b/packages/dreamux/tests/claude-code-runtime.test.ts
@@ -6,7 +6,10 @@ import { join } from 'node:path';
 import { dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
-import { createClaudeCodeAgentRuntimeProvider } from '../src/agent-runtime/claude-code.js';
+import {
+  createClaudeCodeAgentRuntimeProvider,
+  type ClaudeCodeAgentRuntimeProviderOptions,
+} from '../src/agent-runtime/claude-code.js';
 import {
   createDefaultClaudeCodeSession,
   type ClaudeCodeSession,
@@ -22,6 +25,7 @@ import { codexMcpServerArgs } from '../src/codex/mcp-config.js';
 import { DispatcherStore } from '../src/runtime/dispatcher-store.js';
 import { dispatcherClaudeCodeMcpConfigPath } from '../src/runtime/paths.js';
 import { defaultDispatcherClaudeCodeConfig } from '../src/runtime/config.js';
+import { createBuiltinProviderRegistry } from '../src/registry/index.js';
 import { testDispatcherConfig, testDreamuxConfig } from './helpers/config.js';
 import type {
   AgentRuntime,
@@ -33,6 +37,16 @@ const FEISHU_MCP: AgentRuntimeMcpServer = {
   command: '/pkg/bin/dreamux',
   args: ['feishu-mcp', '--dispatcher', 'flow', '--admin-socket', '/tmp/a.sock'],
 };
+
+function claudeCodeProvider(
+  options: Omit<ClaudeCodeAgentRuntimeProviderOptions, 'descriptor'> = {},
+) {
+  const registry = createBuiltinProviderRegistry();
+  return createClaudeCodeAgentRuntimeProvider({
+    ...options,
+    descriptor: registry.resolve('builtin:claude-code'),
+  });
+}
 
 function claudeDispatcher(id = 'flow') {
   return testDispatcherConfig({
@@ -190,7 +204,7 @@ describe('claude-code pure translation (not Codex renamed)', () => {
 
 describe('builtin:claude-code provider', () => {
   it('exposes the claude-code ref and task-notification delivery shape', () => {
-    const provider = createClaudeCodeAgentRuntimeProvider({ sessionFactory: fakeFleet().factory });
+    const provider = claudeCodeProvider({ sessionFactory: fakeFleet().factory });
     expect(provider.ref).toBe('builtin:claude-code');
     expect(provider.descriptor.kind).toBe('agentRuntime');
     expect(provider.delivery.teammateCompletion.map((s) => s.kind)).toEqual([
@@ -226,7 +240,7 @@ describe('ClaudeCodeRuntime resident lifecycle (fake session)', () => {
     }
     const row = store.get('flow');
     expect(row).not.toBeNull();
-    const runtime = createClaudeCodeAgentRuntimeProvider({
+    const runtime = claudeCodeProvider({
       sessionFactory: fleet.factory,
     }).createRuntime({
       row: row!,
@@ -494,7 +508,7 @@ describe('ClaudeCodeRuntime resident lifecycle (fake session)', () => {
     const dispatcher = claudeDispatcher('flow');
     const store = new DispatcherStore(testDreamuxConfig([dispatcher]));
     const row = store.get('flow');
-    const runtime = createClaudeCodeAgentRuntimeProvider({
+    const runtime = claudeCodeProvider({
       sessionFactory: stallFactory,
     }).createRuntime({
       row: row!,

--- a/packages/dreamux/tests/e2e.test.ts
+++ b/packages/dreamux/tests/e2e.test.ts
@@ -37,6 +37,7 @@ import {
 } from '../src/feishu/bot.js';
 import { runFeishuMcp } from '../src/mcp/feishu-mcp.js';
 import { BUILT_IN_DEFAULTS, type DreamuxConfig } from '../src/runtime/config.js';
+import { createBuiltinProviderRegistry } from '../src/registry/index.js';
 import {
   dispatcherCodexCwd,
   dispatcherCodexHome,
@@ -148,7 +149,8 @@ function buildServer(opts: {
  * gates inbound, but core must refuse model-driven outbound through it.
  */
 function inboundOnlyChannelProvider(): ChannelProvider {
-  const base = builtinFeishuChannelProvider();
+  const registry = createBuiltinProviderRegistry();
+  const base = builtinFeishuChannelProvider(registry.resolve('builtin:feishu'));
   return {
     ref: base.ref,
     descriptor: base.descriptor,

--- a/packages/dreamux/tests/global-config.test.ts
+++ b/packages/dreamux/tests/global-config.test.ts
@@ -34,6 +34,10 @@ import {
   stateRoot,
 } from '../src/runtime/paths.js';
 import { codexArgsToCli, parseCodexArgs } from '../src/runtime/codex-args.js';
+import {
+  createBuiltinProviderRegistry,
+  parseProviderRef,
+} from '../src/registry/index.js';
 import { testDispatcherConfig } from './helpers/config.js';
 
 function writeConfigObjectAt(configDir: string, value: unknown): void {
@@ -439,6 +443,30 @@ describe('global config (~/.dreamux/config.json)', () => {
 
     await expect(loadConfig({ configDir })).rejects.toThrow(
       /is a agentRuntime provider, expected channel/,
+    );
+  });
+
+  it('validates config provider refs through the injected provider registry', async () => {
+    const registry = createBuiltinProviderRegistry();
+    registry.register({
+      id: 'custom-runtime',
+      kind: 'agentRuntime',
+      ref: parseProviderRef('builtin:custom-runtime'),
+    });
+    writeConfigObject({
+      dispatchers: [
+        testDispatcherConfig({
+          id: 'flow',
+          runtime: { provider: 'builtin:custom-runtime', config: {} },
+        }),
+      ],
+    });
+
+    await expect(loadConfig({ configDir, providerRegistry: registry })).rejects.toThrow(
+      /registered but not runnable in this phase/,
+    );
+    await expect(loadConfig({ configDir })).rejects.toThrow(
+      /unknown builtin provider 'custom-runtime'/,
     );
   });
 

--- a/packages/dreamux/tests/registry.test.ts
+++ b/packages/dreamux/tests/registry.test.ts
@@ -2,80 +2,67 @@ import { describe, expect, it } from 'vitest';
 
 import {
   BUILTIN_PROVIDERS,
-  CapabilityRegistry,
-  DuplicateCapabilityError,
   DuplicateProviderError,
+  ProviderRegistry,
   ReservedExternalProviderError,
   UnknownBuiltinProviderError,
-  capabilityId,
-  createBuiltinRegistry,
+  createBuiltinProviderRegistry,
   type ProviderDescriptor,
 } from '../src/registry/index.js';
 import { InvalidProviderRefError, parseProviderRef } from '../src/registry/provider-ref.js';
 
-function descriptor(id: string, kind: ProviderDescriptor['kind'] = 'channel'): ProviderDescriptor {
-  return { id, kind, ref: parseProviderRef(`builtin:${id}`), capabilities: [] };
+function descriptor(
+  id: string,
+  kind: ProviderDescriptor['kind'] = 'channel',
+): ProviderDescriptor {
+  return { id, kind, ref: parseProviderRef(`builtin:${id}`) };
 }
 
-describe('CapabilityRegistry — registration', () => {
+describe('ProviderRegistry — registration', () => {
   it('registers and looks up a provider', () => {
-    const registry = new CapabilityRegistry();
+    const registry = new ProviderRegistry();
     registry.register(descriptor('feishu'));
     expect(registry.has('feishu')).toBe(true);
     expect(registry.get('feishu')?.kind).toBe('channel');
   });
 
   it('rejects a duplicate provider id', () => {
-    const registry = new CapabilityRegistry();
+    const registry = new ProviderRegistry();
     registry.register(descriptor('feishu'));
-    expect(() => registry.register(descriptor('feishu'))).toThrow(DuplicateProviderError);
-  });
-
-  it('rejects duplicate capability ids within a provider', () => {
-    const registry = new CapabilityRegistry();
-    const dup: ProviderDescriptor = {
-      id: 'feishu',
-      kind: 'channel',
-      ref: parseProviderRef('builtin:feishu'),
-      capabilities: [
-        { id: capabilityId('feishu', 'reply'), kind: 'reply' },
-        { id: capabilityId('feishu', 'reply'), kind: 'reply' },
-      ],
-    };
-    expect(() => registry.register(dup)).toThrow(DuplicateCapabilityError);
+    expect(() => registry.register(descriptor('feishu'))).toThrow(
+      DuplicateProviderError,
+    );
   });
 
   it('lists providers by kind', () => {
-    const registry = new CapabilityRegistry();
+    const registry = new ProviderRegistry();
     registry.register(descriptor('feishu', 'channel'));
     registry.register(descriptor('codex', 'agentRuntime'));
-    expect(registry.listByKind('agentRuntime').map((d) => d.id)).toEqual(['codex']);
+    expect(registry.listByKind('agentRuntime').map((d) => d.id)).toEqual([
+      'codex',
+    ]);
     expect(registry.list()).toHaveLength(2);
   });
 });
 
-describe('capabilityId', () => {
-  it('namespaces a capability under its provider', () => {
-    expect(capabilityId('feishu', 'mcpServer')).toBe('feishu:mcpServer');
-  });
-});
-
-describe('CapabilityRegistry — resolve', () => {
+describe('ProviderRegistry — resolve', () => {
   it('resolves a registered builtin ref (string or object)', () => {
-    const registry = createBuiltinRegistry();
+    const registry = createBuiltinProviderRegistry();
     expect(registry.resolve('builtin:feishu').id).toBe('feishu');
-    expect(registry.resolve(parseProviderRef('builtin:codex')).kind).toBe('agentRuntime');
+    expect(registry.resolve(parseProviderRef('builtin:codex')).kind).toBe(
+      'agentRuntime',
+    );
   });
 
   it('throws on an unknown builtin', () => {
-    const registry = createBuiltinRegistry();
+    const registry = createBuiltinProviderRegistry();
     expect(() => registry.resolve('builtin:does-not-exist')).toThrow(
       UnknownBuiltinProviderError,
     );
   });
 
   it('refuses to resolve a reserved external npm ref', () => {
-    const registry = createBuiltinRegistry();
+    const registry = createBuiltinProviderRegistry();
     expect(() => registry.resolve('npm:@example/dreamux-provider')).toThrow(
       ReservedExternalProviderError,
     );
@@ -85,14 +72,14 @@ describe('CapabilityRegistry — resolve', () => {
   });
 
   it('surfaces malformed refs through the parser', () => {
-    const registry = createBuiltinRegistry();
+    const registry = createBuiltinProviderRegistry();
     expect(() => registry.resolve('not-a-ref')).toThrow(InvalidProviderRefError);
   });
 });
 
-describe('createBuiltinRegistry', () => {
-  it('registers exactly the confirmed phase-1 builtins', () => {
-    const registry = createBuiltinRegistry();
+describe('createBuiltinProviderRegistry', () => {
+  it('registers exactly the confirmed builtins', () => {
+    const registry = createBuiltinProviderRegistry();
     const ids = registry.list().map((d) => d.id).sort();
     expect(ids).toEqual(['claude-code', 'codex', 'feishu']);
     for (const spec of BUILTIN_PROVIDERS) {
@@ -100,23 +87,18 @@ describe('createBuiltinRegistry', () => {
     }
   });
 
-  it('declares the Codex runtime capabilities wired by the provider PR', () => {
-    const registry = createBuiltinRegistry();
-    const capabilities = registry
-      .resolve('builtin:codex')
-      .capabilities.map((capability) => capability.id)
-      .sort();
-
-    expect(capabilities).toEqual([
-      'codex:inboundTurn',
-      'codex:lifecycle',
-      'codex:mcpInjection',
-      'codex:teammateCompletion.codexInboxTurn',
-    ]);
+  it('does not duplicate provider capabilities', () => {
+    const registry = createBuiltinProviderRegistry();
+    expect(registry.resolve('builtin:codex')).not.toHaveProperty(
+      'capabilities',
+    );
+    expect(registry.resolve('builtin:feishu')).not.toHaveProperty(
+      'capabilities',
+    );
   });
 
   it('does not execute or expose external providers', () => {
-    const registry = createBuiltinRegistry();
+    const registry = createBuiltinProviderRegistry();
     // Reserved external refs never become registered providers.
     expect(registry.has('@example/dreamux-provider')).toBe(false);
   });


### PR DESCRIPTION
## 背景

Refs #135。

本 PR 是 provider architecture realignment 的 PR A：先把旧的 capability mirror registry 收口成进程内 provider-ref registry，只负责解析 / 校验 provider ref 与 provider kind，不再复制 provider capability。

## 删除 / 替换旧路径

- 删除 `packages/dreamux/src/registry/registry.ts` 中的 `CapabilityRegistry`、`CapabilityDescriptor`、`DuplicateCapabilityError`、`capabilityId` 旧 capability mirror 路径；替换为 `ProviderRegistry`，只保留 provider descriptor 注册、查询与 `builtin:` / `npm:` ref resolve。
- 删除 `packages/dreamux/src/registry/builtins.ts` 中 builtin provider 的 capability 列表；Feishu channel capability 改由 `packages/dreamux/src/channel/feishu-provider.ts` 的 provider 实例声明，agent runtime 的 delivery capability 继续由各 runtime provider 实例声明。
- 替换 `packages/dreamux/src/agent-runtime/codex.ts`、`packages/dreamux/src/agent-runtime/claude-code.ts`、`packages/dreamux/src/channel/feishu-provider.ts` 内部自行创建 builtin registry 并 resolve descriptor 的旧路径；descriptor 改为由 Server / catalog / resolver 从同一个 provider registry resolve 后注入。
- 替换 `packages/dreamux/src/channel/channel-providers.ts` 的隐式 builtin registry 创建路径；channel resolver 现在必须接收 registry，并以 registry resolve 结果驱动 runnable factory。
- 替换 `packages/dreamux/src/runtime/config.ts` 中 provider ref 合法性依赖硬编码 `BUILTIN_*_REF` 等值判断的旧路径；config provider validation 先走注入的 registry resolve，再进入 Phase 1 wired-parser 检查。
- `packages/dreamux/src/server.ts` 开始持有 server-owned provider registry，并把同一实例注入 channel resolver 与 agent runtime catalog，避免 channel / runtime 两边各建一份 registry。

## Must-fix Gate

- 接口分层：本 PR 不修改 `AgentRuntime` 实例接口，没有把 `spawn` / `close` / `list` 塞进 runtime；这些仍留给后续 Dispatcher Service 编排层处理。
- no-sync-IO：本 PR 没有新增 `src/**` 同步 IO；`rush lint` 已通过 no-sync gate。
- PR D 统一创建路径：本 PR 不改 teammate session / history / resume 行为，不引入新的 teammate 创建路径。
- 不新增第三套 provider / catalog：本 PR 没有新增 runtime catalog，也没有新增 provider tree；只把旧 capability registry 改成单一 provider registry。
- config validation：已新增测试覆盖注入 registry 的 provider ref 校验，证明合法性来自 registry resolve，而不是硬编码 builtin ref 列表。

## 验证

- `node common/scripts/install-run-rush.js build`
- `node common/scripts/install-run-rush.js lint`
- `node common/scripts/install-run-rush.js test`（使用短临时目录环境运行，避免本机默认临时目录触发既有 Unix socket 长度限制）
- `node common/scripts/install-run-rush.js change --verify --target-branch origin/next --no-fetch`
- committed diff 泄漏 grep：无命中
