### PR TITLE
Fix beta CLI cold-start TDZ regression

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -173,6 +173,8 @@ jobs:
       # built first or dependents fail to find its types on a clean runner.
       - name: rush build
         run: node common/scripts/install-run-rush.js build
+      - name: rush built CLI smoke
+        run: node common/scripts/install-run-rush.js smoke-built-cli
       - name: rush typecheck
         run: node common/scripts/install-run-rush.js typecheck
       # Enforce the issue #85 synchronous-blocking-IO ban (n/no-sync + import /

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -173,6 +173,7 @@ jobs:
         run: |
           node common/scripts/install-run-rush.js install
           node common/scripts/install-run-rush.js build
+          node common/scripts/install-run-rush.js smoke-built-cli
 
       - name: Publish changed packages (rush native)
         env:
@@ -221,6 +222,7 @@ jobs:
         run: |
           node common/scripts/install-run-rush.js install
           node common/scripts/install-run-rush.js build
+          node common/scripts/install-run-rush.js smoke-built-cli
 
       - name: Apply prerelease version (ephemeral, never committed)
         # github.run_number gives every dispatch a unique, monotonic prerelease

--- a/common/changes/@excitedjs/dreamux/fix-beta56-cli-tdz_2026-06-09-01-20.json
+++ b/common/changes/@excitedjs/dreamux/fix-beta56-cli-tdz_2026-06-09-01-20.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Fix a built CLI startup crash caused by ESM initialization cycles reading imported bindings too early, and add a built dreamux --version smoke gate before CI and release publish steps.",
+      "type": "patch",
+      "packageName": "@excitedjs/dreamux"
+    }
+  ],
+  "packageName": "@excitedjs/dreamux",
+  "email": "053700@gmail.com"
+}

--- a/common/config/rush/command-line.json
+++ b/common/config/rush/command-line.json
@@ -40,6 +40,15 @@
       "enableParallelism": true,
       "ignoreMissingScript": true,
       "incremental": false
+    },
+    {
+      "name": "smoke-built-cli",
+      "commandKind": "bulk",
+      "summary": "Run each project's built CLI smoke checks.",
+      "description": "Bulk-runs built CLI smoke checks across packages that declare a `smoke-built-cli` script. Run after `rush build`; the dreamux check starts `bin/dreamux --version` in a fresh Node process so ESM initialization cycles fail before publish.",
+      "enableParallelism": true,
+      "ignoreMissingScript": true,
+      "incremental": false
     }
   ]
 }

--- a/packages/dreamux/package.json
+++ b/packages/dreamux/package.json
@@ -30,6 +30,7 @@
     "build": "tsc -p tsconfig.json",
     "typecheck": "tsc -p tsconfig.json --noEmit",
     "lint": "eslint .",
+    "smoke-built-cli": "node ./scripts/smoke-built-cli.mjs",
     "test": "vitest run",
     "test:watch": "vitest",
     "clean": "rm -rf dist",

--- a/packages/dreamux/scripts/smoke-built-cli.mjs
+++ b/packages/dreamux/scripts/smoke-built-cli.mjs
@@ -1,0 +1,53 @@
+import { spawn } from 'node:child_process';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const packageJsonUrl = new URL('../package.json', import.meta.url);
+const packageRoot = dirname(fileURLToPath(packageJsonUrl));
+const bin = join(packageRoot, 'bin', 'dreamux');
+
+const child = spawn(bin, ['--version'], {
+  env: {
+    ...process.env,
+    DREAMUX_NODE_BIN: process.execPath,
+  },
+  stdio: ['ignore', 'pipe', 'pipe'],
+});
+
+let stdout = '';
+let stderr = '';
+
+child.stdout.setEncoding('utf8');
+child.stderr.setEncoding('utf8');
+child.stdout.on('data', (chunk) => {
+  stdout += chunk;
+});
+child.stderr.on('data', (chunk) => {
+  stderr += chunk;
+});
+
+child.once('error', (err) => {
+  console.error(`dreamux built CLI smoke failed to start: ${err.message}`);
+  process.exit(1);
+});
+
+child.once('exit', (code, signal) => {
+  if (signal !== null) {
+    console.error(`dreamux built CLI smoke terminated by ${signal}`);
+    if (stderr.trim() !== '') console.error(stderr.trim());
+    process.exit(1);
+  }
+  if (code !== 0) {
+    console.error(`dreamux built CLI smoke exited with code ${code}`);
+    if (stdout.trim() !== '') console.error(`stdout:\n${stdout.trim()}`);
+    if (stderr.trim() !== '') console.error(`stderr:\n${stderr.trim()}`);
+    process.exit(code ?? 1);
+  }
+  const version = stdout.trim();
+  if (version === '') {
+    console.error('dreamux built CLI smoke produced empty --version output');
+    if (stderr.trim() !== '') console.error(`stderr:\n${stderr.trim()}`);
+    process.exit(1);
+  }
+  console.log(`dreamux built CLI smoke ok: ${version}`);
+});

