### PR TITLE
Wire teammate→dispatcher reverse completion delivery (#147)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -152,6 +152,12 @@ explicitly supersedes the top-level design.
   first.** Any
   RPC before `initialize` is rejected with `Not initialized` on codex
   0.134+ — confirmed end-to-end in `tests/codex-0135-live.test.ts`.
+- **Teammate reverse-delivery requires codex 0.137+.** `completionInput`
+  delivers a finished teammate's result to the dispatcher via
+  `thread/inject_items` (codex 0.137+; see issue #147), then triggers a turn.
+  Older codex versions lack that RPC, so completion delivery fails loudly with a
+  0.137 hint rather than silently dropping. The proactive doctor/version gate for
+  this lives with the per-runtime `diagnostic` capability (issue #148).
 - **Tests that depend on a real codex install fail loudly when codex is
   missing**, not silent skip. Opt-in skip via `DREAMUX_SKIP_LIVE_CODEX=1`
   (see `tests/codex-0135-live.test.ts`'s docstring).

--- a/common/changes/@excitedjs/dreamux/issue147-reverse-completion_2026-06-08-00-00.json
+++ b/common/changes/@excitedjs/dreamux/issue147-reverse-completion_2026-06-08-00-00.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Wire teammate -> dispatcher reverse completion delivery (issue #147): a finished teammate's result is now delivered back to the dispatcher as a new turn via the runtime's completionInput, using each engine's native mechanism (codex thread/inject_items + a trigger turn; claude-code native <task-notification> with isSynthetic). A teammate turn that errors at the model level (codex fatal 'error' notification) is delivered as 'failed' instead of hanging. NOTE: codex reverse-delivery requires codex 0.137+ (thread/inject_items); on older codex it fails loudly with a 0.137 hint rather than dropping the completion silently. Also fixes spawning a cross-provider teammate (e.g. a builtin:claude-code teammate under a builtin:codex dispatcher), which previously threw 'is not wired to Claude Code'.",
+      "type": "minor",
+      "packageName": "@excitedjs/dreamux"
+    }
+  ],
+  "packageName": "@excitedjs/dreamux",
+  "email": "053700@gmail.com"
+}

--- a/packages/dreamux/src/agent-runtime/CLAUDE.md
+++ b/packages/dreamux/src/agent-runtime/CLAUDE.md
@@ -50,3 +50,16 @@ channel payload is now neutral too (D): `channelInput` takes
 `InboundTurnInput { text; sourceId }` — turn text plus a dedupe/correlation id —
 and channel routing attributes (chat id, sender id, message id) stay in the
 channel layer and never cross into the runtime.
+
+The reverse-delivery loop is now wired end-to-end (#147), so `completionInput`
+is a live caller rather than zero-caller. A runtime fires the neutral
+`TurnSettledSignal { turnId; status }` through the optional
+`AgentRuntimeCreateContext.onTurnSettled` hook when a delivered turn reaches a
+terminal state (completed / failed / stopped) — seam ①. The teammate service
+launches teammate runtimes with that hook (and only then), maps each settle to a
+`CompletionEnvelope`, and hands it to its `onTeamMateCompletion` sink — seam ②;
+the dispatcher's own runtime gets no hook, so it never self-delivers. The facade
+bridges that sink to `DispatcherAgentService.deliverCompletion`, which calls the
+live dispatcher runtime's `completionInput` with bounded retry-on-`failed` — seam
+③. This makes the dispatcher base-prompt promise ("a finished TeamMate is
+delivered back to you as a new turn") real.

--- a/packages/dreamux/src/agent-runtime/builtin/claude-code/rpc.ts
+++ b/packages/dreamux/src/agent-runtime/builtin/claude-code/rpc.ts
@@ -15,7 +15,7 @@ import {
   parseLine,
   TurnAggregator,
 } from './stream.js';
-import type { ParsedLine, TurnOutcome } from './types.js';
+import type { ParsedLine, TurnOutcome, TurnSubmitOptions } from './types.js';
 
 interface PendingTurn {
   resolve: (outcome: TurnOutcome) => void;
@@ -39,7 +39,10 @@ export class ClaudeCodeStreamRpc {
     private readonly options: ClaudeCodeStreamRpcOptions,
   ) {}
 
-  async submitTurn(prompt: string): Promise<TurnOutcome> {
+  async submitTurn(
+    prompt: string,
+    options: TurnSubmitOptions = {},
+  ): Promise<TurnOutcome> {
     if (!this.stdin.writable) {
       return Promise.reject(new Error('claude resident child is not running'));
     }
@@ -73,7 +76,7 @@ export class ClaudeCodeStreamRpc {
         this.options.reapOnTimeout();
       }, this.options.turnTimeoutMs);
       this.pending = pending;
-      this.stdin.write(`${buildUserMessage(prompt)}\n`, (err) => {
+      this.stdin.write(`${buildUserMessage(prompt, options)}\n`, (err) => {
         if (err != null && this.pending === pending) {
           this.settlePending()?.reject(
             err instanceof Error ? err : new Error(String(err)),

--- a/packages/dreamux/src/agent-runtime/builtin/claude-code/runtime.ts
+++ b/packages/dreamux/src/agent-runtime/builtin/claude-code/runtime.ts
@@ -258,7 +258,7 @@ export class ClaudeCodeRuntime implements AgentRuntime {
     if (this.stopped) return { status: 'stopped' };
     const turnId = `claude-system-${++this.turnCounter}`;
     void this.runTurnOnQueue(notice.text, turnId).then(
-      () => this.markTurnSucceeded(),
+      () => this.markTurnSucceeded(turnId),
       (err) => this.markTurnFailed(turnId, err),
     );
     return { status: 'submitted', turnId };
@@ -286,7 +286,7 @@ export class ClaudeCodeRuntime implements AgentRuntime {
     // completion. Instead, a failed turn drives the runtime to `degraded` with a
     // persisted `last_error` (visible via status/doctor) — never swallowed.
     void this.runTurnOnQueue(input.text, turnId).then(
-      () => this.markTurnSucceeded(),
+      () => this.markTurnSucceeded(turnId),
       (err) => this.markTurnFailed(turnId, err),
     );
     return { status: 'submitted', turnId };
@@ -332,13 +332,23 @@ export class ClaudeCodeRuntime implements AgentRuntime {
     return run;
   }
 
-  private async markTurnSucceeded(): Promise<void> {
+  private async markTurnSucceeded(turnId: string): Promise<void> {
+    this.context.onTurnSettled?.({ turnId, status: 'completed' });
     if (this.stopped) return;
     if (this.status !== 'ready') await this.setStatus('ready');
   }
 
   private async markTurnFailed(turnId: string, err: unknown): Promise<void> {
     this.log('error', `claude-code turn ${turnId} failed`, err);
+    // A turn that fails after stop() was requested (the resident child is being
+    // torn down) is a `stopped` settlement; otherwise it is a genuine `failed`.
+    // Fire before the stopped early-return so an interrupted teammate turn is
+    // never lost.
+    this.context.onTurnSettled?.({
+      turnId,
+      status: this.stopped ? 'stopped' : 'failed',
+      error: err instanceof Error ? err : new Error(String(err)),
+    });
     if (this.stopped) return;
     // Surface the failure as durable runtime state rather than swallowing it.
     await this.setStatus('degraded', err);

--- a/packages/dreamux/src/agent-runtime/builtin/claude-code/runtime.ts
+++ b/packages/dreamux/src/agent-runtime/builtin/claude-code/runtime.ts
@@ -74,6 +74,7 @@ import {
   createDefaultClaudeCodeSession,
   type ClaudeCodeSession,
   type ClaudeCodeSessionFactory,
+  type TurnSubmitOptions,
 } from './supervisor.js';
 import type {
   InboundDeliveryHooks,
@@ -122,13 +123,26 @@ interface ClaudeCodeRuntimeDeps {
   resolveBinPath: (bin: string) => string;
 }
 
-/** Format a TeamMate completion as a Claude Code task-notification turn. */
+/**
+ * Format a TeamMate completion as a Claude Code `<task-notification>` — the
+ * native shape claude-code emits for background / sub-agent task completions
+ * (constants/xml.ts: `task-notification` / `task-id` / `status` / `summary`).
+ * The result is delivered inline in a `<result>` tag because dreamux has no
+ * output file, so claude-code's optional `<output-file>` / `<tool-use-id>` tags
+ * are intentionally omitted. Delivered with `isSynthetic: true` (see
+ * {@link ClaudeCodeRuntime.completionInput}) so claude-code treats it as a
+ * notification, not human input.
+ */
 function formatTaskNotification(completion: CompletionEnvelope): string {
   return [
-    `<teammate_session_completion source="${completion.source}" ` +
-      `id="${completion.id}" status="${completion.status}">`,
+    '<task-notification>',
+    `<task-id>${completion.id}</task-id>`,
+    `<status>${completion.status}</status>`,
+    `<summary>TeamMate "${completion.source}" session ${completion.status}</summary>`,
+    '<result>',
     completion.result,
-    '</teammate_session_completion>',
+    '</result>',
+    '</task-notification>',
   ].join('\n');
 }
 
@@ -298,15 +312,18 @@ export class ClaudeCodeRuntime implements AgentRuntime {
     if (this.stopped) {
       return { status: 'unsupported', reason: 'runtime stopped' };
     }
-    // Task-notification delivery entry: notify the Claude Code session with a
-    // task-completion turn. Delivery AWAITS the turn so the result is real —
-    // `accepted` only after the notification turn actually ran, `failed`
-    // otherwise — which is the semantics the PR8 Dispatcher Service relies on
-    // for delivery retry. The executable retry/pull loop itself stays in PR8.
+    // Native task-notification delivery: a stream-json user message whose body
+    // is the `<task-notification>` tag, marked `isSynthetic: true` so claude-code
+    // routes it as a background-completion notification (internal `isMeta`:
+    // hidden in the TUI, model-visible) rather than human input. Delivery AWAITS
+    // the serial-queue turn so `accepted` means it actually ran and `failed`
+    // otherwise — the semantics the Dispatcher Service relies on for delivery
+    // retry.
     try {
       await this.runTurnOnQueue(
         formatTaskNotification(completion),
         `claude-teammate-${completion.id}`,
+        { isSynthetic: true },
       );
       return { status: 'accepted' };
     } catch (err) {
@@ -323,8 +340,12 @@ export class ClaudeCodeRuntime implements AgentRuntime {
    * see the real outcome. The queue itself continues regardless of outcome so a
    * failed turn does not wedge later turns.
    */
-  private runTurnOnQueue(prompt: string, turnId: string): Promise<void> {
-    const run = this.queue.then(() => this.runTurn(prompt, turnId));
+  private runTurnOnQueue(
+    prompt: string,
+    turnId: string,
+    options?: TurnSubmitOptions,
+  ): Promise<void> {
+    const run = this.queue.then(() => this.runTurn(prompt, turnId, options));
     this.queue = run.then(
       () => undefined,
       () => undefined,
@@ -393,9 +414,13 @@ export class ClaudeCodeRuntime implements AgentRuntime {
     await this.setStatus('degraded', new Error('claude resident child exited'));
   }
 
-  private async runTurn(prompt: string, turnId: string): Promise<void> {
+  private async runTurn(
+    prompt: string,
+    turnId: string,
+    options?: TurnSubmitOptions,
+  ): Promise<void> {
     const session = await this.ensureSession();
-    const outcome = await session.submitTurn(prompt);
+    const outcome = await session.submitTurn(prompt, options);
     if (
       outcome.sessionId !== null &&
       outcome.sessionId !== '' &&

--- a/packages/dreamux/src/agent-runtime/builtin/claude-code/stream.ts
+++ b/packages/dreamux/src/agent-runtime/builtin/claude-code/stream.ts
@@ -31,6 +31,7 @@ import type {
   ParsedLine,
   ResultEnvelope,
   TurnOutcome,
+  TurnSubmitOptions,
 } from './types.js';
 
 export type {
@@ -179,12 +180,25 @@ export function parseLine(line: string): ParsedLine {
 
 // ─── Outbound message builders (stdin) ──────────────────────────────────────
 
-/** One user turn as a stream-json `user` message line (no trailing newline). */
-export function buildUserMessage(text: string): string {
-  return JSON.stringify({
+/**
+ * One user turn as a stream-json `user` message line (no trailing newline).
+ *
+ * `isSynthetic` / `priority` are siblings of `message` on the stdin envelope
+ * (claude-code SDKUserMessage schema), not part of the message body. They are
+ * only set for the native completion-notification idiom; a plain channel turn
+ * omits them entirely and reads as a normal human user turn.
+ */
+export function buildUserMessage(
+  text: string,
+  options: TurnSubmitOptions = {},
+): string {
+  const envelope: Record<string, unknown> = {
     type: 'user',
     message: { role: 'user', content: [{ type: 'text', text }] },
-  });
+  };
+  if (options.isSynthetic === true) envelope['isSynthetic'] = true;
+  if (options.priority !== undefined) envelope['priority'] = options.priority;
+  return JSON.stringify(envelope);
 }
 
 /**

--- a/packages/dreamux/src/agent-runtime/builtin/claude-code/supervisor.ts
+++ b/packages/dreamux/src/agent-runtime/builtin/claude-code/supervisor.ts
@@ -20,6 +20,7 @@ import type {
   ClaudeCodeSession,
   ClaudeCodeSessionSpec,
   TurnOutcome,
+  TurnSubmitOptions,
 } from './types.js';
 
 /** The live session: spawns and supervises the real `claude` child. */
@@ -103,14 +104,17 @@ class LiveClaudeCodeSession implements ClaudeCodeSession {
     child.once('exit', () => this.onChildExit());
   }
 
-  async submitTurn(prompt: string): Promise<TurnOutcome> {
+  async submitTurn(
+    prompt: string,
+    options: TurnSubmitOptions = {},
+  ): Promise<TurnOutcome> {
     if (this.stopped) {
       return Promise.reject(new Error('claude resident session is stopped'));
     }
     if (this.child === null || this.exited || this.rpc === null) {
       return Promise.reject(new Error('claude resident child is not running'));
     }
-    return this.rpc.submitTurn(prompt);
+    return this.rpc.submitTurn(prompt, options);
   }
 
   async stop(): Promise<void> {
@@ -171,4 +175,5 @@ export type {
   ClaudeCodeSessionFactory,
   ClaudeCodeSessionSpec,
   TurnOutcome,
+  TurnSubmitOptions,
 } from './types.js';

--- a/packages/dreamux/src/agent-runtime/builtin/claude-code/types.ts
+++ b/packages/dreamux/src/agent-runtime/builtin/claude-code/types.ts
@@ -53,6 +53,23 @@ export interface ResultEnvelope {
   readonly errors: readonly string[];
 }
 
+/**
+ * Per-turn stdin delivery options. The default (an absent object) produces a
+ * plain human-equivalent user turn; completion delivery opts into the native
+ * notification idiom.
+ */
+export interface TurnSubmitOptions {
+  /**
+   * Mark the stdin user message synthetic. claude-code maps this to its
+   * internal `isMeta`: hidden in the TUI transcript but model-visible and sent
+   * to the API like a normal user turn — the native channel for a background /
+   * sub-agent completion notification. Never set on human channel turns.
+   */
+  isSynthetic?: boolean;
+  /** Optional stdin delivery priority (claude-code `priority`). */
+  priority?: 'now' | 'next' | 'later';
+}
+
 /** The reduced outcome of one assistant turn, terminated by a `result`. */
 export interface TurnOutcome {
   readonly isError: boolean;
@@ -90,7 +107,7 @@ export interface ClaudeCodeSession {
   /** Spawn the child and resolve once it is up (reject on spawn error). */
   start(): Promise<void>;
   /** Submit one user turn; resolve with the outcome when `result` lands. */
-  submitTurn(prompt: string): Promise<TurnOutcome>;
+  submitTurn(prompt: string, options?: TurnSubmitOptions): Promise<TurnOutcome>;
   /** Whether the child is currently alive. */
   isAlive(): boolean;
   /**

--- a/packages/dreamux/src/agent-runtime/builtin/codex/events.ts
+++ b/packages/dreamux/src/agent-runtime/builtin/codex/events.ts
@@ -12,6 +12,7 @@ import type {
   ItemCompletedNotification,
   ThreadItem,
   TurnCompletedNotification,
+  TurnErrorNotification,
   TurnStartResponse,
   UserInput,
 } from './types.js';
@@ -61,9 +62,13 @@ export interface TurnSubscriptionOptions {
 }
 
 /**
- * Subscribe to turn notifications for one thread. Returns a collector
- * whose `awaitTurn()` resolves on `turn/completed`. Items arriving on the
- * parallel `item/completed` stream are buffered and merged in.
+ * Subscribe to turn notifications for one thread. Returns a collector whose
+ * `awaitTurn()` resolves on `turn/completed` and REJECTS on a terminal turn
+ * failure — either an `error` notification with `willRetry === false` (a fatal
+ * error that interrupts the turn; codex emits no `turn/completed` after it, so a
+ * resolve-only collector would hang forever) or a `turn/completed` carrying a
+ * `turn.error`. Items arriving on the parallel `item/completed` stream are
+ * buffered and merged into the resolved turn.
  */
 export function subscribeTurnCollection(
   client: CodexWsClient,
@@ -73,9 +78,22 @@ export function subscribeTurnCollection(
   const acceptAnyThread = options.acceptAnyThread === true;
   const itemsByTurn = new Map<string, ThreadItem[]>();
   let cached: CollectedTurn | null = null;
+  let failure: Error | null = null;
   let awaiting: Promise<CollectedTurn> | null = null;
   let resolveTurn: ((turn: CollectedTurn) => void) | null = null;
+  let rejectTurn: ((err: Error) => void) | null = null;
   let done = false;
+
+  const settleFailure = (err: Error): void => {
+    if (done) return;
+    done = true;
+    failure = err;
+    if (rejectTurn !== null) {
+      rejectTurn(err);
+      rejectTurn = null;
+      resolveTurn = null;
+    }
+  };
 
   client.onNotification((notif) => {
     const p = (notif.params ?? {}) as Record<string, unknown>;
@@ -98,12 +116,25 @@ export function subscribeTurnCollection(
       itemsByTurn.set(params.turnId, bucket);
     } else if (notif.method === 'turn/completed') {
       const params = notif.params as TurnCompletedNotification;
+      if (params.turn.error != null) {
+        settleFailure(new Error(params.turn.error.message || 'codex turn failed'));
+        return;
+      }
       done = true;
       const items = itemsByTurn.get(params.turn.id) ?? params.turn.items ?? [];
       cached = { threadId, turnId: params.turn.id, items };
       if (resolveTurn !== null) {
         resolveTurn(cached);
         resolveTurn = null;
+        rejectTurn = null;
+      }
+    } else if (notif.method === 'error') {
+      const params = notif.params as TurnErrorNotification;
+      // Only a fatal (non-retried) error terminates the turn. A transient
+      // `willRetry: true` error is followed by codex's own retry and an
+      // eventual `turn/completed`, so we ignore it here.
+      if (params.willRetry === false) {
+        settleFailure(new Error(params.error?.message ?? 'codex turn error'));
       }
     }
   });
@@ -111,9 +142,11 @@ export function subscribeTurnCollection(
   return {
     awaitTurn(): Promise<CollectedTurn> {
       if (cached !== null) return Promise.resolve(cached);
+      if (failure !== null) return Promise.reject(failure);
       if (awaiting !== null) return awaiting;
-      awaiting = new Promise<CollectedTurn>((res) => {
+      awaiting = new Promise<CollectedTurn>((res, rej) => {
         resolveTurn = res;
+        rejectTurn = rej;
       });
       return awaiting;
     },

--- a/packages/dreamux/src/agent-runtime/builtin/codex/events.ts
+++ b/packages/dreamux/src/agent-runtime/builtin/codex/events.ts
@@ -132,6 +132,23 @@ function traceItemType(params: Record<string, unknown>): string | null {
 }
 
 /**
+ * Append raw Responses API items to a thread's model-visible history without
+ * starting a turn (`thread/inject_items`, codex 0.137+). codex folds the items
+ * onto the active turn when one is running and otherwise records them against a
+ * default turn context (codex_thread.rs `inject_response_items` →
+ * `inject_no_new_turn`); either way it never rejects on a busy thread, so a
+ * rejection here is a genuine RPC error. Persisted to the rollout, so injected
+ * items survive resume.
+ */
+export async function injectThreadItems(
+  client: CodexWsClient,
+  threadId: string,
+  items: ReadonlyArray<Record<string, unknown>>,
+): Promise<void> {
+  await client.request('thread/inject_items', { threadId, items });
+}
+
+/**
  * Send a `turn/start` request and resolve once Codex accepts the submission.
  * This is the production Feishu inbound primitive: it intentionally does not
  * wait for `turn/completed`.

--- a/packages/dreamux/src/agent-runtime/builtin/codex/provider.ts
+++ b/packages/dreamux/src/agent-runtime/builtin/codex/provider.ts
@@ -89,6 +89,7 @@ export function createCodexAgentRuntimeProvider(
         resolveExtraArgs: () => runtimeArgs,
         handshakeTimeoutMs: codexConfig.initialize_timeout_ms,
         extraEnv: codexConfig.extra_env,
+        onTurnSettled: context.onTurnSettled,
         log: context.log,
         ...(options.codexProcessFactory !== undefined
           ? { codexProcessFactory: options.codexProcessFactory }

--- a/packages/dreamux/src/agent-runtime/builtin/codex/provider.ts
+++ b/packages/dreamux/src/agent-runtime/builtin/codex/provider.ts
@@ -57,7 +57,8 @@ export const CODEX_AGENT_RUNTIME_CAPABILITIES: AgentRuntimeCapabilities = {
     {
       kind: 'codexInboxTurn',
       description:
-        'write completion to a runtime inbox, then trigger a dispatcher turn',
+        'inject the completion into thread history (thread/inject_items), then ' +
+        'trigger a dispatcher turn',
     },
   ],
 };

--- a/packages/dreamux/src/agent-runtime/builtin/codex/runtime-support.ts
+++ b/packages/dreamux/src/agent-runtime/builtin/codex/runtime-support.ts
@@ -26,10 +26,12 @@ export function codexProcessEnv(
   return env;
 }
 
-/** Frame a TeamMate completion as the text of a delivered Codex turn. */
-export function formatCodexTeamMateCompletion(
-  completion: CompletionEnvelope,
-): string {
+/**
+ * Frame a TeamMate completion as recognizable notification text. Delivered as
+ * the body of a developer-role history item (not a fake user turn), so codex
+ * treats it as injected context rather than user intent.
+ */
+function frameCodexCompletion(completion: CompletionEnvelope): string {
   return [
     `<teammate_session_completion source="${completion.source}" ` +
       `id="${completion.id}" status="${completion.status}">`,
@@ -37,6 +39,40 @@ export function formatCodexTeamMateCompletion(
     '</teammate_session_completion>',
   ].join('\n');
 }
+
+/**
+ * Build the raw Responses API item injected into the dispatcher thread's
+ * model-visible history via `thread/inject_items`. A `message` item with role
+ * `developer` carries the completion as system-injected context — codex appends
+ * it to history without starting a user turn (codex_thread.rs
+ * `inject_response_items`). The shape matches codex's `ResponseItem::Message`
+ * (`type: "message"`, `role`, `content`) with a `ContentItem::InputText`
+ * (`type: "input_text"`); `id` / `phase` are omitted (codex `skip_serializing`).
+ *
+ * Role `developer` (not codex's own user-role `<subagent_notification>`) is
+ * deliberate: that tag is wired to codex's real subagent system, whereas a
+ * neutral developer message is model-visible text codex will not try to
+ * interpret as engine-internal state.
+ */
+export function buildCodexCompletionItem(
+  completion: CompletionEnvelope,
+): Record<string, unknown> {
+  return {
+    type: 'message',
+    role: 'developer',
+    content: [{ type: 'input_text', text: frameCodexCompletion(completion) }],
+  };
+}
+
+/**
+ * Minimal user-turn text that wakes the idle dispatcher after a completion is
+ * injected. The injected developer item carries the actual result; this turn
+ * only triggers the model to read the just-injected notification and act.
+ */
+export const CODEX_COMPLETION_TRIGGER_TEXT =
+  'A TeamMate session you dispatched has settled. Its outcome was just delivered ' +
+  'into your context as a <teammate_session_completion> item. Review it and take ' +
+  'any needed follow-up; if nothing is needed, you may end this turn.';
 
 export const defaultCodexRuntimePaths: AgentRuntimePathContext = {
   dispatcherDir,

--- a/packages/dreamux/src/agent-runtime/builtin/codex/runtime.ts
+++ b/packages/dreamux/src/agent-runtime/builtin/codex/runtime.ts
@@ -469,9 +469,15 @@ export class CodexRuntime implements AgentRuntime {
           buildCodexCompletionItem(completion),
         ]);
       } catch (err) {
+        const cause = err instanceof Error ? err.message : String(err);
+        // `thread/inject_items` exists only on codex 0.137+. On an older codex
+        // it RPC-fails here, so surface the version requirement loudly rather
+        // than letting the dispatcher silently never see the completion.
         return {
           status: 'failed',
-          error: err instanceof Error ? err : new Error(String(err)),
+          error: new Error(
+            `teammate completion thread/inject_items failed (requires codex 0.137+): ${cause}`,
+          ),
         };
       }
       this.rememberInjectedCompletion(completion.id);

--- a/packages/dreamux/src/agent-runtime/builtin/codex/runtime.ts
+++ b/packages/dreamux/src/agent-runtime/builtin/codex/runtime.ts
@@ -40,7 +40,7 @@ import type {
 import {
   TurnManager,
 } from './turn-manager.js';
-import type { CollectedTurn } from './events.js';
+import { injectThreadItems, type CollectedTurn } from './events.js';
 import type {
   InboundDeliveryHooks,
   InboundTurnInput,
@@ -68,10 +68,11 @@ import type {
 import { BUILTIN_CODEX_PROVIDER_REF } from '../../../config/config.js';
 import { CODEX_AGENT_RUNTIME_CAPABILITIES } from './provider.js';
 import {
+  buildCodexCompletionItem,
+  CODEX_COMPLETION_TRIGGER_TEXT,
   codexProcessEnv,
   codexRowStateStore,
   defaultCodexRuntimePaths,
-  formatCodexTeamMateCompletion,
 } from './runtime-support.js';
 
 const DEFAULT_RESTART_BACKOFF_BASE_MS = 1000;
@@ -419,25 +420,50 @@ export class CodexRuntime implements AgentRuntime {
   }
 
   /**
-   * Codex TeamMate completion delivery (issue #110 PR8): inbox + turn trigger.
-   * The completion is delivered into the dispatcher's Codex thread as a turn via
-   * the public `channelInput` seam — not turn-manager internals — so it
-   * survives the planned move of queue/state to a per-dispatcher state owner.
+   * Codex TeamMate completion delivery — the native inbox-then-trigger idiom.
    *
-   * Each attempt uses a fresh, non-routable source id. The turn manager commits
-   * its dedup id before `turn/start` and does not roll it back on failure, so a
-   * retry that reused one id would come back `duplicate` and be mis-counted as
-   * delivered when nothing was submitted. The Dispatcher Service only retries on
-   * `failed` (turn/start RPC failed → definitely not submitted), so a unique id
-   * per attempt re-submits safely without any double-injection risk.
+   * Two steps, in order:
+   *  1. `thread/inject_items` appends the completion to the dispatcher thread's
+   *     model-visible history as a developer-role message (no fake user turn).
+   *     codex folds the item onto the active turn when one is running and never
+   *     rejects on a busy thread, so a failure here is a genuine RPC error.
+   *  2. a minimal trigger turn through the public `channelInput` seam wakes the
+   *     idle dispatcher so it reads the just-injected notification and acts.
+   *
+   * The trigger turn uses a fresh, non-routable source id per attempt. The turn
+   * manager commits its dedup id before `turn/start` and does not roll it back
+   * on failure, so a retry that reused one id would come back `duplicate` and be
+   * mis-counted as delivered when nothing was submitted. The Dispatcher Service
+   * only retries on `failed` (definitely not submitted), so a unique id per
+   * attempt re-submits the trigger safely.
    */
   async completionInput(
     completion: CompletionEnvelope,
   ): Promise<TeamMateCompletionDeliveryResult> {
+    if (this.client === null || this.turnManager === null || this.stopping) {
+      return { status: 'unsupported', reason: 'dispatcher runtime stopped' };
+    }
+    const threadId = this.threadId;
+    if (threadId === null) {
+      return {
+        status: 'failed',
+        error: new Error('teammate completion delivery has no thread id'),
+      };
+    }
     this.teammateDeliverySeq += 1;
+    try {
+      await injectThreadItems(this.client, threadId, [
+        buildCodexCompletionItem(completion),
+      ]);
+    } catch (err) {
+      return {
+        status: 'failed',
+        error: err instanceof Error ? err : new Error(String(err)),
+      };
+    }
     const delivery = await this.channelInput({
       sourceId: `teammate:${completion.id}#${this.teammateDeliverySeq}`,
-      text: formatCodexTeamMateCompletion(completion),
+      text: CODEX_COMPLETION_TRIGGER_TEXT,
     });
     switch (delivery.status) {
       case 'submitted':
@@ -451,12 +477,12 @@ export class CodexRuntime implements AgentRuntime {
         // turn was NOT freshly submitted, so do not report it as delivered.
         return {
           status: 'failed',
-          error: new Error('teammate completion turn unexpectedly deduplicated'),
+          error: new Error('teammate completion trigger unexpectedly deduplicated'),
         };
       case 'skipped':
         return {
           status: 'failed',
-          error: new Error('teammate completion turn unexpectedly skipped'),
+          error: new Error('teammate completion trigger unexpectedly skipped'),
         };
     }
   }

--- a/packages/dreamux/src/agent-runtime/builtin/codex/runtime.ts
+++ b/packages/dreamux/src/agent-runtime/builtin/codex/runtime.ts
@@ -136,6 +136,15 @@ export class CodexRuntime implements AgentRuntime {
   private status: DispatcherStatus = 'declared';
   /** Monotonic per-attempt suffix for TeamMate delivery turn dedup ids (#110 PR8). */
   private teammateDeliverySeq = 0;
+  /**
+   * Completion ids whose item has already been injected into the thread. The
+   * Dispatcher Service retries `completionInput` on `failed`; if the inject
+   * succeeded but the trigger turn failed, the retry must NOT re-inject the same
+   * item (that would persist a duplicate completion to the rollout). Bounded so
+   * a long-lived dispatcher does not grow this set without limit.
+   */
+  private readonly injectedCompletionIds = new Set<string>();
+  private readonly injectedCompletionOrder: string[] = [];
   private readonly log: NonNullable<CodexRuntimeDeps['log']>;
   private stopping = false;
   private restarting = false;
@@ -451,15 +460,21 @@ export class CodexRuntime implements AgentRuntime {
       };
     }
     this.teammateDeliverySeq += 1;
-    try {
-      await injectThreadItems(this.client, threadId, [
-        buildCodexCompletionItem(completion),
-      ]);
-    } catch (err) {
-      return {
-        status: 'failed',
-        error: err instanceof Error ? err : new Error(String(err)),
-      };
+    // Inject the completion item at most once per completion id. On a retry
+    // (trigger turn failed last time) the item is already in the thread, so we
+    // skip straight to re-triggering instead of persisting a duplicate.
+    if (!this.injectedCompletionIds.has(completion.id)) {
+      try {
+        await injectThreadItems(this.client, threadId, [
+          buildCodexCompletionItem(completion),
+        ]);
+      } catch (err) {
+        return {
+          status: 'failed',
+          error: err instanceof Error ? err : new Error(String(err)),
+        };
+      }
+      this.rememberInjectedCompletion(completion.id);
     }
     const delivery = await this.channelInput({
       sourceId: `teammate:${completion.id}#${this.teammateDeliverySeq}`,
@@ -634,6 +649,17 @@ export class CodexRuntime implements AgentRuntime {
     // `stopped` settlement for interrupted turns is emitted by the turn manager
     // on `stop()`.
     this.deps.onTurnSettled?.({ turnId: turn.turnId, status: 'completed' });
+  }
+
+  /** Record a completion id as injected, evicting the oldest past a small cap. */
+  private rememberInjectedCompletion(id: string): void {
+    if (this.injectedCompletionIds.has(id)) return;
+    this.injectedCompletionIds.add(id);
+    this.injectedCompletionOrder.push(id);
+    while (this.injectedCompletionOrder.length > 256) {
+      const evicted = this.injectedCompletionOrder.shift();
+      if (evicted !== undefined) this.injectedCompletionIds.delete(evicted);
+    }
   }
 
   private setStatus(s: DispatcherStatus): void {

--- a/packages/dreamux/src/agent-runtime/builtin/codex/runtime.ts
+++ b/packages/dreamux/src/agent-runtime/builtin/codex/runtime.ts
@@ -40,7 +40,12 @@ import type {
 import {
   TurnManager,
 } from './turn-manager.js';
-import type { InboundDeliveryHooks, InboundTurnInput } from '../../turn.js';
+import type { CollectedTurn } from './events.js';
+import type {
+  InboundDeliveryHooks,
+  InboundTurnInput,
+  TurnSettledSignal,
+} from '../../turn.js';
 import { createFailFastApprovalHandler } from './approval.js';
 import {
   dispatcherCodexHomeDoctorContext,
@@ -105,6 +110,11 @@ export interface CodexRuntimeDeps {
   restartBackoffBaseMs?: number;
   /** Codex child/WS restart backoff cap (tests may override). */
   restartBackoffMaxMs?: number;
+  /**
+   * Fired each time a delivered turn reaches a terminal state. Supplied by the
+   * launcher (teammate service) and omitted for dispatcher launches.
+   */
+  onTurnSettled?: (settled: TurnSettledSignal) => void;
   log?: (level: 'info' | 'warn' | 'error', msg: string, err?: unknown) => void;
 }
 
@@ -324,6 +334,7 @@ export class CodexRuntime implements AgentRuntime {
       getThreadId: () => this.threadId,
       client: this.client,
       onTurnCompleted: (turn) => this.recordCollectedTurn(turn),
+      onTurnSettled: this.deps.onTurnSettled,
       log: this.log,
     });
   }
@@ -587,14 +598,16 @@ export class CodexRuntime implements AgentRuntime {
     });
   }
 
-  private recordCollectedTurn(turn: {
-    items: Array<{ type: string; text?: string }>;
-  }): void {
+  private recordCollectedTurn(turn: CollectedTurn): void {
     const messages = turn.items.filter((item) => item.type === 'agentMessage');
     const last = messages[messages.length - 1];
     if (typeof last?.text === 'string' && last.text.length > 0) {
       this.lastResult = { text: last.text };
     }
+    // A turn reaching `turn/completed` is the `completed` terminal state. The
+    // `stopped` settlement for interrupted turns is emitted by the turn manager
+    // on `stop()`.
+    this.deps.onTurnSettled?.({ turnId: turn.turnId, status: 'completed' });
   }
 
   private setStatus(s: DispatcherStatus): void {

--- a/packages/dreamux/src/agent-runtime/builtin/codex/turn-manager.ts
+++ b/packages/dreamux/src/agent-runtime/builtin/codex/turn-manager.ts
@@ -12,6 +12,7 @@ import {
   subscribeTurnCollection,
   submitTurnStart,
   type CollectedTurn,
+  type TurnCollector,
 } from './events.js';
 import type { CodexWsClient } from './rpc.js';
 import {
@@ -20,6 +21,7 @@ import {
   type InboundDeliveryResult,
   type NoticeInjectionResult,
   type InboundDeliveryHooks,
+  type TurnSettledSignal,
 } from '../../turn.js';
 
 export interface TurnManagerOptions {
@@ -38,6 +40,14 @@ export interface TurnManagerOptions {
   log?: (level: 'info' | 'warn' | 'error', msg: string, err?: unknown) => void;
   /** Best-effort runtime-local snapshot hook for `AgentRuntime.getLast()`. */
   onTurnCompleted?: (turn: CollectedTurn) => void;
+  /**
+   * Fired when a submitted turn is cut short by `stop()` before it reached
+   * `turn/completed` (a crashed or torn-down runtime). The successful
+   * `completed` settlement is fired by the runtime from its `onTurnCompleted`
+   * handler; this hook only covers the `stopped` case so an in-flight teammate
+   * turn never vanishes silently.
+   */
+  onTurnSettled?: (settled: TurnSettledSignal) => void;
 }
 
 export class TurnManager {
@@ -51,6 +61,12 @@ export class TurnManager {
    * in-flight inbound and skip rather than wake the thread twice (issue #78).
    */
   private inboundSubmitted = false;
+  /**
+   * Turn ids submitted to Codex that have not yet reached `turn/completed`. On
+   * `stop()` each still-pending turn is settled as `stopped` so a teammate turn
+   * interrupted by teardown is not lost.
+   */
+  private readonly pendingTurnIds = new Set<string>();
   private readonly log: NonNullable<TurnManagerOptions['log']>;
   private readonly messageIdDedupeWindow: number;
 
@@ -99,10 +115,7 @@ export class TurnManager {
         input.text,
         this.opts.turnCwd ?? null,
       );
-      void collector.awaitTurn().then(
-        (turn) => this.opts.onTurnCompleted?.(turn),
-        () => undefined,
-      );
+      this.trackTurn(res.turn.id, collector);
       return { status: 'submitted', turnId: res.turn.id };
     } catch (err) {
       const error = err instanceof Error ? err : new Error(String(err));
@@ -144,10 +157,7 @@ export class TurnManager {
         text,
         this.opts.turnCwd ?? null,
       );
-      void collector.awaitTurn().then(
-        (turn) => this.opts.onTurnCompleted?.(turn),
-        () => undefined,
-      );
+      this.trackTurn(res.turn.id, collector);
       this.log('info', `injected restart notice into thread ${threadId}`);
       return { status: 'submitted', turnId: res.turn.id };
     } catch (err) {
@@ -159,6 +169,33 @@ export class TurnManager {
 
   async stop(): Promise<void> {
     this.stopped = true;
+    // Any turn still in flight at teardown will never reach `turn/completed`
+    // (the WS is closing). Settle each as `stopped` so an interrupted teammate
+    // turn is delivered with a status rather than vanishing.
+    for (const turnId of this.pendingTurnIds) {
+      this.opts.onTurnSettled?.({ turnId, status: 'stopped' });
+    }
+    this.pendingTurnIds.clear();
+  }
+
+  /**
+   * Record a submitted turn as pending and wire its completion. On
+   * `turn/completed` the turn is removed from the pending set and the snapshot
+   * hook fires (which is where the runtime emits the `completed` settlement).
+   */
+  private trackTurn(turnId: string, collector: TurnCollector): void {
+    this.pendingTurnIds.add(turnId);
+    void collector.awaitTurn().then(
+      (turn) => {
+        // Only forward completion if this turn was still pending. If `stop()`
+        // already settled it as `stopped`, the delete returns false and we drop
+        // the late completion so a turn is never settled twice.
+        if (this.pendingTurnIds.delete(turnId)) this.opts.onTurnCompleted?.(turn);
+      },
+      () => {
+        this.pendingTurnIds.delete(turnId);
+      },
+    );
   }
 
   private async notifyAccepted(

--- a/packages/dreamux/src/agent-runtime/builtin/codex/turn-manager.ts
+++ b/packages/dreamux/src/agent-runtime/builtin/codex/turn-manager.ts
@@ -181,7 +181,11 @@ export class TurnManager {
   /**
    * Record a submitted turn as pending and wire its completion. On
    * `turn/completed` the turn is removed from the pending set and the snapshot
-   * hook fires (which is where the runtime emits the `completed` settlement).
+   * hook fires (which is where the runtime emits the `completed` settlement). On
+   * a terminal turn failure (collector rejects: codex `error` with
+   * `willRetry: false`, or a `turn/completed` carrying `turn.error`) the turn is
+   * settled as `failed` here, so a teammate turn that errors at the model level
+   * is delivered with a status instead of hanging until teardown.
    */
   private trackTurn(turnId: string, collector: TurnCollector): void {
     this.pendingTurnIds.add(turnId);
@@ -192,8 +196,16 @@ export class TurnManager {
         // the late completion so a turn is never settled twice.
         if (this.pendingTurnIds.delete(turnId)) this.opts.onTurnCompleted?.(turn);
       },
-      () => {
-        this.pendingTurnIds.delete(turnId);
+      (err) => {
+        // Same mutual-exclusion guard as the completed path: only settle as
+        // `failed` if `stop()` did not already settle it as `stopped`.
+        if (this.pendingTurnIds.delete(turnId)) {
+          this.opts.onTurnSettled?.({
+            turnId,
+            status: 'failed',
+            error: err instanceof Error ? err : new Error(String(err)),
+          });
+        }
       },
     );
   }

--- a/packages/dreamux/src/agent-runtime/builtin/codex/types.ts
+++ b/packages/dreamux/src/agent-runtime/builtin/codex/types.ts
@@ -90,7 +90,22 @@ export interface ThreadItem {
 
 export interface TurnCompletedNotification {
   threadId: string;
-  turn: { id: string; items?: ThreadItem[] };
+  turn: { id: string; items?: ThreadItem[]; error?: { message: string } };
+}
+
+/**
+ * codex `error` server notification (method `"error"`). `willRetry: true` is a
+ * transient error that does NOT interrupt the turn (codex retries internally);
+ * `willRetry: false` is a fatal error that interrupts the turn — and codex does
+ * NOT emit a subsequent `turn/completed` for it, so a turn collector that only
+ * waits for `turn/completed` would hang forever. We treat `willRetry === false`
+ * as the turn's terminal failure.
+ */
+export interface TurnErrorNotification {
+  threadId?: string;
+  turnId?: string;
+  willRetry?: boolean;
+  error: { message: string; [k: string]: unknown };
 }
 
 export interface ItemCompletedNotification {

--- a/packages/dreamux/src/agent-runtime/turn.ts
+++ b/packages/dreamux/src/agent-runtime/turn.ts
@@ -45,3 +45,18 @@ export interface InboundDeliveryHooks {
    */
   onAccepted?: (input: InboundTurnInput) => void | Promise<void>;
 }
+
+/**
+ * A neutral "turn settled" signal: a delivered turn reached a terminal state.
+ * `completed` is a successful turn, `failed` a turn that errored, `stopped` a
+ * turn cut short by runtime teardown/stop. `turnId` is the runtime's turn id
+ * when known (null when the turn never got one). Capability-neutral — carries no
+ * channel or runtime specifics. This is the opposite lifetime of
+ * {@link InboundDeliveryResult}: that one returns on submit, this one fires
+ * later when the turn actually settles.
+ */
+export interface TurnSettledSignal {
+  turnId: string | null;
+  status: 'completed' | 'failed' | 'stopped';
+  error?: Error;
+}

--- a/packages/dreamux/src/agent-runtime/types.ts
+++ b/packages/dreamux/src/agent-runtime/types.ts
@@ -3,6 +3,7 @@ import type {
   InboundDeliveryResult,
   InboundTurnInput,
   NoticeInjectionResult,
+  TurnSettledSignal,
 } from './turn.js';
 import type { DispatcherConfig } from '../config/config.js';
 import type { DispatcherProviderConfig } from '../config/config.js';
@@ -185,6 +186,14 @@ export interface AgentRuntimeCreateContext {
   state?: AgentRuntimeStateStore;
   paths?: AgentRuntimePathContext;
   mcpServers: readonly AgentRuntimeMcpServer[];
+  /**
+   * Fired by the runtime each time a delivered turn reaches a terminal state
+   * (success, failure, or stop). Capability-neutral; the launcher opts in. The
+   * teammate service passes it to bridge a finished teammate turn back to its
+   * dispatcher; the dispatcher launcher does NOT pass it, so a dispatcher never
+   * self-delivers its own turn settlements.
+   */
+  onTurnSettled?: (settled: TurnSettledSignal) => void;
   log: (level: 'info' | 'warn' | 'error', msg: string, err?: unknown) => void;
 }
 

--- a/packages/dreamux/src/dispatcher-service/dispatcher/service.ts
+++ b/packages/dreamux/src/dispatcher-service/dispatcher/service.ts
@@ -2,6 +2,7 @@ import type {
   AgentRuntime,
   AgentRuntimeMcpServer,
   AgentRuntimeProviderCatalog,
+  CompletionEnvelope,
 } from '../../agent-runtime/index.js';
 import type { FeishuBot } from '../../channel/feishu/bot.js';
 import {
@@ -118,6 +119,73 @@ export class DispatcherAgentService {
 
   getRuntime(id: string): AgentRuntime | null {
     return this.slots.get(id)?.runtime ?? null;
+  }
+
+  /**
+   * Seam ③ of the reverse-delivery path (issue #147): deliver a teammate
+   * completion into the live dispatcher runtime, waking it for a fresh turn. The
+   * retry policy lives here — `completionInput` mints a unique sourceId per call,
+   * so re-delivering on a `failed` result (definitely not submitted) is safe.
+   *
+   * Never throws into the teammate settle path: an absent slot/runtime,
+   * a runtime without completion delivery, an `unsupported` result (runtime
+   * stopped), a thrown call, or exhausted retries all log and return.
+   */
+  async deliverCompletion(
+    dispatcherId: string,
+    completion: CompletionEnvelope,
+  ): Promise<void> {
+    const slot = this.slots.get(dispatcherId);
+    if (slot === undefined) {
+      this.opts.log.warn(
+        { dispatcher_id: dispatcherId, source: completion.source },
+        'dropping teammate completion: dispatcher not running',
+      );
+      return;
+    }
+    const deliver = slot.runtime.completionInput;
+    if (deliver === undefined) {
+      slot.log.warn(
+        { dispatcher_id: dispatcherId, source: completion.source },
+        'dropping teammate completion: runtime has no completion delivery',
+      );
+      return;
+    }
+    const maxAttempts = 3;
+    for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
+      let outcome;
+      try {
+        outcome = await deliver.call(slot.runtime, completion);
+      } catch (err) {
+        slot.log.warn(
+          { dispatcher_id: dispatcherId, source: completion.source, err: errInfo(err) },
+          'teammate completion delivery threw',
+        );
+        return;
+      }
+      if (outcome.status === 'accepted') return;
+      if (outcome.status === 'unsupported') {
+        slot.log.warn(
+          { dispatcher_id: dispatcherId, source: completion.source, reason: outcome.reason },
+          'dropping teammate completion: runtime delivery unsupported',
+        );
+        return;
+      }
+      slot.log.warn(
+        {
+          dispatcher_id: dispatcherId,
+          source: completion.source,
+          attempt,
+          max_attempts: maxAttempts,
+          err: errInfo(outcome.error),
+        },
+        'teammate completion delivery failed',
+      );
+    }
+    slot.log.warn(
+      { dispatcher_id: dispatcherId, source: completion.source, max_attempts: maxAttempts },
+      'teammate completion delivery exhausted retries; dropping',
+    );
   }
 
   summarize(): DispatcherSummary[] {

--- a/packages/dreamux/src/dispatcher-service/service.ts
+++ b/packages/dreamux/src/dispatcher-service/service.ts
@@ -60,6 +60,11 @@ export class DispatcherService {
       config: opts.config,
       dispatchers: opts.dispatchers,
       agentRuntimeProviders: opts.agentRuntimeProviders,
+      // Reverse delivery (issue #147): a settled teammate turn bridges here to
+      // the dispatcher runtime's completionInput, becoming a fresh dispatcher
+      // turn. The facade is where both services meet.
+      onTeamMateCompletion: (id, completion) =>
+        this.dispatchers.deliverCompletion(id, completion),
       log: opts.log,
     });
   }

--- a/packages/dreamux/src/dispatcher-service/teammate/service.ts
+++ b/packages/dreamux/src/dispatcher-service/teammate/service.ts
@@ -7,7 +7,9 @@ import type {
   AgentRuntimeProvider,
   AgentRuntimeProviderCatalog,
   AgentRuntimeTurnResult,
+  CompletionEnvelope,
 } from '../../agent-runtime/index.js';
+import type { TurnSettledSignal } from '../../agent-runtime/turn.js';
 import {
   BUILTIN_CLAUDE_CODE_PROVIDER_REF,
   BUILTIN_CODEX_PROVIDER_REF,
@@ -58,6 +60,18 @@ export interface TeamMateAgentServiceOptions {
     dispatcherId: string;
     name: string;
   }) => readonly AgentRuntimeMcpServer[];
+  /**
+   * Reverse-delivery sink: invoked when a teammate turn reaches a terminal state
+   * (success, failure, or stop). The facade bridges it to the dispatcher
+   * runtime's `completionInput`, turning a finished teammate into a fresh
+   * dispatcher turn (issue #147). A teammate runtime is launched with
+   * `onTurnSettled` only when this sink is present, so settlement never delivers
+   * into a void.
+   */
+  onTeamMateCompletion?: (
+    dispatcherId: string,
+    completion: CompletionEnvelope,
+  ) => void | Promise<void>;
   log: DreamuxLogger;
 }
 
@@ -271,6 +285,12 @@ export class TeamMateAgentService {
       resumeCapability.supported ? resumeCapability.checkpoint : null,
     );
     const row = this.runtimeRow(identity);
+    const onTeamMateCompletion = this.opts.onTeamMateCompletion;
+    // Bound late so the settle handler closes over the runtime instance directly
+    // rather than re-reading the live map: close() deletes the live entry right
+    // after stop() fires its terminal `stopped` settles, which would otherwise
+    // race the lookup.
+    let liveRuntime: AgentRuntime | null = null;
     const runtime = provider.createRuntime({
       row,
       dispatcher: this.dispatcherConfig(dispatcherId),
@@ -284,6 +304,25 @@ export class TeamMateAgentService {
           name: identity.name,
         }) ?? []),
       ],
+      // Attach the settle hook only when a sink is wired (the dispatcher's own
+      // runtime never gets one, so it cannot self-deliver). The handler runs off
+      // the synchronous callback and isolates every error so a delivery failure
+      // can never crash the teammate runtime or the settle path.
+      ...(onTeamMateCompletion !== undefined
+        ? {
+            onTurnSettled: (settled: TurnSettledSignal): void => {
+              const settledRuntime = liveRuntime;
+              if (settledRuntime === null) return;
+              void this.deliverTurnSettled(
+                dispatcherId,
+                identity.name,
+                settledRuntime,
+                settled,
+                onTeamMateCompletion,
+              );
+            },
+          }
+        : {}),
       log: (level, message, err) =>
         this.opts.log[level](
           {
@@ -294,6 +333,7 @@ export class TeamMateAgentService {
           message,
         ),
     });
+    liveRuntime = runtime;
     if (identity.checkpoint !== null) {
       await runtime.resume({ checkpoint: identity.checkpoint });
     } else {
@@ -315,6 +355,48 @@ export class TeamMateAgentService {
       text: prompt,
     });
     return toTurnResult(result);
+  }
+
+  /**
+   * Seam ② of the reverse-delivery path (issue #147): turn a settled teammate
+   * turn into a {@link CompletionEnvelope} and hand it to the sink. Reads the
+   * teammate's final assistant-visible result via `getLast`. A `stopped` turn
+   * maps to envelope status `failed` (the envelope carries only completed/failed)
+   * so a torn-down teammate still surfaces, never silently vanishing. Every step
+   * is error-isolated: this runs `void`-ed off the synchronous settle callback,
+   * so any escape would become an unhandled rejection.
+   */
+  private async deliverTurnSettled(
+    dispatcherId: string,
+    name: string,
+    runtime: AgentRuntime,
+    settled: TurnSettledSignal,
+    sink: NonNullable<TeamMateAgentServiceOptions['onTeamMateCompletion']>,
+  ): Promise<void> {
+    try {
+      let result = '';
+      try {
+        const last = await runtime.getLast();
+        result = last?.text ?? '';
+      } catch (err) {
+        this.opts.log.warn(
+          { dispatcher_id: dispatcherId, teammate: name, err: errInfo(err) },
+          'teammate completion getLast failed',
+        );
+      }
+      const envelope: CompletionEnvelope = {
+        source: name,
+        id: settled.turnId !== null ? `${name}:${settled.turnId}` : name,
+        status: settled.status === 'completed' ? 'completed' : 'failed',
+        result,
+      };
+      await sink(dispatcherId, envelope);
+    } catch (err) {
+      this.opts.log.warn(
+        { dispatcher_id: dispatcherId, teammate: name, err: errInfo(err) },
+        'teammate completion delivery failed',
+      );
+    }
   }
 
   private async mustIdentity(

--- a/packages/dreamux/src/dispatcher-service/teammate/service.ts
+++ b/packages/dreamux/src/dispatcher-service/teammate/service.ts
@@ -291,9 +291,19 @@ export class TeamMateAgentService {
     // after stop() fires its terminal `stopped` settles, which would otherwise
     // race the lookup.
     let liveRuntime: AgentRuntime | null = null;
+    // Only inherit the dispatcher's runtime config when the teammate runs the
+    // SAME provider. A teammate on a different provider (e.g. a claude-code
+    // teammate under a codex dispatcher) must fall back to its provider's
+    // defaults: the dispatcher's config block is the wrong shape, and the
+    // provider's createRuntime would reject it ("... is not wired to ...").
+    const dispatcherCfg = this.dispatcherConfig(dispatcherId);
+    const inheritedConfig =
+      dispatcherCfg !== null && dispatcherCfg.runtime.provider === provider.ref
+        ? dispatcherCfg
+        : null;
     const runtime = provider.createRuntime({
       row,
-      dispatcher: this.dispatcherConfig(dispatcherId),
+      dispatcher: inheritedConfig,
       dispatchers: this.opts.dispatchers,
       cwd: identity.cwd,
       state,

--- a/packages/dreamux/tests/claude-code-runtime.test.ts
+++ b/packages/dreamux/tests/claude-code-runtime.test.ts
@@ -16,6 +16,7 @@ import {
   type ClaudeCodeSessionFactory,
   type ClaudeCodeSessionSpec,
   type TurnOutcome,
+  type TurnSubmitOptions,
 } from '../src/agent-runtime/builtin/claude-code/supervisor.js';
 import { claudeCodeMcpConfig } from '../src/agent-runtime/builtin/claude-code/mcp-config.js';
 import { claudeCodeResidentArgs } from '../src/agent-runtime/builtin/claude-code/args.js';
@@ -73,6 +74,8 @@ function okOutcome(sessionId: string | null = 'session-abc'): TurnOutcome {
 interface FakeSession extends ClaudeCodeSession {
   readonly spec: ClaudeCodeSessionSpec;
   readonly prompts: string[];
+  /** Per-turn submit options captured alongside each prompt. */
+  readonly submitOptions: Array<TurnSubmitOptions | undefined>;
   startCount(): number;
   /** Simulate an unexpected child exit (fires the registered onExit). */
   triggerExit(): void;
@@ -101,9 +104,11 @@ function fakeFleet(
     let starts = 0;
     let onExit: (() => void) | null = null;
     const prompts: string[] = [];
+    const submitOptions: Array<TurnSubmitOptions | undefined> = [];
     const session: FakeSession = {
       spec,
       prompts,
+      submitOptions,
       startCount: () => starts,
       async start() {
         starts += 1;
@@ -114,8 +119,9 @@ function fakeFleet(
       setOnExit(handler) {
         onExit = handler;
       },
-      async submitTurn(prompt) {
+      async submitTurn(prompt, options) {
         prompts.push(prompt);
+        submitOptions.push(options);
         const outcome = outcomes[Math.min(turnIndex, outcomes.length - 1)];
         turnIndex += 1;
         if (outcome instanceof Error) throw outcome;
@@ -408,11 +414,26 @@ describe('ClaudeCodeRuntime resident lifecycle (fake session)', () => {
 
     await waitFor(() => fleet.sessions[0]?.prompts.length === 1);
     const prompt = fleet.sessions[0]?.prompts[0] ?? '';
-    expect(prompt).toContain('<teammate_session_completion');
-    expect(prompt).toContain('source="teammate"');
-    expect(prompt).toContain('id="mate-1"');
-    expect(prompt).toContain('status="completed"');
+    // Native claude-code <task-notification> shape, not a self-authored tag.
+    expect(prompt).toContain('<task-notification>');
+    expect(prompt).toContain('<task-id>mate-1</task-id>');
+    expect(prompt).toContain('<status>completed</status>');
+    expect(prompt).toContain('teammate');
+    expect(prompt).toContain('<result>');
     expect(prompt).toContain('all done');
+    expect(prompt).not.toContain('<teammate_session_completion');
+    // Delivered with isSynthetic so claude-code treats it as a notification.
+    expect(fleet.sessions[0]?.submitOptions[0]).toEqual({ isSynthetic: true });
+  });
+
+  it('does not mark a normal channel turn as synthetic', async () => {
+    const fleet = fakeFleet([okOutcome('session-abc')]);
+    const { runtime } = makeRuntime(fleet);
+    await runtime.start();
+
+    await runtime.channelInput({ sourceId: 'm1', text: 'hello' });
+    await waitFor(() => fleet.sessions[0]?.prompts.length === 1);
+    expect(fleet.sessions[0]?.submitOptions[0]).toBeUndefined();
   });
 
   it('stop() reaps the resident session and refuses further inbound', async () => {

--- a/packages/dreamux/tests/claude-code-runtime.test.ts
+++ b/packages/dreamux/tests/claude-code-runtime.test.ts
@@ -30,6 +30,7 @@ import type {
   AgentRuntime,
   AgentRuntimeMcpServer,
 } from '../src/agent-runtime/types.js';
+import type { TurnSettledSignal } from '../src/agent-runtime/turn.js';
 
 const FEISHU_MCP: AgentRuntimeMcpServer = {
   name: 'feishu',
@@ -263,7 +264,10 @@ describe('ClaudeCodeRuntime resident lifecycle (fake session)', () => {
 
   function makeRuntime(
     fleet: FakeFleet,
-    opts: { resumeSession?: string } = {},
+    opts: {
+      resumeSession?: string;
+      onTurnSettled?: (settled: TurnSettledSignal) => void;
+    } = {},
   ): { runtime: AgentRuntime; store: DispatcherStore; fleet: FakeFleet } {
     const dispatcher = claudeDispatcher('flow');
     const store = new DispatcherStore(testDreamuxConfig([dispatcher]));
@@ -280,6 +284,9 @@ describe('ClaudeCodeRuntime resident lifecycle (fake session)', () => {
       dispatchers: store,
       cwd: defaultDispatcherCwd('flow'),
       mcpServers: [FEISHU_MCP],
+      ...(opts.onTurnSettled !== undefined
+        ? { onTurnSettled: opts.onTurnSettled }
+        : {}),
       log: () => {
         /* test sink */
       },
@@ -574,5 +581,92 @@ describe('ClaudeCodeRuntime resident lifecycle (fake session)', () => {
     // A delivery failure is reported to the caller (PR8 retry) but does not by
     // itself degrade the whole runtime.
     expect(runtime.getStatus()).toBe('ready');
+  });
+
+  it('fires onTurnSettled(completed) with the turn id when an inbound turn succeeds', async () => {
+    const settled: TurnSettledSignal[] = [];
+    const fleet = fakeFleet([okOutcome('session-abc')]);
+    const { runtime } = makeRuntime(fleet, {
+      onTurnSettled: (s) => settled.push(s),
+    });
+    await runtime.start();
+
+    const submit = await runtime.channelInput({ sourceId: 'm1', text: 'go' });
+    expect(submit.status).toBe('submitted');
+
+    await waitFor(() => settled.length === 1);
+    expect(settled[0]?.status).toBe('completed');
+    expect(settled[0]?.turnId).toBe(
+      submit.status === 'submitted' ? submit.turnId : undefined,
+    );
+  });
+
+  it('fires onTurnSettled(failed) with the error when an inbound turn fails', async () => {
+    const settled: TurnSettledSignal[] = [];
+    const fleet = fakeFleet([new Error('turn boom')]);
+    const { runtime } = makeRuntime(fleet, {
+      onTurnSettled: (s) => settled.push(s),
+    });
+    await runtime.start();
+
+    await runtime.channelInput({ sourceId: 'm1', text: 'go' });
+
+    await waitFor(() => settled.length === 1);
+    expect(settled[0]?.status).toBe('failed');
+    expect(settled[0]?.error?.message).toContain('turn boom');
+  });
+
+  it('fires onTurnSettled(stopped) for a turn cut short by stop()', async () => {
+    const settled: TurnSettledSignal[] = [];
+    // A turn whose submitTurn never settles on its own; stop() tears the session
+    // down, which rejects the in-flight turn — it must settle as `stopped`.
+    let releaseTurn: (() => void) | null = null;
+    const blockingFactory: ClaudeCodeSessionFactory = (spec) => {
+      let alive = false;
+      const session: ClaudeCodeSession = {
+        isAlive: () => alive,
+        setOnExit: () => {
+          /* not used */
+        },
+        async start() {
+          alive = true;
+        },
+        async submitTurn() {
+          return new Promise<TurnOutcome>((_resolve, reject) => {
+            releaseTurn = () =>
+              reject(new Error('claude resident session stopped mid-turn'));
+          });
+        },
+        async stop() {
+          alive = false;
+          releaseTurn?.();
+        },
+      };
+      void spec;
+      return session;
+    };
+    const dispatcher = claudeDispatcher('flow');
+    const store = new DispatcherStore(testDreamuxConfig([dispatcher]));
+    const row = store.get('flow');
+    const runtime = claudeCodeProvider({
+      sessionFactory: blockingFactory,
+    }).createRuntime({
+      row: row!,
+      dispatcher,
+      dispatchers: store,
+      cwd: defaultDispatcherCwd('flow'),
+      mcpServers: [],
+      onTurnSettled: (s) => settled.push(s),
+      log: () => {
+        /* test sink */
+      },
+    });
+    await runtime.start();
+    await runtime.channelInput({ sourceId: 'm1', text: 'go' });
+    await waitFor(() => releaseTurn !== null);
+
+    await runtime.stop();
+    await waitFor(() => settled.length === 1);
+    expect(settled[0]?.status).toBe('stopped');
   });
 });

--- a/packages/dreamux/tests/claude-code-stream.test.ts
+++ b/packages/dreamux/tests/claude-code-stream.test.ts
@@ -195,6 +195,24 @@ describe('outbound builders', () => {
     });
   });
 
+  it('buildUserMessage omits isSynthetic / priority by default', () => {
+    const parsed = JSON.parse(buildUserMessage('hi'));
+    expect('isSynthetic' in parsed).toBe(false);
+    expect('priority' in parsed).toBe(false);
+  });
+
+  it('buildUserMessage sets isSynthetic / priority as siblings of message', () => {
+    const parsed = JSON.parse(
+      buildUserMessage('done', { isSynthetic: true, priority: 'now' }),
+    );
+    expect(parsed).toEqual({
+      type: 'user',
+      message: { role: 'user', content: [{ type: 'text', text: 'done' }] },
+      isSynthetic: true,
+      priority: 'now',
+    });
+  });
+
   it('buildCanUseToolAllow echoes the tool input back as updatedInput', () => {
     const parsed = JSON.parse(buildCanUseToolAllow('r1', { command: 'ls' }));
     expect(parsed).toEqual({

--- a/packages/dreamux/tests/codex-completion.test.ts
+++ b/packages/dreamux/tests/codex-completion.test.ts
@@ -128,7 +128,29 @@ describe('codex teammate completion delivery (native inject + trigger)', () => {
       result: 'it broke',
     });
     expect(result.status).toBe('failed');
-    // The inject already happened; only the trigger failed. A retry re-injects.
+    // The inject already happened; only the trigger failed. A retry re-triggers
+    // WITHOUT re-injecting (see the idempotency test below).
+    expect(fake.injectItemsParams).toHaveLength(1);
+  });
+
+  it('does not re-inject the same completion on a retry (idempotent)', async () => {
+    const fake = await startFakeCodex({ failTurnStart: true });
+    fakes.push(fake);
+    const runtime = await makeRuntime(fake);
+
+    const completion = {
+      source: 'teammate',
+      id: 'mate-retry',
+      status: 'failed' as const,
+      result: 'broke',
+    };
+    // The Dispatcher Service retries completionInput on `failed` with the same
+    // envelope. The item must be injected only once across attempts so no
+    // duplicate <teammate_session_completion> is persisted to the thread.
+    const first = await runtime.completionInput!(completion);
+    expect(first.status).toBe('failed');
+    const second = await runtime.completionInput!(completion);
+    expect(second.status).toBe('failed');
     expect(fake.injectItemsParams).toHaveLength(1);
   });
 

--- a/packages/dreamux/tests/codex-completion.test.ts
+++ b/packages/dreamux/tests/codex-completion.test.ts
@@ -1,0 +1,150 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { createCodexAgentRuntimeProvider } from '../src/agent-runtime/builtin/codex/provider.js';
+import {
+  CodexProcess,
+  type CodexProcessOptions,
+} from '../src/agent-runtime/builtin/codex/supervisor.js';
+import { CodexWsClient } from '../src/agent-runtime/builtin/codex/rpc.js';
+import { DispatcherStore } from '../src/state/dispatcher-store.js';
+import { createBuiltinProviderRegistry } from '../src/registry/index.js';
+import { testDispatcherConfig, testDreamuxConfig } from './helpers/config.js';
+import { startFakeCodex, type FakeCodex } from './fake-codex.js';
+import type {
+  AgentRuntime,
+  AgentRuntimePathContext,
+} from '../src/agent-runtime/types.js';
+
+/** A codex app-server child stub: the runtime talks to the fake over WS instead. */
+class NoopCodexProcess extends CodexProcess {
+  constructor(opts: CodexProcessOptions) {
+    super(opts);
+  }
+  override async start(): Promise<void> {
+    /* no child; the runtime connects to the in-process fake codex */
+  }
+  override async reap(): Promise<void> {
+    /* nothing to reap */
+  }
+}
+
+describe('codex teammate completion delivery (native inject + trigger)', () => {
+  const tmpDirs: string[] = [];
+  const fakes: FakeCodex[] = [];
+  const runtimes: AgentRuntime[] = [];
+
+  afterEach(async () => {
+    for (const runtime of runtimes.splice(0)) await runtime.stop();
+    for (const fake of fakes.splice(0)) await fake.close();
+    for (const dir of tmpDirs.splice(0)) rmSync(dir, { recursive: true, force: true });
+  });
+
+  async function makeRuntime(fake: FakeCodex): Promise<AgentRuntime> {
+    const dispatcher = testDispatcherConfig({ id: 'flow' });
+    const store = new DispatcherStore(testDreamuxConfig([dispatcher]));
+    const row = store.get('flow');
+    expect(row).not.toBeNull();
+    const tmp = mkdtempSync(join(tmpdir(), 'dx-codex-completion-'));
+    tmpDirs.push(tmp);
+    const paths: AgentRuntimePathContext = {
+      dispatcherDir: () => tmp,
+      stdoutLogPath: () => join(tmp, 'out.log'),
+      stderrLogPath: () => join(tmp, 'err.log'),
+    };
+    const provider = createCodexAgentRuntimeProvider({
+      descriptor: createBuiltinProviderRegistry().resolve('builtin:codex'),
+      codexProcessFactory: (o) => new NoopCodexProcess(o),
+      codexClientFactory: () => new CodexWsClient({ url: fake.url }),
+      codexHomeDoctor: () => {
+        /* fake codex tests need no real operator auth */
+      },
+    });
+    const runtime = provider.createRuntime({
+      row: row!,
+      dispatcher,
+      dispatchers: store,
+      cwd: tmp,
+      mcpServers: [],
+      paths,
+      log: () => {
+        /* test sink */
+      },
+    });
+    runtimes.push(runtime);
+    await runtime.start();
+    return runtime;
+  }
+
+  it('injects a developer item then triggers a turn, reporting accepted', async () => {
+    const fake = await startFakeCodex();
+    fakes.push(fake);
+    const runtime = await makeRuntime(fake);
+
+    const result = await runtime.completionInput!({
+      source: 'teammate',
+      id: 'mate-1',
+      status: 'completed',
+      result: 'all done',
+    });
+    expect(result).toEqual({ status: 'accepted' });
+
+    // Step 1: inject_items carried a developer-role message item (not a turn).
+    expect(fake.injectItemsParams).toHaveLength(1);
+    const inject = fake.injectItemsParams[0]!;
+    expect(inject['threadId']).toBe(runtime.getThreadId());
+    const items = inject['items'] as Array<Record<string, unknown>>;
+    expect(items).toHaveLength(1);
+    expect(items[0]?.['type']).toBe('message');
+    expect(items[0]?.['role']).toBe('developer');
+    const content = items[0]?.['content'] as Array<Record<string, unknown>>;
+    expect(content[0]?.['type']).toBe('input_text');
+    const text = content[0]?.['text'] as string;
+    expect(text).toContain('<teammate_session_completion');
+    expect(text).toContain('source="teammate"');
+    expect(text).toContain('id="mate-1"');
+    expect(text).toContain('status="completed"');
+    expect(text).toContain('all done');
+
+    // Step 2: a trigger turn was submitted (and ordered after the inject).
+    expect(fake.turnsHandled).toBe(1);
+    const injectIdx = fake.methodLog.indexOf('thread/inject_items');
+    const turnIdx = fake.methodLog.indexOf('turn/start');
+    expect(injectIdx).toBeGreaterThanOrEqual(0);
+    expect(turnIdx).toBeGreaterThan(injectIdx);
+  });
+
+  it('reports failed (after the item was injected) when the trigger turn is refused', async () => {
+    const fake = await startFakeCodex({ failTurnStart: true });
+    fakes.push(fake);
+    const runtime = await makeRuntime(fake);
+
+    const result = await runtime.completionInput!({
+      source: 'teammate',
+      id: 'mate-2',
+      status: 'failed',
+      result: 'it broke',
+    });
+    expect(result.status).toBe('failed');
+    // The inject already happened; only the trigger failed. A retry re-injects.
+    expect(fake.injectItemsParams).toHaveLength(1);
+  });
+
+  it('reports unsupported once the runtime is stopped', async () => {
+    const fake = await startFakeCodex();
+    fakes.push(fake);
+    const runtime = await makeRuntime(fake);
+    await runtime.stop();
+
+    const result = await runtime.completionInput!({
+      source: 'teammate',
+      id: 'mate-3',
+      status: 'completed',
+      result: 'late',
+    });
+    expect(result.status).toBe('unsupported');
+    expect(fake.injectItemsParams).toHaveLength(0);
+  });
+});

--- a/packages/dreamux/tests/fake-codex.ts
+++ b/packages/dreamux/tests/fake-codex.ts
@@ -60,6 +60,8 @@ export interface FakeCodex {
   readonly threadStartParams: ReadonlyArray<Readonly<Record<string, unknown>>>;
   /** thread/resume params received in order. */
   readonly threadResumeParams: ReadonlyArray<Readonly<Record<string, unknown>>>;
+  /** thread/inject_items params received in order. */
+  readonly injectItemsParams: ReadonlyArray<Readonly<Record<string, unknown>>>;
   close(): Promise<void>;
 }
 
@@ -75,6 +77,7 @@ export async function startFakeCodex(opts: FakeCodexOptions = {}): Promise<FakeC
   const methodLog: string[] = [];
   const threadStartParams: Array<Record<string, unknown>> = [];
   const threadResumeParams: Array<Record<string, unknown>> = [];
+  const injectItemsParams: Array<Record<string, unknown>> = [];
   const enforceInit = opts.enforceInitHandshake !== false;
   const clients = new Set<WebSocket>();
   let activeTurn: {
@@ -158,6 +161,11 @@ export async function startFakeCodex(opts: FakeCodexOptions = {}): Promise<FakeC
       }
       const tid = String(params['threadId'] ?? `thread_fake_${nextThreadId++}`);
       send(ws, { id, result: { thread: { id: tid } } });
+      return;
+    }
+    if (method === 'thread/inject_items') {
+      injectItemsParams.push({ ...params });
+      send(ws, { id, result: {} });
       return;
     }
     if (method === 'turn/start') {
@@ -252,6 +260,9 @@ export async function startFakeCodex(opts: FakeCodexOptions = {}): Promise<FakeC
     },
     get threadResumeParams() {
       return threadResumeParams;
+    },
+    get injectItemsParams() {
+      return injectItemsParams;
     },
     async close(): Promise<void> {
       for (const ws of clients) ws.terminate();

--- a/packages/dreamux/tests/teammate-agent-service.test.ts
+++ b/packages/dreamux/tests/teammate-agent-service.test.ts
@@ -15,7 +15,9 @@ import {
   type AgentRuntimeResumeInput,
   type AgentRuntimeSystemInput,
   type AgentRuntimeTurnResult,
+  type CompletionEnvelope,
 } from '../src/agent-runtime/index.js';
+import type { TurnSettledSignal } from '../src/agent-runtime/turn.js';
 import type { InboundTurnInput } from '../src/agent-runtime/turn.js';
 import { TeamMateAgentService } from '../src/dispatcher-service/teammate/service.js';
 import { DispatcherStore } from '../src/state/dispatcher-store.js';
@@ -97,6 +99,16 @@ class FakeRuntime implements AgentRuntime {
 
   getCapabilities(): AgentRuntimeCapabilities {
     return FAKE_CAPABILITIES;
+  }
+
+  /** True when the launcher wired the reverse-delivery settle hook. */
+  hasSettleHook(): boolean {
+    return this.context.onTurnSettled !== undefined;
+  }
+
+  /** Simulate the runtime firing a terminal turn-settled signal. */
+  settle(status: TurnSettledSignal['status'], turnId: string | null): void {
+    this.context.onTurnSettled?.({ turnId, status });
   }
 }
 
@@ -298,4 +310,153 @@ describe('TeamMateAgentService', () => {
     expect(historyFile).toContain('"type":"spawn"');
     expect(historyFile).toContain('"type":"close"');
   });
+
+  it('does not wire the settle hook when no completion sink is configured', async () => {
+    const { catalog, provider } = providerCatalog();
+    const config = testDreamuxConfig();
+    const service = new TeamMateAgentService({
+      config,
+      dispatchers: new DispatcherStore(config),
+      agentRuntimeProviders: catalog,
+      log: noopLog(),
+    });
+    await service.spawn({
+      dispatcherId: 'flow',
+      name: 'solo',
+      prompt: 'Start.',
+      cwd: root,
+    });
+    expect(provider.runtimes[0]?.hasSettleHook()).toBe(false);
+  });
+
+  it('delivers a settled teammate turn upward as a completion envelope', async () => {
+    const { catalog, provider } = providerCatalog();
+    const config = testDreamuxConfig();
+    const received: Array<{ id: string; env: CompletionEnvelope }> = [];
+    const service = new TeamMateAgentService({
+      config,
+      dispatchers: new DispatcherStore(config),
+      agentRuntimeProviders: catalog,
+      onTeamMateCompletion: (id, env) => {
+        received.push({ id, env });
+      },
+      log: noopLog(),
+    });
+
+    await service.spawn({
+      dispatcherId: 'flow',
+      name: 'reviewer',
+      prompt: 'Review.',
+      cwd: root,
+    });
+    expect(provider.runtimes[0]?.hasSettleHook()).toBe(true);
+
+    provider.runtimes[0]?.settle('completed', 'turn-1');
+    await flush();
+
+    expect(received).toEqual([
+      {
+        id: 'flow',
+        env: {
+          source: 'reviewer',
+          id: 'reviewer:turn-1',
+          status: 'completed',
+          result: 'last fake result',
+        },
+      },
+    ]);
+  });
+
+  it('delivers terminal failure/stop settlements with status failed', async () => {
+    const { catalog, provider } = providerCatalog();
+    const config = testDreamuxConfig();
+    const received: CompletionEnvelope[] = [];
+    const service = new TeamMateAgentService({
+      config,
+      dispatchers: new DispatcherStore(config),
+      agentRuntimeProviders: catalog,
+      onTeamMateCompletion: (_id, env) => {
+        received.push(env);
+      },
+      log: noopLog(),
+    });
+
+    await service.spawn({
+      dispatcherId: 'flow',
+      name: 'breaker',
+      prompt: 'Run.',
+      cwd: root,
+    });
+
+    provider.runtimes[0]?.settle('failed', 'turn-7');
+    provider.runtimes[0]?.settle('stopped', null);
+    await flush();
+
+    expect(received).toEqual([
+      {
+        source: 'breaker',
+        id: 'breaker:turn-7',
+        status: 'failed',
+        result: 'last fake result',
+      },
+      {
+        source: 'breaker',
+        id: 'breaker',
+        status: 'failed',
+        result: 'last fake result',
+      },
+    ]);
+  });
+
+  it('delivers concurrent teammate completions without dropping any', async () => {
+    const { catalog, provider } = providerCatalog();
+    const config = testDreamuxConfig();
+    const received: CompletionEnvelope[] = [];
+    const service = new TeamMateAgentService({
+      config,
+      dispatchers: new DispatcherStore(config),
+      agentRuntimeProviders: catalog,
+      onTeamMateCompletion: (_id, env) => {
+        received.push(env);
+      },
+      log: noopLog(),
+    });
+
+    await service.spawn({
+      dispatcherId: 'flow',
+      name: 'one',
+      prompt: 'A.',
+      cwd: root,
+    });
+    await service.spawn({
+      dispatcherId: 'flow',
+      name: 'two',
+      prompt: 'B.',
+      cwd: root,
+    });
+
+    provider.runtimes[0]?.settle('completed', 'turn-1');
+    provider.runtimes[1]?.settle('completed', 'turn-1');
+    await flush();
+
+    expect(received.map((env) => env.source).sort()).toEqual(['one', 'two']);
+    expect(received).toHaveLength(2);
+  });
 });
+
+function noopLog(): {
+  info: () => undefined;
+  warn: () => undefined;
+  error: () => undefined;
+} {
+  return {
+    info: () => undefined,
+    warn: () => undefined,
+    error: () => undefined,
+  };
+}
+
+/** Drain the microtask/macrotask the void-ed settle handler runs on. */
+async function flush(): Promise<void> {
+  await new Promise((resolve) => setImmediate(resolve));
+}

--- a/packages/dreamux/tests/teammate-agent-service.test.ts
+++ b/packages/dreamux/tests/teammate-agent-service.test.ts
@@ -113,16 +113,24 @@ class FakeRuntime implements AgentRuntime {
 }
 
 class FakeProvider implements AgentRuntimeProvider {
-  readonly ref = 'builtin:codex';
+  readonly ref: string;
   readonly runtimes: FakeRuntime[] = [];
+  /** Every create context this provider was asked to build, for assertions. */
+  readonly contexts: AgentRuntimeCreateContext[] = [];
 
-  constructor(readonly descriptor: AgentRuntimeProvider['descriptor']) {}
+  constructor(
+    readonly descriptor: AgentRuntimeProvider['descriptor'],
+    ref: string = 'builtin:codex',
+  ) {
+    this.ref = ref;
+  }
 
   getCapabilities(): AgentRuntimeCapabilities {
     return FAKE_CAPABILITIES;
   }
 
   createRuntime(context: AgentRuntimeCreateContext): AgentRuntime {
+    this.contexts.push(context);
     const runtime = new FakeRuntime(context);
     this.runtimes.push(runtime);
     return runtime;
@@ -177,6 +185,55 @@ describe('TeamMateAgentService', () => {
     else process.env['HOME'] = previousHome;
     resetRuntimeConfig();
     rmSync(root, { recursive: true, force: true });
+  });
+
+  it('does not inherit the dispatcher config for a cross-provider teammate', async () => {
+    // Dispatcher 'flow' runs builtin:codex. A builtin:claude-code teammate must
+    // NOT receive the codex dispatcher's config block (wrong shape — the real
+    // claude provider would throw "is not wired to Claude Code"); it falls back
+    // to its own provider defaults (context.dispatcher === null). A same-provider
+    // teammate still inherits the dispatcher config.
+    const config = testDreamuxConfig();
+    const registry = createBuiltinProviderRegistry();
+    const codexDesc = registry.resolve('builtin:codex');
+    const claudeDesc = registry.resolve('builtin:claude-code');
+    const codexProvider = new FakeProvider(codexDesc, 'builtin:codex');
+    const claudeProvider = new FakeProvider(claudeDesc, 'builtin:claude-code');
+    registry.registerImplementation(codexDesc.id, codexProvider);
+    registry.registerImplementation(claudeDesc.id, claudeProvider);
+    const service = new TeamMateAgentService({
+      config,
+      dispatchers: new DispatcherStore(config),
+      agentRuntimeProviders: new AgentRuntimeProviderCatalog({ registry }),
+      log: {
+        info: () => undefined,
+        warn: () => undefined,
+        error: () => undefined,
+      },
+    });
+
+    await service.spawn({
+      dispatcherId: 'flow',
+      name: 'claude-mate',
+      providerRef: 'builtin:claude-code',
+      prompt: 'go',
+      cwd: root,
+    });
+    expect(claudeProvider.contexts).toHaveLength(1);
+    expect(claudeProvider.contexts[0]?.dispatcher).toBeNull();
+
+    await service.spawn({
+      dispatcherId: 'flow',
+      name: 'codex-mate',
+      providerRef: 'builtin:codex',
+      prompt: 'go',
+      cwd: root,
+    });
+    expect(codexProvider.contexts).toHaveLength(1);
+    expect(codexProvider.contexts[0]?.dispatcher).not.toBeNull();
+    expect(codexProvider.contexts[0]?.dispatcher?.runtime.provider).toBe(
+      'builtin:codex',
+    );
   });
 
   it('spawns a named resumable teammate and records forward-only history', async () => {

--- a/packages/dreamux/tests/teammate-completion-delivery.test.ts
+++ b/packages/dreamux/tests/teammate-completion-delivery.test.ts
@@ -1,0 +1,240 @@
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import {
+  AgentRuntimeProviderCatalog,
+  type AgentRuntime,
+  type AgentRuntimeCapabilities,
+  type AgentRuntimeCreateContext,
+  type AgentRuntimeProvider,
+  type CompletionEnvelope,
+  type TeamMateCompletionDeliveryResult,
+} from '../src/agent-runtime/index.js';
+import { createFakeFeishuBot } from '../src/channel/feishu/bot.js';
+import { DispatcherAgentService } from '../src/dispatcher-service/dispatcher/service.js';
+import { resetRuntimeConfig } from '../src/platform/paths.js';
+import { createBuiltinProviderRegistry } from '../src/registry/index.js';
+import { DispatcherStore } from '../src/state/dispatcher-store.js';
+import { testDreamuxConfig } from './helpers/config.js';
+
+const CAPABILITIES: AgentRuntimeCapabilities = {
+  resume: { supported: true, checkpoint: 'codexThread' },
+  steer: { supported: true },
+  events: { kind: 'push' },
+  last: { supported: true },
+  context: { supported: true },
+  systemPrompt: { mode: 'replace' },
+  teammateCompletion: [{ kind: 'codexInboxTurn', description: 'inbox turn' }],
+};
+
+/**
+ * Scripted dispatcher runtime: `completionInput` returns the next queued result
+ * (defaulting to accepted) and counts every call, so Seam ③ retry behavior is
+ * observable. `omitCompletionInput` models a runtime that declares no completion
+ * delivery at all.
+ */
+interface DeliveryBehavior {
+  results: TeamMateCompletionDeliveryResult[];
+  calls: number;
+  omitCompletionInput: boolean;
+}
+
+function makeRuntime(behavior: DeliveryBehavior): AgentRuntime {
+  let status: ReturnType<AgentRuntime['getStatus']> = 'declared';
+  const runtime: AgentRuntime = {
+    providerRef: 'builtin:codex',
+    async start() {
+      status = 'ready';
+    },
+    async resume() {
+      status = 'ready';
+    },
+    async stop() {
+      status = 'stopped';
+    },
+    async channelInput() {
+      return { status: 'submitted', turnId: 'turn-1' };
+    },
+    async systemInput() {
+      return { status: 'skipped' };
+    },
+    getStatus: () => status,
+    getThreadId: () => 'thread-1',
+    wasThreadResumed: () => false,
+    async getLast() {
+      return { text: null };
+    },
+    async getContext() {
+      return { usedTokens: null, windowTokens: null };
+    },
+    getCapabilities: () => CAPABILITIES,
+  };
+  if (!behavior.omitCompletionInput) {
+    runtime.completionInput = async (): Promise<TeamMateCompletionDeliveryResult> => {
+      behavior.calls += 1;
+      return behavior.results.shift() ?? { status: 'accepted' };
+    };
+  }
+  return runtime;
+}
+
+class ScriptedProvider implements AgentRuntimeProvider {
+  readonly ref = 'builtin:codex';
+
+  constructor(
+    readonly descriptor: AgentRuntimeProvider['descriptor'],
+    private readonly behavior: DeliveryBehavior,
+  ) {}
+
+  getCapabilities(): AgentRuntimeCapabilities {
+    return CAPABILITIES;
+  }
+
+  createRuntime(_context: AgentRuntimeCreateContext): AgentRuntime {
+    return makeRuntime(this.behavior);
+  }
+}
+
+function buildService(
+  behavior: DeliveryBehavior,
+  adminSocketPath: string,
+): DispatcherAgentService {
+  const config = testDreamuxConfig();
+  const registry = createBuiltinProviderRegistry();
+  const descriptor = registry.resolve('builtin:codex');
+  registry.registerImplementation(
+    descriptor.id,
+    new ScriptedProvider(descriptor, behavior),
+  );
+  return new DispatcherAgentService({
+    config,
+    dispatchers: new DispatcherStore(config),
+    agentRuntimeProviders: new AgentRuntimeProviderCatalog({ registry }),
+    adminSocketPath,
+    channelLoggerFactory: () => noopLog() as never,
+    botFactory: () => createFakeFeishuBot('app-flow'),
+    skipBotSecret: true,
+    log: noopLog() as never,
+  });
+}
+
+function envelope(): CompletionEnvelope {
+  return { source: 'reviewer', id: 'reviewer:turn-1', status: 'completed', result: 'done' };
+}
+
+describe('DispatcherAgentService.deliverCompletion (Seam ③)', () => {
+  let root: string;
+  let adminSocketPath: string;
+  let previousHome: string | undefined;
+
+  beforeEach(() => {
+    root = mkdtempSync(join(tmpdir(), 'dx-'));
+    adminSocketPath = join(root, 'a.sock');
+    previousHome = process.env['HOME'];
+    process.env['HOME'] = join(root, 'home');
+    resetRuntimeConfig();
+  });
+
+  afterEach(() => {
+    if (previousHome === undefined) delete process.env['HOME'];
+    else process.env['HOME'] = previousHome;
+    resetRuntimeConfig();
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  it('retries a failed delivery until accepted', async () => {
+    const behavior: DeliveryBehavior = {
+      results: [
+        { status: 'failed', error: new Error('boom 1') },
+        { status: 'failed', error: new Error('boom 2') },
+        { status: 'accepted' },
+      ],
+      calls: 0,
+      omitCompletionInput: false,
+    };
+    const service = buildService(behavior, adminSocketPath);
+    await service.startDispatcher('flow');
+
+    await expect(service.deliverCompletion('flow', envelope())).resolves.toBeUndefined();
+    expect(behavior.calls).toBe(3);
+
+    await service.shutdown();
+  });
+
+  it('stops after exhausting retries without throwing', async () => {
+    const behavior: DeliveryBehavior = {
+      results: [
+        { status: 'failed', error: new Error('boom 1') },
+        { status: 'failed', error: new Error('boom 2') },
+        { status: 'failed', error: new Error('boom 3') },
+        { status: 'failed', error: new Error('boom 4') },
+      ],
+      calls: 0,
+      omitCompletionInput: false,
+    };
+    const service = buildService(behavior, adminSocketPath);
+    await service.startDispatcher('flow');
+
+    await expect(service.deliverCompletion('flow', envelope())).resolves.toBeUndefined();
+    expect(behavior.calls).toBe(3);
+
+    await service.shutdown();
+  });
+
+  it('drops a single time on an unsupported result', async () => {
+    const behavior: DeliveryBehavior = {
+      results: [{ status: 'unsupported', reason: 'runtime stopped' }],
+      calls: 0,
+      omitCompletionInput: false,
+    };
+    const service = buildService(behavior, adminSocketPath);
+    await service.startDispatcher('flow');
+
+    await expect(service.deliverCompletion('flow', envelope())).resolves.toBeUndefined();
+    expect(behavior.calls).toBe(1);
+
+    await service.shutdown();
+  });
+
+  it('drops when the dispatcher is not running', async () => {
+    const behavior: DeliveryBehavior = {
+      results: [],
+      calls: 0,
+      omitCompletionInput: false,
+    };
+    const service = buildService(behavior, adminSocketPath);
+    // Never started: no live slot.
+    await expect(service.deliverCompletion('flow', envelope())).resolves.toBeUndefined();
+    expect(behavior.calls).toBe(0);
+  });
+
+  it('drops when the runtime declares no completion delivery', async () => {
+    const behavior: DeliveryBehavior = {
+      results: [],
+      calls: 0,
+      omitCompletionInput: true,
+    };
+    const service = buildService(behavior, adminSocketPath);
+    await service.startDispatcher('flow');
+
+    await expect(service.deliverCompletion('flow', envelope())).resolves.toBeUndefined();
+    expect(behavior.calls).toBe(0);
+
+    await service.shutdown();
+  });
+});
+
+function noopLog(): {
+  info: () => undefined;
+  warn: () => undefined;
+  error: () => undefined;
+} {
+  return {
+    info: () => undefined,
+    warn: () => undefined,
+    error: () => undefined,
+  };
+}

--- a/packages/dreamux/tests/teammate-completion-e2e.test.ts
+++ b/packages/dreamux/tests/teammate-completion-e2e.test.ts
@@ -1,0 +1,310 @@
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import {
+  AgentRuntimeProviderCatalog,
+  type AgentRuntime,
+  type AgentRuntimeCapabilities,
+  type AgentRuntimeCreateContext,
+  type AgentRuntimeLastResult,
+  type AgentRuntimeProvider,
+  type AgentRuntimeResumeInput,
+  type AgentRuntimeSystemInput,
+  type AgentRuntimeTurnResult,
+  type CompletionEnvelope,
+  type TeamMateCompletionDeliveryResult,
+} from '../src/agent-runtime/index.js';
+import type { InboundTurnInput, TurnSettledSignal } from '../src/agent-runtime/turn.js';
+import { createFakeFeishuBot } from '../src/channel/feishu/bot.js';
+import { DispatcherService } from '../src/dispatcher-service/service.js';
+import { resetRuntimeConfig } from '../src/platform/paths.js';
+import { createBuiltinProviderRegistry } from '../src/registry/index.js';
+import { DispatcherStore } from '../src/state/dispatcher-store.js';
+import { testDreamuxConfig } from './helpers/config.js';
+
+const FAKE_CAPABILITIES: AgentRuntimeCapabilities = {
+  resume: { supported: true, checkpoint: 'codexThread' },
+  steer: { supported: true },
+  events: { kind: 'push' },
+  last: { supported: true },
+  context: { supported: true },
+  systemPrompt: { mode: 'replace' },
+  teammateCompletion: [{ kind: 'codexInboxTurn', description: 'inbox turn' }],
+};
+
+/**
+ * One fake runtime used for both roles in the facade:
+ *  - the dispatcher's own runtime (created via {@link DispatcherService.startDispatcher})
+ *  - the teammate's runtime (created via {@link DispatcherService.spawnTeamMate})
+ *
+ * It records whether the launcher wired `onTurnSettled` (the reverse-delivery
+ * settle hook) and every `completionInput` envelope it receives, so a test can
+ * assert the full Seam ①→②→③ join end-to-end.
+ */
+class FakeRuntime implements AgentRuntime {
+  readonly providerRef = 'builtin:codex';
+  private status: ReturnType<AgentRuntime['getStatus']> = 'declared';
+  private threadId: string | null = null;
+  private resumed = false;
+  private turns = 0;
+  readonly delivered: CompletionEnvelope[] = [];
+
+  constructor(private readonly context: AgentRuntimeCreateContext) {}
+
+  async start(): Promise<void> {
+    this.status = 'ready';
+    this.threadId = `${this.context.row.dispatcher_id}-thread`;
+    await this.context.state?.setThreadId(this.context.row.dispatcher_id, this.threadId);
+    await this.context.state?.setStatus(this.context.row.dispatcher_id, 'ready');
+  }
+
+  async resume(input: AgentRuntimeResumeInput = {}): Promise<void> {
+    this.resumed = true;
+    this.status = 'ready';
+    this.threadId = input.checkpoint?.id ?? null;
+    await this.context.state?.setStatus(this.context.row.dispatcher_id, 'ready');
+  }
+
+  async stop(): Promise<void> {
+    this.status = 'stopped';
+    await this.context.state?.setStatus(this.context.row.dispatcher_id, 'stopped');
+  }
+
+  async channelInput(_input: InboundTurnInput): Promise<AgentRuntimeTurnResult> {
+    this.turns += 1;
+    return { status: 'submitted', turnId: `turn-${this.turns}` };
+  }
+
+  async systemInput(_notice: AgentRuntimeSystemInput): Promise<AgentRuntimeTurnResult> {
+    return { status: 'skipped' };
+  }
+
+  async completionInput(
+    completion: CompletionEnvelope,
+  ): Promise<TeamMateCompletionDeliveryResult> {
+    this.delivered.push(completion);
+    return { status: 'accepted' };
+  }
+
+  getStatus(): ReturnType<AgentRuntime['getStatus']> {
+    return this.status;
+  }
+
+  getThreadId(): string | null {
+    return this.threadId;
+  }
+
+  wasThreadResumed(): boolean {
+    return this.resumed;
+  }
+
+  async getLast(): Promise<AgentRuntimeLastResult> {
+    return { text: 'reviewer final answer' };
+  }
+
+  async getContext(): Promise<{ usedTokens: number; windowTokens: number }> {
+    return { usedTokens: 12, windowTokens: 100 };
+  }
+
+  getCapabilities(): AgentRuntimeCapabilities {
+    return FAKE_CAPABILITIES;
+  }
+
+  /** True when the launcher wired the reverse-delivery settle hook. */
+  hasSettleHook(): boolean {
+    return this.context.onTurnSettled !== undefined;
+  }
+
+  /** Simulate the runtime firing a terminal turn-settled signal. */
+  settle(status: TurnSettledSignal['status'], turnId: string | null): void {
+    this.context.onTurnSettled?.({ turnId, status });
+  }
+}
+
+class FakeProvider implements AgentRuntimeProvider {
+  readonly ref = 'builtin:codex';
+  readonly runtimes: FakeRuntime[] = [];
+
+  constructor(readonly descriptor: AgentRuntimeProvider['descriptor']) {}
+
+  getCapabilities(): AgentRuntimeCapabilities {
+    return FAKE_CAPABILITIES;
+  }
+
+  createRuntime(context: AgentRuntimeCreateContext): AgentRuntime {
+    const runtime = new FakeRuntime(context);
+    this.runtimes.push(runtime);
+    return runtime;
+  }
+}
+
+function buildFacade(
+  provider: FakeProvider,
+  adminSocketPath: string,
+): DispatcherService {
+  const config = testDreamuxConfig();
+  const registry = createBuiltinProviderRegistry();
+  const descriptor = registry.resolve('builtin:codex');
+  registry.registerImplementation(descriptor.id, provider);
+  return new DispatcherService({
+    config,
+    dispatchers: new DispatcherStore(config),
+    agentRuntimeProviders: new AgentRuntimeProviderCatalog({ registry }),
+    adminSocketPath,
+    channelLoggerFactory: () => noopLog() as never,
+    botFactory: () => createFakeFeishuBot('app-flow'),
+    skipBotSecret: true,
+    log: noopLog() as never,
+  });
+}
+
+describe('reverse delivery end-to-end (Seam ①→②→③ through the facade)', () => {
+  let root: string;
+  let adminSocketPath: string;
+  let previousHome: string | undefined;
+
+  beforeEach(() => {
+    root = mkdtempSync(join(tmpdir(), 'dx-reverse-e2e-'));
+    adminSocketPath = join(root, 'a.sock');
+    previousHome = process.env['HOME'];
+    process.env['HOME'] = join(root, 'home');
+    resetRuntimeConfig();
+  });
+
+  afterEach(() => {
+    if (previousHome === undefined) delete process.env['HOME'];
+    else process.env['HOME'] = previousHome;
+    resetRuntimeConfig();
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  it("settles a teammate turn and reaches the dispatcher runtime's completionInput", async () => {
+    const descriptor = createBuiltinProviderRegistry().resolve('builtin:codex');
+    const provider = new FakeProvider(descriptor);
+    const facade = buildFacade(provider, adminSocketPath);
+
+    await facade.startDispatcher('flow');
+    await facade.spawnTeamMate({
+      dispatcherId: 'flow',
+      name: 'reviewer',
+      prompt: 'Review the change.',
+      cwd: root,
+    });
+
+    const dispatcherRuntime = provider.runtimes[0]!;
+    const teammateRuntime = provider.runtimes[1]!;
+
+    // Self-delivery guard: only the teammate runtime carries the settle hook.
+    expect(dispatcherRuntime.hasSettleHook()).toBe(false);
+    expect(teammateRuntime.hasSettleHook()).toBe(true);
+
+    teammateRuntime.settle('completed', 'turn-1');
+    await flush();
+
+    expect(dispatcherRuntime.delivered).toEqual([
+      {
+        source: 'reviewer',
+        id: 'reviewer:turn-1',
+        status: 'completed',
+        result: 'reviewer final answer',
+      },
+    ]);
+
+    await facade.shutdown();
+  });
+
+  it('delivers a terminal failure/stop settlement to completionInput (not dropped)', async () => {
+    const descriptor = createBuiltinProviderRegistry().resolve('builtin:codex');
+    const provider = new FakeProvider(descriptor);
+    const facade = buildFacade(provider, adminSocketPath);
+
+    await facade.startDispatcher('flow');
+    await facade.spawnTeamMate({
+      dispatcherId: 'flow',
+      name: 'breaker',
+      prompt: 'Run.',
+      cwd: root,
+    });
+
+    const dispatcherRuntime = provider.runtimes[0]!;
+    const teammateRuntime = provider.runtimes[1]!;
+
+    teammateRuntime.settle('failed', 'turn-3');
+    teammateRuntime.settle('stopped', null);
+    await flush();
+
+    expect(dispatcherRuntime.delivered).toEqual([
+      {
+        source: 'breaker',
+        id: 'breaker:turn-3',
+        status: 'failed',
+        result: 'reviewer final answer',
+      },
+      {
+        source: 'breaker',
+        id: 'breaker',
+        status: 'failed',
+        result: 'reviewer final answer',
+      },
+    ]);
+
+    await facade.shutdown();
+  });
+
+  it('delivers two concurrent teammate completions without a busy-loop', async () => {
+    const descriptor = createBuiltinProviderRegistry().resolve('builtin:codex');
+    const provider = new FakeProvider(descriptor);
+    const facade = buildFacade(provider, adminSocketPath);
+
+    await facade.startDispatcher('flow');
+    await facade.spawnTeamMate({
+      dispatcherId: 'flow',
+      name: 'one',
+      prompt: 'A.',
+      cwd: root,
+    });
+    await facade.spawnTeamMate({
+      dispatcherId: 'flow',
+      name: 'two',
+      prompt: 'B.',
+      cwd: root,
+    });
+
+    const dispatcherRuntime = provider.runtimes[0]!;
+    const teammateOne = provider.runtimes[1]!;
+    const teammateTwo = provider.runtimes[2]!;
+
+    teammateOne.settle('completed', 'turn-1');
+    teammateTwo.settle('completed', 'turn-1');
+    await flush();
+
+    // Both delivered exactly once each: accepted submit never retries.
+    expect(dispatcherRuntime.delivered.map((env) => env.source).sort()).toEqual([
+      'one',
+      'two',
+    ]);
+    expect(dispatcherRuntime.delivered).toHaveLength(2);
+
+    await facade.shutdown();
+  });
+});
+
+function noopLog(): {
+  info: () => undefined;
+  warn: () => undefined;
+  error: () => undefined;
+} {
+  return {
+    info: () => undefined,
+    warn: () => undefined,
+    error: () => undefined,
+  };
+}
+
+/** Drain the macrotask the void-ed settle handler runs on. */
+async function flush(): Promise<void> {
+  await new Promise((resolve) => setImmediate(resolve));
+}

--- a/packages/dreamux/tests/turn-manager.test.ts
+++ b/packages/dreamux/tests/turn-manager.test.ts
@@ -188,6 +188,45 @@ describe('TurnManager turn settlement', () => {
     await manager.stop();
     expect(settled).toEqual([]);
   });
+
+  it('settles a turn as failed on a fatal codex error notification (willRetry:false)', async () => {
+    const client = new ErroringFakeCodexClient(false);
+    const settled: TurnSettledSignal[] = [];
+    const manager = new TurnManager({
+      dispatcherId: 'flow',
+      getThreadId: () => 'thread-1',
+      client: client as never,
+      onTurnCompleted: () => undefined,
+      onTurnSettled: (s) => settled.push(s),
+    });
+
+    const res = await manager.enqueue(input('msg-1', 'work'));
+    expect(res).toEqual({ status: 'submitted', turnId: 'turn-1' });
+
+    await waitFor(() => settled.length === 1);
+    expect(settled[0]?.turnId).toBe('turn-1');
+    expect(settled[0]?.status).toBe('failed');
+    expect(settled[0]?.error?.message).toContain('boom');
+  });
+
+  it('ignores a transient codex error (willRetry:true) and completes normally', async () => {
+    const client = new ErroringFakeCodexClient(true);
+    const completed: CollectedTurn[] = [];
+    const settled: TurnSettledSignal[] = [];
+    const manager = new TurnManager({
+      dispatcherId: 'flow',
+      getThreadId: () => 'thread-1',
+      client: client as never,
+      onTurnCompleted: (turn) => completed.push(turn),
+      onTurnSettled: (s) => settled.push(s),
+    });
+
+    await manager.enqueue(input('msg-1', 'work'));
+    await waitFor(() => completed.length === 1);
+    expect(completed[0]?.turnId).toBe('turn-1');
+    // A transient error must not produce a `failed` settlement.
+    expect(settled.filter((s) => s.status === 'failed')).toEqual([]);
+  });
 });
 
 async function waitFor(predicate: () => boolean, timeoutMs = 2000): Promise<void> {
@@ -260,6 +299,50 @@ class FakeCodexClient {
           turn: { id: turnId, items: [] },
         },
       });
+    });
+    return { turn: { id: turnId } } as TurnStartResponse as R;
+  }
+
+  private emit(notification: ServerNotification): void {
+    for (const handler of this.handlers) handler(notification);
+  }
+}
+
+/**
+ * Acks turn/start then emits a codex `error` notification. With willRetry=false
+ * (fatal) it emits no turn/completed — the turn must still settle as `failed`.
+ * With willRetry=true (transient) a normal turn/completed follows.
+ */
+class ErroringFakeCodexClient {
+  private readonly handlers: NotificationHandler[] = [];
+  private nextTurnId = 1;
+
+  constructor(private readonly willRetry: boolean) {}
+
+  onNotification(handler: NotificationHandler): void {
+    this.handlers.push(handler);
+  }
+
+  async request<R>(method: string, params: unknown): Promise<R> {
+    if (method !== 'turn/start') throw new Error(`unexpected method ${method}`);
+    const p = params as { threadId: string; input: Array<{ text: string }> };
+    const turnId = `turn-${this.nextTurnId++}`;
+    queueMicrotask(() => {
+      this.emit({
+        method: 'error',
+        params: {
+          threadId: p.threadId,
+          turnId,
+          willRetry: this.willRetry,
+          error: { message: 'boom' },
+        },
+      });
+      if (this.willRetry) {
+        this.emit({
+          method: 'turn/completed',
+          params: { threadId: p.threadId, turn: { id: turnId, items: [] } },
+        });
+      }
     });
     return { turn: { id: turnId } } as TurnStartResponse as R;
   }

--- a/packages/dreamux/tests/turn-manager.test.ts
+++ b/packages/dreamux/tests/turn-manager.test.ts
@@ -3,6 +3,8 @@ import { describe, expect, it } from 'vitest';
 import { TurnManager } from '../src/agent-runtime/builtin/codex/turn-manager.js';
 import type { NotificationHandler } from '../src/agent-runtime/builtin/codex/rpc.js';
 import type { ServerNotification, TurnStartResponse } from '../src/agent-runtime/builtin/codex/types.js';
+import type { CollectedTurn } from '../src/agent-runtime/builtin/codex/events.js';
+import type { TurnSettledSignal } from '../src/agent-runtime/turn.js';
 
 describe('TurnManager inbound submission', () => {
   it('submits every accepted message through turn/start without coalescing', async () => {
@@ -128,11 +130,97 @@ describe('TurnManager restart-notice injection', () => {
   });
 });
 
+describe('TurnManager turn settlement', () => {
+  it('forwards the completed turn (with its turn id) on turn/completed', async () => {
+    const client = new FakeCodexClient();
+    const completed: CollectedTurn[] = [];
+    const manager = new TurnManager({
+      dispatcherId: 'flow',
+      getThreadId: () => 'thread-1',
+      client: client as never,
+      onTurnCompleted: (turn) => completed.push(turn),
+    });
+
+    const res = await manager.enqueue(input('msg-1', 'work'));
+    expect(res).toEqual({ status: 'submitted', turnId: 'turn-1' });
+
+    await waitFor(() => completed.length === 1);
+    expect(completed[0]?.turnId).toBe('turn-1');
+  });
+
+  it('settles each still-pending turn as stopped on stop()', async () => {
+    // A manual client never emits turn/completed, so the submitted turn stays
+    // in flight until stop() tears it down.
+    const client = new ManualFakeCodexClient();
+    const settled: TurnSettledSignal[] = [];
+    const manager = new TurnManager({
+      dispatcherId: 'flow',
+      getThreadId: () => 'thread-1',
+      client: client as never,
+      onTurnSettled: (s) => settled.push(s),
+    });
+
+    const res = await manager.enqueue(input('msg-1', 'work'));
+    expect(res).toEqual({ status: 'submitted', turnId: 'turn-1' });
+    expect(settled).toEqual([]);
+
+    await manager.stop();
+    expect(settled).toEqual([{ turnId: 'turn-1', status: 'stopped' }]);
+  });
+
+  it('does not re-settle a completed turn as stopped', async () => {
+    const client = new FakeCodexClient();
+    const settled: TurnSettledSignal[] = [];
+    const manager = new TurnManager({
+      dispatcherId: 'flow',
+      getThreadId: () => 'thread-1',
+      client: client as never,
+      // The auto-completing client clears the pending turn before stop().
+      onTurnCompleted: () => undefined,
+      onTurnSettled: (s) => settled.push(s),
+    });
+
+    await manager.enqueue(input('msg-1', 'work'));
+    await waitFor(() => client.inputs.length === 1);
+    // Let the queued turn/completed microtask clear the pending set.
+    await new Promise<void>((resolve) => setTimeout(resolve, 0));
+
+    await manager.stop();
+    expect(settled).toEqual([]);
+  });
+});
+
+async function waitFor(predicate: () => boolean, timeoutMs = 2000): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (predicate()) return;
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+  throw new Error('waitFor timed out');
+}
+
 function input(messageId: string, text: string) {
   return {
     sourceId: messageId,
     text,
   };
+}
+
+/** A fake client that acks turn/start but never emits turn/completed. */
+class ManualFakeCodexClient {
+  readonly inputs: string[] = [];
+  private nextTurnId = 1;
+
+  onNotification(_handler: NotificationHandler): void {
+    /* no notifications are ever emitted */
+  }
+
+  async request<R>(method: string, params: unknown): Promise<R> {
+    if (method !== 'turn/start') throw new Error(`unexpected method ${method}`);
+    const p = params as { input: Array<{ text: string }> };
+    this.inputs.push(p.input[0]?.text ?? '');
+    return { turn: { id: `turn-${this.nextTurnId++}` } } as TurnStartResponse as R;
+  }
 }
 
 class FakeCodexClient {


### PR DESCRIPTION
Implements the teammate → dispatcher reverse-completion path (issue #147): a
finished teammate's result is now delivered back to the dispatcher as a new
turn, using each engine's native mechanism instead of a hand-rolled XML user
turn.

## What

- **Seam ① `onTurnSettled`** — neutral turn-settled signal on the AgentRuntime
  create context (completed / failed / stopped). Only the teammate launcher
  attaches it, so the dispatcher's own runtime never self-delivers.
- **Seam ② / ③** — the teammate service builds a `CompletionEnvelope` on settle
  and hands it to a sink; the facade bridges it to
  `DispatcherAgentService.deliverCompletion`, which calls the live dispatcher
  runtime's `completionInput` with bounded retry-on-`failed`.
- **Engine-native delivery** — codex injects a developer-role item via
  `thread/inject_items` (codex 0.137+) then triggers a turn; claude-code sends a
  native `<task-notification>` user message with `isSynthetic: true`.

## Hardening (post-review)

- codex now settles a turn as `failed` on a fatal `error` notification
  (`willRetry: false`) or a `turn/completed` carrying `turn.error`, so an
  errored teammate turn no longer hangs until teardown.
- codex completion injection is idempotent across retries (no duplicate item).
- below codex 0.137 the delivery fails loudly with a version hint instead of
  silently dropping; documented in CLAUDE.md; the proactive doctor/version gate
  is folded into the per-runtime `diagnostic` capability (#148).
- fixes spawning a cross-provider teammate (claude-code teammate under a codex
  dispatcher) which previously threw "is not wired to Claude Code".

## Verify

tsc clean, eslint clean, full suite 499 passed / 2 skipped (live-codex).

🤖 Generated with [Claude Code](https://claude.com/claude-code)