### PR TITLE
实体化 Dispatcher Service

### DIFF
--- a/.agents/decisions/provider-architecture-realignment.md
+++ b/.agents/decisions/provider-architecture-realignment.md
@@ -130,6 +130,17 @@ see its `verbs/` (spawn/resume/history), `persistence/history-index.ts` and
 - `server.ts` loses the ~12 `*TeamMate*FromMcp` methods, channel `*FromMcp`
   handlers, and hard-spliced MCP injection — they move into the Dispatcher
   Service and the channel/runtime plugins.
+- The Dispatcher Service extraction starts with teammate orchestration:
+  `server.ts` wires a `DispatcherService`, admin/MCP handlers validate params
+  and delegate to it, and the service owns scheduling authority, ledgers,
+  wait-broker notifications, worker execution, completion delivery, logs,
+  capability probing, and worker reaping. Worker runtime construction stays in
+  a separate dispatcher-service factory module so the service does not absorb
+  runtime-specific details.
+- This extraction intentionally keeps the existing TeamMate worker provider
+  tree until the agent-centric TeamMate replacement lands. The old
+  `server.ts` orchestration path is removed in this step; deleting
+  `/packages/dreamux/src/teammate/worker/` remains a separate migration step.
 - Hard-coded `BUILTIN_*_REF` branching across core (`server.ts`,
   `/packages/dreamux/src/runtime/config.ts`,
   `/packages/dreamux/src/cli/doctor.ts`) is expected to shrink as core consumes

--- a/common/changes/@excitedjs/dreamux/worktree-dreamux-codex_2026-06-07-21-04.json
+++ b/common/changes/@excitedjs/dreamux/worktree-dreamux-codex_2026-06-07-21-04.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Move TeamMate orchestration into Dispatcher Service and slim server wiring.",
+      "type": "minor",
+      "packageName": "@excitedjs/dreamux"
+    }
+  ],
+  "packageName": "@excitedjs/dreamux",
+  "email": "053700@gmail.com"
+}