--- a/packages/dreamux/src/agent-runtime/builtin/codex/codex-home.ts
+++ b/packages/dreamux/src/agent-runtime/builtin/codex/codex-home.ts
@@ -14,7 +14,7 @@ async function pathExists(path: string): Promise<boolean> {
 import { parse as parseToml, TomlError } from 'smol-toml';
 
 import {
-  DREAMUX_UNIX_SOCKET_PATH_MAX_BYTES,
+  DREAMUX_UNIX_SOCKET_PATH_MAX_BYTES as DISPATCHER_APP_SERVER_SOCKET_PATH_MAX_BYTES,
   defaultDispatcherCwd,
   unixSocketPathFitsBudget,
 } from '../../../platform/paths.js';
@@ -27,8 +27,7 @@ import {
   dispatcherWorkspaceSkillPath,
 } from './paths.js';
 
-export const DISPATCHER_APP_SERVER_SOCKET_PATH_MAX_BYTES =
-  DREAMUX_UNIX_SOCKET_PATH_MAX_BYTES;
+export { DISPATCHER_APP_SERVER_SOCKET_PATH_MAX_BYTES };
 
 export interface DispatcherCodexHomeDoctorContext {
   dispatcherId: string;

--- a/packages/dreamux/src/platform/paths.ts
+++ b/packages/dreamux/src/platform/paths.ts
@@ -42,7 +42,7 @@ export const BUNDLED_SKILL_NAMES = [
 
 export type BundledSkillName = typeof BUNDLED_SKILL_NAMES[number];
 
-let currentConfig: DreamuxConfig = BUILT_IN_DEFAULTS;
+let currentConfig: DreamuxConfig | null = null;
 
 /**
  * Set the active configuration snapshot. Called once by Server.start() with
@@ -55,11 +55,11 @@ export function setRuntimeConfig(config: DreamuxConfig): void {
 
 /** Test hook: revert to the built-in defaults. */
 export function resetRuntimeConfig(): void {
-  currentConfig = BUILT_IN_DEFAULTS;
+  currentConfig = null;
 }
 
 export function getRuntimeConfig(): DreamuxConfig {
-  return currentConfig;
+  return currentConfig ?? BUILT_IN_DEFAULTS;
 }
 
 export function dreamuxRoot(): string {


### PR DESCRIPTION
## Root cause

`@excitedjs/dreamux@0.13.0-beta.56` could crash before printing `dreamux --version` after the top-level `agents[]` config refactor. The built CLI cold-start path exposed an ESM initialization cycle: config loading imports the builtin runtime catalog, builtin runtime modules import path helpers, and those path helpers loop back through `platform/paths`. A couple of module-top-level reads touched imported bindings while they were still in the temporal dead zone.

## Minimal fix

- Delay `BUILT_IN_DEFAULTS` fallback reads in `platform/paths` until `getRuntimeConfig()` is called.
- Re-export the Codex socket path budget binding without copying it at module initialization time.

This keeps the existing public helper names and avoids a larger import graph refactor in the beta fix.

## Added harness

Adds a `smoke-built-cli` Rush command. The Dreamux package script starts the built `bin/dreamux --version` entry in a fresh Node process, which catches cold-start ESM initialization failures against compiled output.

The new gate runs:

- in CI immediately after `rush build`;
- in stable release before publish;
- in beta release before prerelease apply / pack / publish.

## Validation

Commands run locally:

```sh
npm pack @excitedjs/dreamux@0.13.0-beta.56
# install the packed beta into a temporary local prefix and run .bin/dreamux --version
node common/scripts/install-run-rush.js update
node common/scripts/install-run-rush.js build
node common/scripts/install-run-rush.js smoke-built-cli
packages/dreamux/bin/dreamux --version
node packages/dreamux/dist/cli/dreamux.js --version
node common/scripts/install-run-rush.js lint
node common/scripts/install-run-rush.js typecheck
npx vitest run tests/runtime-paths.test.ts tests/dispatcher-codex-home.test.ts tests/global-config.test.ts tests/bin-launcher.test.ts
DREAMUX_SKIP_LIVE_CODEX=1 node common/scripts/install-run-rush.js test
node common/scripts/install-run-rush.js change --verify --target-branch origin/next --no-fetch
```

Static coverage checked:

- existing ESLint would not have caught this because it currently enforces the synchronous-blocking-IO gate, not import cycles;
- `madge` can see the relevant cycles, but it also reports existing broader cycles, so turning it into an immediate hard gate would be noisy;
- `dpdm` and default `dependency-cruiser --no-config` did not catch the actual source graph with the current TypeScript + `.js` specifier setup.

## Residual risk

The import cycle still exists. This PR removes the module-top-level TDZ reads that broke the beta CLI and adds a cold-start guard for the built CLI path; it is not full import-cycle governance. A broader cycle cleanup/static report can follow separately.