### PR TITLE
加载 npm AgentRuntime provider

### DIFF
--- a/.agents/decisions/agent-runtime-provider.md
+++ b/.agents/decisions/agent-runtime-provider.md
@@ -31,6 +31,35 @@ The provider contract must cover:
 - inbound dispatcher turn submission;
 - runtime-specific TeamMate completion delivery.
 
+External `npm:` Agent Runtime providers use the same contract. The selected
+provider ref controls how Dreamux reads the package:
+
+```ts
+// npm:some-runtime
+export default createProvider;
+
+// npm:some-runtime#namedProvider
+export const namedProvider = createProvider;
+
+function createProvider(context: {
+  ref: string;
+  descriptor: ProviderDescriptor;
+}): AgentRuntimeProvider | Promise<AgentRuntimeProvider>;
+```
+
+The factory must return an `AgentRuntimeProvider` whose `ref` and
+`descriptor.ref` match the canonical config ref and whose `descriptor.kind` is
+`agentRuntime`. The provider must implement `getCapabilities()` and
+`createRuntime(context)`. It may implement `readConfig(rawConfig, context)` when
+it owns provider-specific config validation and normalization. Capability
+declarations are provider-owned: the registry stores the implementation handle
+only and never mirrors or assumes support for `resume`, `steer`, `events`,
+`last`, `context`, or TeamMate completion delivery.
+
+`AgentRuntime` is a single-instance runtime interface. Dispatcher orchestration
+verbs such as spawn, list, and close stay on Dispatcher Service and must not be
+added to the runtime instance contract.
+
 Dreamux injects only these MCP surfaces:
 
 - Channel provider MCP descriptors;
@@ -97,6 +126,13 @@ Implementation status:
   capability and provides the runtime's delivery entry point; the executable
   completion delivery loop (ledger, retry, pull fallback) still belongs to the
   later server-hosted TeamMate PRs.
+- External `npm:` Agent Runtime loading is implemented through the provider
+  registry. Config loading scans `dispatchers[].runtime.provider`, dynamically
+  imports npm runtime providers before validation, calls their provider factory,
+  and registers the result into the same registry instance that the
+  `AgentRuntimeProviderCatalog` views at server startup. Missing packages,
+  missing exports, invalid descriptors, invalid capability declarations, and
+  non-runnable descriptors fail loudly with the selected provider ref.
 
 ## Consequences
 
@@ -106,6 +142,9 @@ Implementation status:
   ledger contracts.
 - Runtime-specific delivery failures can be reported back to Dispatcher Service,
   which owns retry and result retrieval.
+- Third-party Agent Runtime packages do not require a parallel registry or a
+  parallel Dispatcher Service path; they enter through the same provider
+  implementation handle used by builtin providers.
 - Codex auth, config, and memory remain under Codex's normal ownership. Dreamux
   must not create dispatcher-private Codex homes unless a later decision
   supersedes this one.

--- a/.agents/decisions/provider-architecture-realignment.md
+++ b/.agents/decisions/provider-architecture-realignment.md
@@ -1,7 +1,7 @@
 # Provider architecture realignment
 
-- **Status:** Accepted (remediation tracked in issue #135; implementation in
-  progress through the PR E channel/lifecycle cut)
+- **Status:** Accepted (remediation tracked in issue #135; implemented through
+  the PR F external Agent Runtime loading cut)
 - **Date:** 2026-06-08
 - **Affects:** Agent Runtime providers, TeamMate agent state, Dispatcher
   Service, Capability Registry, Channel providers, MCP injection, `server.ts`
@@ -53,8 +53,8 @@ The target architecture is:
   must not be modifiable by external plugins.
 - **External provider loading is made real for the `agentRuntime` seam.** The
   `npm:` ref grammar must actually load external/closed-source or third-party
-  runtimes (e.g. opencode, gemini cli, and runtimes that cannot be vendored into
-  this open repo), not just reserve syntax.
+  runtimes that cannot be vendored into this open repo, not just reserve
+  syntax.
 - **The `channel` plugin seam is interface-only this cycle.** Define the TS
   interface with proper reservations for subscription-style channels (github /
   jira) that inject arbitrary channel MCP and push subscribed events to agents;
@@ -66,15 +66,18 @@ The target architecture is:
   to the dispatcher). The current `ChannelConnection = FeishuBot` and 1:1
   dispatcher binding are temporary.
 - **The Capability Registry is demoted to a provider registry / loader.** It
-  resolves `builtin:` and `npm:` refs to provider implementations and is a
-  server-owned singleton. The capability *mirror* (registry-declared
-  capabilities duplicated by provider methods, kept in sync by a drift test) is
-  removed; capability is a single provider-owned declaration that core actually
-  reads — to compose the channel tool surface, and to know per-runtime support
-  (resume / steer / completion-delivery shape). Runtime catalogs are registry
-  views: they resolve descriptors from the singleton registry and read the
-  implementation already registered there, rather than maintaining a second
-  provider map.
+  resolves `builtin:` and `npm:` refs to provider implementations. The config
+  loader creates or receives one registry instance, loads external runtime
+  providers into that instance, validates config through it, and passes the same
+  instance into server startup. No default builtin singleton may become a
+  separate fallback that rejects already-loaded `npm:` refs. The capability
+  *mirror* (registry-declared capabilities duplicated by provider methods, kept
+  in sync by a drift test) is removed; capability is a single provider-owned
+  declaration that core actually reads — to compose the channel tool surface,
+  and to know per-runtime support (resume / steer / completion-delivery shape).
+  Runtime catalogs are registry views: they resolve descriptors from the
+  registry and read the implementation already registered there, rather than
+  maintaining a second provider map.
 - **Channel tool handlers move out of core.** A channel plugin owns its MCP
   end-to-end (tool definitions + handlers); core injects the descriptor and
   provides the connection, and no longer carries `*FromMcp` handlers in
@@ -147,6 +150,9 @@ see its `verbs/` (spawn/resume/history), `persistence/history-index.ts` and
   live dispatcher slots, start coalescing, stop, runtime lookup, restart-notice
   injection, and Feishu channel MCP dispatch. `/packages/dreamux/src/server.ts`
   is wiring only.
+- PR F implements `npm:` Agent Runtime loading: dynamic import, provider factory
+  validation, same-registry registration, provider-owned capability
+  declarations, and fail-loud startup errors.
 - Hard-coded `BUILTIN_*_REF` branching across core (`server.ts`,
   `/packages/dreamux/src/runtime/config.ts`,
   `/packages/dreamux/src/cli/doctor.ts`) is expected to shrink as core consumes

--- a/.agents/decisions/provider-references-and-capability-registry.md
+++ b/.agents/decisions/provider-references-and-capability-registry.md
@@ -14,9 +14,9 @@ into a provider architecture for Channel providers, Agent Runtime providers, and
 Dispatcher Service capabilities.
 
 The architecture needs a public ref syntax that can describe builtin providers
-now and external package/export providers later. It also needs a registry that
-lets Dreamux core discover capabilities without hard-coding every channel,
-runtime, or MCP surface in the server.
+and externally installed package/export providers. It also needs a registry that
+lets Dreamux core discover runtime implementations without hard-coding every
+runtime or MCP surface in the server.
 
 ## Decision
 
@@ -43,26 +43,34 @@ The normalized form separates source, package, export, and builtin id so config
 validation and future manifests do not depend on ad hoc string parsing after
 startup.
 
-Phase 1 registers builtin provider descriptors and runs only provider
-implementations that have been wired by their dedicated PRs. Npm refs may be
-parsed, stored, and validated as reserved syntax, but they must fail clearly if
-selected for execution. Dreamux must not install, import, or execute external
-npm providers in Phase 1.
+Builtin Agent Runtime provider descriptors are registered eagerly. External
+`agentRuntime` refs in `dispatchers[].runtime.provider` are loaded before config
+validation by dynamic-importing the installed npm package, selecting its default
+export or `#named` export, calling the provider factory, and registering the
+returned provider implementation into the same registry instance used by config
+validation and server startup. Dreamux does not install provider packages; a
+missing package, missing export, invalid provider contract, or incomplete
+capability declaration fails startup loudly with the selected provider ref.
 
-Issue #135 demotes the Capability Registry into a provider registry for the
-`agentRuntime` seam. Wired builtin runtime providers attach their implemented
-capabilities to the runtime implementation as the provider PRs land. The Codex
-runtime provider declares runtime lifecycle, Dreamux MCP injection, inbound turn
-submission, and Codex-style TeamMate completion delivery capability metadata.
-Claude Code owns the same AgentRuntime interface with its own delivery shape.
-Feishu is no longer a provider-registry entry; it is a built-in bidirectional
-channel.
+External `channel` refs remain an interface-only reservation in this cycle.
+They are parsed by the same provider-ref grammar, but config validation rejects
+them because no external channel loader exists yet.
+
+Issue #135 demotes the Capability Registry into a provider registry / loader for
+the `agentRuntime` seam. Wired runtime providers attach their implemented
+capabilities to the provider implementation. The Codex runtime provider declares
+runtime lifecycle, Dreamux MCP injection, inbound turn submission, and
+Codex-style TeamMate completion delivery capability metadata. Claude Code owns
+the same AgentRuntime interface with its own delivery shape. External runtime
+providers self-declare capabilities through the same `AgentRuntimeProvider`
+contract; the registry does not mirror or synthesize them. Feishu is no longer a
+provider-registry entry; it is a built-in bidirectional channel.
 
 The provider registry is process-local and server-owned. It records:
 
 - provider descriptors;
 - provider kind (`agentRuntime` in the current implementation);
-- provider-local implementation handles and runtime capability declarations;
+- provider-local implementation handles;
 - validation status.
 
 Core consumers must consume runtime providers from the registry view instead of
@@ -73,10 +81,11 @@ channel module and injected by the Dispatcher Service.
 
 - Builtin Agent Runtime providers become explicit extension points rather than
   special server branches.
-- External provider syntax can be documented early without creating package
-  loading or supply-chain risk in Phase 1.
-- Startup validation must distinguish "unknown builtin", "reserved external
-  runtime provider", and "valid but unsupported in this phase".
+- External Agent Runtime packages use the same registry, lifecycle, and
+  Dispatcher Service creation path as builtin providers.
+- Startup validation must distinguish "unknown builtin", "external package or
+  export failed to load", "invalid provider contract", and "registered
+  descriptor without runnable implementation".
 - Feishu channel behavior is reviewed at the channel module boundary, not as a
   registry provider descriptor.
 
