### PR TITLE
统一 AgentRuntime contract

### DIFF
--- a/.agents/decisions/provider-architecture-realignment.md
+++ b/.agents/decisions/provider-architecture-realignment.md
@@ -1,6 +1,7 @@
 # Provider architecture realignment
 
-- **Status:** Accepted (remediation tracked in issue #135; not yet implemented)
+- **Status:** Accepted (remediation tracked in issue #135; implementation in
+  progress)
 - **Date:** 2026-06-08
 - **Affects:** Agent Runtime providers, TeamMate worker providers, Dispatcher
   Service, Capability Registry, Channel providers, MCP injection, `server.ts`
@@ -31,8 +32,11 @@ The target architecture is:
   with a **role-specific injected MCP tool set** plus a **role-specific system
   prompt**. The `TeamMateWorkerProvider` parallel tree
   (`/packages/dreamux/src/teammate/worker/`) is removed. The runtime interface
-  must cover inbound/turn submission, steering, resume, stop/close, and
-  upward result delivery. The "one task = one turn, reap" worker model is
+  covers single-instance operations only: start/resume/stop, inbound/turn
+  submission, steering capability, last/context reads, and upward result
+  delivery. Dispatcher orchestration verbs such as `spawn`, `close`, and
+  `list` stay on the Dispatcher Service and must not be instance methods on
+  `AgentRuntime`. The "one task = one turn, reap" worker model is
   replaced by a semi-resident, resumable session that the dispatcher controls.
 - **Dispatcher Service is a real module**, not a role smeared across
   `/packages/dreamux/src/server.ts` and `/packages/dreamux/src/teammate/`. It is
@@ -68,7 +72,10 @@ The target architecture is:
   capabilities duplicated by provider methods, kept in sync by a drift test) is
   removed; capability is a single provider-owned declaration that core actually
   reads — to compose the channel tool surface, and to know per-runtime support
-  (resume / steer / completion-delivery shape).
+  (resume / steer / completion-delivery shape). Runtime catalogs are registry
+  views: they resolve descriptors from the singleton registry and read the
+  implementation already registered there, rather than maintaining a second
+  provider map.
 - **Channel tool handlers move out of core.** A channel plugin owns its MCP
   end-to-end (tool definitions + handlers); core injects the descriptor and
   provides the connection, and no longer carries `*FromMcp` handlers in

--- a/common/changes/@excitedjs/dreamux/worktree-dreamux-codex_2026-06-07-20-34.json
+++ b/common/changes/@excitedjs/dreamux/worktree-dreamux-codex_2026-06-07-20-34.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Realign the AgentRuntime contract around submitTurn and provider-owned capabilities, and make the agent runtime catalog read implementations from the provider registry instead of carrying its own provider map.",
+      "type": "minor",
+      "packageName": "@excitedjs/dreamux"
+    }
+  ],
+  "packageName": "@excitedjs/dreamux",
+  "email": "053700@gmail.com"
+}