--- a/packages/dreamux/src/admin/methods.ts
+++ b/packages/dreamux/src/admin/methods.ts
@@ -138,7 +138,7 @@ export const adminMethods: Record<string, AdminHandler> = {
     const prompt = mustString(params, 'prompt');
     const teammateId = optionalString(params, 'teammate_id');
     try {
-      return await server.scheduleTeamMateFromMcp({
+      return await server.dispatcherService.scheduleTeamMate({
         dispatcherId: id,
         callerKind,
         title,
@@ -172,7 +172,7 @@ export const adminMethods: Record<string, AdminHandler> = {
     }
     const finalText = mustString(params, 'final_text');
     try {
-      return await server.reportTeamMateCompletion({
+      return await server.dispatcherService.reportTeamMateCompletion({
         dispatcherId: id,
         taskId,
         outcome,
@@ -183,9 +183,8 @@ export const adminMethods: Record<string, AdminHandler> = {
     }
   },
 
-  // Executable normal-path create-and-execute tool (issue #126). No worker is
-  // wired yet, so the task is created and the execution sub-result reports
-  // provider_unavailable.
+  // Executable normal-path create-and-execute tool (issue #126). The admin
+  // layer only validates params and delegates orchestration to DispatcherService.
   'mcp.teammate.run': async (server, params) => {
     const id = mustDispatcherId(params);
     mustExistingDispatcher(server, id);
@@ -199,7 +198,7 @@ export const adminMethods: Record<string, AdminHandler> = {
     const providerRef = optionalString(params, 'provider_ref');
     const operationId = optionalString(params, 'operation_id');
     try {
-      return await server.runTeamMateTaskFromMcp({
+      return await server.dispatcherService.runTeamMateTask({
         dispatcherId: id,
         callerKind,
         title,
@@ -232,7 +231,7 @@ export const adminMethods: Record<string, AdminHandler> = {
     const targetMode = optionalString(params, 'target_mode');
     const operationId = optionalString(params, 'operation_id');
     try {
-      return await server.executeTeamMateTaskFromMcp({
+      return await server.dispatcherService.executeTeamMateTask({
         dispatcherId: id,
         taskId,
         ...(providerRef !== null ? { providerRef } : {}),
@@ -254,7 +253,7 @@ export const adminMethods: Record<string, AdminHandler> = {
     const mode = optionalString(params, 'mode');
     const operationId = optionalString(params, 'operation_id');
     try {
-      return await server.sendTeamMateInputFromMcp({
+      return await server.dispatcherService.sendTeamMateInput({
         dispatcherId: id,
         taskId,
         prompt,
@@ -279,7 +278,7 @@ export const adminMethods: Record<string, AdminHandler> = {
     const until = optionalStringArray(params, 'until');
     const timeoutMs = optionalNumber(params, 'timeout_ms');
     try {
-      return await server.awaitTeamMateCompletionFromMcp({
+      return await server.dispatcherService.awaitTeamMateCompletion({
         dispatcherId: id,
         taskId,
         ...(afterEventId !== null ? { afterEventId } : {}),
@@ -297,7 +296,7 @@ export const adminMethods: Record<string, AdminHandler> = {
     const taskId = mustString(params, 'task_id');
     const note = optionalString(params, 'note');
     try {
-      return await server.cancelTeamMateTaskFromMcp({
+      return await server.dispatcherService.cancelTeamMateTask({
         dispatcherId: id,
         taskId,
         ...(note !== null ? { note } : {}),
@@ -325,7 +324,7 @@ export const adminMethods: Record<string, AdminHandler> = {
       );
     }
     try {
-      return await server.getTeamMateTaskLogsFromMcp({
+      return await server.dispatcherService.getTeamMateTaskLogs({
         dispatcherId: id,
         taskId,
         ...(maxBytes !== null ? { maxBytes } : {}),
@@ -339,26 +338,26 @@ export const adminMethods: Record<string, AdminHandler> = {
   },
 
   'mcp.teammate.capabilities': (server) =>
-    server.getTeamMateCapabilitiesFromMcp(),
+    server.dispatcherService.getTeamMateCapabilities(),
 
   'mcp.teammate.list': async (server, params) => {
     const id = mustDispatcherId(params);
     mustExistingDispatcher(server, id);
-    return { tasks: await server.listTeamMateTasksFromMcp(id) };
+    return { tasks: await server.dispatcherService.listTeamMateTasks(id) };
   },
 
   'mcp.teammate.get': async (server, params) => {
     const id = mustDispatcherId(params);
     mustExistingDispatcher(server, id);
     const taskId = mustString(params, 'task_id');
-    return { task: await server.getTeamMateTaskFromMcp(id, taskId) };
+    return { task: await server.dispatcherService.getTeamMateTask(id, taskId) };
   },
 
   'mcp.teammate.pull': async (server, params) => {
     const id = mustDispatcherId(params);
     mustExistingDispatcher(server, id);
     const taskId = optionalString(params, 'task_id');
-    const result = await server.pullTeamMateResultFromMcp(
+    const result = await server.dispatcherService.pullTeamMateResult(
       id,
       taskId !== null ? taskId : undefined,
     );

--- a/packages/dreamux/src/dispatcher-service/service.ts
+++ b/packages/dreamux/src/dispatcher-service/service.ts
@@ -1,0 +1,538 @@
+import type {
+  AgentRuntime,
+  AgentRuntimeProviderCatalog,
+} from '../agent-runtime/index.js';
+import type { ClaudeCodeSessionFactory } from '../agent-runtime/claude-code-session.js';
+import type { CodexProcess, CodexProcessOptions } from '../codex/supervisor.js';
+import type { CodexWsClient } from '../codex/rpc.js';
+import type { DreamuxConfig } from '../runtime/config.js';
+import type { DispatcherStore } from '../runtime/dispatcher-store.js';
+import type { DreamuxLogger } from '../runtime/logger.js';
+import {
+  NestedTeamMateDispatchError,
+  resolveTeammateTarget,
+  TEAMMATE_INPUT_MODES,
+  TEAMMATE_TARGET_MODES,
+  TeamMateTaskLedger,
+  type TeamMateScheduleCallerKind,
+  type TeamMateTaskRecord,
+} from '../teammate/ledger.js';
+import {
+  TeamMateDeliveryService,
+  type TeamMateDeliveryReport,
+} from '../teammate/delivery.js';
+import {
+  TeamMateWorkerExecutionService,
+  type TeamMateExecutionOutcome,
+} from '../teammate/worker-execution.js';
+import {
+  readTeamMateWorkerLogs,
+} from '../teammate/worker-logs.js';
+import { TeamMateWorkerProviderCatalog } from '../teammate/worker/catalog.js';
+import type { TeamMateWorkerProvider } from '../teammate/worker/types.js';
+import {
+  awaitTeamMateCompletion,
+  clampWaitTimeout,
+  lastEventId,
+  TEAMMATE_WAIT_DEFAULT_MS,
+  TEAMMATE_WAIT_MAX_MS,
+  TeamMateWaitBroker,
+} from '../teammate/wait-broker.js';
+import {
+  isTerminalLifecycle,
+  parseWaitUntil,
+  toExecutionResult,
+  toProviderCapability,
+  toTeamMatePullResult,
+  toTeamMateTaskSummary,
+} from './teammate-presenters.js';
+import type {
+  ServerMcpAwaitTeamMateCompletionInput,
+  ServerMcpAwaitTeamMateCompletionResult,
+  ServerMcpCancelTeamMateTaskInput,
+  ServerMcpCancelTeamMateTaskResult,
+  ServerMcpExecuteTeamMateTaskInput,
+  ServerMcpRunTeamMateTaskInput,
+  ServerMcpRunTeamMateTaskResult,
+  ServerMcpScheduleTeamMateInput,
+  ServerMcpScheduleTeamMateResult,
+  ServerMcpSendTeamMateInputInput,
+  ServerMcpSendTeamMateInputResult,
+  ServerMcpTeamMateTaskLogsInput,
+  ServerMcpTeamMateTaskLogsResult,
+  ServerTeamMateCapabilities,
+  ServerTeamMateCompletionInput,
+  ServerTeamMateProviderCapability,
+  ServerTeamMatePullResult,
+  ServerTeamMateTaskSummary,
+  WorkerBinaryProbe,
+} from './teammate-types.js';
+import {
+  createDefaultTeamMateWorkerCatalog,
+  createDefaultWorkerBinaryProbe,
+} from './worker-factory.js';
+
+export interface DispatcherServiceOptions {
+  config: DreamuxConfig;
+  dispatchers: DispatcherStore;
+  agentRuntimeProviders: AgentRuntimeProviderCatalog;
+  resolveRuntime: (dispatcherId: string) => AgentRuntime | null;
+  codexBinPath?: string;
+  codexProcessFactory?: (opts: CodexProcessOptions) => CodexProcess;
+  codexClientFactory?: (socketPath: string) => CodexWsClient;
+  claudeCodeWorkerSessionFactory?: ClaudeCodeSessionFactory;
+  teamMateWorkerProviders?: TeamMateWorkerProviderCatalog;
+  workerBinaryProbe?: WorkerBinaryProbe;
+  teamMateDeliveryMaxAttempts?: number;
+  teamMateDeliveryBackoffMs?: (attempt: number) => number;
+  log: DreamuxLogger;
+}
+
+/**
+ * Dispatcher Service owns server-side teammate orchestration for dispatchers.
+ *
+ * The stdio MCP shim and admin method layer should only map tool/admin calls
+ * into this service. Ledger writes, wait-broker notifications, worker
+ * lifecycle, completion delivery, and capability probing live here.
+ */
+export class DispatcherService {
+  private readonly teamMateLedgers = new Map<string, TeamMateTaskLedger>();
+  private readonly teamMateWaitBroker = new TeamMateWaitBroker();
+  private readonly teamMateDelivery: TeamMateDeliveryService;
+  private readonly teamMateWorkers: TeamMateWorkerProviderCatalog;
+  private readonly workerBinaryProbe: WorkerBinaryProbe;
+  private readonly teamMateWorkerExecution: TeamMateWorkerExecutionService;
+
+  constructor(private readonly opts: DispatcherServiceOptions) {
+    this.teamMateDelivery = new TeamMateDeliveryService({
+      ledger: (dispatcherId) => this.teamMateLedger(dispatcherId),
+      resolveRuntime: (dispatcherId) => this.opts.resolveRuntime(dispatcherId),
+      notifyEvent: (dispatcherId, taskId) =>
+        this.teamMateWaitBroker.notify(dispatcherId, taskId),
+      log: (level, message, fields) => this.opts.log[level](fields ?? {}, message),
+      ...(opts.teamMateDeliveryMaxAttempts !== undefined
+        ? { maxAttempts: opts.teamMateDeliveryMaxAttempts }
+        : {}),
+      ...(opts.teamMateDeliveryBackoffMs !== undefined
+        ? { backoffMs: opts.teamMateDeliveryBackoffMs }
+        : {}),
+    });
+    this.teamMateWorkers =
+      opts.teamMateWorkerProviders ??
+      createDefaultTeamMateWorkerCatalog({
+        config: opts.config,
+        dispatchers: opts.dispatchers,
+        ...(opts.codexBinPath !== undefined
+          ? { codexBinPath: opts.codexBinPath }
+          : {}),
+        ...(opts.codexProcessFactory !== undefined
+          ? { codexProcessFactory: opts.codexProcessFactory }
+          : {}),
+        ...(opts.codexClientFactory !== undefined
+          ? { codexClientFactory: opts.codexClientFactory }
+          : {}),
+        ...(opts.claudeCodeWorkerSessionFactory !== undefined
+          ? { claudeCodeWorkerSessionFactory: opts.claudeCodeWorkerSessionFactory }
+          : {}),
+        log: opts.log,
+      });
+    this.workerBinaryProbe =
+      opts.workerBinaryProbe ?? createDefaultWorkerBinaryProbe(opts.codexBinPath);
+    this.teamMateWorkerExecution = new TeamMateWorkerExecutionService({
+      ledger: (dispatcherId) => this.teamMateLedger(dispatcherId),
+      workers: () => this.teamMateWorkers,
+      reportCompletion: (report) =>
+        this.teamMateDelivery.reportCompletion(report),
+      notifyEvent: (dispatcherId, taskId) =>
+        this.teamMateWaitBroker.notify(dispatcherId, taskId),
+      log: (level, message, fields) => this.opts.log[level](fields ?? {}, message),
+    });
+  }
+
+  async scheduleTeamMate(
+    input: ServerMcpScheduleTeamMateInput,
+  ): Promise<ServerMcpScheduleTeamMateResult> {
+    this.assertTeamMateSchedulingAuthority(input.callerKind);
+    const task = await this.teamMateLedger(input.dispatcherId).acceptTask({
+      title: input.title,
+      prompt: input.prompt,
+      callerKind: input.callerKind,
+      ...(input.teammateId !== undefined
+        ? { teammateId: input.teammateId }
+        : {}),
+    });
+    this.teamMateWaitBroker.notify(input.dispatcherId, task.task_id);
+    this.opts.log.info(
+      {
+        dispatcher_id: input.dispatcherId,
+        task_id: task.task_id,
+        caller_kind: input.callerKind,
+      },
+      'teammate task accepted',
+    );
+    return {
+      status: 'accepted',
+      task_id: task.task_id,
+      dispatcher_id: task.dispatcher_id,
+      created_at: task.created_at,
+      ...(task.teammate_id !== null ? { teammate_id: task.teammate_id } : {}),
+    };
+  }
+
+  async runTeamMateTask(
+    input: ServerMcpRunTeamMateTaskInput,
+  ): Promise<ServerMcpRunTeamMateTaskResult> {
+    this.assertTeamMateSchedulingAuthority(input.callerKind);
+    const target = resolveTeammateTarget(
+      input.targetPath,
+      this.mustDispatcherDir(input.dispatcherId),
+    );
+    const accepted = await this.teamMateLedger(input.dispatcherId).acceptTask({
+      title: input.title,
+      prompt: input.prompt,
+      callerKind: input.callerKind,
+      target,
+      origin: 'dispatcher',
+      ...(input.teammateId !== undefined ? { teammateId: input.teammateId } : {}),
+      ...(input.intent !== undefined ? { intent: input.intent } : {}),
+      ...(input.targetMode !== undefined ? { targetMode: input.targetMode } : {}),
+      ...(input.providerRef !== undefined
+        ? { providerRef: input.providerRef }
+        : {}),
+      ...(input.operationId !== undefined
+        ? { operationId: input.operationId }
+        : {}),
+    });
+    this.teamMateWaitBroker.notify(input.dispatcherId, accepted.task_id);
+    this.opts.log.info(
+      {
+        dispatcher_id: input.dispatcherId,
+        task_id: accepted.task_id,
+        caller_kind: input.callerKind,
+      },
+      'teammate task run requested',
+    );
+    const execution = await this.teamMateWorkerExecution.execute({
+      dispatcherId: input.dispatcherId,
+      taskId: accepted.task_id,
+      ...(input.providerRef !== undefined ? { providerRef: input.providerRef } : {}),
+    });
+    return this.teamMateExecutionResult(input.dispatcherId, accepted, execution);
+  }
+
+  async executeTeamMateTask(
+    input: ServerMcpExecuteTeamMateTaskInput,
+  ): Promise<ServerMcpRunTeamMateTaskResult> {
+    const task = await this.teamMateLedger(input.dispatcherId).getTask(
+      input.taskId,
+    );
+    if (task === null) {
+      throw new Error(`TeamMate task ${JSON.stringify(input.taskId)} does not exist`);
+    }
+    const execution = await this.teamMateWorkerExecution.execute({
+      dispatcherId: input.dispatcherId,
+      taskId: input.taskId,
+      ...(input.providerRef !== undefined ? { providerRef: input.providerRef } : {}),
+    });
+    return this.teamMateExecutionResult(input.dispatcherId, task, execution);
+  }
+
+  async sendTeamMateInput(
+    input: ServerMcpSendTeamMateInputInput,
+  ): Promise<ServerMcpSendTeamMateInputResult> {
+    const ledger = this.teamMateLedger(input.dispatcherId);
+    const { task, input: recorded } = await ledger.appendInput(input.taskId, {
+      text: input.prompt,
+      mode: input.mode ?? 'steer',
+    });
+    this.teamMateWaitBroker.notify(input.dispatcherId, task.task_id);
+    const routed = await this.teamMateWorkerExecution.sendInput({
+      dispatcherId: input.dispatcherId,
+      taskId: input.taskId,
+      inputId: recorded.input_id,
+      text: recorded.text,
+      mode: recorded.mode,
+    });
+    let status: 'queued' | 'submitted' = 'queued';
+    let latest = task;
+    if (routed.delivered && routed.disposition?.status === 'accepted') {
+      latest = await ledger.markInputSubmitted(input.taskId, recorded.input_id);
+      this.teamMateWaitBroker.notify(input.dispatcherId, input.taskId);
+      status = 'submitted';
+    }
+    return {
+      input_id: recorded.input_id,
+      mode: recorded.mode,
+      status,
+      after_event_id: lastEventId(latest),
+      task: toTeamMateTaskSummary(latest),
+    };
+  }
+
+  async cancelTeamMateTask(
+    input: ServerMcpCancelTeamMateTaskInput,
+  ): Promise<ServerMcpCancelTeamMateTaskResult> {
+    const ledger = this.teamMateLedger(input.dispatcherId);
+    const task = await ledger.getTask(input.taskId);
+    if (task === null) {
+      throw new Error(
+        `TeamMate task ${JSON.stringify(input.taskId)} does not exist`,
+      );
+    }
+    if (isTerminalLifecycle(task.lifecycle_status)) {
+      return {
+        task_id: task.task_id,
+        status: 'already_terminal',
+        lifecycle_status: task.lifecycle_status,
+        cancelled_live_session: false,
+        after_event_id: lastEventId(task),
+        task: toTeamMateTaskSummary(task),
+      };
+    }
+    const reason = input.note ?? null;
+    const cancelled = await this.teamMateWorkerExecution.cancel({
+      dispatcherId: input.dispatcherId,
+      taskId: input.taskId,
+      reason,
+    });
+    if (!cancelled.cancelledLiveSession) {
+      const fresh = await ledger.getTask(input.taskId);
+      if (fresh !== null && isTerminalLifecycle(fresh.lifecycle_status)) {
+        return {
+          task_id: fresh.task_id,
+          status: 'already_terminal',
+          lifecycle_status: fresh.lifecycle_status,
+          cancelled_live_session: false,
+          after_event_id: lastEventId(fresh),
+          task: toTeamMateTaskSummary(fresh),
+        };
+      }
+      await ledger.recordClose(input.taskId, {
+        status: 'cancelled',
+        ...(reason !== null && reason !== '' ? { note: reason } : {}),
+      });
+      this.teamMateWaitBroker.notify(input.dispatcherId, input.taskId);
+    }
+    const latest = (await ledger.getTask(input.taskId)) ?? task;
+    return {
+      task_id: latest.task_id,
+      status:
+        latest.lifecycle_status === 'cancelled' ? 'cancelled' : 'already_terminal',
+      lifecycle_status: latest.lifecycle_status,
+      cancelled_live_session: cancelled.cancelledLiveSession,
+      after_event_id: lastEventId(latest),
+      task: toTeamMateTaskSummary(latest),
+    };
+  }
+
+  async getTeamMateTaskLogs(
+    input: ServerMcpTeamMateTaskLogsInput,
+  ): Promise<ServerMcpTeamMateTaskLogsResult> {
+    const task = await this.teamMateLedger(input.dispatcherId).getTask(
+      input.taskId,
+    );
+    if (task === null) {
+      throw new Error(
+        `TeamMate task ${JSON.stringify(input.taskId)} does not exist`,
+      );
+    }
+    const effectiveRef =
+      this.teamMateWorkers.resolve(task.provider_ref)?.ref ?? task.provider_ref;
+    const logs = await readTeamMateWorkerLogs({
+      dispatcherId: input.dispatcherId,
+      taskId: input.taskId,
+      providerRef: effectiveRef,
+      ...(input.maxBytes !== undefined ? { maxBytes: input.maxBytes } : {}),
+      ...(input.stream !== undefined ? { stream: input.stream } : {}),
+    });
+    return {
+      task_id: task.task_id,
+      provider_ref: effectiveRef,
+      lifecycle_status: task.lifecycle_status,
+      logs_supported: logs.logs_supported,
+      streams: logs.streams,
+    };
+  }
+
+  async awaitTeamMateCompletion(
+    input: ServerMcpAwaitTeamMateCompletionInput,
+  ): Promise<ServerMcpAwaitTeamMateCompletionResult> {
+    const ledger = this.teamMateLedger(input.dispatcherId);
+    const until = parseWaitUntil(input.until);
+    const afterEventId =
+      input.afterEventId !== undefined && Number.isFinite(input.afterEventId)
+        ? Math.max(0, Math.floor(input.afterEventId))
+        : 0;
+    const outcome = await awaitTeamMateCompletion(this.teamMateWaitBroker, {
+      dispatcherId: input.dispatcherId,
+      taskId: input.taskId,
+      afterEventId,
+      until,
+      timeoutMs: clampWaitTimeout(input.timeoutMs),
+      loadTask: () => ledger.getTask(input.taskId),
+    });
+    if (outcome.status === 'not_found') {
+      throw new Error(
+        `TeamMate task ${JSON.stringify(input.taskId)} does not exist`,
+      );
+    }
+    if (outcome.status === 'still_running') {
+      return {
+        status: 'still_running',
+        task_id: input.taskId,
+        after_event_id: outcome.last_event_id,
+        task: toTeamMateTaskSummary(outcome.task),
+      };
+    }
+    const task = outcome.task;
+    const status: ServerMcpAwaitTeamMateCompletionResult['status'] =
+      task.lifecycle_status === 'completed' ||
+      task.lifecycle_status === 'failed' ||
+      task.lifecycle_status === 'cancelled'
+        ? task.lifecycle_status
+        : 'reached';
+    return {
+      status,
+      task_id: input.taskId,
+      after_event_id: outcome.last_event_id,
+      task: toTeamMateTaskSummary(task),
+      result: task.result === null ? null : toTeamMatePullResult(task),
+    };
+  }
+
+  async getTeamMateCapabilities(): Promise<ServerTeamMateCapabilities> {
+    const workers = this.teamMateWorkers;
+    const workerByRef = new Map(
+      workers.list().map((worker) => [worker.ref, worker] as const),
+    );
+    const providers: ServerTeamMateProviderCapability[] = [];
+    const seen = new Set<string>();
+    for (const runtime of this.opts.agentRuntimeProviders.list()) {
+      providers.push(
+        await this.toProviderCapabilityProbed(
+          runtime.ref,
+          workerByRef.get(runtime.ref),
+        ),
+      );
+      seen.add(runtime.ref);
+    }
+    for (const worker of workers.list()) {
+      if (seen.has(worker.ref)) continue;
+      providers.push(await this.toProviderCapabilityProbed(worker.ref, worker));
+      seen.add(worker.ref);
+    }
+    return {
+      execution_available: providers.some((p) => p.worker_available),
+      wait: { default_ms: TEAMMATE_WAIT_DEFAULT_MS, max_ms: TEAMMATE_WAIT_MAX_MS },
+      target_modes: [...TEAMMATE_TARGET_MODES],
+      input_modes: [...TEAMMATE_INPUT_MODES],
+      default_input_mode: 'steer',
+      providers,
+    };
+  }
+
+  async reportTeamMateCompletion(
+    input: ServerTeamMateCompletionInput,
+  ): Promise<TeamMateDeliveryReport> {
+    return this.teamMateDelivery.reportCompletion({
+      dispatcherId: input.dispatcherId,
+      taskId: input.taskId,
+      outcome: input.outcome,
+      finalText: input.finalText,
+    });
+  }
+
+  async listTeamMateTasks(
+    dispatcherId: string,
+  ): Promise<ServerTeamMateTaskSummary[]> {
+    const tasks = await this.teamMateLedger(dispatcherId).listTasks({
+      onCorrupt: (taskId, err) =>
+        this.opts.log.warn(
+          { dispatcher_id: dispatcherId, task_id: taskId, err: errInfo(err) },
+          'skipping corrupt TeamMate task file',
+        ),
+    });
+    return tasks.map(toTeamMateTaskSummary);
+  }
+
+  async getTeamMateTask(
+    dispatcherId: string,
+    taskId: string,
+  ): Promise<TeamMateTaskRecord | null> {
+    return this.teamMateLedger(dispatcherId).getTask(taskId);
+  }
+
+  async pullTeamMateResult(
+    dispatcherId: string,
+    taskId?: string,
+  ): Promise<ServerTeamMatePullResult | null> {
+    const ledger = this.teamMateLedger(dispatcherId);
+    const task =
+      taskId !== undefined
+        ? await ledger.getTask(taskId)
+        : await ledger.latestResultTask();
+    if (task === null || task.result === null) return null;
+    return toTeamMatePullResult(task);
+  }
+
+  async reapAllTeamMateWorkers(): Promise<void> {
+    await this.teamMateWorkerExecution.reapAll();
+  }
+
+  private async teamMateExecutionResult(
+    dispatcherId: string,
+    fallback: TeamMateTaskRecord,
+    execution: TeamMateExecutionOutcome,
+  ): Promise<ServerMcpRunTeamMateTaskResult> {
+    const latest =
+      (await this.teamMateLedger(dispatcherId).getTask(fallback.task_id)) ??
+      fallback;
+    return {
+      task: toTeamMateTaskSummary(latest),
+      execution: toExecutionResult(execution),
+    };
+  }
+
+  private async toProviderCapabilityProbed(
+    ref: string,
+    worker: TeamMateWorkerProvider | undefined,
+  ): Promise<ServerTeamMateProviderCapability> {
+    if (worker === undefined) return toProviderCapability(ref, undefined, null);
+    const availability = await this.workerBinaryProbe(ref);
+    return toProviderCapability(ref, worker, availability);
+  }
+
+  private assertTeamMateSchedulingAuthority(
+    callerKind: TeamMateScheduleCallerKind,
+  ): void {
+    if (callerKind === 'teammate') {
+      throw new NestedTeamMateDispatchError();
+    }
+  }
+
+  private mustDispatcherDir(dispatcherId: string): string {
+    const dir = this.opts.dispatchers.get(dispatcherId)?.codex_cwd ?? null;
+    if (dir === null || dir === '') {
+      throw new Error(
+        `dispatcher '${dispatcherId}' has no configured working directory; ` +
+          'a path target cannot be resolved',
+      );
+    }
+    return dir;
+  }
+
+  private teamMateLedger(dispatcherId: string): TeamMateTaskLedger {
+    const existing = this.teamMateLedgers.get(dispatcherId);
+    if (existing !== undefined) return existing;
+    const created = new TeamMateTaskLedger(dispatcherId);
+    this.teamMateLedgers.set(dispatcherId, created);
+    return created;
+  }
+}
+
+function errInfo(err: unknown): Record<string, unknown> {
+  if (err instanceof Error) {
+    return { type: err.name, message: err.message, stack: err.stack };
+  }
+  return { value: String(err) };
+}

--- a/packages/dreamux/src/dispatcher-service/teammate-presenters.ts
+++ b/packages/dreamux/src/dispatcher-service/teammate-presenters.ts
@@ -1,0 +1,137 @@
+import {
+  legacyTaskStatus,
+  type TeamMateLifecycleStatus,
+  type TeamMateTaskRecord,
+} from '../teammate/ledger.js';
+import type { TeamMateExecutionOutcome } from '../teammate/worker-execution.js';
+import type { TeamMateWorkerProvider } from '../teammate/worker/types.js';
+import {
+  isWaitToken,
+  lastEventId,
+  TEAMMATE_WAIT_DEFAULT_UNTIL,
+  type TeamMateWaitToken,
+} from '../teammate/wait-broker.js';
+import type {
+  ServerTeamMateExecutionResult,
+  ServerTeamMateProviderCapability,
+  ServerTeamMatePullResult,
+  ServerTeamMateTaskSummary,
+  TeamMateWorkerAvailability,
+} from './teammate-types.js';
+
+export function isTerminalLifecycle(
+  status: TeamMateLifecycleStatus,
+): status is 'completed' | 'failed' | 'cancelled' {
+  return (
+    status === 'completed' || status === 'failed' || status === 'cancelled'
+  );
+}
+
+export function toTeamMateTaskSummary(
+  task: TeamMateTaskRecord,
+): ServerTeamMateTaskSummary {
+  return {
+    task_id: task.task_id,
+    status: legacyTaskStatus(task),
+    lifecycle_status: task.lifecycle_status,
+    delivery_status: task.delivery_status,
+    title: task.title,
+    teammate_id: task.teammate_id,
+    provider_ref: task.provider_ref,
+    created_at: task.created_at,
+    updated_at: task.updated_at,
+    last_event_id: lastEventId(task),
+    delivery_attempts: task.delivery?.attempts ?? 0,
+    has_result: task.result !== null,
+  };
+}
+
+export function toTeamMatePullResult(
+  task: TeamMateTaskRecord,
+): ServerTeamMatePullResult {
+  if (task.result === null) {
+    throw new Error(
+      `TeamMate task ${JSON.stringify(task.task_id)} has no retained result`,
+    );
+  }
+  return {
+    task_id: task.task_id,
+    status: legacyTaskStatus(task),
+    lifecycle_status: task.lifecycle_status,
+    delivery_status: task.delivery_status,
+    outcome: task.result.outcome,
+    text: task.result.text,
+    delivered: task.delivery_status === 'delivered',
+    delivery_attempts: task.delivery?.attempts ?? 0,
+  };
+}
+
+/** Map the execution service outcome onto the public `execution` sub-result. */
+export function toExecutionResult(
+  outcome: TeamMateExecutionOutcome,
+): ServerTeamMateExecutionResult {
+  if (outcome.status === 'provider_unavailable') {
+    return {
+      status: 'provider_unavailable',
+      reason: outcome.reason,
+      code: outcome.code,
+      retryable: outcome.retryable,
+    };
+  }
+  return {
+    status: outcome.status,
+    ...(outcome.provider_ref !== '' ? { provider_ref: outcome.provider_ref } : {}),
+  };
+}
+
+/**
+ * Build a provider capability row for `get_capabilities`. When the catalog has
+ * a worker for the ref, its static capabilities are reported, downgraded to
+ * unavailable when the binary probe could not resolve the worker's binary.
+ */
+export function toProviderCapability(
+  ref: string,
+  worker: TeamMateWorkerProvider | undefined,
+  availability: TeamMateWorkerAvailability | null,
+): ServerTeamMateProviderCapability {
+  if (worker === undefined) {
+    return {
+      provider_ref: ref,
+      worker_available: false,
+      unsupported_reason:
+        'TeamMate worker execution is not implemented yet (issue #126)',
+      modes: { steer: false, queue: false, interrupt: false },
+      resume: false,
+      logs: false,
+    };
+  }
+  const caps = worker.capabilities();
+  const binaryUnavailable = availability !== null && !availability.available;
+  const workerAvailable = caps.worker_available && !binaryUnavailable;
+  return {
+    provider_ref: ref,
+    worker_available: workerAvailable,
+    unsupported_reason: binaryUnavailable
+      ? availability.reason
+      : caps.unsupported_reason,
+    modes: { ...caps.modes },
+    resume: caps.resume,
+    logs: caps.logs,
+  };
+}
+
+/** Validate and default the `await_completion.until` token set. */
+export function parseWaitUntil(until: string[] | undefined): Set<TeamMateWaitToken> {
+  if (until === undefined) return new Set(TEAMMATE_WAIT_DEFAULT_UNTIL);
+  if (!Array.isArray(until) || until.length === 0) {
+    throw new Error('until must be a non-empty array of states');
+  }
+  const tokens = new Set<TeamMateWaitToken>();
+  for (const token of until) {
+    if (!isWaitToken(token)) {
+      throw new Error(`unsupported await_completion state: ${String(token)}`);
+    }
+    tokens.add(token);
+  }
+  return tokens;
+}

--- a/packages/dreamux/src/dispatcher-service/teammate-types.ts
+++ b/packages/dreamux/src/dispatcher-service/teammate-types.ts
@@ -1,0 +1,207 @@
+import type {
+  TeamMateDeliveryStatus,
+  TeamMateInputMode,
+  TeamMateLifecycleStatus,
+  TeamMateScheduleCallerKind,
+  TeamMateTargetMode,
+} from '../teammate/ledger.js';
+import type {
+  TeamMateWorkerLogStream,
+  TeamMateWorkerLogStreamKind,
+} from '../teammate/worker-logs.js';
+
+export interface ServerMcpScheduleTeamMateInput {
+  dispatcherId: string;
+  callerKind: TeamMateScheduleCallerKind;
+  title: string;
+  prompt: string;
+  teammateId?: string;
+}
+
+export interface ServerMcpScheduleTeamMateResult {
+  status: 'accepted';
+  task_id: string;
+  dispatcher_id: string;
+  created_at: number;
+  teammate_id?: string;
+}
+
+export interface ServerTeamMateCompletionInput {
+  dispatcherId: string;
+  taskId: string;
+  outcome: 'completed' | 'failed';
+  finalText: string;
+}
+
+export interface ServerTeamMateTaskSummary {
+  task_id: string;
+  /** Back-compat projection of lifecycle + delivery into the v1 status enum. */
+  status: string;
+  lifecycle_status: TeamMateLifecycleStatus;
+  delivery_status: TeamMateDeliveryStatus;
+  title: string;
+  teammate_id: string | null;
+  provider_ref: string | null;
+  created_at: number;
+  updated_at: number;
+  last_event_id: number;
+  delivery_attempts: number;
+  has_result: boolean;
+}
+
+export interface ServerTeamMatePullResult {
+  task_id: string;
+  status: string;
+  lifecycle_status: TeamMateLifecycleStatus;
+  delivery_status: TeamMateDeliveryStatus;
+  outcome: 'completed' | 'failed';
+  text: string;
+  delivered: boolean;
+  delivery_attempts: number;
+}
+
+export interface ServerMcpRunTeamMateTaskInput {
+  dispatcherId: string;
+  callerKind: TeamMateScheduleCallerKind;
+  title: string;
+  prompt: string;
+  targetPath: string;
+  teammateId?: string;
+  intent?: string;
+  targetMode?: TeamMateTargetMode;
+  providerRef?: string;
+  operationId?: string;
+}
+
+export interface ServerMcpExecuteTeamMateTaskInput {
+  dispatcherId: string;
+  taskId: string;
+  providerRef?: string;
+  targetMode?: TeamMateTargetMode;
+  operationId?: string;
+}
+
+export interface ServerMcpSendTeamMateInputInput {
+  dispatcherId: string;
+  taskId: string;
+  prompt: string;
+  mode?: TeamMateInputMode;
+  operationId?: string;
+}
+
+export interface ServerMcpAwaitTeamMateCompletionInput {
+  dispatcherId: string;
+  taskId: string;
+  afterEventId?: number;
+  until?: string[];
+  timeoutMs?: number;
+}
+
+/**
+ * Execution attempt outcome (issue #126). With no worker wired this reports
+ * `provider_unavailable`; a wired worker reports the lifecycle status and
+ * resolved provider ref.
+ */
+export interface ServerTeamMateExecutionResult {
+  status: 'running' | 'completed' | 'failed' | 'cancelled' | 'provider_unavailable';
+  provider_ref?: string;
+  reason?: string;
+  code?: string;
+  retryable?: boolean;
+}
+
+export interface ServerMcpRunTeamMateTaskResult {
+  task: ServerTeamMateTaskSummary;
+  execution: ServerTeamMateExecutionResult;
+}
+
+export interface ServerMcpSendTeamMateInputResult {
+  input_id: string;
+  mode: TeamMateInputMode;
+  /**
+   * `submitted` when a live worker session accepted the input, `queued`
+   * otherwise. The input is durably recorded either way.
+   */
+  status: 'queued' | 'submitted';
+  after_event_id: number;
+  task: ServerTeamMateTaskSummary;
+}
+
+export interface ServerMcpAwaitTeamMateCompletionResult {
+  status: 'completed' | 'failed' | 'cancelled' | 'reached' | 'still_running';
+  task_id: string;
+  after_event_id: number;
+  task: ServerTeamMateTaskSummary | null;
+  result?: ServerTeamMatePullResult | null;
+}
+
+export interface ServerMcpCancelTeamMateTaskInput {
+  dispatcherId: string;
+  taskId: string;
+  /** Optional close note recorded with the cancellation. */
+  note?: string;
+}
+
+export interface ServerMcpCancelTeamMateTaskResult {
+  task_id: string;
+  /**
+   * `cancelled` when this call closed a live/open task, `already_terminal` when
+   * the task had already finished.
+   */
+  status: 'cancelled' | 'already_terminal';
+  lifecycle_status: TeamMateLifecycleStatus;
+  /** Whether a live worker session in this process was reaped by the cancel. */
+  cancelled_live_session: boolean;
+  after_event_id: number;
+  task: ServerTeamMateTaskSummary;
+}
+
+export interface ServerMcpTeamMateTaskLogsInput {
+  dispatcherId: string;
+  taskId: string;
+  maxBytes?: number;
+  stream?: TeamMateWorkerLogStreamKind;
+}
+
+export interface ServerMcpTeamMateTaskLogsResult {
+  task_id: string;
+  provider_ref: string | null;
+  lifecycle_status: TeamMateLifecycleStatus;
+  /** Whether this task's worker has a known on-disk log layout. */
+  logs_supported: boolean;
+  streams: TeamMateWorkerLogStream[];
+}
+
+/** Worker capability advertisement for a built-in runtime. */
+export interface ServerTeamMateProviderCapability {
+  provider_ref: string;
+  worker_available: boolean;
+  unsupported_reason: string;
+  modes: { steer: boolean; queue: boolean; interrupt: boolean };
+  resume: boolean;
+  logs: boolean;
+}
+
+export interface ServerTeamMateCapabilities {
+  execution_available: boolean;
+  wait: { default_ms: number; max_ms: number };
+  target_modes: TeamMateTargetMode[];
+  input_modes: TeamMateInputMode[];
+  default_input_mode: TeamMateInputMode;
+  providers: ServerTeamMateProviderCapability[];
+}
+
+/** Whether a worker's configured binary can be resolved in the service env. */
+export interface TeamMateWorkerAvailability {
+  available: boolean;
+  /** Human-readable reason when `available` is false; empty otherwise. */
+  reason: string;
+}
+
+/**
+ * Probe whether the binary a worker provider would launch is resolvable in the
+ * dispatcher service environment.
+ */
+export type WorkerBinaryProbe = (
+  providerRef: string,
+) => Promise<TeamMateWorkerAvailability>;

--- a/packages/dreamux/src/dispatcher-service/worker-factory.ts
+++ b/packages/dreamux/src/dispatcher-service/worker-factory.ts
@@ -1,0 +1,162 @@
+import type { ClaudeCodeSessionFactory } from '../agent-runtime/claude-code-session.js';
+import type { CodexProcess, CodexProcessOptions } from '../codex/supervisor.js';
+import type { CodexWsClient } from '../codex/rpc.js';
+import {
+  BUILTIN_CLAUDE_CODE_PROVIDER_REF,
+  BUILTIN_CODEX_PROVIDER_REF,
+  DEFAULT_CLAUDE_CODE_BIN,
+  DEFAULT_CODEX_BIN,
+  defaultDispatcherClaudeCodeConfig,
+  defaultDispatcherCodexConfig,
+  dispatcherClaudeCodeConfig,
+  dispatcherCodexConfig,
+  type DispatcherClaudeCodeConfig,
+  type DispatcherCodexConfig,
+  type DreamuxConfig,
+} from '../runtime/config.js';
+import type { DispatcherStore } from '../runtime/dispatcher-store.js';
+import type { DreamuxLogger } from '../runtime/logger.js';
+import {
+  dispatcherProcessEnv,
+  resolveExecutableOnPath,
+} from '../runtime/package-bin.js';
+import { dispatcherCodexCwd } from '../runtime/paths.js';
+import { createClaudeCodeTeamMateWorkerProvider } from '../teammate/worker/claude-code-provider.js';
+import { createCodexTeamMateWorkerProvider } from '../teammate/worker/codex-provider.js';
+import { TeamMateWorkerProviderCatalog } from '../teammate/worker/catalog.js';
+import type {
+  TeamMateWorkerAvailability,
+  WorkerBinaryProbe,
+} from './teammate-types.js';
+
+export interface DefaultTeamMateWorkerCatalogOptions {
+  config: DreamuxConfig;
+  dispatchers: DispatcherStore;
+  codexBinPath?: string;
+  codexProcessFactory?: (opts: CodexProcessOptions) => CodexProcess;
+  codexClientFactory?: (socketPath: string) => CodexWsClient;
+  claudeCodeWorkerSessionFactory?: ClaudeCodeSessionFactory;
+  log: DreamuxLogger;
+}
+
+export function createDefaultTeamMateWorkerCatalog(
+  opts: DefaultTeamMateWorkerCatalogOptions,
+): TeamMateWorkerProviderCatalog {
+  return new TeamMateWorkerProviderCatalog({
+    providers: [
+      createCodexTeamMateWorkerProvider({
+        resolveBinPath: (dispatcherBin) =>
+          resolveCodexBinPath(opts.codexBinPath, dispatcherBin),
+        resolveCodexConfig: (dispatcherId) =>
+          resolveDispatcherCodexConfig(opts, dispatcherId),
+        resolveDispatcherCwd: (dispatcherId) =>
+          resolveDispatcherCwd(opts, dispatcherId),
+        ...(opts.codexProcessFactory !== undefined
+          ? { codexProcessFactory: opts.codexProcessFactory }
+          : {}),
+        ...(opts.codexClientFactory !== undefined
+          ? { codexClientFactory: opts.codexClientFactory }
+          : {}),
+        log: (level, message, fields) => opts.log[level](fields ?? {}, message),
+      }),
+      createClaudeCodeTeamMateWorkerProvider({
+        resolveBinPath: (dispatcherBin) => dispatcherBin,
+        resolveClaudeCodeConfig: (dispatcherId) =>
+          resolveDispatcherClaudeCodeConfig(opts, dispatcherId),
+        resolveDispatcherCwd: (dispatcherId) =>
+          resolveDispatcherCwd(opts, dispatcherId),
+        ...(opts.claudeCodeWorkerSessionFactory !== undefined
+          ? { sessionFactory: opts.claudeCodeWorkerSessionFactory }
+          : {}),
+        log: (level, message, fields) => opts.log[level](fields ?? {}, message),
+      }),
+    ],
+    defaultRef: BUILTIN_CODEX_PROVIDER_REF,
+  });
+}
+
+export function createDefaultWorkerBinaryProbe(
+  codexBinPath: string | undefined,
+): WorkerBinaryProbe {
+  return async (providerRef) => {
+    const availability = await defaultWorkerBinaryProbe(
+      providerRef,
+      codexBinPath,
+    );
+    return availability;
+  };
+}
+
+async function defaultWorkerBinaryProbe(
+  providerRef: string,
+  codexBinPath: string | undefined,
+): Promise<TeamMateWorkerAvailability> {
+  let bin: string;
+  if (providerRef === BUILTIN_CODEX_PROVIDER_REF) {
+    bin = resolveCodexBinPath(codexBinPath, DEFAULT_CODEX_BIN);
+  } else if (providerRef === BUILTIN_CLAUDE_CODE_PROVIDER_REF) {
+    bin = DEFAULT_CLAUDE_CODE_BIN;
+  } else {
+    return { available: true, reason: '' };
+  }
+  const resolved = await resolveExecutableOnPath(
+    bin,
+    dispatcherProcessEnv(process.env),
+  );
+  if (resolved !== null) return { available: true, reason: '' };
+  return {
+    available: false,
+    reason:
+      `worker binary '${bin}' was not found on the dispatcher service PATH; ` +
+      'install it (or set the binary/PATH for this runtime) before routing tasks here',
+  };
+}
+
+function resolveCodexBinPath(
+  codexBinPath: string | undefined,
+  dispatcherBin: string,
+): string {
+  if (codexBinPath !== undefined) return codexBinPath;
+  const fromEnv = process.env['CODEX_HOST_CODEX_BIN'];
+  if (fromEnv !== undefined && fromEnv !== '') return fromEnv;
+  return dispatcherBin;
+}
+
+function resolveDispatcherCodexConfig(
+  opts: DefaultTeamMateWorkerCatalogOptions,
+  dispatcherId: string,
+): DispatcherCodexConfig {
+  const dispatcher = opts.config.dispatchers.find(
+    (entry) => entry.id === dispatcherId,
+  );
+  if (
+    dispatcher === undefined ||
+    dispatcher.runtime.provider !== BUILTIN_CODEX_PROVIDER_REF
+  ) {
+    return defaultDispatcherCodexConfig();
+  }
+  return dispatcherCodexConfig(dispatcher);
+}
+
+function resolveDispatcherClaudeCodeConfig(
+  opts: DefaultTeamMateWorkerCatalogOptions,
+  dispatcherId: string,
+): DispatcherClaudeCodeConfig {
+  const dispatcher = opts.config.dispatchers.find(
+    (entry) => entry.id === dispatcherId,
+  );
+  if (
+    dispatcher === undefined ||
+    dispatcher.runtime.provider !== BUILTIN_CLAUDE_CODE_PROVIDER_REF
+  ) {
+    return defaultDispatcherClaudeCodeConfig();
+  }
+  return dispatcherClaudeCodeConfig(dispatcher);
+}
+
+function resolveDispatcherCwd(
+  opts: DefaultTeamMateWorkerCatalogOptions,
+  dispatcherId: string,
+): string {
+  return opts.dispatchers.get(dispatcherId)?.codex_cwd ?? dispatcherCodexCwd(dispatcherId);
+}

--- a/packages/dreamux/src/server.ts
+++ b/packages/dreamux/src/server.ts
@@ -53,24 +53,11 @@ import {
 import type { PeerBot } from './channel/chat-bots-store.js';
 import { resolveBotSecret } from './runtime/secrets.js';
 import {
-  BUILTIN_CLAUDE_CODE_PROVIDER_REF,
   BUILTIN_CODEX_PROVIDER_REF,
   BUILTIN_FEISHU_PROVIDER_REF,
   BUILT_IN_DEFAULTS,
-  DEFAULT_CLAUDE_CODE_BIN,
-  DEFAULT_CODEX_BIN,
-  defaultDispatcherClaudeCodeConfig,
-  defaultDispatcherCodexConfig,
-  dispatcherClaudeCodeConfig,
-  dispatcherCodexConfig,
-  type DispatcherClaudeCodeConfig,
-  type DispatcherCodexConfig,
   type DreamuxConfig,
 } from './runtime/config.js';
-import {
-  dispatcherProcessEnv,
-  resolveExecutableOnPath,
-} from './runtime/package-bin.js';
 import {
   DispatcherStore,
   type DispatcherRow,
@@ -91,50 +78,13 @@ import {
 } from './runtime/logger.js';
 import { createAdminSocketServer, type AdminSocketServer } from './admin/socket.js';
 import { RestartIntentConsumer } from './daemon/restart-intent.js';
-import {
-  NestedTeamMateDispatchError,
-  legacyTaskStatus,
-  resolveTeammateTarget,
-  TEAMMATE_INPUT_MODES,
-  TEAMMATE_TARGET_MODES,
-  type TeamMateDeliveryStatus,
-  type TeamMateInputMode,
-  type TeamMateLifecycleStatus,
-  type TeamMateScheduleCallerKind,
-  type TeamMateTargetMode,
-  type TeamMateTaskRecord,
-  TeamMateTaskLedger,
-} from './teammate/ledger.js';
 import { teammateMcpServerDescriptor } from './teammate/mcp-config.js';
-import {
-  TeamMateDeliveryService,
-  type TeamMateDeliveryReport,
-} from './teammate/delivery.js';
-import {
-  TeamMateWorkerExecutionService,
-  type TeamMateExecutionOutcome,
-} from './teammate/worker-execution.js';
-import {
-  readTeamMateWorkerLogs,
-  type TeamMateWorkerLogStream,
-  type TeamMateWorkerLogStreamKind,
-} from './teammate/worker-logs.js';
-import { TeamMateWorkerProviderCatalog } from './teammate/worker/catalog.js';
-import type { TeamMateWorkerProvider } from './teammate/worker/types.js';
-import { createCodexTeamMateWorkerProvider } from './teammate/worker/codex-provider.js';
-import { createClaudeCodeTeamMateWorkerProvider } from './teammate/worker/claude-code-provider.js';
+import type { TeamMateWorkerProviderCatalog } from './teammate/worker/catalog.js';
 import type { ClaudeCodeSessionFactory } from './agent-runtime/claude-code-session.js';
-import {
-  awaitTeamMateCompletion,
-  clampWaitTimeout,
-  isWaitToken,
-  lastEventId,
-  TEAMMATE_WAIT_DEFAULT_MS,
-  TEAMMATE_WAIT_DEFAULT_UNTIL,
-  TEAMMATE_WAIT_MAX_MS,
-  TeamMateWaitBroker,
-  type TeamMateWaitToken,
-} from './teammate/wait-broker.js';
+import { DispatcherService } from './dispatcher-service/service.js';
+import type { WorkerBinaryProbe } from './dispatcher-service/teammate-types.js';
+
+export type { WorkerBinaryProbe } from './dispatcher-service/teammate-types.js';
 
 export const RECEIVED_REACTION_EMOJI = 'Get';
 export const IN_PROGRESS_REACTION_EMOJI = 'OnIt';
@@ -322,215 +272,10 @@ export interface ServerMcpListChatBotsResult {
   trusted: WireChatBot[];
 }
 
-export interface ServerMcpScheduleTeamMateInput {
-  dispatcherId: string;
-  callerKind: TeamMateScheduleCallerKind;
-  title: string;
-  prompt: string;
-  teammateId?: string;
-}
-
-export interface ServerMcpScheduleTeamMateResult {
-  status: 'accepted';
-  task_id: string;
-  dispatcher_id: string;
-  created_at: number;
-  teammate_id?: string;
-}
-
-export interface ServerTeamMateCompletionInput {
-  dispatcherId: string;
-  taskId: string;
-  outcome: 'completed' | 'failed';
-  finalText: string;
-}
-
-export interface ServerTeamMateTaskSummary {
-  task_id: string;
-  /** Back-compat projection of lifecycle + delivery into the v1 status enum. */
-  status: string;
-  lifecycle_status: TeamMateLifecycleStatus;
-  delivery_status: TeamMateDeliveryStatus;
-  title: string;
-  teammate_id: string | null;
-  provider_ref: string | null;
-  created_at: number;
-  updated_at: number;
-  last_event_id: number;
-  delivery_attempts: number;
-  has_result: boolean;
-}
-
-export interface ServerTeamMatePullResult {
-  task_id: string;
-  status: string;
-  lifecycle_status: TeamMateLifecycleStatus;
-  delivery_status: TeamMateDeliveryStatus;
-  outcome: 'completed' | 'failed';
-  text: string;
-  delivered: boolean;
-  delivery_attempts: number;
-}
-
-export interface ServerMcpRunTeamMateTaskInput {
-  dispatcherId: string;
-  callerKind: TeamMateScheduleCallerKind;
-  title: string;
-  prompt: string;
-  targetPath: string;
-  teammateId?: string;
-  intent?: string;
-  targetMode?: TeamMateTargetMode;
-  providerRef?: string;
-  operationId?: string;
-}
-
-export interface ServerMcpExecuteTeamMateTaskInput {
-  dispatcherId: string;
-  taskId: string;
-  providerRef?: string;
-  targetMode?: TeamMateTargetMode;
-  operationId?: string;
-}
-
-export interface ServerMcpSendTeamMateInputInput {
-  dispatcherId: string;
-  taskId: string;
-  prompt: string;
-  mode?: TeamMateInputMode;
-  operationId?: string;
-}
-
-export interface ServerMcpAwaitTeamMateCompletionInput {
-  dispatcherId: string;
-  taskId: string;
-  afterEventId?: number;
-  until?: string[];
-  timeoutMs?: number;
-}
-
-/**
- * Execution attempt outcome (issue #126). With no worker wired (production MVP)
- * this is always `provider_unavailable`, exactly as PR1; an injected worker
- * catalog produces `running`/`completed`/`failed`/`cancelled` with the resolved
- * `provider_ref`. The `reason`/`code`/`retryable` fields are present only for
- * `provider_unavailable`.
- */
-export interface ServerTeamMateExecutionResult {
-  status: 'running' | 'completed' | 'failed' | 'cancelled' | 'provider_unavailable';
-  provider_ref?: string;
-  reason?: string;
-  code?: string;
-  retryable?: boolean;
-}
-
-export interface ServerMcpRunTeamMateTaskResult {
-  task: ServerTeamMateTaskSummary;
-  execution: ServerTeamMateExecutionResult;
-}
-
-export interface ServerMcpSendTeamMateInputResult {
-  input_id: string;
-  mode: TeamMateInputMode;
-  /**
-   * `submitted` when a live worker session accepted the input, `queued`
-   * otherwise (no worker, or the worker rejected it) — the input is still
-   * durably recorded either way (issue #126 PR2).
-   */
-  status: 'queued' | 'submitted';
-  after_event_id: number;
-  task: ServerTeamMateTaskSummary;
-}
-
-export interface ServerMcpAwaitTeamMateCompletionResult {
-  status: 'completed' | 'failed' | 'cancelled' | 'reached' | 'still_running';
-  task_id: string;
-  after_event_id: number;
-  task: ServerTeamMateTaskSummary | null;
-  result?: ServerTeamMatePullResult | null;
-}
-
-export interface ServerMcpCancelTeamMateTaskInput {
-  dispatcherId: string;
-  taskId: string;
-  /** Optional close note recorded with the cancellation. */
-  note?: string;
-}
-
-export interface ServerMcpCancelTeamMateTaskResult {
-  task_id: string;
-  /**
-   * `cancelled` when this call closed a live/open task, `already_terminal` when
-   * the task had already finished (idempotent no-op).
-   */
-  status: 'cancelled' | 'already_terminal';
-  lifecycle_status: TeamMateLifecycleStatus;
-  /** Whether a live worker session in this process was reaped by the cancel. */
-  cancelled_live_session: boolean;
-  after_event_id: number;
-  task: ServerTeamMateTaskSummary;
-}
-
-export interface ServerMcpTeamMateTaskLogsInput {
-  dispatcherId: string;
-  taskId: string;
-  maxBytes?: number;
-  stream?: TeamMateWorkerLogStreamKind;
-}
-
-export interface ServerMcpTeamMateTaskLogsResult {
-  task_id: string;
-  provider_ref: string | null;
-  lifecycle_status: TeamMateLifecycleStatus;
-  /** Whether this task's worker has a known on-disk log layout. */
-  logs_supported: boolean;
-  streams: TeamMateWorkerLogStream[];
-}
-
-/** Worker capability advertisement for a built-in runtime (placeholder in PR1). */
-export interface ServerTeamMateProviderCapability {
-  provider_ref: string;
-  worker_available: boolean;
-  unsupported_reason: string;
-  modes: { steer: boolean; queue: boolean; interrupt: boolean };
-  resume: boolean;
-  logs: boolean;
-}
-
-export interface ServerTeamMateCapabilities {
-  execution_available: boolean;
-  wait: { default_ms: number; max_ms: number };
-  target_modes: TeamMateTargetMode[];
-  input_modes: TeamMateInputMode[];
-  default_input_mode: TeamMateInputMode;
-  providers: ServerTeamMateProviderCapability[];
-}
-
-/** Whether a worker's configured binary can be resolved in the service env. */
-export interface TeamMateWorkerAvailability {
-  available: boolean;
-  /** Human-readable reason when `available` is false; empty otherwise. */
-  reason: string;
-}
-
-/**
- * Probe whether the binary a worker provider would launch is resolvable in the
- * dispatcher service environment (issue #126 PR7). `get_capabilities` consults
- * it so the advertisement never claims a provider is available when its binary
- * cannot be started — the installed-state bug where `builtin:claude-code`
- * reported available while `claude` was absent. Injectable so tests stay
- * deterministic regardless of the CI host's PATH. An unknown ref (an injected
- * fake) is reported available so its static capabilities stand unprobed.
- */
-export type WorkerBinaryProbe = (
-  providerRef: string,
-) => Promise<TeamMateWorkerAvailability>;
-
 export class Server {
   readonly repos: Repos;
+  readonly dispatcherService: DispatcherService;
   private readonly slots = new Map<string, DispatcherSlot>();
-  private readonly teamMateLedgers = new Map<string, TeamMateTaskLedger>();
-  private readonly teamMateWaitBroker = new TeamMateWaitBroker();
   /**
    * PR #3 review #4: in-flight startDispatcher promises, keyed by id.
    * Two concurrent callers must await the same start, not race to spawn
@@ -550,10 +295,6 @@ export class Server {
   private readonly channelProviderResolver: (ref: string) => ChannelProvider;
   private readonly providerRegistry: ProviderRegistry;
   private readonly agentRuntimeProviders: AgentRuntimeProviderCatalog;
-  private readonly teamMateDelivery: TeamMateDeliveryService;
-  private readonly teamMateWorkers: TeamMateWorkerProviderCatalog;
-  private readonly workerBinaryProbe: WorkerBinaryProbe;
-  private readonly teamMateWorkerExecution: TeamMateWorkerExecutionService;
 
   constructor(opts: ServerOptions = {}) {
     this.opts = opts;
@@ -562,10 +303,11 @@ export class Server {
     this.channelProviderResolver =
       opts.channelProviderResolver ??
       ((ref) => resolveChannelProvider(ref, { registry: this.providerRegistry }));
+    const config = opts.config ?? BUILT_IN_DEFAULTS;
     // Install the config snapshot before any paths.* / runtime.* lookup
     // happens. paths.stateRoot / adminSocketPath / etc. consult this
     // snapshot for non-env defaults (env vars still win).
-    setRuntimeConfig(opts.config ?? BUILT_IN_DEFAULTS);
+    setRuntimeConfig(config);
     // Default loggers are stderr-only (zero files opened) so tests that
     // construct a Server without injecting a logger never touch ~/.dreamux.
     this.log = opts.logger ?? createLogger({ name: 'server' });
@@ -597,79 +339,38 @@ export class Server {
         registry: this.providerRegistry,
         codex: codexProviderOptions,
       });
-    this.teamMateDelivery = new TeamMateDeliveryService({
-      ledger: (dispatcherId) => this.teamMateLedger(dispatcherId),
+    this.repos = {
+      dispatchers: new DispatcherStore(config),
+    };
+    this.dispatcherService = new DispatcherService({
+      config,
+      dispatchers: this.repos.dispatchers,
+      agentRuntimeProviders: this.agentRuntimeProviders,
       resolveRuntime: (dispatcherId) => this.getRuntime(dispatcherId),
-      notifyEvent: (dispatcherId, taskId) =>
-        this.teamMateWaitBroker.notify(dispatcherId, taskId),
-      log: (level, message, fields) => this.log[level](fields ?? {}, message),
+      log: this.log,
+      ...(opts.codexBinPath !== undefined ? { codexBinPath: opts.codexBinPath } : {}),
+      ...(opts.codexProcessFactory !== undefined
+        ? { codexProcessFactory: opts.codexProcessFactory }
+        : {}),
+      ...(opts.codexClientFactory !== undefined
+        ? { codexClientFactory: opts.codexClientFactory }
+        : {}),
+      ...(opts.claudeCodeWorkerSessionFactory !== undefined
+        ? { claudeCodeWorkerSessionFactory: opts.claudeCodeWorkerSessionFactory }
+        : {}),
+      ...(opts.teamMateWorkerProviders !== undefined
+        ? { teamMateWorkerProviders: opts.teamMateWorkerProviders }
+        : {}),
+      ...(opts.workerBinaryProbe !== undefined
+        ? { workerBinaryProbe: opts.workerBinaryProbe }
+        : {}),
       ...(opts.teamMateDeliveryMaxAttempts !== undefined
-        ? { maxAttempts: opts.teamMateDeliveryMaxAttempts }
+        ? { teamMateDeliveryMaxAttempts: opts.teamMateDeliveryMaxAttempts }
         : {}),
       ...(opts.teamMateDeliveryBackoffMs !== undefined
-        ? { backoffMs: opts.teamMateDeliveryBackoffMs }
+        ? { teamMateDeliveryBackoffMs: opts.teamMateDeliveryBackoffMs }
         : {}),
     });
-    // Default worker catalog wires BOTH real workers (issue #126 PR3 Codex, PR4
-    // Claude Code), so a production `dreamux serve` executes TeamMate tasks for
-    // real and `get_capabilities` reports both `builtin:codex` and
-    // `builtin:claude-code` as worker-available. The default route stays Codex
-    // (`defaultRef`); a task selects the Claude Code worker by pinning
-    // `provider_ref: builtin:claude-code` (default routing remains Codex, not
-    // dispatcher-aware, to keep this a pure addition). Tests still fully control
-    // execution by injecting `teamMateWorkerProviders` (the fake provider, or an
-    // empty catalog for the no-worker path). Each worker reuses the same
-    // process/session test seams as the dispatcher runtime, so a fake test drives
-    // it without spawning a real binary.
-    this.teamMateWorkers =
-      opts.teamMateWorkerProviders ??
-      new TeamMateWorkerProviderCatalog({
-        providers: [
-          createCodexTeamMateWorkerProvider({
-            resolveBinPath: (dispatcherBin) =>
-              this.resolveCodexBinPath(dispatcherBin),
-            resolveCodexConfig: (dispatcherId) =>
-              this.resolveDispatcherCodexConfig(dispatcherId),
-            resolveDispatcherCwd: (dispatcherId) =>
-              this.resolveDispatcherCwd(dispatcherId),
-            ...(opts.codexProcessFactory !== undefined
-              ? { codexProcessFactory: opts.codexProcessFactory }
-              : {}),
-            ...(opts.codexClientFactory !== undefined
-              ? { codexClientFactory: opts.codexClientFactory }
-              : {}),
-            log: (level, message, fields) =>
-              this.log[level](fields ?? {}, message),
-          }),
-          createClaudeCodeTeamMateWorkerProvider({
-            resolveBinPath: (dispatcherBin) => dispatcherBin,
-            resolveClaudeCodeConfig: (dispatcherId) =>
-              this.resolveDispatcherClaudeCodeConfig(dispatcherId),
-            resolveDispatcherCwd: (dispatcherId) =>
-              this.resolveDispatcherCwd(dispatcherId),
-            ...(opts.claudeCodeWorkerSessionFactory !== undefined
-              ? { sessionFactory: opts.claudeCodeWorkerSessionFactory }
-              : {}),
-            log: (level, message, fields) =>
-              this.log[level](fields ?? {}, message),
-          }),
-        ],
-        defaultRef: BUILTIN_CODEX_PROVIDER_REF,
-      });
-    this.workerBinaryProbe =
-      opts.workerBinaryProbe ?? ((ref) => this.defaultWorkerBinaryProbe(ref));
-    this.teamMateWorkerExecution = new TeamMateWorkerExecutionService({
-      ledger: (dispatcherId) => this.teamMateLedger(dispatcherId),
-      workers: () => this.teamMateWorkers,
-      reportCompletion: (report) =>
-        this.teamMateDelivery.reportCompletion(report),
-      notifyEvent: (dispatcherId, taskId) =>
-        this.teamMateWaitBroker.notify(dispatcherId, taskId),
-      log: (level, message, fields) => this.log[level](fields ?? {}, message),
-    });
-    this.repos = {
-      dispatchers: new DispatcherStore(opts.config ?? BUILT_IN_DEFAULTS),
-    };
   }
 
   /** Effective config (caller-supplied or built-in defaults). */
@@ -692,107 +393,6 @@ export class Server {
     const fromEnv = process.env['CODEX_HOST_CODEX_BIN'];
     if (fromEnv !== undefined && fromEnv !== '') return fromEnv;
     return dispatcherBin;
-  }
-
-  /**
-   * Default `get_capabilities` binary probe (issue #126 PR7): resolve a built-in
-   * worker's binary on the dispatcher service PATH the same way the worker would
-   * launch it (Codex honours the `CODEX_HOST_CODEX_BIN` override via
-   * `resolveCodexBinPath`). An unknown ref is reported available — an injected
-   * test/fake worker has no real binary to probe, so its static capabilities
-   * stand. This advertises *resolvability*; the worker's own spawn-time failure
-   * stays the backstop for a binary that resolves but cannot start.
-   */
-  private async defaultWorkerBinaryProbe(
-    providerRef: string,
-  ): Promise<TeamMateWorkerAvailability> {
-    let bin: string;
-    if (providerRef === BUILTIN_CODEX_PROVIDER_REF) {
-      bin = this.resolveCodexBinPath(DEFAULT_CODEX_BIN);
-    } else if (providerRef === BUILTIN_CLAUDE_CODE_PROVIDER_REF) {
-      bin = DEFAULT_CLAUDE_CODE_BIN;
-    } else {
-      return { available: true, reason: '' };
-    }
-    const resolved = await resolveExecutableOnPath(
-      bin,
-      dispatcherProcessEnv(process.env),
-    );
-    if (resolved !== null) return { available: true, reason: '' };
-    return {
-      available: false,
-      reason:
-        `worker binary '${bin}' was not found on the dispatcher service PATH; ` +
-        'install it (or set the binary/PATH for this runtime) before routing tasks here',
-    };
-  }
-
-  /**
-   * Codex launch config for one dispatcher's TeamMate worker (issue #126 PR3).
-   *
-   * The default TeamMate worker is Codex regardless of the dispatcher's OWN
-   * runtime (a Claude Code worker is a later slice), so a TeamMate task from a
-   * non-Codex dispatcher (e.g. `builtin:claude-code`) must still get a *valid*
-   * Codex launch config — the built-in defaults — rather than the dispatcher's
-   * incompatible non-Codex runtime config. Only a `builtin:codex` dispatcher
-   * inherits its own approval/sandbox/env/handshake settings (so the worker is
-   * never more permissive than that dispatcher). An unknown dispatcher also
-   * falls back to the defaults. This keeps run_task from accepting and then
-   * hard-failing for a non-Codex dispatcher.
-   */
-  private resolveDispatcherCodexConfig(
-    dispatcherId: string,
-  ): DispatcherCodexConfig {
-    const dispatcher = this.effectiveConfig().dispatchers.find(
-      (entry) => entry.id === dispatcherId,
-    );
-    if (
-      dispatcher === undefined ||
-      dispatcher.runtime.provider !== BUILTIN_CODEX_PROVIDER_REF
-    ) {
-      return defaultDispatcherCodexConfig();
-    }
-    return dispatcherCodexConfig(dispatcher);
-  }
-
-  /**
-   * Claude Code launch config for one dispatcher's TeamMate worker (issue #126
-   * PR4). Mirrors {@link resolveDispatcherCodexConfig}: a TeamMate task can pin
-   * the Claude Code worker (`provider_ref: builtin:claude-code`) regardless of
-   * the dispatcher's OWN runtime, so a task from a non-Claude-Code dispatcher
-   * (e.g. `builtin:codex`) must still get a *valid* Claude Code launch config —
-   * the built-in defaults — rather than the dispatcher's incompatible non-Claude
-   * runtime config (`dispatcherClaudeCodeConfig` throws for a non-claude-code
-   * provider). Only a `builtin:claude-code` dispatcher inherits its own
-   * model/permission/env/timeout settings; an unknown dispatcher also falls back
-   * to the defaults. This keeps run_task from accepting and then hard-failing for
-   * a non-Claude-Code dispatcher.
-   */
-  private resolveDispatcherClaudeCodeConfig(
-    dispatcherId: string,
-  ): DispatcherClaudeCodeConfig {
-    const dispatcher = this.effectiveConfig().dispatchers.find(
-      (entry) => entry.id === dispatcherId,
-    );
-    if (
-      dispatcher === undefined ||
-      dispatcher.runtime.provider !== BUILTIN_CLAUDE_CODE_PROVIDER_REF
-    ) {
-      return defaultDispatcherClaudeCodeConfig();
-    }
-    return dispatcherClaudeCodeConfig(dispatcher);
-  }
-
-  /**
-   * Fallback working directory for a TeamMate worker whose task carries no
-   * resolved target (e.g. a `schedule`d task later executed). Mirrors the
-   * dispatcher runtime's own cwd resolution.
-   */
-  private resolveDispatcherCwd(dispatcherId: string): string {
-    return (
-      this.repos.dispatchers.get(dispatcherId)?.codex_cwd ??
-      dispatcherCodexCwd(dispatcherId)
-    );
   }
 
   /** Bring up admin socket + all enabled dispatchers. */
@@ -1298,486 +898,6 @@ export class Server {
     };
   }
 
-  /**
-   * Compatibility create-only tool (`schedule`): accepts a task into the ledger
-   * and returns immediately. It never starts a worker — the executable normal
-   * path is {@link runTeamMateTaskFromMcp}. (issue #126.)
-   */
-  async scheduleTeamMateFromMcp(
-    input: ServerMcpScheduleTeamMateInput,
-  ): Promise<ServerMcpScheduleTeamMateResult> {
-    this.assertTeamMateSchedulingAuthority(input.callerKind);
-    const task = await this.teamMateLedger(input.dispatcherId).acceptTask({
-      title: input.title,
-      prompt: input.prompt,
-      callerKind: input.callerKind,
-      ...(input.teammateId !== undefined
-        ? { teammateId: input.teammateId }
-        : {}),
-    });
-    this.teamMateWaitBroker.notify(input.dispatcherId, task.task_id);
-    this.log.info(
-      {
-        dispatcher_id: input.dispatcherId,
-        task_id: task.task_id,
-        caller_kind: input.callerKind,
-      },
-      'teammate task accepted',
-    );
-    return {
-      status: 'accepted',
-      task_id: task.task_id,
-      dispatcher_id: task.dispatcher_id,
-      created_at: task.created_at,
-      ...(task.teammate_id !== null ? { teammate_id: task.teammate_id } : {}),
-    };
-  }
-
-  /**
-   * Primary create-and-execute tool (`run_task`, issue #126). Creates a v2 task
-   * with a resolved local target, then attempts execution through the worker
-   * provider seam. With no worker wired (production MVP) the task is created
-   * durably and the execution sub-result reports `provider_unavailable`; an
-   * injected worker catalog starts a live session and drives the lifecycle.
-   */
-  async runTeamMateTaskFromMcp(
-    input: ServerMcpRunTeamMateTaskInput,
-  ): Promise<ServerMcpRunTeamMateTaskResult> {
-    this.assertTeamMateSchedulingAuthority(input.callerKind);
-    const target = resolveTeammateTarget(
-      input.targetPath,
-      this.mustDispatcherDir(input.dispatcherId),
-    );
-    const accepted = await this.teamMateLedger(input.dispatcherId).acceptTask({
-      title: input.title,
-      prompt: input.prompt,
-      callerKind: input.callerKind,
-      target,
-      origin: 'dispatcher',
-      ...(input.teammateId !== undefined ? { teammateId: input.teammateId } : {}),
-      ...(input.intent !== undefined ? { intent: input.intent } : {}),
-      ...(input.targetMode !== undefined ? { targetMode: input.targetMode } : {}),
-      ...(input.providerRef !== undefined
-        ? { providerRef: input.providerRef }
-        : {}),
-      ...(input.operationId !== undefined
-        ? { operationId: input.operationId }
-        : {}),
-    });
-    this.teamMateWaitBroker.notify(input.dispatcherId, accepted.task_id);
-    this.log.info(
-      {
-        dispatcher_id: input.dispatcherId,
-        task_id: accepted.task_id,
-        caller_kind: input.callerKind,
-      },
-      'teammate task run requested',
-    );
-    const execution = await this.teamMateWorkerExecution.execute({
-      dispatcherId: input.dispatcherId,
-      taskId: accepted.task_id,
-      ...(input.providerRef !== undefined ? { providerRef: input.providerRef } : {}),
-    });
-    return this.teamMateExecutionResult(input.dispatcherId, accepted, execution);
-  }
-
-  /**
-   * Start or retry execution for an already-accepted task (`execute_task`,
-   * issue #126). With no worker wired this returns `provider_unavailable` with
-   * the current snapshot (it never fakes a running worker); an injected worker
-   * catalog starts/retries a live session.
-   */
-  async executeTeamMateTaskFromMcp(
-    input: ServerMcpExecuteTeamMateTaskInput,
-  ): Promise<ServerMcpRunTeamMateTaskResult> {
-    const task = await this.teamMateLedger(input.dispatcherId).getTask(
-      input.taskId,
-    );
-    if (task === null) {
-      throw new Error(`TeamMate task ${JSON.stringify(input.taskId)} does not exist`);
-    }
-    const execution = await this.teamMateWorkerExecution.execute({
-      dispatcherId: input.dispatcherId,
-      taskId: input.taskId,
-      ...(input.providerRef !== undefined ? { providerRef: input.providerRef } : {}),
-    });
-    return this.teamMateExecutionResult(input.dispatcherId, task, execution);
-  }
-
-  /**
-   * Build the `{ task, execution }` wire result. The task summary is re-read so
-   * it reflects any lifecycle transition the worker's `onRunning`/terminal
-   * callbacks landed during execution; the local target path stays out of it.
-   */
-  private async teamMateExecutionResult(
-    dispatcherId: string,
-    fallback: TeamMateTaskRecord,
-    execution: TeamMateExecutionOutcome,
-  ): Promise<ServerMcpRunTeamMateTaskResult> {
-    const latest =
-      (await this.teamMateLedger(dispatcherId).getTask(fallback.task_id)) ??
-      fallback;
-    return {
-      task: toTeamMateTaskSummary(latest),
-      execution: toExecutionResult(execution),
-    };
-  }
-
-  /**
-   * Record a follow-up input to a steerable task session (`send_input`, issue
-   * #126). The default mode is `steer`; without a worker the input is queued in
-   * the ledger and waits for a future worker. Returns the new input id and the
-   * `after_event_id` cursor for waiting.
-   */
-  async sendTeamMateInputFromMcp(
-    input: ServerMcpSendTeamMateInputInput,
-  ): Promise<ServerMcpSendTeamMateInputResult> {
-    const ledger = this.teamMateLedger(input.dispatcherId);
-    // Record the input durably first (`queued` + an `input_queued` event), so it
-    // survives even if no worker is live.
-    const { task, input: recorded } = await ledger.appendInput(input.taskId, {
-      text: input.prompt,
-      mode: input.mode ?? 'steer',
-    });
-    this.teamMateWaitBroker.notify(input.dispatcherId, task.task_id);
-    // Route to a live worker session, if any. An accepted disposition promotes
-    // the input to `submitted`; with no live worker it stays `queued`.
-    const routed = await this.teamMateWorkerExecution.sendInput({
-      dispatcherId: input.dispatcherId,
-      taskId: input.taskId,
-      inputId: recorded.input_id,
-      text: recorded.text,
-      mode: recorded.mode,
-    });
-    let status: 'queued' | 'submitted' = 'queued';
-    let latest = task;
-    if (routed.delivered && routed.disposition?.status === 'accepted') {
-      latest = await ledger.markInputSubmitted(input.taskId, recorded.input_id);
-      this.teamMateWaitBroker.notify(input.dispatcherId, input.taskId);
-      status = 'submitted';
-    }
-    return {
-      input_id: recorded.input_id,
-      mode: recorded.mode,
-      status,
-      after_event_id: lastEventId(latest),
-      task: toTeamMateTaskSummary(latest),
-    };
-  }
-
-  /**
-   * Cancel a TeamMate task without shelling out to kill a worker process
-   * (`cancel_task`, issue #126 PR5). A live worker session in this process is
-   * driven through its provider `cancel()`, whose `onCancelled` callback is the
-   * sole writer of the `cancelled` close + wait-broker notify; a task with no
-   * live session (accepted/queued, or running but orphaned across a restart) is
-   * closed directly here. A terminal task is an idempotent no-op. An
-   * orphaned-running task's ledger is closed but its process cannot be reaped by
-   * this server — the (deferred) orphan-reconciliation path owns that.
-   */
-  async cancelTeamMateTaskFromMcp(
-    input: ServerMcpCancelTeamMateTaskInput,
-  ): Promise<ServerMcpCancelTeamMateTaskResult> {
-    const ledger = this.teamMateLedger(input.dispatcherId);
-    const task = await ledger.getTask(input.taskId);
-    if (task === null) {
-      throw new Error(
-        `TeamMate task ${JSON.stringify(input.taskId)} does not exist`,
-      );
-    }
-    if (isTerminalLifecycle(task.lifecycle_status)) {
-      return {
-        task_id: task.task_id,
-        status: 'already_terminal',
-        lifecycle_status: task.lifecycle_status,
-        cancelled_live_session: false,
-        after_event_id: lastEventId(task),
-        task: toTeamMateTaskSummary(task),
-      };
-    }
-    const reason = input.note ?? null;
-    const cancelled = await this.teamMateWorkerExecution.cancel({
-      dispatcherId: input.dispatcherId,
-      taskId: input.taskId,
-      reason,
-    });
-    if (!cancelled.cancelledLiveSession) {
-      // No live worker here owns the task; close the ledger directly and wake
-      // any waiters. The live-session path already closed + notified via the
-      // provider's onCancelled callback, so we must not double it.
-      //
-      // Re-read first: between the terminal check above and here the worker can
-      // have completed concurrently (it deleted its session, so cancel() found
-      // none). recordClose would otherwise stamp a spurious `cancelled` close +
-      // `closed` event + a second notify on an already-completed task — so bail
-      // to an idempotent no-op instead.
-      const fresh = await ledger.getTask(input.taskId);
-      if (fresh !== null && isTerminalLifecycle(fresh.lifecycle_status)) {
-        return {
-          task_id: fresh.task_id,
-          status: 'already_terminal',
-          lifecycle_status: fresh.lifecycle_status,
-          cancelled_live_session: false,
-          after_event_id: lastEventId(fresh),
-          task: toTeamMateTaskSummary(fresh),
-        };
-      }
-      await ledger.recordClose(input.taskId, {
-        status: 'cancelled',
-        ...(reason !== null && reason !== '' ? { note: reason } : {}),
-      });
-      this.teamMateWaitBroker.notify(input.dispatcherId, input.taskId);
-    }
-    const latest = (await ledger.getTask(input.taskId)) ?? task;
-    // Derive the reported status from the post-state, never hardcode: a live
-    // cancel that raced a completion lands `completed`, and the response must
-    // not claim `cancelled` while the lifecycle says otherwise.
-    return {
-      task_id: latest.task_id,
-      status:
-        latest.lifecycle_status === 'cancelled' ? 'cancelled' : 'already_terminal',
-      lifecycle_status: latest.lifecycle_status,
-      cancelled_live_session: cancelled.cancelledLiveSession,
-      after_event_id: lastEventId(latest),
-      task: toTeamMateTaskSummary(latest),
-    };
-  }
-
-  /**
-   * Read a bounded tail of a TeamMate worker's diagnostic logs (`get_task_logs`,
-   * issue #126 PR5), so a dispatcher can inspect a slow or failed worker over MCP
-   * instead of tailing a file in a shell. Returns the worker's stderr (and, for
-   * Codex, app-server stdout protocol frames) — NOT the clean result, which is
-   * read with get_task / pull_result / await_completion. Log paths are
-   * server-built from the ledger-validated id, so no caller input reaches the
-   * filesystem.
-   */
-  async getTeamMateTaskLogsFromMcp(
-    input: ServerMcpTeamMateTaskLogsInput,
-  ): Promise<ServerMcpTeamMateTaskLogsResult> {
-    const task = await this.teamMateLedger(input.dispatcherId).getTask(
-      input.taskId,
-    );
-    if (task === null) {
-      throw new Error(
-        `TeamMate task ${JSON.stringify(input.taskId)} does not exist`,
-      );
-    }
-    // A task that did not pin a provider ran on the catalog default, so resolve
-    // the EFFECTIVE worker ref (not the null pin) to find its log layout — else
-    // default-routed tasks would always report logs unsupported.
-    const effectiveRef =
-      this.teamMateWorkers.resolve(task.provider_ref)?.ref ?? task.provider_ref;
-    const logs = await readTeamMateWorkerLogs({
-      dispatcherId: input.dispatcherId,
-      taskId: input.taskId,
-      providerRef: effectiveRef,
-      ...(input.maxBytes !== undefined ? { maxBytes: input.maxBytes } : {}),
-      ...(input.stream !== undefined ? { stream: input.stream } : {}),
-    });
-    return {
-      task_id: task.task_id,
-      provider_ref: effectiveRef,
-      lifecycle_status: task.lifecycle_status,
-      logs_supported: logs.logs_supported,
-      streams: logs.streams,
-    };
-  }
-
-  /**
-   * Server-owned bounded wait for a task to reach a terminal state without shell
-   * polling (`await_completion`, issue #126). Timeout is a successful
-   * `still_running` result with the latest snapshot, never a tool failure. The
-   * ledger is the source of truth; the caller resumes with `after_event_id`.
-   */
-  async awaitTeamMateCompletionFromMcp(
-    input: ServerMcpAwaitTeamMateCompletionInput,
-  ): Promise<ServerMcpAwaitTeamMateCompletionResult> {
-    const ledger = this.teamMateLedger(input.dispatcherId);
-    const until = parseWaitUntil(input.until);
-    const afterEventId =
-      input.afterEventId !== undefined && Number.isFinite(input.afterEventId)
-        ? Math.max(0, Math.floor(input.afterEventId))
-        : 0;
-    const outcome = await awaitTeamMateCompletion(this.teamMateWaitBroker, {
-      dispatcherId: input.dispatcherId,
-      taskId: input.taskId,
-      afterEventId,
-      until,
-      timeoutMs: clampWaitTimeout(input.timeoutMs),
-      loadTask: () => ledger.getTask(input.taskId),
-    });
-    if (outcome.status === 'not_found') {
-      throw new Error(
-        `TeamMate task ${JSON.stringify(input.taskId)} does not exist`,
-      );
-    }
-    if (outcome.status === 'still_running') {
-      return {
-        status: 'still_running',
-        task_id: input.taskId,
-        after_event_id: outcome.last_event_id,
-        task: toTeamMateTaskSummary(outcome.task),
-      };
-    }
-    const task = outcome.task;
-    const status: ServerMcpAwaitTeamMateCompletionResult['status'] =
-      task.lifecycle_status === 'completed' ||
-      task.lifecycle_status === 'failed' ||
-      task.lifecycle_status === 'cancelled'
-        ? task.lifecycle_status
-        : 'reached';
-    return {
-      status,
-      task_id: input.taskId,
-      after_event_id: outcome.last_event_id,
-      task: toTeamMateTaskSummary(task),
-      result: task.result === null ? null : toTeamMatePullResult(task),
-    };
-  }
-
-  /**
-   * Read-only capability advertisement (`get_capabilities`, issue #126). The
-   * worker catalog is the source of truth: each built-in runtime is reported
-   * with its worker capability looked up from the catalog (unavailable when the
-   * catalog has no worker for it), and any worker provider not also an agent
-   * runtime (e.g. an injected fake) is appended.
-   *
-   * PR7: a provider with a wired worker is also probed for binary resolvability
-   * in the dispatcher service environment, so a worker whose binary cannot be
-   * started (the installed-state `builtin:claude-code` ENOENT) reports
-   * `worker_available: false` with a reason rather than lying. `execution_available`
-   * is derived from the probed rows — one source of truth, no skew.
-   */
-  async getTeamMateCapabilitiesFromMcp(): Promise<ServerTeamMateCapabilities> {
-    const workers = this.teamMateWorkers;
-    const workerByRef = new Map(
-      workers.list().map((worker) => [worker.ref, worker] as const),
-    );
-    const providers: ServerTeamMateProviderCapability[] = [];
-    const seen = new Set<string>();
-    for (const runtime of this.agentRuntimeProviders.list()) {
-      providers.push(
-        await this.toProviderCapabilityProbed(
-          runtime.ref,
-          workerByRef.get(runtime.ref),
-        ),
-      );
-      seen.add(runtime.ref);
-    }
-    for (const worker of workers.list()) {
-      if (seen.has(worker.ref)) continue;
-      providers.push(await this.toProviderCapabilityProbed(worker.ref, worker));
-      seen.add(worker.ref);
-    }
-    return {
-      execution_available: providers.some((p) => p.worker_available),
-      wait: { default_ms: TEAMMATE_WAIT_DEFAULT_MS, max_ms: TEAMMATE_WAIT_MAX_MS },
-      target_modes: [...TEAMMATE_TARGET_MODES],
-      input_modes: [...TEAMMATE_INPUT_MODES],
-      default_input_mode: 'steer',
-      providers,
-    };
-  }
-
-  /**
-   * Build one `get_capabilities` row, probing a wired worker's binary
-   * resolvability (issue #126 PR7). A ref with no wired worker keeps the
-   * worker-unavailable placeholder and is not probed (there is nothing to run).
-   */
-  private async toProviderCapabilityProbed(
-    ref: string,
-    worker: TeamMateWorkerProvider | undefined,
-  ): Promise<ServerTeamMateProviderCapability> {
-    if (worker === undefined) return toProviderCapability(ref, undefined, null);
-    const availability = await this.workerBinaryProbe(ref);
-    return toProviderCapability(ref, worker, availability);
-  }
-
-  /**
-   * Record a TeamMate task's final result and deliver it into the dispatcher
-   * context with bounded retry (issue #110 PR8). The result is persisted before
-   * delivery, so a downed runtime ends in `delivery_failed` with the result
-   * still pull-able. This is the worker/operator ingest entry — deliberately not
-   * a dispatcher-facing MCP tool, so a dispatcher model cannot fake completions.
-   */
-  async reportTeamMateCompletion(
-    input: ServerTeamMateCompletionInput,
-  ): Promise<TeamMateDeliveryReport> {
-    // The delivery service wakes await_completion waiters via notifyEvent the
-    // instant the result is recorded and on each terminal delivery transition.
-    return this.teamMateDelivery.reportCompletion({
-      dispatcherId: input.dispatcherId,
-      taskId: input.taskId,
-      outcome: input.outcome,
-      finalText: input.finalText,
-    });
-  }
-
-  /**
-   * The scheduling-authority boundary (issue #126). Ordinary TeamMates cannot
-   * nested-dispatch; a future Team leader's scheduling authority will be granted
-   * here as an explicit role/capability, not by relaxing the ledger backstop.
-   */
-  private assertTeamMateSchedulingAuthority(
-    callerKind: TeamMateScheduleCallerKind,
-  ): void {
-    if (callerKind === 'teammate') {
-      throw new NestedTeamMateDispatchError();
-    }
-  }
-
-  private mustDispatcherDir(dispatcherId: string): string {
-    const dir = this.repos.dispatchers.get(dispatcherId)?.codex_cwd ?? null;
-    if (dir === null || dir === '') {
-      throw new Error(
-        `dispatcher '${dispatcherId}' has no configured working directory; ` +
-          'a path target cannot be resolved',
-      );
-    }
-    return dir;
-  }
-
-  /** List a dispatcher's TeamMate tasks (corrupt files skipped, not fatal). */
-  async listTeamMateTasksFromMcp(
-    dispatcherId: string,
-  ): Promise<ServerTeamMateTaskSummary[]> {
-    const tasks = await this.teamMateLedger(dispatcherId).listTasks({
-      onCorrupt: (taskId, err) =>
-        this.log.warn(
-          { dispatcher_id: dispatcherId, task_id: taskId, err: errInfo(err) },
-          'skipping corrupt TeamMate task file',
-        ),
-    });
-    return tasks.map(toTeamMateTaskSummary);
-  }
-
-  /** Fetch one TeamMate task in full (fail-loud on a corrupt specific task). */
-  async getTeamMateTaskFromMcp(
-    dispatcherId: string,
-    taskId: string,
-  ): Promise<TeamMateTaskRecord | null> {
-    return this.teamMateLedger(dispatcherId).getTask(taskId);
-  }
-
-  /**
-   * Pull a retained TeamMate result — the fallback after push delivery failed.
-   * Returns the result for the given task, or the latest result-bearing task
-   * when no id is given. Works at `delivery_failed` (the whole point of pull).
-   */
-  async pullTeamMateResultFromMcp(
-    dispatcherId: string,
-    taskId?: string,
-  ): Promise<ServerTeamMatePullResult | null> {
-    const ledger = this.teamMateLedger(dispatcherId);
-    const task =
-      taskId !== undefined
-        ? await ledger.getTask(taskId)
-        : await ledger.latestResultTask();
-    if (task === null || task.result === null) return null;
-    return toTeamMatePullResult(task);
-  }
-
   private dreamuxMcpServerDescriptors(
     channelProvider: ChannelProvider,
     context: { dispatcherId: string; adminSocketPath: string },
@@ -1789,14 +909,6 @@ export class Server {
         callerKind: 'dispatcher',
       }),
     ];
-  }
-
-  private teamMateLedger(dispatcherId: string): TeamMateTaskLedger {
-    const existing = this.teamMateLedgers.get(dispatcherId);
-    if (existing !== undefined) return existing;
-    const created = new TeamMateTaskLedger(dispatcherId);
-    this.teamMateLedgers.set(dispatcherId, created);
-    return created;
   }
 
   private mustRunningSlot(id: string): DispatcherSlot {
@@ -1836,7 +948,7 @@ export class Server {
     // do not leak past server exit. This is a pure resource release with no
     // ledger transition (issue #126 PR3): an in-flight task stays `running` for
     // the deferred orphan-reconciliation path rather than being force-failed.
-    await this.teamMateWorkerExecution.reapAll();
+    await this.dispatcherService.reapAllTeamMateWorkers();
     for (const id of Array.from(this.slots.keys())) {
       await this.stopDispatcher(id);
     }
@@ -1852,127 +964,6 @@ function toWireChatBot(bot: PeerBot): WireChatBot {
     open_id: bot.openId,
     ...(bot.name !== undefined && bot.name !== '' ? { name: bot.name } : {}),
   };
-}
-
-function isTerminalLifecycle(
-  status: TeamMateLifecycleStatus,
-): status is 'completed' | 'failed' | 'cancelled' {
-  return (
-    status === 'completed' || status === 'failed' || status === 'cancelled'
-  );
-}
-
-function toTeamMateTaskSummary(
-  task: TeamMateTaskRecord,
-): ServerTeamMateTaskSummary {
-  return {
-    task_id: task.task_id,
-    status: legacyTaskStatus(task),
-    lifecycle_status: task.lifecycle_status,
-    delivery_status: task.delivery_status,
-    title: task.title,
-    teammate_id: task.teammate_id,
-    provider_ref: task.provider_ref,
-    created_at: task.created_at,
-    updated_at: task.updated_at,
-    last_event_id: lastEventId(task),
-    delivery_attempts: task.delivery?.attempts ?? 0,
-    has_result: task.result !== null,
-  };
-}
-
-function toTeamMatePullResult(
-  task: TeamMateTaskRecord,
-): ServerTeamMatePullResult {
-  if (task.result === null) {
-    throw new Error(
-      `TeamMate task ${JSON.stringify(task.task_id)} has no retained result`,
-    );
-  }
-  return {
-    task_id: task.task_id,
-    status: legacyTaskStatus(task),
-    lifecycle_status: task.lifecycle_status,
-    delivery_status: task.delivery_status,
-    outcome: task.result.outcome,
-    text: task.result.text,
-    delivered: task.delivery_status === 'delivered',
-    delivery_attempts: task.delivery?.attempts ?? 0,
-  };
-}
-
-/** Map the execution service outcome onto the public `execution` sub-result. */
-function toExecutionResult(
-  outcome: TeamMateExecutionOutcome,
-): ServerTeamMateExecutionResult {
-  if (outcome.status === 'provider_unavailable') {
-    return {
-      status: 'provider_unavailable',
-      reason: outcome.reason,
-      code: outcome.code,
-      retryable: outcome.retryable,
-    };
-  }
-  return {
-    status: outcome.status,
-    ...(outcome.provider_ref !== '' ? { provider_ref: outcome.provider_ref } : {}),
-  };
-}
-
-/**
- * Build a provider capability row for `get_capabilities`. When the catalog has a
- * worker for the ref, its static capabilities are reported, downgraded to
- * unavailable when the binary probe (issue #126 PR7) could not resolve the
- * worker's binary — so a wired-but-unstartable worker advertises
- * `worker_available: false` with the probe's reason instead of lying. A ref with
- * no wired worker is listed as worker-unavailable and is not probed (`availability`
- * is null).
- */
-function toProviderCapability(
-  ref: string,
-  worker: TeamMateWorkerProvider | undefined,
-  availability: TeamMateWorkerAvailability | null,
-): ServerTeamMateProviderCapability {
-  if (worker === undefined) {
-    return {
-      provider_ref: ref,
-      worker_available: false,
-      unsupported_reason:
-        'TeamMate worker execution is not implemented yet (issue #126)',
-      modes: { steer: false, queue: false, interrupt: false },
-      resume: false,
-      logs: false,
-    };
-  }
-  const caps = worker.capabilities();
-  const binaryUnavailable = availability !== null && !availability.available;
-  const workerAvailable = caps.worker_available && !binaryUnavailable;
-  return {
-    provider_ref: ref,
-    worker_available: workerAvailable,
-    unsupported_reason: binaryUnavailable
-      ? availability.reason
-      : caps.unsupported_reason,
-    modes: { ...caps.modes },
-    resume: caps.resume,
-    logs: caps.logs,
-  };
-}
-
-/** Validate and default the `await_completion.until` token set (issue #126). */
-function parseWaitUntil(until: string[] | undefined): Set<TeamMateWaitToken> {
-  if (until === undefined) return new Set(TEAMMATE_WAIT_DEFAULT_UNTIL);
-  if (!Array.isArray(until) || until.length === 0) {
-    throw new Error('until must be a non-empty array of states');
-  }
-  const tokens = new Set<TeamMateWaitToken>();
-  for (const token of until) {
-    if (!isWaitToken(token)) {
-      throw new Error(`unsupported await_completion state: ${String(token)}`);
-    }
-    tokens.add(token);
-  }
-  return tokens;
 }
 
 async function setInboundReaction(

--- a/packages/dreamux/tests/e2e.test.ts
+++ b/packages/dreamux/tests/e2e.test.ts
@@ -338,14 +338,14 @@ describe('dreamux cross-module e2e', () => {
     server = buildServer({ runtimeDir, fake, bot });
     await server.start();
 
-    const scheduled = await server.scheduleTeamMateFromMcp({
+    const scheduled = await server.dispatcherService.scheduleTeamMate({
       dispatcherId: 'flow',
       callerKind: 'dispatcher',
       title: 'Summarize',
       prompt: 'summarize the issue',
       teammateId: 'reviewer-1',
     });
-    const report = await server.reportTeamMateCompletion({
+    const report = await server.dispatcherService.reportTeamMateCompletion({
       dispatcherId: 'flow',
       taskId: scheduled.task_id,
       outcome: 'completed',
@@ -362,7 +362,7 @@ describe('dreamux cross-module e2e', () => {
     ).toBe(true);
 
     // And it is retrievable via the pull path.
-    const pulled = await server.pullTeamMateResultFromMcp('flow', scheduled.task_id);
+    const pulled = await server.dispatcherService.pullTeamMateResult('flow', scheduled.task_id);
     expect(pulled).toMatchObject({
       task_id: scheduled.task_id,
       status: 'delivered',

--- a/packages/dreamux/tests/smoke.test.ts
+++ b/packages/dreamux/tests/smoke.test.ts
@@ -1862,7 +1862,7 @@ describe('dreamux MVP smoke', () => {
         codexBinPath: process.execPath,
       });
 
-      const caps = await server.getTeamMateCapabilitiesFromMcp();
+      const caps = await server.dispatcherService.getTeamMateCapabilities();
       const codex = caps.providers.find(
         (p) => p.provider_ref === 'builtin:codex',
       );
@@ -2335,7 +2335,7 @@ describe('dreamux MVP smoke', () => {
     // Do NOT start() — that would spawn the claude-code runtime. The worker
     // catalog, ledger, and dispatcher rows are wired in the constructor, so the
     // MCP entry point can be driven directly.
-    const result = await server.runTeamMateTaskFromMcp({
+    const result = await server.dispatcherService.runTeamMateTask({
       dispatcherId: 'flow',
       callerKind: 'dispatcher',
       title: 'CC dispatcher task',
@@ -2350,7 +2350,7 @@ describe('dreamux MVP smoke', () => {
 
     // Capabilities reports the default Codex worker as available regardless of
     // the dispatcher's own (claude-code) runtime.
-    const caps = await server.getTeamMateCapabilitiesFromMcp();
+    const caps = await server.dispatcherService.getTeamMateCapabilities();
     const codex = caps.providers.find((p) => p.provider_ref === 'builtin:codex');
     expect(codex?.worker_available).toBe(true);
     expect(caps.execution_available).toBe(true);
@@ -2373,7 +2373,7 @@ describe('dreamux MVP smoke', () => {
       }),
       teamMateDeliveryBackoffMs: () => 0,
     });
-    const result = await server.runTeamMateTaskFromMcp({
+    const result = await server.dispatcherService.runTeamMateTask({
       dispatcherId: 'flow',
       callerKind: 'dispatcher',
       title: 'CC worker from codex dispatcher',


### PR DESCRIPTION
## 变更

本 PR 实体化 Dispatcher Service，把 TeamMate 编排从 `packages/dreamux/src/server.ts` 迁出。`server.ts` 现在负责 server wiring / runtime 装配，TeamMate 的 scheduling authority、ledger、delivery、wait-broker、worker execution、logs、capability probing 和 worker reaping 由 `packages/dreamux/src/dispatcher-service/service.ts` 承接。

`server.ts` 行数对比：2095 行 -> 1086 行，减少 1009 行。

## 删除 / 替换旧路径

- 删除 `packages/dreamux/src/server.ts` 内的 TeamMate 状态字段：`teamMateLedgers`、`teamMateWaitBroker`、`teamMateDelivery`、`teamMateWorkers`、`teamMateWorkerExecution`。
- 删除 `packages/dreamux/src/server.ts` 内的 TeamMate 编排入口：`scheduleTeamMateFromMcp`、`runTeamMateTaskFromMcp`、`executeTeamMateTaskFromMcp`、`sendTeamMateInputFromMcp`、`cancelTeamMateTaskFromMcp`、`getTeamMateTaskLogsFromMcp`、`awaitTeamMateCompletionFromMcp`、`getTeamMateCapabilitiesFromMcp`、`listTeamMateTasksFromMcp`、`getTeamMateTaskFromMcp`、`pullTeamMateResultFromMcp`。
- 替换 `packages/dreamux/src/admin/methods.ts` 的 TeamMate admin/MCP 路径：handler 只做参数校验和错误映射，然后调用 `server.dispatcherService.*`。
- 把 wire types / presenter helpers / worker factory 拆到 `packages/dreamux/src/dispatcher-service/teammate-types.ts`、`packages/dreamux/src/dispatcher-service/teammate-presenters.ts`、`packages/dreamux/src/dispatcher-service/worker-factory.ts`，避免把新的 Dispatcher Service 做成单个 god file。
- 本 PR 不半做 worker 平行树废除；`packages/dreamux/src/teammate/worker/` 仍由后续 PR D 删除 / 替换。

## Gate

- gate#1 接口分层：`spawn` / `close` / `list` 仍不是 `AgentRuntime` 实例接口；本 PR 只把 TeamMate 编排动词落到 Dispatcher Service。
- MCP 工具层薄化：admin/MCP handler 不再内联 ledger / delivery / wait-broker / worker 编排。
- 反缝合：旧 `server.ts` 实现已删除并由 Dispatcher Service 替换，不保留双份实现。
- no-sync-IO：没有新增 `*Sync` 调用；`rush lint` 通过 no-sync gate。
- god-object 拆解：`server.ts` 瘦身，Dispatcher Service 按类型、presenter、worker factory 拆分职责。

## 验证

- `node common/scripts/install-run-rush.js build`
- `node common/scripts/install-run-rush.js lint`
- `TMPDIR=/tmp node common/scripts/install-run-rush.js test`
- `node common/scripts/install-run-rush.js change --verify --target-branch origin/next --no-fetch`
- 提交前泄漏 grep：无命中

补充：`.agents/scripts/check.sh` 在本机系统 Bash 3.2 下被 `declare -A` 阻塞，未改脚本；仓库构建、lint、test、change verify 均已通过。