@@ -85,9 +94,9 @@ channel module and injected by the Dispatcher Service.
 - **Hard-code builtin providers until external plugins exist:** rejected because
   Channel and Agent Runtime abstractions would still be shaped by Feishu and
   Codex implementation details.
-- **Load npm providers immediately:** rejected for Phase 1. The Epic needs the
-  schema and manifest model first; package installation and execution policy
-  can be decided later.
+- **Load external channel providers with external runtimes:** rejected for this
+  cycle. Runtime provider loading is now implemented, while subscription-style
+  channel plugins still need their own routing and push-delivery contract.
 - **Use only object refs in config:** rejected for operator ergonomics. String
   refs are concise, while the normalized object form keeps implementation
   unambiguous.

--- a/.agents/root.md
+++ b/.agents/root.md
@@ -8,12 +8,13 @@ when you need the *why* behind a piece of code or a decision history.
 
 A long-running Node process that hosts N **Dispatchers**. Each Dispatcher binds
 one built-in Feishu bidirectional channel (`builtin:feishu`), one Agent Runtime
-provider (`builtin:codex` or `builtin:claude-code`), and Dreamux-owned MCP
-surfaces for channel reply and TeamMate scheduling/retrieval. All inbound chats
-for a dispatcher enter that dispatcher's runtime context; channel outbound is
-sent only when the runtime calls the dispatcher-bound channel MCP server owned
-by the Feishu channel module. The current architecture is split between the
-original local-runtime baseline and the issue #135 realigned provider surfaces:
+provider (`builtin:codex`, `builtin:claude-code`, or an installed `npm:`
+Agent Runtime provider), and Dreamux-owned MCP surfaces for channel reply and
+TeamMate scheduling/retrieval. All inbound chats for a dispatcher enter that
+dispatcher's runtime context; channel outbound is sent only when the runtime
+calls the dispatcher-bound channel MCP server owned by the Feishu channel
+module. The current architecture is split between the original local-runtime
+baseline and the issue #135 realigned provider surfaces:
 
 - [Top-level design](decisions/top-level-design.md) — original MVP baseline;
   still authoritative for unchanged local state/log ownership, Feishu access,

--- a/common/changes/@excitedjs/dreamux/issue135-pr-f-external-agent-runtime_2026-06-08-00-00.json
+++ b/common/changes/@excitedjs/dreamux/issue135-pr-f-external-agent-runtime_2026-06-08-00-00.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Load installed npm Agent Runtime providers from dispatchers[].runtime.provider before config validation. External runtime providers now enter through the same provider registry, AgentRuntimeProvider catalog, DispatcherService creation path, and provider-owned capability declaration contract as builtin runtimes. Missing packages, missing exports, invalid provider contracts, incomplete capability declarations, and non-runnable descriptors fail loudly with the selected provider ref.",
+      "type": "minor",
+      "packageName": "@excitedjs/dreamux"
+    }
+  ],
+  "packageName": "@excitedjs/dreamux",
+  "email": "053700@gmail.com"
+}