--- a/packages/dreamux/src/agent-runtime/catalog.ts
+++ b/packages/dreamux/src/agent-runtime/catalog.ts
@@ -32,22 +32,20 @@ export class WrongProviderKindError extends Error {
 
 export interface AgentRuntimeProviderCatalogOptions {
   registry: ProviderRegistry;
-  providers: readonly AgentRuntimeProvider[];
 }
 
 export class AgentRuntimeProviderCatalog {
   private readonly registry: ProviderRegistry;
-  private readonly providers = new Map<string, AgentRuntimeProvider>();
 
   constructor(options: AgentRuntimeProviderCatalogOptions) {
     this.registry = options.registry;
-    for (const provider of options.providers) {
-      this.providers.set(provider.ref, provider);
-    }
   }
 
   list(): AgentRuntimeProvider[] {
-    return [...this.providers.values()];
+    return this.registry
+      .listByKind('agentRuntime')
+      .map((descriptor) => this.runtimeProviderForDescriptor(descriptor))
+      .filter((provider): provider is AgentRuntimeProvider => provider !== null);
   }
 
   resolve(ref: string): AgentRuntimeProvider {
@@ -64,14 +62,21 @@ export class AgentRuntimeProviderCatalog {
       throw new WrongProviderKindError(descriptor);
     }
     const canonicalRef = formatProviderRef(descriptor.ref);
-    const provider = this.providers.get(canonicalRef);
-    if (provider === undefined) {
+    const provider = this.runtimeProviderForDescriptor(descriptor);
+    if (provider === null) {
       throw new UnsupportedAgentRuntimeProviderError(
         canonicalRef,
         'the provider is registered but has no runtime implementation wired in this phase',
       );
     }
     return provider;
+  }
+
+  private runtimeProviderForDescriptor(
+    descriptor: ProviderDescriptor,
+  ): AgentRuntimeProvider | null {
+    const implementation = this.registry.getImplementation(descriptor.id);
+    return asAgentRuntimeProvider(implementation);
   }
 }
 
@@ -86,17 +91,33 @@ export function createBuiltinAgentRuntimeProviderCatalog(
 ): AgentRuntimeProviderCatalog {
   const codexDescriptor = options.registry.resolve('builtin:codex');
   const claudeCodeDescriptor = options.registry.resolve('builtin:claude-code');
-  return new AgentRuntimeProviderCatalog({
-    providers: [
-      createCodexAgentRuntimeProvider({
-        ...options.codex,
-        descriptor: codexDescriptor,
-      }),
-      createClaudeCodeAgentRuntimeProvider({
-        ...(options.claudeCode ?? {}),
-        descriptor: claudeCodeDescriptor,
-      }),
-    ],
-    registry: options.registry,
-  });
+  options.registry.registerImplementation(
+    codexDescriptor.id,
+    createCodexAgentRuntimeProvider({
+      ...options.codex,
+      descriptor: codexDescriptor,
+    }),
+  );
+  options.registry.registerImplementation(
+    claudeCodeDescriptor.id,
+    createClaudeCodeAgentRuntimeProvider({
+      ...(options.claudeCode ?? {}),
+      descriptor: claudeCodeDescriptor,
+    }),
+  );
+  return new AgentRuntimeProviderCatalog({ registry: options.registry });
+}
+
+function asAgentRuntimeProvider(value: unknown): AgentRuntimeProvider | null {
+  if (typeof value !== 'object' || value === null) return null;
+  const candidate = value as Partial<AgentRuntimeProvider>;
+  if (
+    typeof candidate.ref !== 'string' ||
+    candidate.descriptor === undefined ||
+    typeof candidate.getCapabilities !== 'function' ||
+    typeof candidate.createRuntime !== 'function'
+  ) {
+    return null;
+  }
+  return value as AgentRuntimeProvider;
 }

--- a/packages/dreamux/src/agent-runtime/claude-code.ts
+++ b/packages/dreamux/src/agent-runtime/claude-code.ts
@@ -30,7 +30,7 @@
  * exit, error `result`) is never swallowed. For inbound/restart turns it drives
  * the runtime to `degraded` with a persisted `last_error` (observable via
  * status/doctor). For `deliverTeamMateCompletion` it surfaces as a `failed`
- * result the caller can act on (PR8 delivery retry). `enqueueInbound` still
+ * result the caller can act on (PR8 delivery retry). `submitTurn` still
  * returns after accept (submit != completion) so the channel can ack promptly.
  *
  * Restart: an unexpected child exit marks the runtime `degraded`; the next turn
@@ -80,14 +80,18 @@ import {
 } from './claude-code-session.js';
 import type {
   InboundDeliveryHooks,
-  InboundDeliveryResult,
-  InboundTurnInput,
 } from '../dispatcher/turn-manager.js';
 import type { DispatcherStatus } from '../runtime/dispatcher-store.js';
 import type {
+  AgentRuntimeCapabilities,
+  AgentRuntimeContextSnapshot,
   AgentRuntime,
   AgentRuntimeCreateContext,
+  AgentRuntimeLastResult,
   AgentRuntimeProvider,
+  AgentRuntimeResumeInput,
+  AgentRuntimeTurnInput,
+  AgentRuntimeTurnResult,
   TeamMateCompletionDeliveryResult,
   TeamMateCompletionEnvelope,
 } from './types.js';
@@ -99,6 +103,21 @@ export interface ClaudeCodeAgentRuntimeProviderOptions {
   /** Override the resident-session factory (tests inject a fake). */
   sessionFactory?: ClaudeCodeSessionFactory;
 }
+
+export const CLAUDE_CODE_AGENT_RUNTIME_CAPABILITIES: AgentRuntimeCapabilities = {
+  resume: { supported: true, checkpoint: 'claudeCodeSession' },
+  steer: { supported: false },
+  events: { kind: 'synthesized' },
+  last: { supported: false },
+  context: { supported: false },
+  teammateCompletion: [
+    {
+      kind: 'claudeCodeTaskNotification',
+      description:
+        'notify the runtime through a Claude Code task notification path',
+    },
+  ],
+};
 
 interface ClaudeCodeRuntimeDeps {
   sessionFactory: ClaudeCodeSessionFactory;
@@ -119,10 +138,16 @@ function errMessage(err: unknown): string {
   return err instanceof Error ? err.message : String(err);
 }
 
+function isSystemTurn(
+  input: AgentRuntimeTurnInput,
+): input is Extract<AgentRuntimeTurnInput, { kind: 'system' }> {
+  return 'kind' in input && input.kind === 'system';
+}
+
 /**
  * The Claude Code agent runtime for one dispatcher. A single resident
  * stream-json child serves every turn. Turns run serially (one at a time) and
- * `enqueueInbound` returns after the message is accepted — not after the turn
+ * `submitTurn` returns after the message is accepted — not after the turn
  * completes — matching the Codex runtime's submit-then-serialize contract.
  */
 export class ClaudeCodeRuntime implements AgentRuntime {
@@ -137,7 +162,7 @@ export class ClaudeCodeRuntime implements AgentRuntime {
   private readonly stderrLogPath: string;
   private status: DispatcherStatus = 'declared';
   private threadId: string | null;
-  private readonly resumed: boolean;
+  private resumed: boolean;
   private stopped = false;
   private readonly seen = new Set<string>();
   private queue: Promise<void> = Promise.resolve();
@@ -166,12 +191,37 @@ export class ClaudeCodeRuntime implements AgentRuntime {
     return this.status;
   }
 
+  getCapabilities(): AgentRuntimeCapabilities {
+    return CLAUDE_CODE_AGENT_RUNTIME_CAPABILITIES;
+  }
+
   getThreadId(): string | null {
     return this.threadId;
   }
 
   wasThreadResumed(): boolean {
     return this.resumed;
+  }
+
+  async getLast(): Promise<AgentRuntimeLastResult | null> {
+    return null;
+  }
+
+  async getContext(): Promise<AgentRuntimeContextSnapshot | null> {
+    return null;
+  }
+
+  async resume(input: AgentRuntimeResumeInput = {}): Promise<void> {
+    if (input.checkpoint !== undefined && input.checkpoint !== null) {
+      if (input.checkpoint.kind !== 'claudeCodeSession') {
+        throw new Error(
+          `unsupported resume checkpoint for Claude Code runtime: ${input.checkpoint.kind}`,
+        );
+      }
+      this.threadId = input.checkpoint.id;
+      this.resumed = true;
+    }
+    await this.start();
   }
 
   async start(): Promise<void> {
@@ -206,11 +256,19 @@ export class ClaudeCodeRuntime implements AgentRuntime {
     await this.setStatus('stopped');
   }
 
-  async enqueueInbound(
-    input: InboundTurnInput,
+  async submitTurn(
+    input: AgentRuntimeTurnInput,
     hooks: InboundDeliveryHooks = {},
-  ): Promise<InboundDeliveryResult> {
+  ): Promise<AgentRuntimeTurnResult> {
     if (this.stopped) return { status: 'stopped' };
+    if (isSystemTurn(input)) {
+      const turnId = `claude-system-${++this.turnCounter}`;
+      void this.runTurnOnQueue(input.text, turnId).then(
+        () => this.markTurnSucceeded(),
+        (err) => this.markTurnFailed(turnId, err),
+      );
+      return { status: 'submitted', turnId };
+    }
     const key = input.source_message_id ?? '';
     if (key !== '' && this.seen.has(key)) return { status: 'duplicate' };
     if (key !== '') this.seen.add(key);
@@ -232,15 +290,6 @@ export class ClaudeCodeRuntime implements AgentRuntime {
       (err) => this.markTurnFailed(turnId, err),
     );
     return { status: 'submitted', turnId };
-  }
-
-  async injectRestartNotice(text: string): Promise<void> {
-    if (this.stopped) return;
-    const turnId = `claude-restart-${++this.turnCounter}`;
-    void this.runTurnOnQueue(text, turnId).then(
-      () => this.markTurnSucceeded(),
-      (err) => this.markTurnFailed(turnId, err),
-    );
   }
 
   async deliverTeamMateCompletion(
@@ -388,15 +437,7 @@ export function createClaudeCodeAgentRuntimeProvider(
   return {
     ref: BUILTIN_CLAUDE_CODE_PROVIDER_REF,
     descriptor: options.descriptor,
-    delivery: {
-      teammateCompletion: [
-        {
-          kind: 'claudeCodeTaskNotification',
-          description:
-            'notify the runtime through a Claude Code task notification path',
-        },
-      ],
-    },
+    getCapabilities: () => CLAUDE_CODE_AGENT_RUNTIME_CAPABILITIES,
     createRuntime(context: AgentRuntimeCreateContext): AgentRuntime {
       return new ClaudeCodeRuntime(context, { sessionFactory, resolveBinPath });
     },

--- a/packages/dreamux/src/agent-runtime/codex.ts
+++ b/packages/dreamux/src/agent-runtime/codex.ts
@@ -14,6 +14,7 @@ import type { DispatcherCodexHomeDoctor } from '../runtime/dispatcher-codex-home
 import { codexArgsToCli, parseCodexArgs } from '../runtime/codex-args.js';
 import { type ProviderDescriptor } from '../registry/index.js';
 import type {
+  AgentRuntimeCapabilities,
   AgentRuntime,
   AgentRuntimeProvider,
   AgentRuntimeMcpServer,
@@ -29,21 +30,28 @@ export interface CodexAgentRuntimeProviderOptions {
   restartBackoffMaxMs?: number;
 }
 
+export const CODEX_AGENT_RUNTIME_CAPABILITIES: AgentRuntimeCapabilities = {
+  resume: { supported: true, checkpoint: 'codexThread' },
+  steer: { supported: true },
+  events: { kind: 'push' },
+  last: { supported: false },
+  context: { supported: false },
+  teammateCompletion: [
+    {
+      kind: 'codexInboxTurn',
+      description:
+        'write completion to a runtime inbox, then trigger a dispatcher turn',
+    },
+  ],
+};
+
 export function createCodexAgentRuntimeProvider(
   options: CodexAgentRuntimeProviderOptions,
 ): AgentRuntimeProvider {
   return {
     ref: BUILTIN_CODEX_PROVIDER_REF,
     descriptor: options.descriptor,
-    delivery: {
-      teammateCompletion: [
-        {
-          kind: 'codexInboxTurn',
-          description:
-            'write completion to a runtime inbox, then trigger a dispatcher turn',
-        },
-      ],
-    },
+    getCapabilities: () => CODEX_AGENT_RUNTIME_CAPABILITIES,
     createRuntime(context): AgentRuntime {
       const codexConfig =
         context.dispatcher === null

--- a/packages/dreamux/src/agent-runtime/types.ts
+++ b/packages/dreamux/src/agent-runtime/types.ts
@@ -2,6 +2,7 @@ import type {
   InboundDeliveryHooks,
   InboundDeliveryResult,
   InboundTurnInput,
+  NoticeInjectionResult,
 } from '../dispatcher/turn-manager.js';
 import type { DispatcherConfig } from '../runtime/config.js';
 import type {
@@ -27,7 +28,26 @@ export type TeamMateCompletionDeliveryShape =
       description: 'notify the runtime through a Claude Code task notification path';
     };
 
-export interface AgentRuntimeDeliveryCapabilities {
+export type AgentRuntimeResumeCheckpoint =
+  | { kind: 'codexThread'; id: string }
+  | { kind: 'claudeCodeSession'; id: string };
+
+export type AgentRuntimeResumeCapability =
+  | { supported: true; checkpoint: AgentRuntimeResumeCheckpoint['kind'] }
+  | { supported: false };
+
+export interface AgentRuntimeCapabilities {
+  /** Whether this runtime can resume a prior checkpoint, and which checkpoint id it expects. */
+  resume: AgentRuntimeResumeCapability;
+  /** Whether a follow-up turn can steer/fold into an active turn. */
+  steer: { supported: boolean };
+  /** How runtime events are surfaced to Dreamux. */
+  events: { kind: 'push' | 'synthesized' };
+  /** Whether the runtime can report the last assistant/user-visible result. */
+  last: { supported: boolean };
+  /** Whether the runtime can report context-window usage. */
+  context: { supported: boolean };
+  /** Upward delivery shapes this runtime supports for teammate completion. */
   teammateCompletion: readonly TeamMateCompletionDeliveryShape[];
 }
 
@@ -43,18 +63,44 @@ export type TeamMateCompletionDeliveryResult =
   | { status: 'unsupported'; reason: string }
   | { status: 'failed'; error: Error };
 
+export type AgentRuntimeTurnInput =
+  | InboundTurnInput
+  | {
+      kind: 'system';
+      text: string;
+      reason: 'restart-notice' | 'teammate-completion' | 'runtime-control';
+    };
+
+export type AgentRuntimeTurnResult = InboundDeliveryResult | NoticeInjectionResult;
+
+export interface AgentRuntimeResumeInput {
+  checkpoint?: AgentRuntimeResumeCheckpoint | null;
+}
+
+export interface AgentRuntimeLastResult {
+  text: string | null;
+}
+
+export interface AgentRuntimeContextSnapshot {
+  usedTokens: number | null;
+  windowTokens: number | null;
+}
+
 export interface AgentRuntime {
   readonly providerRef: string;
   start(): Promise<void>;
+  resume(input?: AgentRuntimeResumeInput): Promise<void>;
   stop(): Promise<void>;
-  enqueueInbound(
-    input: InboundTurnInput,
+  submitTurn(
+    input: AgentRuntimeTurnInput,
     hooks?: InboundDeliveryHooks,
-  ): Promise<InboundDeliveryResult>;
-  injectRestartNotice(text: string): Promise<void>;
+  ): Promise<AgentRuntimeTurnResult>;
   getStatus(): DispatcherStatus;
   getThreadId(): string | null;
   wasThreadResumed(): boolean;
+  getLast(): Promise<AgentRuntimeLastResult | null>;
+  getContext(): Promise<AgentRuntimeContextSnapshot | null>;
+  getCapabilities(): AgentRuntimeCapabilities;
   deliverTeamMateCompletion?(
     completion: TeamMateCompletionEnvelope,
   ): Promise<TeamMateCompletionDeliveryResult>;
@@ -71,6 +117,6 @@ export interface AgentRuntimeCreateContext {
 export interface AgentRuntimeProvider {
   readonly ref: string;
   readonly descriptor: ProviderDescriptor;
-  readonly delivery: AgentRuntimeDeliveryCapabilities;
+  getCapabilities(): AgentRuntimeCapabilities;
   createRuntime(context: AgentRuntimeCreateContext): AgentRuntime;
 }

--- a/packages/dreamux/src/dispatcher/runtime.ts
+++ b/packages/dreamux/src/dispatcher/runtime.ts
@@ -40,8 +40,6 @@ import type {
 import {
   TurnManager,
   type InboundDeliveryHooks,
-  type InboundDeliveryResult,
-  type InboundTurnInput,
 } from './turn-manager.js';
 import { createFailFastApprovalHandler } from './approval.js';
 import {
@@ -59,10 +57,17 @@ import { installBundledWorkspaceSkills } from '../runtime/bundled-skills.js';
 import { DREAMUX_DISPATCHER_BASE_INSTRUCTIONS } from './base-prompt.js';
 import type {
   AgentRuntime,
+  AgentRuntimeCapabilities,
+  AgentRuntimeContextSnapshot,
+  AgentRuntimeLastResult,
+  AgentRuntimeResumeInput,
+  AgentRuntimeTurnInput,
+  AgentRuntimeTurnResult,
   TeamMateCompletionDeliveryResult,
   TeamMateCompletionEnvelope,
 } from '../agent-runtime/types.js';
 import { BUILTIN_CODEX_PROVIDER_REF } from '../runtime/config.js';
+import { CODEX_AGENT_RUNTIME_CAPABILITIES } from '../agent-runtime/codex.js';
 
 const DEFAULT_RESTART_BACKOFF_BASE_MS = 1000;
 const DEFAULT_RESTART_BACKOFF_MAX_MS = 30_000;
@@ -136,6 +141,10 @@ export class DispatcherRuntime implements AgentRuntime {
     return this.status;
   }
 
+  getCapabilities(): AgentRuntimeCapabilities {
+    return CODEX_AGENT_RUNTIME_CAPABILITIES;
+  }
+
   getThreadId(): string | null {
     return this.threadId;
   }
@@ -145,19 +154,35 @@ export class DispatcherRuntime implements AgentRuntime {
     return this.threadResumed;
   }
 
-  /**
-   * Inject a best-effort one-shot restart notice into the resumed thread. The
-   * server calls this only after the dispatcher slot is ready (so the resumed
-   * turn can reply through Feishu). Never throws — failures are logged.
-   */
-  async injectRestartNotice(text: string): Promise<void> {
-    if (this.turnManager === null) return;
+  async getLast(): Promise<AgentRuntimeLastResult | null> {
+    return null;
+  }
+
+  async getContext(): Promise<AgentRuntimeContextSnapshot | null> {
+    return null;
+  }
+
+  async resume(input: AgentRuntimeResumeInput = {}): Promise<void> {
+    if (input.checkpoint !== undefined && input.checkpoint !== null) {
+      if (input.checkpoint.kind !== 'codexThread') {
+        throw new Error(
+          `unsupported resume checkpoint for Codex runtime: ${input.checkpoint.kind}`,
+        );
+      }
+      this.threadId = input.checkpoint.id;
+    }
+    await this.start();
+  }
+
+  private async submitRestartNotice(text: string): Promise<AgentRuntimeTurnResult> {
+    if (this.turnManager === null) return { status: 'stopped' };
     const result = await this.turnManager.injectNotice(text);
     if (result.status === 'submitted') {
       this.log('info', 'restart notice injected into resumed thread');
     } else if (result.status === 'skipped') {
       this.log('info', 'restart notice skipped; a live inbound already arrived');
     }
+    return result;
   }
 
   /**
@@ -341,10 +366,13 @@ export class DispatcherRuntime implements AgentRuntime {
    * Submit any accepted inbound message arriving for this dispatcher. Called by
    * the Feishu inbound layer.
    */
-  async enqueueInbound(
-    input: InboundTurnInput,
+  async submitTurn(
+    input: AgentRuntimeTurnInput,
     hooks: InboundDeliveryHooks = {},
-  ): Promise<InboundDeliveryResult> {
+  ): Promise<AgentRuntimeTurnResult> {
+    if (isSystemTurn(input)) {
+      return this.submitRestartNotice(input.text);
+    }
     if (this.turnManager === null) {
       return { status: 'failed', error: new Error('turn manager not initialized') };
     }
@@ -354,7 +382,7 @@ export class DispatcherRuntime implements AgentRuntime {
   /**
    * Codex TeamMate completion delivery (issue #110 PR8): inbox + turn trigger.
    * The completion is delivered into the dispatcher's Codex thread as a turn via
-   * the public `enqueueInbound` seam — not turn-manager internals — so it
+   * the public `submitTurn` seam — not turn-manager internals — so it
    * survives the planned move of queue/state to a per-dispatcher state owner.
    *
    * Each attempt uses a fresh, non-routable source id. The turn manager commits
@@ -369,7 +397,7 @@ export class DispatcherRuntime implements AgentRuntime {
     completion: TeamMateCompletionEnvelope,
   ): Promise<TeamMateCompletionDeliveryResult> {
     this.teammateDeliverySeq += 1;
-    const delivery = await this.enqueueInbound({
+    const delivery = await this.submitTurn({
       source_chat_id: 'teammate',
       source_message_id: `teammate:${completion.taskId}#${this.teammateDeliverySeq}`,
       sender_id: null,
@@ -388,6 +416,11 @@ export class DispatcherRuntime implements AgentRuntime {
         return {
           status: 'failed',
           error: new Error('teammate completion turn unexpectedly deduplicated'),
+        };
+      case 'skipped':
+        return {
+          status: 'failed',
+          error: new Error('teammate completion turn unexpectedly skipped'),
         };
     }
   }
@@ -544,4 +577,10 @@ function formatTeamMateCompletion(
     completion.finalText,
     '</teammate_task_completion>',
   ].join('\n');
+}
+
+function isSystemTurn(
+  input: AgentRuntimeTurnInput,
+): input is Extract<AgentRuntimeTurnInput, { kind: 'system' }> {
+  return 'kind' in input && input.kind === 'system';
 }

--- a/packages/dreamux/src/registry/registry.ts
+++ b/packages/dreamux/src/registry/registry.ts
@@ -32,6 +32,14 @@ export class DuplicateProviderError extends Error {
   }
 }
 
+/** Thrown when registering a runnable implementation for the same provider twice. */
+export class DuplicateProviderImplementationError extends Error {
+  constructor(readonly id: string) {
+    super(`provider ${JSON.stringify(id)} already has a runnable implementation`);
+    this.name = 'DuplicateProviderImplementationError';
+  }
+}
+
 /** Thrown when resolving a `builtin:` ref whose id is not registered. */
 export class UnknownBuiltinProviderError extends Error {
   constructor(readonly id: string) {
@@ -60,6 +68,7 @@ export class ReservedExternalProviderError extends Error {
  */
 export class ProviderRegistry {
   private readonly providers = new Map<string, ProviderDescriptor>();
+  private readonly implementations = new Map<string, unknown>();
 
   /**
    * Register a provider. Throws {@link DuplicateProviderError} on a repeated id.
@@ -77,6 +86,20 @@ export class ProviderRegistry {
 
   get(id: string): ProviderDescriptor | undefined {
     return this.providers.get(id);
+  }
+
+  registerImplementation(providerId: string, implementation: unknown): void {
+    if (!this.providers.has(providerId)) {
+      throw new UnknownBuiltinProviderError(providerId);
+    }
+    if (this.implementations.has(providerId)) {
+      throw new DuplicateProviderImplementationError(providerId);
+    }
+    this.implementations.set(providerId, implementation);
+  }
+
+  getImplementation(providerId: string): unknown | undefined {
+    return this.implementations.get(providerId);
   }
 
   list(): ProviderDescriptor[] {

--- a/packages/dreamux/src/server.ts
+++ b/packages/dreamux/src/server.ts
@@ -1045,7 +1045,7 @@ export class Server {
             sender_id: event.senderId,
             parsed_text: formatted.formattedText,
           };
-          const delivery = await runtime.enqueueInbound(input, {
+          const delivery = await runtime.submitTurn(input, {
             onAccepted: async (acceptedInput) => {
               await setInboundReaction(
                 id,
@@ -1136,7 +1136,17 @@ export class Server {
       const notice = this.restartIntent?.claim(id, Date.now()) ?? null;
       if (notice !== null) {
         try {
-          await runtime.injectRestartNotice(notice);
+          const result = await runtime.submitTurn({
+            kind: 'system',
+            text: notice,
+            reason: 'restart-notice',
+          });
+          if (result.status === 'failed') {
+            channelLog.warn(
+              { dispatcher_id: id, err: errInfo(result.error) },
+              'restart notice injection failed',
+            );
+          }
         } catch (err) {
           channelLog.warn(
             { dispatcher_id: id, err: errInfo(err) },

--- a/packages/dreamux/tests/agent-runtime-provider.test.ts
+++ b/packages/dreamux/tests/agent-runtime-provider.test.ts
@@ -5,6 +5,7 @@ import {
   UnsupportedAgentRuntimeProviderError,
   WrongProviderKindError,
   createBuiltinAgentRuntimeProviderCatalog,
+  createCodexAgentRuntimeProvider,
 } from '../src/agent-runtime/index.js';
 import {
   UnknownBuiltinProviderError,
@@ -26,9 +27,9 @@ describe('AgentRuntimeProviderCatalog', () => {
 
     expect(provider.ref).toBe('builtin:codex');
     expect(provider.descriptor.kind).toBe('agentRuntime');
-    expect(provider.delivery.teammateCompletion.map((shape) => shape.kind)).toEqual([
-      'codexInboxTurn',
-    ]);
+    expect(
+      provider.getCapabilities().teammateCompletion.map((shape) => shape.kind),
+    ).toEqual(['codexInboxTurn']);
   });
 
   it('creates a Codex-backed AgentRuntime without starting it', () => {
@@ -58,9 +59,9 @@ describe('AgentRuntimeProviderCatalog', () => {
     expect(provider.descriptor.kind).toBe('agentRuntime');
     // Distinct delivery shape from Codex — proves the abstraction is not
     // Codex-only.
-    expect(provider.delivery.teammateCompletion.map((shape) => shape.kind)).toEqual([
-      'claudeCodeTaskNotification',
-    ]);
+    expect(
+      provider.getCapabilities().teammateCompletion.map((shape) => shape.kind),
+    ).toEqual(['claudeCodeTaskNotification']);
   });
 
   it('rejects non-runtime builtins through the runtime catalog', () => {
@@ -86,10 +87,15 @@ describe('AgentRuntimeProviderCatalog', () => {
 
   it('supports registry injection for future provider composition tests', () => {
     const registry = createBuiltinProviderRegistry();
-    const catalog = new AgentRuntimeProviderCatalog({
-      registry,
-      providers: [builtinCatalog().resolve('builtin:codex')],
-    });
+    const descriptor = registry.resolve('builtin:codex');
+    registry.registerImplementation(
+      descriptor.id,
+      createCodexAgentRuntimeProvider({
+        descriptor,
+        resolveBinPath: (bin) => bin,
+      }),
+    );
+    const catalog = new AgentRuntimeProviderCatalog({ registry });
 
     expect(catalog.list().map((provider) => provider.ref)).toEqual([
       'builtin:codex',

--- a/packages/dreamux/tests/claude-code-live.test.ts
+++ b/packages/dreamux/tests/claude-code-live.test.ts
@@ -126,7 +126,7 @@ describe('claude-code live integration (opt-in)', () => {
     await runtime.start();
     expect(runtime.getStatus()).toBe('ready');
 
-    const first = await runtime.enqueueInbound({
+    const first = await runtime.submitTurn({
       source_chat_id: 'c',
       source_message_id: 'live-1',
       sender_id: 'u',
@@ -143,7 +143,7 @@ describe('claude-code live integration (opt-in)', () => {
 
     // Second turn over the SAME resident process: the runtime must stay ready
     // and keep the same session id (no re-spawn, no new session).
-    const second = await runtime.enqueueInbound({
+    const second = await runtime.submitTurn({
       source_chat_id: 'c',
       source_message_id: 'live-2',
       sender_id: 'u',

--- a/packages/dreamux/tests/claude-code-runtime.test.ts
+++ b/packages/dreamux/tests/claude-code-runtime.test.ts
@@ -207,9 +207,9 @@ describe('builtin:claude-code provider', () => {
     const provider = claudeCodeProvider({ sessionFactory: fakeFleet().factory });
     expect(provider.ref).toBe('builtin:claude-code');
     expect(provider.descriptor.kind).toBe('agentRuntime');
-    expect(provider.delivery.teammateCompletion.map((s) => s.kind)).toEqual([
-      'claudeCodeTaskNotification',
-    ]);
+    expect(
+      provider.getCapabilities().teammateCompletion.map((s) => s.kind),
+    ).toEqual(['claudeCodeTaskNotification']);
   });
 });
 
@@ -290,7 +290,7 @@ describe('ClaudeCodeRuntime resident lifecycle (fake session)', () => {
     const { runtime } = makeRuntime(fleet);
     await runtime.start();
 
-    await runtime.enqueueInbound({
+    await runtime.submitTurn({
       source_chat_id: 'c',
       source_message_id: 'm1',
       sender_id: 'u',
@@ -298,7 +298,7 @@ describe('ClaudeCodeRuntime resident lifecycle (fake session)', () => {
     });
     await waitFor(() => fleet.sessions[0]?.prompts.length === 1);
 
-    await runtime.enqueueInbound({
+    await runtime.submitTurn({
       source_chat_id: 'c',
       source_message_id: 'm2',
       sender_id: 'u',
@@ -338,7 +338,7 @@ describe('ClaudeCodeRuntime resident lifecycle (fake session)', () => {
     await runtime.start();
 
     const accepted: string[] = [];
-    const first = await runtime.enqueueInbound(
+    const first = await runtime.submitTurn(
       { source_chat_id: 'c', source_message_id: 'm1', sender_id: 'u', parsed_text: 'do it' },
       { onAccepted: (input) => void accepted.push(input.source_message_id ?? '') },
     );
@@ -349,7 +349,7 @@ describe('ClaudeCodeRuntime resident lifecycle (fake session)', () => {
     expect(fleet.sessions[0]?.prompts[0]).toBe('do it');
     await waitFor(() => runtime.getThreadId() === 'session-abc');
 
-    const dup = await runtime.enqueueInbound({
+    const dup = await runtime.submitTurn({
       source_chat_id: 'c',
       source_message_id: 'm1',
       sender_id: 'u',
@@ -388,7 +388,7 @@ describe('ClaudeCodeRuntime resident lifecycle (fake session)', () => {
     await runtime.stop();
     expect(runtime.getStatus()).toBe('stopped');
     expect(fleet.sessions[0]?.isAlive()).toBe(false);
-    const after = await runtime.enqueueInbound({
+    const after = await runtime.submitTurn({
       source_chat_id: 'c',
       source_message_id: 'm9',
       sender_id: 'u',
@@ -404,7 +404,7 @@ describe('ClaudeCodeRuntime resident lifecycle (fake session)', () => {
     await runtime.start();
     expect(runtime.getStatus()).toBe('ready');
 
-    const submit = await runtime.enqueueInbound({
+    const submit = await runtime.submitTurn({
       source_chat_id: 'c',
       source_message_id: 'm1',
       sender_id: 'u',
@@ -422,7 +422,7 @@ describe('ClaudeCodeRuntime resident lifecycle (fake session)', () => {
     ]);
     const { runtime, store } = makeRuntime(fleet);
     await runtime.start();
-    await runtime.enqueueInbound({
+    await runtime.submitTurn({
       source_chat_id: 'c',
       source_message_id: 'm1',
       sender_id: 'u',
@@ -437,7 +437,7 @@ describe('ClaudeCodeRuntime resident lifecycle (fake session)', () => {
     const { runtime } = makeRuntime(fleet);
     await runtime.start();
 
-    await runtime.enqueueInbound({
+    await runtime.submitTurn({
       source_chat_id: 'c',
       source_message_id: 'm1',
       sender_id: 'u',
@@ -445,7 +445,7 @@ describe('ClaudeCodeRuntime resident lifecycle (fake session)', () => {
     });
     await waitFor(() => runtime.getStatus() === 'degraded');
 
-    await runtime.enqueueInbound({
+    await runtime.submitTurn({
       source_chat_id: 'c',
       source_message_id: 'm2',
       sender_id: 'u',
@@ -460,7 +460,7 @@ describe('ClaudeCodeRuntime resident lifecycle (fake session)', () => {
     await runtime.start();
 
     // First turn establishes the session id.
-    await runtime.enqueueInbound({
+    await runtime.submitTurn({
       source_chat_id: 'c',
       source_message_id: 'm1',
       sender_id: 'u',
@@ -474,7 +474,7 @@ describe('ClaudeCodeRuntime resident lifecycle (fake session)', () => {
     expect(store.get('flow')?.last_error).toContain('exited');
 
     // Next turn re-spawns a fresh session that resumes the captured session id.
-    await runtime.enqueueInbound({
+    await runtime.submitTurn({
       source_chat_id: 'c',
       source_message_id: 'm2',
       sender_id: 'u',
@@ -521,7 +521,7 @@ describe('ClaudeCodeRuntime resident lifecycle (fake session)', () => {
     });
     await runtime.start();
 
-    await runtime.enqueueInbound({
+    await runtime.submitTurn({
       source_chat_id: 'c',
       source_message_id: 'm1',
       sender_id: 'u',

--- a/packages/dreamux/tests/teammate-delivery.test.ts
+++ b/packages/dreamux/tests/teammate-delivery.test.ts
@@ -13,14 +13,22 @@ import { DispatcherStore } from '../src/runtime/dispatcher-store.js';
 import { resetRuntimeConfig } from '../src/runtime/paths.js';
 import { testDispatcherConfig, testDreamuxConfig } from './helpers/config.js';
 import type {
-  InboundDeliveryResult,
-  InboundTurnInput,
-} from '../src/dispatcher/turn-manager.js';
-import type {
   AgentRuntime,
+  AgentRuntimeCapabilities,
+  AgentRuntimeTurnInput,
+  AgentRuntimeTurnResult,
   TeamMateCompletionDeliveryResult,
   TeamMateCompletionEnvelope,
 } from '../src/agent-runtime/types.js';
+
+const TEST_RUNTIME_CAPABILITIES: AgentRuntimeCapabilities = {
+  resume: { supported: false },
+  steer: { supported: false },
+  events: { kind: 'synthesized' },
+  last: { supported: false },
+  context: { supported: false },
+  teammateCompletion: [],
+};
 
 /** A fake runtime that only implements the delivery seam, with a scripted plan. */
 function deliveryRuntime(
@@ -32,12 +40,15 @@ function deliveryRuntime(
     calls,
     providerRef: 'builtin:codex',
     start: async () => {},
+    resume: async () => {},
     stop: async () => {},
-    enqueueInbound: async () => ({ status: 'failed', error: new Error('n/a') }),
-    injectRestartNotice: async () => {},
+    submitTurn: async () => ({ status: 'failed', error: new Error('n/a') }),
     getStatus: () => 'ready',
     getThreadId: () => null,
     wasThreadResumed: () => false,
+    getLast: async () => null,
+    getContext: async () => null,
+    getCapabilities: () => TEST_RUNTIME_CAPABILITIES,
     async deliverTeamMateCompletion(
       envelope: TeamMateCompletionEnvelope,
     ): Promise<TeamMateCompletionDeliveryResult> {
@@ -55,12 +66,15 @@ function nonDeliveringRuntime(): AgentRuntime {
   return {
     providerRef: 'builtin:codex',
     start: async () => {},
+    resume: async () => {},
     stop: async () => {},
-    enqueueInbound: async () => ({ status: 'failed', error: new Error('n/a') }),
-    injectRestartNotice: async () => {},
+    submitTurn: async () => ({ status: 'failed', error: new Error('n/a') }),
     getStatus: () => 'ready',
     getThreadId: () => null,
     wasThreadResumed: () => false,
+    getLast: async () => null,
+    getContext: async () => null,
+    getCapabilities: () => TEST_RUNTIME_CAPABILITIES,
   };
 }
 
@@ -251,9 +265,12 @@ describe('TeamMate completion delivery', () => {
     const ids: Array<string | null> = [];
     (
       runtime as unknown as {
-        enqueueInbound: (input: InboundTurnInput) => Promise<InboundDeliveryResult>;
+        submitTurn: (input: AgentRuntimeTurnInput) => Promise<AgentRuntimeTurnResult>;
       }
-    ).enqueueInbound = async (input) => {
+    ).submitTurn = async (input) => {
+      if ('kind' in input) {
+        return { status: 'failed', error: new Error('n/a') };
+      }
       ids.push(input.source_message_id);
       return { status: 'failed', error: new Error('turn/start failed') };
     };


### PR DESCRIPTION
## Summary

本 PR 实现 issue #135 拆分中的 PR B：把现有 dispatcher-only runtime seam 收口为统一的 `AgentRuntime` contract，并把 `agent-runtime` catalog 完整退化为 `ProviderRegistry` 的 `agentRuntime` view。

## 删除 / 替换的旧路径

- 删除旧 `AgentRuntime.enqueueInbound(...)` / `AgentRuntime.injectRestartNotice(...)` 接口，替换为单一 `AgentRuntime.submitTurn(...)`。Feishu inbound、restart notice、TeamMate completion delivery 都通过同一 turn submission seam 进入 runtime。
- 删除 provider 上的旧 `delivery` capability mirror，替换为 provider/runtime 自有的 `getCapabilities()`。能力声明不再由 registry/capability mirror 维护第二份数据。
- 删除 `AgentRuntimeProviderCatalog` 内部独立 `Map<ref, AgentRuntimeProvider>`。catalog 的 `list()` / `resolve()` 现在只读取 `ProviderRegistry` 中已注册的 `agentRuntime` descriptor 和 implementation。
- 保留 `teammate/worker/` 旧树不动；按 #135 拆分，它属于后续 PR 的删除范围。本 PR 只替换 dispatcher runtime contract 和 catalog 双重记账路径。

## Gate 对照

- gate#1 接口分层：`AgentRuntime` 只包含单实例动作 `start` / `resume` / `stop` / `submitTurn` / `getLast` / `getContext` / `getCapabilities` 等；`spawn` / `close` / `list` 没有进入 runtime 实例接口，后续归 Dispatcher Service 编排层。
- gate#2 no-sync-IO：本 PR 未新增 `src/**` 同步 IO；`rush lint` 已通过 no-sync gate。
- gate#3 send / resume 不按 runtime 分叉：统一走 `submitTurn` / `resume` contract，runtime 差异通过 `getCapabilities()` 中的 resume checkpoint、steer、events、completion delivery shape 声明。
- gate#4 去双重记账：`agent-runtime` catalog 不再持有独立 provider map；runtime implementation 由 `ProviderRegistry` 持有，catalog 只是 registry view。
- gate#5 反缝合：没有新增第三套 provider/catalog；MCP/Dispatcher Service 大拆分不在本 PR 半做，避免把后续 PR 的 worker 删除范围混进本次 contract 收口。

## Verification

- `node common/scripts/install-run-rush.js build`
- `node common/scripts/install-run-rush.js lint`
- `TMPDIR=<short temp dir> node common/scripts/install-run-rush.js test`
- `node common/scripts/install-run-rush.js change --verify --target-branch origin/next --no-fetch`
- 提交前与 PR 前均对 diff 做公开仓泄漏 grep，自查无内部名称、内部域名、公司邮箱、本机绝对路径或 token/secret 形态内容。

## Notes

- `.agents/scripts/check.sh` 在当前本机 shell 环境无法执行：脚本使用 `declare -A`，本机可用 bash 不支持关联数组。未修改脚本本身。