--- a/packages/dreamux/src/agent-runtime/external-provider.ts
+++ b/packages/dreamux/src/agent-runtime/external-provider.ts
@@ -1,0 +1,324 @@
+import {
+  formatProviderRef,
+  parseProviderRef,
+  type NpmProviderRef,
+  type ProviderDescriptor,
+  type ProviderRegistry,
+} from '../registry/index.js';
+import type {
+  AgentRuntimeCapabilities,
+  AgentRuntimeProvider,
+  TeamMateCompletionDeliveryShape,
+} from './types.js';
+
+export interface ExternalAgentRuntimeProviderFactoryContext {
+  /** Canonical provider ref from config, for example `npm:some-runtime#provider`. */
+  ref: string;
+  /** Descriptor the provider must expose back to Dreamux. */
+  descriptor: ProviderDescriptor;
+}
+
+export type ExternalAgentRuntimeProviderFactory = (
+  context: ExternalAgentRuntimeProviderFactoryContext,
+) => AgentRuntimeProvider | Promise<AgentRuntimeProvider>;
+
+export type ExternalAgentRuntimeModule = Record<string, unknown> & {
+  default?: unknown;
+};
+
+export type ExternalAgentRuntimeModuleImporter = (
+  packageName: string,
+) => Promise<ExternalAgentRuntimeModule>;
+
+export class ExternalAgentRuntimeProviderLoadError extends Error {
+  constructor(
+    readonly providerRef: string,
+    message: string,
+    options: { cause?: unknown } = {},
+  ) {
+    super(
+      `failed to load external agentRuntime provider ${JSON.stringify(providerRef)}: ${message}`,
+      options,
+    );
+    this.name = 'ExternalAgentRuntimeProviderLoadError';
+  }
+}
+
+export class ExternalAgentRuntimeProviderContractError extends Error {
+  constructor(readonly providerRef: string, message: string) {
+    super(
+      `invalid external agentRuntime provider ${JSON.stringify(providerRef)}: ${message}`,
+    );
+    this.name = 'ExternalAgentRuntimeProviderContractError';
+  }
+}
+
+export interface LoadExternalAgentRuntimeProvidersOptions {
+  registry: ProviderRegistry;
+  refs: Iterable<string>;
+  importModule?: ExternalAgentRuntimeModuleImporter;
+}
+
+export async function loadExternalAgentRuntimeProviders(
+  options: LoadExternalAgentRuntimeProvidersOptions,
+): Promise<void> {
+  const importModule = options.importModule ?? defaultImportModule;
+  const refs = uniqueNpmRefs(options.refs);
+  for (const ref of refs) {
+    if (options.registry.hasRef(ref.raw)) continue;
+    await loadOneExternalAgentRuntimeProvider({
+      registry: options.registry,
+      ref,
+      importModule,
+    });
+  }
+}
+
+async function loadOneExternalAgentRuntimeProvider(options: {
+  registry: ProviderRegistry;
+  ref: NpmProviderRef;
+  importModule: ExternalAgentRuntimeModuleImporter;
+}): Promise<void> {
+  const module = await importExternalModule(options.ref, options.importModule);
+  const factory = externalFactoryExport(options.ref, module);
+  const seedDescriptor: ProviderDescriptor = {
+    id: options.ref.raw,
+    kind: 'agentRuntime',
+    ref: options.ref,
+  };
+  let provider: AgentRuntimeProvider;
+  try {
+    provider = await factory({
+      ref: options.ref.raw,
+      descriptor: seedDescriptor,
+    });
+  } catch (err) {
+    throw new ExternalAgentRuntimeProviderLoadError(
+      options.ref.raw,
+      `provider factory threw: ${errMessage(err)}`,
+      { cause: err },
+    );
+  }
+
+  assertExternalAgentRuntimeProvider(options.ref.raw, provider);
+  options.registry.register(provider.descriptor);
+  options.registry.registerImplementation(provider.descriptor.id, provider);
+}
+
+async function importExternalModule(
+  ref: NpmProviderRef,
+  importModule: ExternalAgentRuntimeModuleImporter,
+): Promise<ExternalAgentRuntimeModule> {
+  try {
+    return await importModule(ref.package);
+  } catch (err) {
+    throw new ExternalAgentRuntimeProviderLoadError(
+      ref.raw,
+      `could not import package ${JSON.stringify(ref.package)}: ${errMessage(err)}`,
+      { cause: err },
+    );
+  }
+}
+
+function externalFactoryExport(
+  ref: NpmProviderRef,
+  module: ExternalAgentRuntimeModule,
+): ExternalAgentRuntimeProviderFactory {
+  const exportName = ref.export ?? 'default';
+  const value = ref.export === null ? module.default : module[ref.export];
+  if (typeof value !== 'function') {
+    throw new ExternalAgentRuntimeProviderContractError(
+      ref.raw,
+      `expected ${exportName} export to be an agentRuntime provider factory`,
+    );
+  }
+  return value as ExternalAgentRuntimeProviderFactory;
+}
+
+function assertExternalAgentRuntimeProvider(
+  expectedRef: string,
+  value: unknown,
+): asserts value is AgentRuntimeProvider {
+  if (typeof value !== 'object' || value === null) {
+    throw new ExternalAgentRuntimeProviderContractError(
+      expectedRef,
+      'factory must return an AgentRuntimeProvider object',
+    );
+  }
+  const candidate = value as Partial<AgentRuntimeProvider>;
+  if (candidate.ref !== expectedRef) {
+    throw new ExternalAgentRuntimeProviderContractError(
+      expectedRef,
+      `provider.ref must be ${JSON.stringify(expectedRef)}`,
+    );
+  }
+  assertDescriptor(expectedRef, candidate.descriptor);
+  if (typeof candidate.getCapabilities !== 'function') {
+    throw new ExternalAgentRuntimeProviderContractError(
+      expectedRef,
+      'provider.getCapabilities must be a function',
+    );
+  }
+  if (typeof candidate.createRuntime !== 'function') {
+    throw new ExternalAgentRuntimeProviderContractError(
+      expectedRef,
+      'provider.createRuntime must be a function',
+    );
+  }
+  let capabilities: AgentRuntimeCapabilities;
+  try {
+    capabilities = candidate.getCapabilities();
+  } catch (err) {
+    throw new ExternalAgentRuntimeProviderContractError(
+      expectedRef,
+      `provider.getCapabilities threw: ${errMessage(err)}`,
+    );
+  }
+  assertCapabilities(expectedRef, capabilities);
+}
+
+function assertDescriptor(
+  expectedRef: string,
+  descriptor: ProviderDescriptor | undefined,
+): asserts descriptor is ProviderDescriptor {
+  if (descriptor === undefined) {
+    throw new ExternalAgentRuntimeProviderContractError(
+      expectedRef,
+      'provider.descriptor is required',
+    );
+  }
+  if (descriptor.kind !== 'agentRuntime') {
+    throw new ExternalAgentRuntimeProviderContractError(
+      expectedRef,
+      `provider.descriptor.kind must be "agentRuntime" (got ${JSON.stringify(descriptor.kind)})`,
+    );
+  }
+  if (typeof descriptor.id !== 'string' || descriptor.id.trim() === '') {
+    throw new ExternalAgentRuntimeProviderContractError(
+      expectedRef,
+      'provider.descriptor.id must be a non-empty string',
+    );
+  }
+  if (formatProviderRef(descriptor.ref) !== expectedRef) {
+    throw new ExternalAgentRuntimeProviderContractError(
+      expectedRef,
+      `provider.descriptor.ref must be ${JSON.stringify(expectedRef)}`,
+    );
+  }
+}
+
+function assertCapabilities(
+  expectedRef: string,
+  value: unknown,
+): asserts value is AgentRuntimeCapabilities {
+  if (!isRecord(value)) {
+    throw new ExternalAgentRuntimeProviderContractError(
+      expectedRef,
+      'capabilities must be an object',
+    );
+  }
+  const capabilities = value as Partial<AgentRuntimeCapabilities>;
+  assertResumeCapability(expectedRef, capabilities.resume);
+  assertSupportedBoolean(expectedRef, 'steer', capabilities.steer);
+  if (!isRecord(capabilities.events) || !isEventKind(capabilities.events['kind'])) {
+    throw new ExternalAgentRuntimeProviderContractError(
+      expectedRef,
+      'capabilities.events.kind must be "push" or "synthesized"',
+    );
+  }
+  assertSupportedBoolean(expectedRef, 'last', capabilities.last);
+  assertSupportedBoolean(expectedRef, 'context', capabilities.context);
+  if (!Array.isArray(capabilities.teammateCompletion)) {
+    throw new ExternalAgentRuntimeProviderContractError(
+      expectedRef,
+      'capabilities.teammateCompletion must be an array',
+    );
+  }
+  for (const shape of capabilities.teammateCompletion) {
+    assertTeamMateCompletionShape(expectedRef, shape);
+  }
+}
+
+function assertResumeCapability(expectedRef: string, value: unknown): void {
+  if (!isRecord(value) || typeof value['supported'] !== 'boolean') {
+    throw new ExternalAgentRuntimeProviderContractError(
+      expectedRef,
+      'capabilities.resume.supported must be a boolean',
+    );
+  }
+  if (value['supported'] === true) {
+    if (typeof value['checkpoint'] !== 'string' || value['checkpoint'] === '') {
+      throw new ExternalAgentRuntimeProviderContractError(
+        expectedRef,
+        'capabilities.resume.checkpoint must be a non-empty string when resume is supported',
+      );
+    }
+  }
+}
+
+function assertSupportedBoolean(
+  expectedRef: string,
+  name: string,
+  value: unknown,
+): void {
+  if (!isRecord(value) || typeof value['supported'] !== 'boolean') {
+    throw new ExternalAgentRuntimeProviderContractError(
+      expectedRef,
+      `capabilities.${name}.supported must be a boolean`,
+    );
+  }
+}
+
+function assertTeamMateCompletionShape(
+  expectedRef: string,
+  value: unknown,
+): asserts value is TeamMateCompletionDeliveryShape {
+  if (!isRecord(value)) {
+    throw new ExternalAgentRuntimeProviderContractError(
+      expectedRef,
+      'capabilities.teammateCompletion entries must be objects',
+    );
+  }
+  const kind = value['kind'];
+  if (kind !== 'codexInboxTurn' && kind !== 'claudeCodeTaskNotification') {
+    throw new ExternalAgentRuntimeProviderContractError(
+      expectedRef,
+      'capabilities.teammateCompletion entries must use a known delivery kind',
+    );
+  }
+  if (typeof value['description'] !== 'string' || value['description'] === '') {
+    throw new ExternalAgentRuntimeProviderContractError(
+      expectedRef,
+      'capabilities.teammateCompletion entries must include a description',
+    );
+  }
+}
+
+function uniqueNpmRefs(refs: Iterable<string>): NpmProviderRef[] {
+  const out = new Map<string, NpmProviderRef>();
+  for (const raw of refs) {
+    const parsed = parseProviderRef(raw);
+    if (parsed.source === 'npm') out.set(parsed.raw, parsed);
+  }
+  return [...out.values()];
+}
+
+async function defaultImportModule(
+  packageName: string,
+): Promise<ExternalAgentRuntimeModule> {
+  return import(packageName) as Promise<ExternalAgentRuntimeModule>;
+}
+
+function isEventKind(
+  value: unknown,
+): value is AgentRuntimeCapabilities['events']['kind'] {
+  return value === 'push' || value === 'synthesized';
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function errMessage(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}

--- a/packages/dreamux/src/agent-runtime/index.ts
+++ b/packages/dreamux/src/agent-runtime/index.ts
@@ -2,4 +2,5 @@ export * from './catalog.js';
 export * from './codex.js';
 export * from './claude-code.js';
 export * from './claude-code-session.js';
+export * from './external-provider.js';
 export * from './types.js';

--- a/packages/dreamux/src/agent-runtime/types.ts
+++ b/packages/dreamux/src/agent-runtime/types.ts
@@ -5,6 +5,7 @@ import type {
   NoticeInjectionResult,
 } from '../dispatcher/turn-manager.js';
 import type { DispatcherConfig } from '../runtime/config.js';
+import type { DispatcherProviderConfig } from '../runtime/config.js';
 import type {
   DispatcherRow,
   DispatcherStatus,
@@ -28,9 +29,11 @@ export type TeamMateCompletionDeliveryShape =
       description: 'notify the runtime through a Claude Code task notification path';
     };
 
-export type AgentRuntimeResumeCheckpoint =
-  | { kind: 'codexThread'; id: string }
-  | { kind: 'claudeCodeSession'; id: string };
+export interface AgentRuntimeResumeCheckpoint {
+  /** Runtime-owned checkpoint kind; builtins use `codexThread` and `claudeCodeSession`. */
+  kind: string;
+  id: string;
+}
 
 export type AgentRuntimeResumeCapability =
   | { supported: true; checkpoint: AgentRuntimeResumeCheckpoint['kind'] }
@@ -144,9 +147,20 @@ export interface AgentRuntimeCreateContext {
   log: (level: 'info' | 'warn' | 'error', msg: string, err?: unknown) => void;
 }
 
+export interface AgentRuntimeProviderConfigReadContext {
+  providerRef: string;
+  dispatcherId: string;
+  file: string;
+  prefix: string;
+}
+
 export interface AgentRuntimeProvider {
   readonly ref: string;
   readonly descriptor: ProviderDescriptor;
   getCapabilities(): AgentRuntimeCapabilities;
+  readConfig?(
+    rawConfig: Record<string, unknown>,
+    context: AgentRuntimeProviderConfigReadContext,
+  ): DispatcherProviderConfig;
   createRuntime(context: AgentRuntimeCreateContext): AgentRuntime;
 }

--- a/packages/dreamux/src/cli/server.ts
+++ b/packages/dreamux/src/cli/server.ts
@@ -40,7 +40,7 @@ async function main(): Promise<void> {
 
   // Load ~/.dreamux/config.json before anything else starts. Missing or invalid
   // config is a setup error; `dreamux serve` must not silently create defaults.
-  const { config, configFile } = await loadConfig();
+  const { config, configFile, providerRegistry } = await loadConfig();
 
   await mkdir(stateRoot(), { recursive: true });
   await mkdir(logsRoot(), { recursive: true });
@@ -56,6 +56,7 @@ async function main(): Promise<void> {
 
   const server = new Server({
     config,
+    providerRegistry,
     logger,
     channelLoggerFactory: (id) =>
       createLogger({ name: `channel/${id}`, filePath: feishuChannelLogPath(id) }),
@@ -101,8 +102,8 @@ Environment overrides:
 Dispatcher declarations:
   Edit ~/.dreamux/config.json dispatchers[] and restart dreamux serve.
   Built-in Feishu channel: builtin:feishu.
-  Phase 1 runtime providers: builtin:codex, builtin:claude-code.
-  Npm runtime provider refs are reserved syntax only and are not loaded in this phase.
+  AgentRuntime providers: builtin:codex, builtin:claude-code, or installed npm:<package>[#export].
+  Npm agentRuntime refs load through the same provider registry before config validation.
   Subscription channel plugins are an interface-only reservation.
 `);
 }

--- a/packages/dreamux/src/daemon/install.ts
+++ b/packages/dreamux/src/daemon/install.ts
@@ -26,6 +26,7 @@ import {
 import { TransparentFileLedger } from '../onboard/ledger.js';
 import type { CommandRunner, OnboardFileLedgerEntry } from '../onboard/types.js';
 import {
+  BUILTIN_CODEX_PROVIDER_REF,
   DEFAULT_CODEX_BIN,
   dispatcherCodexConfig,
   type DreamuxConfig,
@@ -54,7 +55,8 @@ export interface DaemonInstallResult {
 
 /**
  * Pick the one codex binary that seeds the managed-service unit PATH. The env
- * override wins; otherwise the enabled dispatchers' `runtime.config.bin` values are used.
+ * override wins; otherwise enabled builtin:codex dispatchers' `runtime.config.bin`
+ * values are used. External-runtime-only configs do not need a Codex PATH seed.
  * The single host unit cannot encode per-dispatcher bins, so when they differ
  * the first is used and a warning names the rest instead of silently dropping
  * them — the server still resolves each dispatcher's own bin at runtime.
@@ -62,17 +64,19 @@ export interface DaemonInstallResult {
 function selectServiceCodexBin(
   config: DreamuxConfig,
   env: NodeJS.ProcessEnv,
-): string {
+): string | null {
   const override = env['CODEX_HOST_CODEX_BIN'];
   if (override !== undefined && override.trim() !== '') return override;
   const bins = [
     ...new Set(
       config.dispatchers
-        .filter((d) => d.enabled)
+        .filter(
+          (d) => d.enabled && d.runtime.provider === BUILTIN_CODEX_PROVIDER_REF,
+        )
         .map((d) => dispatcherCodexConfig(d).bin),
     ),
   ];
-  if (bins.length === 0) return DEFAULT_CODEX_BIN;
+  if (bins.length === 0) return null;
   if (bins.length > 1) {
     console.warn(
       `dreamux daemon install: enabled dispatchers declare ${bins.length} ` +
@@ -97,14 +101,16 @@ export async function runDaemonInstall(
   const { config } = await loadConfig({ configDir: globalConfigDir() });
   setRuntimeConfig(config);
 
-  // The single managed-service unit needs one codex binary to seed its PATH.
-  // It comes from CODEX_HOST_CODEX_BIN (host-level override) or the enabled
-  // dispatchers' runtime.config.bin; the server still resolves each
-  // dispatcher's own bin at runtime.
+  // Seed the service PATH with Codex only when a host override or an enabled
+  // builtin:codex dispatcher needs it. External runtime-only configs do not
+  // get blocked by the old Codex CLI launch check.
   const codexBinSource = selectServiceCodexBin(config, env);
-  const codexBin = dryRun
-    ? codexBinSource
-    : await resolveServiceExecutable(codexBinSource, env);
+  const codexBin =
+    codexBinSource === null
+      ? null
+      : dryRun
+        ? codexBinSource
+        : await resolveServiceExecutable(codexBinSource, env);
   // Best-effort: locate Claude Code so the unit PATH resolves `claude` for
   // server-hosted builtin:claude-code workers. Absent install → omit, warn,
   // and keep the codex-only daemon install working (issue #126 PR8).
@@ -133,9 +139,9 @@ export async function runDaemonInstall(
       });
   const answers: ServiceInstallAnswers = {
     configDir: globalConfigDir(),
-    codexBin,
     dreamuxBin: dreamuxBinPath(env),
     nodeBin,
+    ...(codexBin !== null ? { codexBin } : {}),
     ...(claudeBin !== null ? { claudeBin } : {}),
     startService,
     dryRun,

--- a/packages/dreamux/src/onboard/service.ts
+++ b/packages/dreamux/src/onboard/service.ts
@@ -35,7 +35,12 @@ export const SERVICE_PATH_DEFAULTS = ['/usr/local/bin', '/usr/bin', '/bin'];
 
 export interface ServiceInstallAnswers {
   configDir: string;
-  codexBin: string;
+  /**
+   * Optional Codex binary. Present when enabled builtin:codex dispatchers need
+   * the managed-service PATH to resolve `codex`; omitted for
+   * external-runtime-only installs.
+   */
+  codexBin?: string;
   dreamuxBin: string;
   nodeBin: string;
   /**
@@ -241,10 +246,12 @@ export async function validateManagedServiceLaunch(
     );
   }
 
-  if (!(await runner.check(answers.codexBin, ['--help'], { env }))) {
-    errors.push(
-      `managed service cannot execute Codex CLI at ${answers.codexBin}`,
-    );
+  if (answers.codexBin !== undefined) {
+    if (!(await runner.check(answers.codexBin, ['--help'], { env }))) {
+      errors.push(
+        `managed service cannot execute Codex CLI at ${answers.codexBin}`,
+      );
+    }
   }
 
   return {
@@ -513,7 +520,7 @@ export async function stabilizeHomebrewCellarNode(
 function managedServicePath(answers: ServiceInstallAnswers): string {
   const dirs = [
     dirname(answers.nodeBin),
-    ...absoluteDir(answers.codexBin),
+    ...(answers.codexBin !== undefined ? absoluteDir(answers.codexBin) : []),
     // The Claude Code install dir, when present, so server-hosted
     // builtin:claude-code workers can resolve `claude` (issue #126 PR8).
     ...(answers.claudeBin !== undefined ? absoluteDir(answers.claudeBin) : []),

--- a/packages/dreamux/src/registry/builtins.ts
+++ b/packages/dreamux/src/registry/builtins.ts
@@ -45,16 +45,3 @@ function buildBuiltinProviderRegistry(): ProviderRegistry {
 export function createBuiltinProviderRegistry(): ProviderRegistry {
   return buildBuiltinProviderRegistry();
 }
-
-let defaultProviderRegistry: ProviderRegistry | null = null;
-
-/**
- * Shared builtin registry for config parsing paths that do not yet have a
- * server-owned registry to inject.
- */
-export function defaultBuiltinProviderRegistry(): ProviderRegistry {
-  if (defaultProviderRegistry === null) {
-    defaultProviderRegistry = buildBuiltinProviderRegistry();
-  }
-  return defaultProviderRegistry;
-}

--- a/packages/dreamux/src/registry/index.ts
+++ b/packages/dreamux/src/registry/index.ts
@@ -2,8 +2,8 @@
  * Provider registry + provider references.
  *
  * Process-local provider registration/lookup and the public provider-ref
- * grammar. Builtin providers run; external `npm:` refs are reserved syntax that
- * is parsed and validated but never loaded or executed in this phase.
+ * grammar. Builtin providers are registered eagerly; external `npm:` runtime
+ * refs are dynamically loaded before config validation resolves them.
  */
 
 export * from './provider-ref.js';

--- a/packages/dreamux/src/registry/provider-ref.ts
+++ b/packages/dreamux/src/registry/provider-ref.ts
@@ -12,10 +12,8 @@
  *
  * This module owns the string shorthand <-> normalized object mapping so that
  * config validation and future manifests never re-parse refs with ad hoc string
- * handling after startup. It is pure: no IO, no dynamic import. Phase 1 parses
- * and validates `npm:` refs as reserved syntax only — resolution/execution is
- * the registry's concern (see `registry.ts`) and is not implemented for
- * external packages in this phase.
+ * handling after startup. It is pure: no IO, no dynamic import. Resolution and
+ * dynamic loading stay in the registry / runtime loader layer.
  */
 
 /** Where a provider's implementation comes from. */
@@ -32,7 +30,7 @@ export interface BuiltinProviderRef {
 
 /**
  * An external provider selected by npm package, optionally narrowed to a named
- * export. Reserved syntax in Phase 1: parsed and validated, never loaded.
+ * export.
  */
 export interface NpmProviderRef {
   source: 'npm';
@@ -55,7 +53,7 @@ export const BUILTIN_PROVIDER_ID_RULE =
 /**
  * npm package name: optional `@scope/` prefix then a name segment. Mirrors the
  * common npm naming surface (lowercase, digits, `-`, `.`, `_`) without trying to
- * re-implement the full npm spec — Phase 1 never resolves these.
+ * re-implement the full npm spec.
  */
 const NPM_NAME_SEGMENT = '[a-z0-9][a-z0-9._-]*';
 export const NPM_PACKAGE_PATTERN = new RegExp(
@@ -150,9 +148,7 @@ export function formatProviderRef(ref: ProviderRef): string {
 }
 
 /**
- * True when a ref selects a bundled provider that this phase can resolve and
- * run. External (`npm:`) refs are reserved syntax in Phase 1, so they are valid
- * to write but not runnable.
+ * True when a ref selects a bundled provider.
  */
 export function isBuiltinRef(ref: ProviderRef): ref is BuiltinProviderRef {
   return ref.source === 'builtin';

--- a/packages/dreamux/src/registry/registry.ts
+++ b/packages/dreamux/src/registry/registry.ts
@@ -3,11 +3,12 @@
  *
  * The registry is process-local and server-owned. It validates provider refs and
  * resolves them to provider descriptors; executable providers own their runtime
- * capabilities directly. External `npm:` refs remain reserved until the
- * agentRuntime loader is implemented.
+ * capabilities directly. External `npm:` agentRuntime refs are registered by
+ * the async loader before config validation resolves them.
  */
 
 import {
+  formatProviderRef,
   type ProviderRef,
   isBuiltinRef,
   parseProviderRef,
@@ -18,7 +19,7 @@ export type ProviderKind = 'channel' | 'agentRuntime';
 
 /** A registered provider descriptor. Capabilities live on provider instances. */
 export interface ProviderDescriptor {
-  /** Resolved provider id (the builtin id for builtin refs). */
+  /** Stable registry id; builtin providers use their builtin id. */
   id: string;
   kind: ProviderKind;
   ref: ProviderRef;
@@ -29,6 +30,14 @@ export class DuplicateProviderError extends Error {
   constructor(readonly id: string) {
     super(`provider ${JSON.stringify(id)} is already registered`);
     this.name = 'DuplicateProviderError';
+  }
+}
+
+/** Thrown when registering the same canonical provider ref twice. */
+export class DuplicateProviderRefError extends Error {
+  constructor(readonly ref: string) {
+    super(`provider ref ${JSON.stringify(ref)} is already registered`);
+    this.name = 'DuplicateProviderRefError';
   }
 }
 
@@ -49,14 +58,14 @@ export class UnknownBuiltinProviderError extends Error {
 }
 
 /**
- * Thrown when an external (`npm:`) ref is selected for resolution. Phase 1
- * reserves external refs as syntax but never loads or executes them.
+ * Thrown when an external (`npm:`) ref is selected before the async
+ * agentRuntime loader has registered it.
  */
 export class ReservedExternalProviderError extends Error {
   constructor(readonly ref: string) {
     super(
-      `external provider ref ${JSON.stringify(ref)} is reserved but not ` +
-        `loadable in this phase; only \`builtin:\` providers run today`,
+      `external provider ref ${JSON.stringify(ref)} is not loaded; load the ` +
+        'agentRuntime provider before resolving config',
     );
     this.name = 'ReservedExternalProviderError';
   }
@@ -68,6 +77,7 @@ export class ReservedExternalProviderError extends Error {
  */
 export class ProviderRegistry {
   private readonly providers = new Map<string, ProviderDescriptor>();
+  private readonly providersByRef = new Map<string, ProviderDescriptor>();
   private readonly implementations = new Map<string, unknown>();
 
   /**
@@ -77,7 +87,12 @@ export class ProviderRegistry {
     if (this.providers.has(descriptor.id)) {
       throw new DuplicateProviderError(descriptor.id);
     }
+    const canonicalRef = formatProviderRef(descriptor.ref);
+    if (this.providersByRef.has(canonicalRef)) {
+      throw new DuplicateProviderRefError(canonicalRef);
+    }
     this.providers.set(descriptor.id, descriptor);
+    this.providersByRef.set(canonicalRef, descriptor);
   }
 
   has(id: string): boolean {
@@ -86,6 +101,11 @@ export class ProviderRegistry {
 
   get(id: string): ProviderDescriptor | undefined {
     return this.providers.get(id);
+  }
+
+  hasRef(ref: string | ProviderRef): boolean {
+    const parsed = typeof ref === 'string' ? parseProviderRef(ref) : ref;
+    return this.providersByRef.has(formatProviderRef(parsed));
   }
 
   registerImplementation(providerId: string, implementation: unknown): void {
@@ -115,19 +135,22 @@ export class ProviderRegistry {
    *
    * - `builtin:<id>` resolves to the registered descriptor, or throws
    *   {@link UnknownBuiltinProviderError} if absent.
-   * - `npm:` refs throw {@link ReservedExternalProviderError}: reserved syntax
-   *   is parsed/validated but never loaded or executed in this phase.
+   * - `npm:` refs resolve only after the async agentRuntime loader registers
+   *   their descriptor; otherwise they throw
+   *   {@link ReservedExternalProviderError}.
    *
    * A malformed string ref throws `InvalidProviderRefError` from
    * {@link parseProviderRef}.
    */
   resolve(ref: string | ProviderRef): ProviderDescriptor {
     const parsed = typeof ref === 'string' ? parseProviderRef(ref) : ref;
-    if (!isBuiltinRef(parsed)) {
-      throw new ReservedExternalProviderError(parsed.raw);
-    }
-    const descriptor = this.providers.get(parsed.id);
+    const descriptor = isBuiltinRef(parsed)
+      ? this.providers.get(parsed.id)
+      : this.providersByRef.get(formatProviderRef(parsed));
     if (descriptor === undefined) {
+      if (!isBuiltinRef(parsed)) {
+        throw new ReservedExternalProviderError(parsed.raw);
+      }
       throw new UnknownBuiltinProviderError(parsed.id);
     }
     return descriptor;

--- a/packages/dreamux/src/runtime/config.ts
+++ b/packages/dreamux/src/runtime/config.ts
@@ -11,11 +11,17 @@ import { homedir } from 'node:os';
 import { dirname, isAbsolute, join } from 'node:path';
 import { access, mkdir, open, readFile, stat } from 'node:fs/promises';
 import {
+  loadExternalAgentRuntimeProviders,
+  type ExternalAgentRuntimeModuleImporter,
+} from '../agent-runtime/external-provider.js';
+import type { AgentRuntimeProvider } from '../agent-runtime/types.js';
+import {
   InvalidProviderRefError,
   ReservedExternalProviderError,
   UnknownBuiltinProviderError,
-  defaultBuiltinProviderRegistry,
+  createBuiltinProviderRegistry,
   formatProviderRef,
+  parseProviderRef,
   type ProviderDescriptor,
   type ProviderRegistry,
 } from '../registry/index.js';
@@ -196,6 +202,14 @@ export interface ConfigPathOverrides {
   configDir?: string;
   /** Provider registry used to validate config provider refs. */
   providerRegistry?: ProviderRegistry;
+  /** Test seam for external `npm:` agentRuntime provider loading. */
+  externalAgentRuntimeModuleImporter?: ExternalAgentRuntimeModuleImporter;
+}
+
+export interface LoadConfigResult {
+  config: DreamuxConfig;
+  configFile: string;
+  providerRegistry: ProviderRegistry;
 }
 
 export function globalConfigDir(overrides: ConfigPathOverrides = {}): string {
@@ -219,24 +233,28 @@ export async function loadOrInitConfig(
   config: DreamuxConfig;
   configFile: string;
   createdOnThisBoot: boolean;
+  providerRegistry: ProviderRegistry;
 }> {
   const file = globalConfigFile(overrides);
+  const providerRegistry = providerRegistryFor(overrides);
   await assertNoLegacyTomlOnly(overrides);
   await mkdir(dirname(file), { recursive: true });
 
   const createdOnThisBoot = await atomicWriteIfAbsent(file, DEFAULT_CONFIG_JSON);
-  const config = await readConfigFile(file, providerRegistryFor(overrides));
-  return { config, configFile: file, createdOnThisBoot };
+  const config = await readConfigFile(file, providerRegistry, overrides);
+  return { config, configFile: file, createdOnThisBoot, providerRegistry };
 }
 
 export async function loadConfig(
   overrides: ConfigPathOverrides = {},
-): Promise<{ config: DreamuxConfig; configFile: string }> {
+): Promise<LoadConfigResult> {
   const file = globalConfigFile(overrides);
+  const providerRegistry = providerRegistryFor(overrides);
   await assertNoLegacyTomlOnly(overrides);
   return {
-    config: await readConfigFile(file, providerRegistryFor(overrides)),
+    config: await readConfigFile(file, providerRegistry, overrides),
     configFile: file,
+    providerRegistry,
   };
 }
 
@@ -262,6 +280,7 @@ export function redactConfigForDisplay(raw: string, file: string): string {
 async function readConfigFile(
   file: string,
   providerRegistry: ProviderRegistry,
+  overrides: ConfigPathOverrides,
 ): Promise<DreamuxConfig> {
   if (!(await pathExists(file))) {
     throw new Error(
@@ -281,6 +300,11 @@ async function readConfigFile(
         `Fix the JSON syntax in ${file}, then restart. Run \`dreamux onboard\` if you need to recreate the config.`,
     );
   }
+  await loadExternalAgentRuntimeProviders({
+    registry: providerRegistry,
+    refs: runtimeProviderRefs(parsed),
+    importModule: overrides.externalAgentRuntimeModuleImporter,
+  });
   return mergeWithDefaults(parsed, file, providerRegistry);
 }
 
@@ -328,7 +352,7 @@ export async function assertConfigFileMode(file: string): Promise<void> {
 }
 
 function providerRegistryFor(overrides: ConfigPathOverrides): ProviderRegistry {
-  return overrides.providerRegistry ?? defaultBuiltinProviderRegistry();
+  return overrides.providerRegistry ?? createBuiltinProviderRegistry();
 }
 
 function mergeWithDefaults(
@@ -404,11 +428,7 @@ function readDispatchers(
     }
     ids.add(id);
 
-    const channels = readDispatcherChannels(
-      raw['channels'],
-      file,
-      prefix,
-    );
+    const channels = readDispatcherChannels(raw['channels'], file, prefix);
     const feishu = feishuConfigFromChannels(channels, id);
     const app_id = feishu.app_id;
     const existing = appIdToDispatcher.get(app_id);
@@ -425,7 +445,13 @@ function readDispatchers(
       cwd: cwd === null ? null : expandHome(cwd),
       enabled: readOptionalBoolean(raw, 'enabled', true, file, prefix),
       channels,
-      runtime: readDispatcherRuntime(raw['runtime'], file, prefix, providerRegistry),
+      runtime: readDispatcherRuntime(
+        raw['runtime'],
+        file,
+        prefix,
+        id,
+        providerRegistry,
+      ),
     });
   }
   return out;
@@ -494,6 +520,7 @@ function readDispatcherRuntime(
   rawRuntime: unknown,
   file: string,
   dispatcherPrefix: string,
+  dispatcherId: string,
   providerRegistry: ProviderRegistry,
 ): DispatcherRuntimeConfig {
   const prefix = `${dispatcherPrefix}runtime.`;
@@ -521,11 +548,24 @@ function readDispatcherRuntime(
       config: readRuntimeConfig(config, file, `${prefix}config.`),
     };
   }
-  // A registered agentRuntime builtin with no config parser wired yet. Fail
-  // loud rather than fall back to another runtime.
+  const runtimeProvider = asAgentRuntimeProvider(
+    providerRegistry.getImplementation(provider.descriptor.id),
+  );
+  if (runtimeProvider !== null) {
+    return {
+      provider: provider.ref,
+      config:
+        runtimeProvider.readConfig?.(config, {
+          providerRef: provider.ref,
+          dispatcherId,
+          file,
+          prefix: `${prefix}config.`,
+        }) ?? config,
+    };
+  }
   throw new Error(
-    `dreamux config error in ${file}: ${prefix}provider='${provider.ref}' is registered but not runnable in this phase.\n` +
-      'Wired agent runtimes: "builtin:codex", "builtin:claude-code".',
+    `dreamux config error in ${file}: ${prefix}provider='${provider.ref}' is registered but not runnable.\n` +
+      'Builtin runtimes are wired by dreamux; external runtimes must load and register an agentRuntime provider before config validation.',
   );
 }
 
@@ -757,8 +797,8 @@ function resolveConfigProvider(
     }
     if (err instanceof ReservedExternalProviderError) {
       throw new Error(
-        `dreamux config error in ${file}: ${prefix}provider='${rawProvider}' is reserved for future external providers and is not loadable in this phase.\n` +
-          'Use a builtin runtime provider ref such as "builtin:codex" or "builtin:claude-code".',
+        `dreamux config error in ${file}: ${prefix}provider='${rawProvider}' was not loaded as an external agentRuntime provider.\n` +
+          err.message,
       );
     }
     if (err instanceof UnknownBuiltinProviderError) {
@@ -768,6 +808,41 @@ function resolveConfigProvider(
     }
     throw err;
   }
+}
+
+function runtimeProviderRefs(raw: unknown): string[] {
+  if (!isPlainObject(raw)) return [];
+  const dispatchers = raw['dispatchers'];
+  if (!Array.isArray(dispatchers)) return [];
+  const out: string[] = [];
+  for (const dispatcher of dispatchers) {
+    if (!isPlainObject(dispatcher)) continue;
+    const runtime = dispatcher['runtime'];
+    if (!isPlainObject(runtime)) continue;
+    const provider = runtime['provider'];
+    if (typeof provider !== 'string') continue;
+    try {
+      const parsed = parseProviderRef(provider);
+      if (parsed.source === 'npm') out.push(parsed.raw);
+    } catch {
+      // The normal config validation path reports malformed refs with context.
+    }
+  }
+  return out;
+}
+
+function asAgentRuntimeProvider(value: unknown): AgentRuntimeProvider | null {
+  if (typeof value !== 'object' || value === null) return null;
+  const candidate = value as Partial<AgentRuntimeProvider>;
+  if (
+    typeof candidate.ref !== 'string' ||
+    candidate.descriptor === undefined ||
+    typeof candidate.getCapabilities !== 'function' ||
+    typeof candidate.createRuntime !== 'function'
+  ) {
+    return null;
+  }
+  return value as AgentRuntimeProvider;
 }
 
 function readProviderConfigObject(

--- a/packages/dreamux/src/server.ts
+++ b/packages/dreamux/src/server.ts
@@ -16,6 +16,7 @@ import type { CodexWsClient } from './codex/rpc.js';
 import type { FeishuBot } from './feishu/bot.js';
 import {
   createBuiltinProviderRegistry,
+  parseProviderRef,
   type ProviderRegistry,
 } from './registry/index.js';
 import {
@@ -56,7 +57,11 @@ export interface ServerOptions {
   adminSocketPath?: string;
   /** Inject a custom bot factory (tests use this to plug in a fake). */
   botFactory?: (row: DispatcherRow, secret: string) => FeishuBot;
-  /** Provider registry used by runtime composition. */
+  /**
+   * Provider registry used by runtime composition. When config contains
+   * external npm Agent Runtime refs, this must be the registry returned by
+   * loadConfig() after external provider loading.
+   */
   providerRegistry?: ProviderRegistry;
   /** Codex binary path override (tests, highest precedence). */
   codexBinPath?: string;
@@ -109,6 +114,12 @@ export class Server {
     this.providerRegistry =
       opts.providerRegistry ?? createBuiltinProviderRegistry();
     const config = opts.config ?? BUILT_IN_DEFAULTS;
+    if (
+      opts.providerRegistry === undefined &&
+      opts.agentRuntimeProviderCatalog === undefined
+    ) {
+      assertNoExternalRuntimeConfigWithoutRegistry(config);
+    }
     setRuntimeConfig(config);
     this.log = opts.logger ?? createLogger({ name: 'server' });
     const channelLoggerFactory =
@@ -219,6 +230,18 @@ export class Server {
       this.admin = null;
     }
   }
+}
+
+function assertNoExternalRuntimeConfigWithoutRegistry(config: DreamuxConfig): void {
+  const dispatcher = config.dispatchers.find(
+    (item) => parseProviderRef(item.runtime.provider).source === 'npm',
+  );
+  if (dispatcher === undefined) return;
+  throw new Error(
+    `dispatcher '${dispatcher.id}' uses external AgentRuntime provider ` +
+      `${JSON.stringify(dispatcher.runtime.provider)}, but Server was not ` +
+      'constructed with the providerRegistry returned by loadConfig()',
+  );
 }
 
 function errInfo(err: unknown): { message: string; stack?: string } {

--- a/packages/dreamux/tests/agent-runtime-provider.test.ts
+++ b/packages/dreamux/tests/agent-runtime-provider.test.ts
@@ -2,9 +2,21 @@ import { describe, expect, it } from 'vitest';
 
 import {
   AgentRuntimeProviderCatalog,
+  ExternalAgentRuntimeProviderContractError,
+  ExternalAgentRuntimeProviderLoadError,
   UnsupportedAgentRuntimeProviderError,
   createBuiltinAgentRuntimeProviderCatalog,
   createCodexAgentRuntimeProvider,
+  loadExternalAgentRuntimeProviders,
+  type AgentRuntime,
+  type AgentRuntimeCapabilities,
+  type AgentRuntimeCreateContext,
+  type AgentRuntimeLastResult,
+  type AgentRuntimeProvider,
+  type AgentRuntimeProviderConfigReadContext,
+  type AgentRuntimeTurnInput,
+  type AgentRuntimeTurnResult,
+  type ExternalAgentRuntimeProviderFactory,
 } from '../src/agent-runtime/index.js';
 import {
   UnknownBuiltinProviderError,
@@ -13,11 +25,93 @@ import {
 import { DispatcherStore } from '../src/runtime/dispatcher-store.js';
 import { testDispatcherConfig, testDreamuxConfig } from './helpers/config.js';
 
+const EXTERNAL_CAPABILITIES: AgentRuntimeCapabilities = {
+  resume: { supported: true, checkpoint: 'thirdPartySession' },
+  steer: { supported: false },
+  events: { kind: 'synthesized' },
+  last: { supported: true },
+  context: { supported: true },
+  teammateCompletion: [],
+};
+
 function builtinCatalog(): AgentRuntimeProviderCatalog {
   return createBuiltinAgentRuntimeProviderCatalog({
     registry: createBuiltinProviderRegistry(),
     codex: { resolveBinPath: (bin) => bin },
   });
+}
+
+class FakeExternalRuntime implements AgentRuntime {
+  private status: ReturnType<AgentRuntime['getStatus']> = 'declared';
+  readonly submitted: AgentRuntimeTurnInput[] = [];
+
+  constructor(readonly providerRef: string) {}
+
+  async start(): Promise<void> {
+    this.status = 'ready';
+  }
+
+  async resume(): Promise<void> {
+    this.status = 'ready';
+  }
+
+  async stop(): Promise<void> {
+    this.status = 'stopped';
+  }
+
+  async submitTurn(input: AgentRuntimeTurnInput): Promise<AgentRuntimeTurnResult> {
+    this.submitted.push(input);
+    return { status: 'submitted', turnId: 'turn-external' };
+  }
+
+  getStatus(): ReturnType<AgentRuntime['getStatus']> {
+    return this.status;
+  }
+
+  getThreadId(): string | null {
+    return 'external-session';
+  }
+
+  wasThreadResumed(): boolean {
+    return false;
+  }
+
+  async getLast(): Promise<AgentRuntimeLastResult> {
+    return { text: 'external last' };
+  }
+
+  async getContext(): Promise<{ usedTokens: number; windowTokens: number }> {
+    return { usedTokens: 7, windowTokens: 100 };
+  }
+
+  getCapabilities(): AgentRuntimeCapabilities {
+    return EXTERNAL_CAPABILITIES;
+  }
+}
+
+function externalFactory(options: {
+  created?: AgentRuntimeCreateContext[];
+  configs?: AgentRuntimeProviderConfigReadContext[];
+} = {}): ExternalAgentRuntimeProviderFactory {
+  return ({ ref, descriptor }) => {
+    const provider: AgentRuntimeProvider = {
+      ref,
+      descriptor,
+      getCapabilities: () => EXTERNAL_CAPABILITIES,
+      readConfig(rawConfig, context) {
+        options.configs?.push(context);
+        return {
+          ...rawConfig,
+          read_by_provider: true,
+        };
+      },
+      createRuntime(context) {
+        options.created?.push(context);
+        return new FakeExternalRuntime(ref);
+      },
+    };
+    return provider;
+  };
 }
 
 describe('AgentRuntimeProviderCatalog', () => {
@@ -79,13 +173,109 @@ describe('AgentRuntimeProviderCatalog', () => {
     );
   });
 
-  it('reserves external refs without loading or executing them', () => {
+  it('fails loud on unloaded external refs', () => {
     expect(() => builtinCatalog().resolve('npm:@example/dreamux-runtime')).toThrow(
       UnsupportedAgentRuntimeProviderError,
     );
     expect(() =>
       builtinCatalog().resolve('npm:@example/dreamux-runtime#provider'),
     ).toThrow(UnsupportedAgentRuntimeProviderError);
+  });
+
+  it('loads external npm providers into the same runtime catalog', async () => {
+    const registry = createBuiltinProviderRegistry();
+    const created: AgentRuntimeCreateContext[] = [];
+    const factory = externalFactory({ created });
+    await loadExternalAgentRuntimeProviders({
+      registry,
+      refs: [
+        'npm:@example/dreamux-runtime',
+        'npm:@example/dreamux-runtime#named',
+      ],
+      importModule: async (packageName) => {
+        expect(packageName).toBe('@example/dreamux-runtime');
+        return { default: factory, named: factory };
+      },
+    });
+
+    const catalog = createBuiltinAgentRuntimeProviderCatalog({
+      registry,
+      codex: { resolveBinPath: (bin) => bin },
+    });
+    expect(catalog.list().map((provider) => provider.ref).sort()).toEqual([
+      'builtin:claude-code',
+      'builtin:codex',
+      'npm:@example/dreamux-runtime',
+      'npm:@example/dreamux-runtime#named',
+    ]);
+
+    const provider = catalog.resolve('npm:@example/dreamux-runtime#named');
+    expect(provider.getCapabilities().resume).toEqual({
+      supported: true,
+      checkpoint: 'thirdPartySession',
+    });
+    const dispatcher = testDispatcherConfig({ id: 'flow' });
+    const store = new DispatcherStore(testDreamuxConfig([dispatcher]));
+    const runtime = provider.createRuntime({
+      row: store.get('flow')!,
+      dispatcher,
+      dispatchers: store,
+      mcpServers: [],
+      log: () => undefined,
+    });
+
+    expect(runtime.providerRef).toBe('npm:@example/dreamux-runtime#named');
+    expect(created).toHaveLength(1);
+  });
+
+  it('reports external package import failures with the provider ref', async () => {
+    await expect(
+      loadExternalAgentRuntimeProviders({
+        registry: createBuiltinProviderRegistry(),
+        refs: ['npm:@example/missing-runtime'],
+        importModule: async () => {
+          throw new Error('package not found');
+        },
+      }),
+    ).rejects.toThrow(ExternalAgentRuntimeProviderLoadError);
+    await expect(
+      loadExternalAgentRuntimeProviders({
+        registry: createBuiltinProviderRegistry(),
+        refs: ['npm:@example/missing-runtime'],
+        importModule: async () => {
+          throw new Error('package not found');
+        },
+      }),
+    ).rejects.toThrow(/npm:@example\/missing-runtime/);
+  });
+
+  it('rejects external modules that do not export a provider factory', async () => {
+    await expect(
+      loadExternalAgentRuntimeProviders({
+        registry: createBuiltinProviderRegistry(),
+        refs: ['npm:@example/dreamux-runtime#missing'],
+        importModule: async () => ({ default: externalFactory() }),
+      }),
+    ).rejects.toThrow(ExternalAgentRuntimeProviderContractError);
+  });
+
+  it('rejects external providers with incomplete capabilities', async () => {
+    await expect(
+      loadExternalAgentRuntimeProviders({
+        registry: createBuiltinProviderRegistry(),
+        refs: ['npm:@example/dreamux-runtime'],
+        importModule: async () => ({
+          default: ({ ref, descriptor }) => ({
+            ref,
+            descriptor,
+            getCapabilities: () => ({
+              resume: { supported: false },
+            }),
+            createRuntime: () => new FakeExternalRuntime(ref),
+          }),
+        }),
+      }),
+    ).rejects.toThrow(/capabilities\.steer\.supported/);
   });
 
   it('supports registry injection for future provider composition tests', () => {

--- a/packages/dreamux/tests/global-config.test.ts
+++ b/packages/dreamux/tests/global-config.test.ts
@@ -38,6 +38,10 @@ import {
   createBuiltinProviderRegistry,
   parseProviderRef,
 } from '../src/registry/index.js';
+import type {
+  AgentRuntimeCapabilities,
+  ExternalAgentRuntimeProviderFactory,
+} from '../src/agent-runtime/index.js';
 import { testDispatcherConfig } from './helpers/config.js';
 
 function writeConfigObjectAt(configDir: string, value: unknown): void {
@@ -45,6 +49,33 @@ function writeConfigObjectAt(configDir: string, value: unknown): void {
     mode: 0o600,
   });
 }
+
+const EXTERNAL_RUNTIME_CAPABILITIES: AgentRuntimeCapabilities = {
+  resume: { supported: true, checkpoint: 'externalSession' },
+  steer: { supported: false },
+  events: { kind: 'synthesized' },
+  last: { supported: true },
+  context: { supported: false },
+  teammateCompletion: [],
+};
+
+const externalRuntimeFactory: ExternalAgentRuntimeProviderFactory = ({
+  ref,
+  descriptor,
+}) => ({
+  ref,
+  descriptor,
+  getCapabilities: () => EXTERNAL_RUNTIME_CAPABILITIES,
+  readConfig(rawConfig) {
+    return {
+      ...rawConfig,
+      parsed_by_provider: true,
+    };
+  },
+  createRuntime() {
+    throw new Error('external runtime config test does not create a runtime');
+  },
+});
 
 describe('global config (~/.dreamux/config.json)', () => {
   let configDir: string;
@@ -463,11 +494,77 @@ describe('global config (~/.dreamux/config.json)', () => {
     });
 
     await expect(loadConfig({ configDir, providerRegistry: registry })).rejects.toThrow(
-      /registered but not runnable in this phase/,
+      /registered but not runnable/,
     );
     await expect(loadConfig({ configDir })).rejects.toThrow(
       /unknown builtin provider 'custom-runtime'/,
     );
+  });
+
+  it('loads external npm runtime providers before validating runtime config', async () => {
+    const providerRef = 'npm:@example/dreamux-runtime#provider';
+    writeConfigObject({
+      dispatchers: [
+        testDispatcherConfig({
+          id: 'flow',
+          runtime: {
+            provider: providerRef,
+            config: {
+              provider_option: 'kept',
+            },
+          },
+        }),
+      ],
+    });
+
+    const { config, providerRegistry } = await loadConfig({
+      configDir,
+      externalAgentRuntimeModuleImporter: async (packageName) => {
+        expect(packageName).toBe('@example/dreamux-runtime');
+        return { provider: externalRuntimeFactory };
+      },
+    });
+
+    expect(config.dispatchers[0]?.runtime).toEqual({
+      provider: providerRef,
+      config: {
+        provider_option: 'kept',
+        parsed_by_provider: true,
+      },
+    });
+    expect(providerRegistry.resolve(providerRef).kind).toBe('agentRuntime');
+    expect(providerRegistry.getImplementation(providerRef)).not.toBeUndefined();
+  });
+
+  it('fails loudly when an external npm runtime package cannot be imported', async () => {
+    writeConfigObject({
+      dispatchers: [
+        testDispatcherConfig({
+          id: 'flow',
+          runtime: {
+            provider: 'npm:@example/missing-runtime',
+            config: {},
+          },
+        }),
+      ],
+    });
+
+    await expect(
+      loadConfig({
+        configDir,
+        externalAgentRuntimeModuleImporter: async () => {
+          throw new Error('package not found');
+        },
+      }),
+    ).rejects.toThrow(/npm:@example\/missing-runtime/);
+    await expect(
+      loadConfig({
+        configDir,
+        externalAgentRuntimeModuleImporter: async () => {
+          throw new Error('package not found');
+        },
+      }),
+    ).rejects.toThrow(/could not import package/);
   });
 
   it('accepts a builtin:claude-code runtime with its own config shape', async () => {

--- a/packages/dreamux/tests/registry.test.ts
+++ b/packages/dreamux/tests/registry.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from 'vitest';
 import {
   BUILTIN_PROVIDERS,
   DuplicateProviderError,
+  DuplicateProviderRefError,
   ProviderRegistry,
   ReservedExternalProviderError,
   UnknownBuiltinProviderError,
@@ -16,6 +17,10 @@ function descriptor(
   kind: ProviderDescriptor['kind'] = 'channel',
 ): ProviderDescriptor {
   return { id, kind, ref: parseProviderRef(`builtin:${id}`) };
+}
+
+function npmDescriptor(ref: string): ProviderDescriptor {
+  return { id: ref, kind: 'agentRuntime', ref: parseProviderRef(ref) };
 }
 
 describe('ProviderRegistry — registration', () => {
@@ -60,7 +65,7 @@ describe('ProviderRegistry — resolve', () => {
     );
   });
 
-  it('refuses to resolve a reserved external npm ref', () => {
+  it('fails loud on an unloaded external npm ref', () => {
     const registry = createBuiltinProviderRegistry();
     expect(() => registry.resolve('npm:@example/dreamux-provider')).toThrow(
       ReservedExternalProviderError,
@@ -68,6 +73,19 @@ describe('ProviderRegistry — resolve', () => {
     expect(() =>
       registry.resolve('npm:@example/dreamux-provider#named'),
     ).toThrow(ReservedExternalProviderError);
+  });
+
+  it('resolves an external npm ref after the loader registers it', () => {
+    const registry = createBuiltinProviderRegistry();
+    const descriptor = npmDescriptor('npm:@example/dreamux-provider#runtime');
+    registry.register(descriptor);
+
+    expect(registry.resolve('npm:@example/dreamux-provider#runtime')).toBe(
+      descriptor,
+    );
+    expect(registry.resolve(parseProviderRef(descriptor.ref.raw))).toBe(
+      descriptor,
+    );
   });
 
   it('surfaces malformed refs through the parser', () => {
@@ -93,9 +111,21 @@ describe('createBuiltinProviderRegistry', () => {
     );
   });
 
-  it('does not execute or expose external providers', () => {
+  it('does not expose unloaded external providers', () => {
     const registry = createBuiltinProviderRegistry();
-    // Reserved external refs never become registered providers.
     expect(registry.has('@example/dreamux-provider')).toBe(false);
+    expect(registry.hasRef('npm:@example/dreamux-provider')).toBe(false);
+  });
+
+  it('rejects duplicate canonical refs even when ids differ', () => {
+    const registry = createBuiltinProviderRegistry();
+    registry.register(npmDescriptor('npm:@example/dreamux-provider#runtime'));
+
+    expect(() =>
+      registry.register({
+        ...npmDescriptor('npm:@example/dreamux-provider#runtime'),
+        id: 'different-id',
+      }),
+    ).toThrow(DuplicateProviderRefError);
   });
 });

--- a/packages/dreamux/tests/service-claude-path.test.ts
+++ b/packages/dreamux/tests/service-claude-path.test.ts
@@ -13,8 +13,25 @@ import { delimiter, dirname } from 'node:path';
 import {
   managedServiceEnvironment,
   selectServiceClaudeBin,
+  validateManagedServiceLaunch,
   type ServiceInstallAnswers,
 } from '../src/onboard/service.js';
+import type { CommandRunner } from '../src/onboard/types.js';
+
+class ServiceRunner implements CommandRunner {
+  readonly checks: string[] = [];
+
+  async run(): Promise<void> {}
+
+  async check(command: string): Promise<boolean> {
+    this.checks.push(command);
+    return true;
+  }
+
+  async capture(): Promise<string> {
+    return 'v22.7.0';
+  }
+}
 
 function answers(
   overrides: Partial<ServiceInstallAnswers> = {},
@@ -46,6 +63,18 @@ describe('managed service Claude Code PATH (issue #126 PR8)', () => {
     expect(dirs).not.toContain('/home/op/.local/bin');
     // Codex still seeds the PATH so the codex worker keeps resolving.
     expect(dirs).toContain('/opt/codex/bin');
+  });
+
+  it('does not require Codex for external-runtime-only service installs', async () => {
+    const runner = new ServiceRunner();
+    const env = managedServiceEnvironment(answers({ codexBin: undefined }));
+    const dirs = env['PATH'].split(delimiter);
+
+    expect(dirs).not.toContain('/opt/codex/bin');
+    await expect(
+      validateManagedServiceLaunch(answers({ codexBin: undefined }), runner),
+    ).resolves.toMatchObject({ ok: true });
+    expect(runner.checks).toEqual(['/opt/dreamux/bin/dreamux']);
   });
 
   it('honours the DREAMUX_CLAUDE_BIN override and defaults to claude', () => {

--- a/packages/dreamux/tests/smoke.test.ts
+++ b/packages/dreamux/tests/smoke.test.ts
@@ -64,6 +64,21 @@ import { DREAMUX_DISPATCHER_BASE_INSTRUCTIONS } from '../src/dispatcher/base-pro
 import { startFakeCodex, type FakeCodex } from './fake-codex.js';
 import { testDispatcherConfig } from './helpers/config.js';
 import { Writable } from 'node:stream';
+import {
+  loadExternalAgentRuntimeProviders,
+  type AgentRuntime,
+  type AgentRuntimeCapabilities,
+  type AgentRuntimeCreateContext,
+  type AgentRuntimeLastResult,
+  type AgentRuntimeProvider,
+  type AgentRuntimeTurnInput,
+  type AgentRuntimeTurnResult,
+  type ExternalAgentRuntimeProviderFactory,
+} from '../src/agent-runtime/index.js';
+import {
+  createBuiltinProviderRegistry,
+  type ProviderRegistry,
+} from '../src/registry/index.js';
 
 /** Collect every JSON log line written to an injected logger destination. */
 function captureLogger(name: string): {
@@ -120,9 +135,11 @@ function buildServer(opts: {
   codexRestartBackoffMaxMs?: number;
   channelLoggerFactory?: (dispatcherId: string) => DreamuxLogger;
   codexBinPath?: string;
+  providerRegistry?: ProviderRegistry;
 }): Server {
   return new Server({
     config: opts.config ?? BUILT_IN_DEFAULTS,
+    providerRegistry: opts.providerRegistry,
     adminSocketPath: join(opts.runtimeDir, 'admin.sock'),
     skipBotSecret: opts.skipBotSecret ?? true,
     ...(opts.codexBinPath !== undefined
@@ -152,6 +169,87 @@ function buildServer(opts: {
           },
         }),
   });
+}
+
+const EXTERNAL_RUNTIME_CAPABILITIES: AgentRuntimeCapabilities = {
+  resume: { supported: true, checkpoint: 'externalSession' },
+  steer: { supported: false },
+  events: { kind: 'synthesized' },
+  last: { supported: true },
+  context: { supported: false },
+  teammateCompletion: [],
+};
+
+class SmokeExternalRuntime implements AgentRuntime {
+  private status: ReturnType<AgentRuntime['getStatus']> = 'declared';
+
+  constructor(
+    readonly providerRef: string,
+    private readonly context: AgentRuntimeCreateContext,
+  ) {}
+
+  async start(): Promise<void> {
+    this.status = 'ready';
+    await this.context.dispatchers.setStatus(
+      this.context.row.dispatcher_id,
+      'ready',
+    );
+  }
+
+  async resume(): Promise<void> {
+    await this.start();
+  }
+
+  async stop(): Promise<void> {
+    this.status = 'stopped';
+  }
+
+  async submitTurn(
+    _input: AgentRuntimeTurnInput,
+  ): Promise<AgentRuntimeTurnResult> {
+    return { status: 'submitted', turnId: 'external-turn' };
+  }
+
+  getStatus(): ReturnType<AgentRuntime['getStatus']> {
+    return this.status;
+  }
+
+  getThreadId(): string | null {
+    return 'external-session';
+  }
+
+  wasThreadResumed(): boolean {
+    return false;
+  }
+
+  async getLast(): Promise<AgentRuntimeLastResult> {
+    return { text: 'external last' };
+  }
+
+  async getContext(): Promise<null> {
+    return null;
+  }
+
+  getCapabilities(): AgentRuntimeCapabilities {
+    return EXTERNAL_RUNTIME_CAPABILITIES;
+  }
+}
+
+function smokeExternalFactory(
+  contexts: AgentRuntimeCreateContext[],
+): ExternalAgentRuntimeProviderFactory {
+  return ({ ref, descriptor }) => {
+    const provider: AgentRuntimeProvider = {
+      ref,
+      descriptor,
+      getCapabilities: () => EXTERNAL_RUNTIME_CAPABILITIES,
+      createRuntime(context) {
+        contexts.push(context);
+        return new SmokeExternalRuntime(ref, context);
+      },
+    };
+    return provider;
+  };
 }
 
 class ControllableCodexProcess extends CodexProcess {
@@ -468,6 +566,73 @@ describe('dreamux MVP smoke', () => {
     expect(realpathSync(dispatcherSkillDir)).toBe(
       realpathSync(bundledSkillDir('dispatcher')),
     );
+  });
+
+  it('starts an external npm AgentRuntime through DispatcherService', async () => {
+    const providerRef = 'npm:@example/dreamux-runtime#provider';
+    const registry = createBuiltinProviderRegistry();
+    const contexts: AgentRuntimeCreateContext[] = [];
+    await loadExternalAgentRuntimeProviders({
+      registry,
+      refs: [providerRef],
+      importModule: async (packageName) => {
+        expect(packageName).toBe('@example/dreamux-runtime');
+        return { provider: smokeExternalFactory(contexts) };
+      },
+    });
+    const spawnCounter = { count: 0 };
+    server = buildServer({
+      runtimeDir,
+      fake,
+      bot,
+      providerRegistry: registry,
+      spawnCounter,
+      config: {
+        dispatchers: [
+          testDispatcherConfig({
+            id: 'flow',
+            runtime: {
+              provider: providerRef,
+              config: {
+                external_option: true,
+              },
+            },
+          }),
+        ],
+      },
+    });
+
+    await server.start();
+
+    expect(contexts).toHaveLength(1);
+    expect(contexts[0]?.dispatcher?.runtime.provider).toBe(providerRef);
+    expect(server.dispatcherService.getRuntime('flow')?.providerRef).toBe(
+      providerRef,
+    );
+    expect(spawnCounter.count).toBe(0);
+  });
+
+  it('fails loud when external runtime config is not paired with its loaded registry', () => {
+    const providerRef = 'npm:@example/dreamux-runtime#provider';
+
+    expect(() =>
+      buildServer({
+        runtimeDir,
+        fake,
+        bot,
+        config: {
+          dispatchers: [
+            testDispatcherConfig({
+              id: 'flow',
+              runtime: {
+                provider: providerRef,
+                config: {},
+              },
+            }),
+          ],
+        },
+      }),
+    ).toThrow(/providerRegistry returned by loadConfig/);
   });
 
   it('starts fresh Codex threads with Dreamux dispatcher base instructions', async () => {


### PR DESCRIPTION
## 变更摘要

本 PR 让 `npm:<package>[#export]` 形态的外部 AgentRuntime provider 真正进入统一 runtime 路径：配置加载阶段先动态 import 已安装的 npm 包，取 default 或 named provider factory，校验 provider 契约和 capability 声明，再注册进同一个 `ProviderRegistry`；后续仍由 `AgentRuntimeProviderCatalog` 和 `DispatcherService` 统一创建 runtime。

## 删 / 替旧路径

- 删除 `packages/dreamux/src/registry/builtins.ts` 里的 `defaultBuiltinProviderRegistry()` 兜底单例，替换为每次 config load 创建或复用同一个 registry instance。
- 替换 `packages/dreamux/src/registry/registry.ts` 对所有 `npm:` ref 的 reserved-only 拒绝路径：未加载的 `npm:` 仍 fail-loud，已由 loader 注册的 `npm:` ref 可被同一 registry resolve。
- 替换 `packages/dreamux/src/runtime/config.ts` 的“只认 builtin runtime”配置路径：`loadConfig()` / `loadOrInitConfig()` 现在返回加载过外部 provider 的 `providerRegistry`，CLI `serve` 将该 registry 传入 `Server`。
- 替换 `Server` 直接 fresh builtin registry 兜底外部配置的隐式路径：若外部 runtime config 未携带 `loadConfig()` 返回的 registry 或自定义 catalog，构造期直接 fail-loud。
- 替换 `dreamux daemon install` 对 Codex CLI 的旧全局假设：只有启用 `builtin:codex` dispatcher 或显式 `CODEX_HOST_CODEX_BIN` 时才要求 Codex bin；外部 runtime-only 配置不再被 Codex PATH 校验挡住。

## npm 加载如何落地

- 新增 `packages/dreamux/src/agent-runtime/external-provider.ts`：
  - 扫描 `dispatchers[].runtime.provider` 里的 `npm:` ref；
  - `await import(packageName)` 动态加载已安装包；
  - `npm:<pkg>` 读取 default export，`npm:<pkg>#<export>` 读取 named export；
  - 调用 provider factory，传入 canonical ref 和 seed descriptor；
  - 校验返回值满足 `AgentRuntimeProvider` 契约；
  - 将 descriptor + implementation 注册进同一个 `ProviderRegistry`。
- 外部 runtime 启动 smoke 覆盖 `DispatcherService` 创建路径，确认没有额外 provider map 或平行 runtime 分支。

## Registry 统一兜底

- `loadConfig()` 创建或接收 registry 后，先把外部 runtime provider 加载进该 registry，再用同一个 registry 做 config validation。
- `serve` 入口使用 `loadConfig()` 返回的 `providerRegistry` 构造 `Server`，避免 PR E forward note 中的 builtin fallback 拒掉已加载 `npm:` ref。
- `Server` 新增早期 guard，防止直接传外部 runtime config 但漏传已加载 registry 时静默落回 builtin-only registry。

## Capability 自声明

- 外部 provider 必须实现 `getCapabilities()` 并自报 `resume` / `steer` / `events` / `last` / `context` / `teammateCompletion`。
- 核心只校验 capability shape，不替外部 provider 镜像、推断或补默认 capability。
- `AgentRuntimeResumeCheckpoint.kind` 放宽为 runtime-owned string，允许外部 runtime 使用自己的 checkpoint kind。

## Fail-loud 行为

以下场景都会带着选中的 provider ref 报清楚错误：

- npm 包 import 失败；
- default / named export 不存在或不是 factory；
- factory 抛错；
- provider descriptor kind / ref 不匹配；
- `getCapabilities` / `createRuntime` 缺失；
- capability 声明不完整；
- config 使用已注册 descriptor 但没有 runnable implementation。

## 外部 provider 契约

契约集中在 `packages/dreamux/src/agent-runtime/types.ts` 与 `packages/dreamux/src/agent-runtime/external-provider.ts`，并同步写入 `.agents/decisions/agent-runtime-provider.md`：

- provider factory 签名；
- `AgentRuntimeProvider` 必需字段与可选 `readConfig(rawConfig, context)`；
- `AgentRuntime` 实例契约；
- capability 声明形状；
- `spawn` / `close` / `list` 等编排动词仍属于 Dispatcher Service，不进入 `AgentRuntime` 实例接口。

## 满足的 gate

- gate#1 接口分层：`spawn` / `close` / `list` 未进入 `AgentRuntime`；外部 runtime 仍只实现单实例 runtime contract。
- gate#2 no-sync-IO：动态 import 与持久路径均为 async；`rush lint` 通过 no-sync-IO gate。
- gate#3 runtime 语义统一：外部 provider 经同一 `AgentRuntimeProviderCatalog` / `DispatcherService` 创建路径，没有 send / resume 分叉。
- gate#4 无第三套 catalog：catalog 是 registry view；外部 provider 注册到同一个 registry，不新增独立 provider map。
- gate#5 反缝合：删除 reserved-only / builtin singleton fallback 旧路径，没有把新 loader 叠在旧拒绝路径旁边。

## 验证

- `node common/scripts/install-run-rush.js build`
- `node common/scripts/install-run-rush.js lint`
- `node common/scripts/install-run-rush.js test`
- `node common/scripts/install-run-rush.js change --verify`
- `git diff --check`
- 差异敏感信息 grep：无匹配

备注：`.agents/scripts/check.sh` 在本机 Bash 3.2 下因不支持 associative array 的 `declare -A` 提前失败，未能作为有效 KB 检查结果计入。
