### PR TITLE
Break config import cycle via caller-composed builtins

### DIFF
--- a/.agents/decisions/agents-config-normalization.md
+++ b/.agents/decisions/agents-config-normalization.md
@@ -74,9 +74,39 @@ deferred and carry per-dispatcher credentials).
 - `DispatcherConfig` also keeps the referenced `agentRuntime` id in memory so the
   config round-trips back to the file shape (`stringifyConfig` is the in-memory →
   file translator; `DEFAULT_CONFIG_JSON` is routed through it).
-- The builtin runtime providers are registered into the registry idempotently
-  (guarded by `getImplementation(id) === undefined`) so config can register them
-  for parsing while the server's factory-bearing registration still wins.
+- The builtin runtime providers must already be registered in the registry
+  `readAgents` validates against (each agent's `config` is parsed through its
+  provider's `readConfig`). Registration is **caller-composed, not done by
+  `config/config.ts`**: the config module is a schema/parse leaf and never
+  imports the runtime catalog. `cli/server.ts` hands `loadConfig` a
+  factory-bearing registry it built; the leaf entry points
+  (doctor / daemon / onboard) call `loadConfigWithBuiltins`
+  (`agent-runtime/load-config.ts`), which builds a registry, registers the
+  builtins idempotently (guarded by `getImplementation(id) === undefined`), then
+  delegates to `loadConfig`. A bare `loadConfig` against a registry with a
+  registered-but-unimplemented builtin fails loud in `readAgents` ("registered
+  but not runnable"). External `npm:` providers still load inside
+  `readConfigFile` via the dynamic-import loader.
+
+#### De-cycle (post-#148 hotfix)
+
+The first #148 cut had `config/config.ts` import
+`registerBuiltinAgentRuntimeProviders` from `agent-runtime/catalog.ts` directly.
+That formed a static ESM import cycle —
+`config/config.ts → catalog → builtin/* → platform/paths.ts → config/config.ts`
+(`platform/paths.ts` reads `BUILT_IN_DEFAULTS` at module top level) — which
+crashed the built CLI on cold start with
+`Cannot access 'BUILT_IN_DEFAULTS' before initialization` (a temporal-dead-zone
+read). `tsc` and `vitest` (transpiled, hoisted) did not surface it; only the
+built artifact did. The fix moves registration out of the leaf to the
+caller-composed `loadConfigWithBuiltins`, severing the upward edge at its root
+(rather than deferring the TDZ read). **Invariant: `config/config.ts` and
+`platform/paths.ts` must never statically import `agent-runtime/catalog.ts` or
+any `agent-runtime/builtin/*` module; `agent-runtime/load-config.ts` must never
+be imported by `platform/paths.ts` or a builtin.** Guarded by the
+`smoke-built-cli` gate (a fresh-Node `bin/dreamux --version` run in CI and
+before release publish), which exercises the compiled cold-start path that the
+unit tests cannot.
 
 ### Provider-self-reported doctor diagnostics (issue #146 doctor half)
 

--- a/.agents/decisions/agents-config-normalization.md
+++ b/.agents/decisions/agents-config-normalization.md
@@ -100,13 +100,31 @@ crashed the built CLI on cold start with
 read). `tsc` and `vitest` (transpiled, hoisted) did not surface it; only the
 built artifact did. The fix moves registration out of the leaf to the
 caller-composed `loadConfigWithBuiltins`, severing the upward edge at its root
-(rather than deferring the TDZ read). **Invariant: `config/config.ts` and
-`platform/paths.ts` must never statically import `agent-runtime/catalog.ts` or
-any `agent-runtime/builtin/*` module; `agent-runtime/load-config.ts` must never
-be imported by `platform/paths.ts` or a builtin.** Guarded by the
-`smoke-built-cli` gate (a fresh-Node `bin/dreamux --version` run in CI and
-before release publish), which exercises the compiled cold-start path that the
-unit tests cannot.
+(rather than deferring the TDZ read).
+
+**Invariant (precise — the hazard is reaching `platform/paths.ts`, not the
+`builtin/` directory name):**
+
+- `config/config.ts` and `platform/paths.ts` must never statically import
+  `agent-runtime/catalog.ts` or any builtin **runtime / provider / transport /
+  paths** module — i.e. anything that transitively imports `platform/paths.ts`.
+  Those are the edges that close the cycle.
+- `config/config.ts` **may** re-export from the builtin **config** modules
+  (`builtin/codex/config.ts`, `builtin/claude-code/config.ts`). This is the
+  intentional M2 back-compat surface so non-builtin callers keep their
+  `config/config.js` import paths. It is cycle-free *because* those two modules
+  are deliberately kept as leaves: they import only `registry/` and
+  `config/validate.ts`, never `platform/paths.ts` and never `config/config.ts`.
+  That leaf property is load-bearing and is guarded by a comment in each of the
+  two files — do not add a `platform/paths` or `config/config` import there.
+- `agent-runtime/load-config.ts` must never be imported by `platform/paths.ts`
+  or by any `builtin/*` module.
+
+Guarded by the `smoke-built-cli` gate (a fresh-Node `bin/dreamux --version` run
+in CI and before release publish), which exercises the compiled cold-start path
+that the unit tests cannot. `madge --circular dist/` (types erased = runtime
+truth) is the check: after this fix it shows no `config`/`paths` cycle, only two
+pre-existing intra-`builtin/codex/` cycles.
 
 ### Provider-self-reported doctor diagnostics (issue #146 doctor half)
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -173,6 +173,8 @@ jobs:
       # built first or dependents fail to find its types on a clean runner.
       - name: rush build
         run: node common/scripts/install-run-rush.js build
+      - name: rush built CLI smoke
+        run: node common/scripts/install-run-rush.js smoke-built-cli
       - name: rush typecheck
         run: node common/scripts/install-run-rush.js typecheck
       # Enforce the issue #85 synchronous-blocking-IO ban (n/no-sync + import /

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -173,6 +173,7 @@ jobs:
         run: |
           node common/scripts/install-run-rush.js install
           node common/scripts/install-run-rush.js build
+          node common/scripts/install-run-rush.js smoke-built-cli
 
       - name: Publish changed packages (rush native)
         env:
@@ -221,6 +222,7 @@ jobs:
         run: |
           node common/scripts/install-run-rush.js install
           node common/scripts/install-run-rush.js build
+          node common/scripts/install-run-rush.js smoke-built-cli
 
       - name: Apply prerelease version (ephemeral, never committed)
         # github.run_number gives every dispatch a unique, monotonic prerelease

--- a/common/changes/@excitedjs/dreamux/fix-config-import-cycle_2026-06-09-12-00.json
+++ b/common/changes/@excitedjs/dreamux/fix-config-import-cycle_2026-06-09-12-00.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Fix the built CLI cold-start crash (Cannot access 'BUILT_IN_DEFAULTS' before initialization) introduced by the #148 agents[] refactor. config/config.ts no longer registers the builtin runtime catalog itself; builtin runtimes are now composed by the caller through loadConfigWithBuiltins, which removes the static import cycle (config -> catalog -> builtin -> platform/paths -> config) at its root rather than deferring the temporal-dead-zone read. Adds a built dreamux --version smoke gate before CI and release publish steps.",
+      "type": "patch",
+      "packageName": "@excitedjs/dreamux"
+    }
+  ],
+  "packageName": "@excitedjs/dreamux",
+  "email": "053700@gmail.com"
+}

--- a/common/config/rush/command-line.json
+++ b/common/config/rush/command-line.json
@@ -40,6 +40,15 @@
       "enableParallelism": true,
       "ignoreMissingScript": true,
       "incremental": false
+    },
+    {
+      "name": "smoke-built-cli",
+      "commandKind": "bulk",
+      "summary": "Run each project's built CLI smoke checks.",
+      "description": "Bulk-runs built CLI smoke checks across packages that declare a `smoke-built-cli` script. Run after `rush build`; the dreamux check starts `bin/dreamux --version` in a fresh Node process so ESM initialization cycles fail before publish.",
+      "enableParallelism": true,
+      "ignoreMissingScript": true,
+      "incremental": false
     }
   ]
 }

--- a/packages/dreamux/CLAUDE.md
+++ b/packages/dreamux/CLAUDE.md
@@ -20,7 +20,7 @@ Two settled shape rules govern where code lives:
 | Path | What lives here | Why |
 |---|---|---|
 | `server.ts` | process entry + wiring only | builds registry/catalog/store/services, opens the admin socket, starts dispatchers; owns no teammate/channel/runtime orchestration |
-| `agent-runtime/` | the AgentRuntime seam: contract (`types.ts`, `turn.ts`), `catalog.ts`, `external-provider.ts` loader, `index.ts` barrel | one runtime abstraction for every agent role — see [`agent-runtime/CLAUDE.md`](src/agent-runtime/CLAUDE.md) |
+| `agent-runtime/` | the AgentRuntime seam: contract (`types.ts`, `turn.ts`), `catalog.ts`, `external-provider.ts` loader, `load-config.ts` (caller-composed builtin registration), `index.ts` barrel | one runtime abstraction for every agent role — see [`agent-runtime/CLAUDE.md`](src/agent-runtime/CLAUDE.md) |
 | `agent-runtime/builtin/codex/` | the whole `builtin:codex` stack: supervisor/rpc/events/handshake/types (transport), runtime, provider, args, codex-home, paths, turn-manager, approval | codex specifics close over here; nothing codex-named leaks out |
 | `agent-runtime/builtin/claude-code/` | the whole `builtin:claude-code` stack: supervisor/rpc/stream/types, runtime, args, paths, mcp-config | claude specifics close over here |
 | `dispatcher-service/` | the Dispatcher Service entity — see [`dispatcher-service/CLAUDE.md`](src/dispatcher-service/CLAUDE.md) | holds the dispatcher agent + orchestrates teammates |

--- a/packages/dreamux/package.json
+++ b/packages/dreamux/package.json
@@ -30,6 +30,7 @@
     "build": "tsc -p tsconfig.json",
     "typecheck": "tsc -p tsconfig.json --noEmit",
     "lint": "eslint .",
+    "smoke-built-cli": "node ./scripts/smoke-built-cli.mjs",
     "test": "vitest run",
     "test:watch": "vitest",
     "clean": "rm -rf dist",

--- a/packages/dreamux/scripts/smoke-built-cli.mjs
+++ b/packages/dreamux/scripts/smoke-built-cli.mjs
@@ -1,0 +1,53 @@
+import { spawn } from 'node:child_process';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const packageJsonUrl = new URL('../package.json', import.meta.url);
+const packageRoot = dirname(fileURLToPath(packageJsonUrl));
+const bin = join(packageRoot, 'bin', 'dreamux');
+
+const child = spawn(bin, ['--version'], {
+  env: {
+    ...process.env,
+    DREAMUX_NODE_BIN: process.execPath,
+  },
+  stdio: ['ignore', 'pipe', 'pipe'],
+});
+
+let stdout = '';
+let stderr = '';
+
+child.stdout.setEncoding('utf8');
+child.stderr.setEncoding('utf8');
+child.stdout.on('data', (chunk) => {
+  stdout += chunk;
+});
+child.stderr.on('data', (chunk) => {
+  stderr += chunk;
+});
+
+child.once('error', (err) => {
+  console.error(`dreamux built CLI smoke failed to start: ${err.message}`);
+  process.exit(1);
+});
+
+child.once('exit', (code, signal) => {
+  if (signal !== null) {
+    console.error(`dreamux built CLI smoke terminated by ${signal}`);
+    if (stderr.trim() !== '') console.error(stderr.trim());
+    process.exit(1);
+  }
+  if (code !== 0) {
+    console.error(`dreamux built CLI smoke exited with code ${code}`);
+    if (stdout.trim() !== '') console.error(`stdout:\n${stdout.trim()}`);
+    if (stderr.trim() !== '') console.error(`stderr:\n${stderr.trim()}`);
+    process.exit(code ?? 1);
+  }
+  const version = stdout.trim();
+  if (version === '') {
+    console.error('dreamux built CLI smoke produced empty --version output');
+    if (stderr.trim() !== '') console.error(`stderr:\n${stderr.trim()}`);
+    process.exit(1);
+  }
+  console.log(`dreamux built CLI smoke ok: ${version}`);
+});

--- a/packages/dreamux/src/agent-runtime/CLAUDE.md
+++ b/packages/dreamux/src/agent-runtime/CLAUDE.md
@@ -7,8 +7,14 @@ agent session; how it talks to its engine is the engine's business.
 ## What goes where
 
 - **Top level** (`types.ts`, `turn.ts`, `catalog.ts`, `external-provider.ts`,
-  `index.ts`) — the **neutral** contract + the catalog (a view over the provider
-  registry) + the `npm:` external-provider loader. Nothing runtime-specific here.
+  `load-config.ts`, `index.ts`) — the **neutral** contract + the catalog (a view
+  over the provider registry) + the `npm:` external-provider loader +
+  `load-config.ts` (the caller-composed `loadConfigWithBuiltins` that registers
+  the builtins then delegates to `config/config.ts`, so the config leaf never
+  imports the catalog — see
+  [`decisions/agents-config-normalization.md`](../../../../.agents/decisions/agents-config-normalization.md)).
+  Nothing runtime-specific here. `load-config.ts` must never be imported by
+  `platform/paths.ts` or a `builtin/*` module (that re-forms the #148 cycle).
 - **`builtin/<name>/`** — one builtin's entire self-contained stack: transport
   (process supervisor + rpc + wire protocol/types + handshake), the runtime
   impl, the provider, CLI args, and its own `paths.ts`.

--- a/packages/dreamux/src/agent-runtime/builtin/claude-code/config.ts
+++ b/packages/dreamux/src/agent-runtime/builtin/claude-code/config.ts
@@ -8,6 +8,12 @@
  * depends only on the neutral validation primitives (config/validate) and
  * the canonical provider ref (registry/). The host config module re-exports
  * these so the non-builtin callers (doctor, tests) keep their import paths.
+ *
+ * Load-bearing: because `config/config.ts` re-exports from here, this file must
+ * stay a leaf — never import `platform/paths` or `config/config` (only
+ * `registry/` + `config/validate`). Adding such an import re-forms the #148
+ * cold-start cycle `config -> ... -> platform/paths -> config`. See
+ * `.agents/decisions/agents-config-normalization.md` (De-cycle).
  */
 
 import { BUILTIN_CLAUDE_CODE_PROVIDER_REF } from '../../../registry/index.js';

--- a/packages/dreamux/src/agent-runtime/builtin/codex/config.ts
+++ b/packages/dreamux/src/agent-runtime/builtin/codex/config.ts
@@ -8,6 +8,12 @@
  * on the neutral validation primitives (config/validate) and the canonical
  * provider ref (registry/). The host config module re-exports these so the
  * non-builtin callers (doctor, daemon, tests) keep their import paths.
+ *
+ * Load-bearing: because `config/config.ts` re-exports from here, this file must
+ * stay a leaf — never import `platform/paths` or `config/config` (only
+ * `registry/` + `config/validate`). Adding such an import re-forms the #148
+ * cold-start cycle `config -> ... -> platform/paths -> config`. See
+ * `.agents/decisions/agents-config-normalization.md` (De-cycle).
  */
 
 import { BUILTIN_CODEX_PROVIDER_REF } from '../../../registry/index.js';

--- a/packages/dreamux/src/agent-runtime/load-config.ts
+++ b/packages/dreamux/src/agent-runtime/load-config.ts
@@ -1,0 +1,60 @@
+import {
+  loadConfig,
+  loadOrInitConfig,
+  type ConfigPathOverrides,
+  type LoadConfigResult,
+} from '../config/config.js';
+import { createBuiltinProviderRegistry } from '../registry/index.js';
+import { registerBuiltinAgentRuntimeProviders } from './catalog.js';
+
+/**
+ * Build a provider registry with the builtin agentRuntime implementations
+ * registered, reusing a caller-supplied registry when present (and registering
+ * idempotently into it). Shared by both load helpers below.
+ */
+function registryWithBuiltins(overrides: ConfigPathOverrides) {
+  const providerRegistry =
+    overrides.providerRegistry ?? createBuiltinProviderRegistry();
+  registerBuiltinAgentRuntimeProviders({ registry: providerRegistry });
+  return providerRegistry;
+}
+
+/**
+ * Load dreamux config with the builtin agentRuntime providers registered, so a
+ * config that declares `builtin:codex` / `builtin:claude-code` agents parses
+ * through each provider's `readConfig`.
+ *
+ * `config/config.ts` is a schema/parse leaf and deliberately does not know about
+ * the runtime catalog — registering the builtins there inverted the layering and
+ * formed the static import cycle that crashed #148. The composition lives here
+ * instead: callers that do not already own a factory-bearing registry (doctor,
+ * daemon, onboard) go through this helper. `cli/server.ts` composes its own
+ * factory-bearing registry and calls `loadConfig` directly, so it does not need
+ * this wrapper.
+ *
+ * Idempotent w.r.t. an already-populated registry: `registerBuiltinAgentRuntimeProviders`
+ * skips a builtin id that already carries an implementation, so passing a
+ * factory-bearing registry through `overrides.providerRegistry` is safe.
+ *
+ * This module must never be imported by `platform/paths.ts` or any
+ * `agent-runtime/builtin/*` module — doing so would re-form the cycle.
+ */
+export async function loadConfigWithBuiltins(
+  overrides: ConfigPathOverrides = {},
+): Promise<LoadConfigResult> {
+  return loadConfig({ ...overrides, providerRegistry: registryWithBuiltins(overrides) });
+}
+
+/**
+ * Like {@link loadConfigWithBuiltins}, but for the load-or-write-default entry
+ * point. Same composition: builtins registered by the caller layer, not by the
+ * config leaf.
+ */
+export async function loadOrInitConfigWithBuiltins(
+  overrides: ConfigPathOverrides = {},
+): ReturnType<typeof loadOrInitConfig> {
+  return loadOrInitConfig({
+    ...overrides,
+    providerRegistry: registryWithBuiltins(overrides),
+  });
+}

--- a/packages/dreamux/src/cli/doctor.ts
+++ b/packages/dreamux/src/cli/doctor.ts
@@ -20,9 +20,9 @@ import {
   type DispatcherConfig,
   globalConfigDir,
   globalConfigFile,
-  loadConfig,
   type DreamuxConfig,
 } from '../config/config.js';
+import { loadConfigWithBuiltins } from '../agent-runtime/load-config.js';
 import {
   AgentRuntimeProviderCatalog,
   registerBuiltinAgentRuntimeProviders,
@@ -215,7 +215,7 @@ async function readConfigForDoctor(
   catalog: AgentRuntimeProviderCatalog;
 }> {
   try {
-    const loaded = await loadConfig({ configDir });
+    const loaded = await loadConfigWithBuiltins({ configDir });
     checks.push({
       name: 'config',
       ok: true,

--- a/packages/dreamux/src/cli/server.ts
+++ b/packages/dreamux/src/cli/server.ts
@@ -43,8 +43,10 @@ async function main(): Promise<void> {
   // Compose the provider registry + builtin runtime catalog (with the real
   // process factories) first, so the builtins carry runnable implementations
   // before config parses agents[] (each agent's config is parsed through its
-  // provider's readConfig). loadConfig's own idempotent registration then
-  // no-ops on these already-registered builtins.
+  // provider's readConfig). config does not register builtins itself (that
+  // would re-form the #148 import cycle); the server owns this composition and
+  // hands the populated registry to loadConfig. Leaf entry points that do not
+  // build their own registry use loadConfigWithBuiltins instead.
   const providerRegistry = createBuiltinProviderRegistry();
   const agentRuntimeProviderCatalog = createBuiltinAgentRuntimeProviderCatalog({
     registry: providerRegistry,

--- a/packages/dreamux/src/config/config.ts
+++ b/packages/dreamux/src/config/config.ts
@@ -36,7 +36,6 @@ import {
 } from './validate.js';
 import type { DispatcherCodexConfig } from '../agent-runtime/builtin/codex/config.js';
 import type { DispatcherClaudeCodeConfig } from '../agent-runtime/builtin/claude-code/config.js';
-import { registerBuiltinAgentRuntimeProviders } from '../agent-runtime/catalog.js';
 import { validateDispatcherId } from '../state/dispatcher-id.js';
 
 // Re-export the relocated builtin runtime config + provider-ref symbols so the
@@ -275,11 +274,16 @@ async function readConfigFile(
         `Fix the JSON syntax in ${file}, then restart. Run \`dreamux onboard\` if you need to recreate the config.`,
     );
   }
-  // Make the builtin provider implementations available for parsing — each
-  // agent's config is parsed through its provider's `readConfig`. Idempotent:
-  // when the server pre-registered the builtins with its process factories, this
-  // no-ops and the factory-bearing registration wins.
-  registerBuiltinAgentRuntimeProviders({ registry: providerRegistry });
+  // Each agent's config is parsed through its provider's `readConfig`, so the
+  // provider implementations must already be registered in `providerRegistry`.
+  // config does not register the builtins itself — that would invert the layering
+  // (a schema/parse leaf reaching up into the runtime catalog and dragging the
+  // whole builtin stack into its module-init, which is the cycle that crashed
+  // #148). The caller composes: `cli/server.ts` hands in a factory-bearing
+  // registry, and the leaf entry points (doctor/daemon/onboard) go through
+  // `loadConfigWithBuiltins`. A builtin agent parsed against a registry with no
+  // implementation fails loud in `readAgents`. External `npm:` providers still
+  // load here because that is a config-file-driven, dynamic-import concern.
   await loadExternalAgentRuntimeProviders({
     registry: providerRegistry,
     refs: agentProviderRefs(parsed),
@@ -426,7 +430,10 @@ function readAgents(
     if (runtimeProvider === null) {
       throw new Error(
         `dreamux config error in ${file}: ${prefix}provider='${provider.ref}' is registered but not runnable.\n` +
-          'Builtin runtimes are wired by dreamux; external runtimes must load and register an agentRuntime provider before config validation.',
+          'Builtin runtimes are wired by the caller: load config through ' +
+          '`loadConfigWithBuiltins` (or pass a providerRegistry that already has the ' +
+          'builtin implementations). External runtimes must load and register an ' +
+          'agentRuntime provider before config validation.',
       );
     }
     out[id] = {

--- a/packages/dreamux/src/daemon/install.ts
+++ b/packages/dreamux/src/daemon/install.ts
@@ -31,8 +31,8 @@ import {
   dispatcherCodexConfig,
   type DreamuxConfig,
   globalConfigDir,
-  loadConfig,
 } from '../config/config.js';
+import { loadConfigWithBuiltins } from '../agent-runtime/load-config.js';
 import { dreamuxBinPath } from '../platform/package-bin.js';
 import { setRuntimeConfig } from '../platform/paths.js';
 
@@ -98,7 +98,7 @@ export async function runDaemonInstall(
 
   // Fail loudly when the operator has not run onboard yet — daemon install
   // re-registers an existing setup, it does not create one.
-  const { config } = await loadConfig({ configDir: globalConfigDir() });
+  const { config } = await loadConfigWithBuiltins({ configDir: globalConfigDir() });
   setRuntimeConfig(config);
 
   // Seed the service PATH with Codex only when a host override or an enabled

--- a/packages/dreamux/src/onboard/run.ts
+++ b/packages/dreamux/src/onboard/run.ts
@@ -4,9 +4,9 @@ import { codexArgsToCli, parseCodexArgs } from '../agent-runtime/builtin/codex/a
 import {
   assertNoLegacyTomlOnly,
   globalConfigFile,
-  loadConfig,
   stringifyConfig,
 } from '../config/config.js';
+import { loadConfigWithBuiltins } from '../agent-runtime/load-config.js';
 import {
   logsRoot,
   setRuntimeConfig,
@@ -193,7 +193,7 @@ async function readExistingDreamuxConfig(configDir: string) {
   const configPath = globalConfigFile({ configDir });
   await assertNoLegacyTomlOnly({ configDir });
   if (!(await pathExists(configPath))) return undefined;
-  return (await loadConfig({ configDir })).config;
+  return (await loadConfigWithBuiltins({ configDir })).config;
 }
 
 /** Async existence probe — the fs/promises replacement for `existsSync`. */

--- a/packages/dreamux/src/onboard/uninstall.ts
+++ b/packages/dreamux/src/onboard/uninstall.ts
@@ -20,9 +20,9 @@ import {
   expandHome,
   globalConfigDir,
   globalConfigFile,
-  loadConfig,
   type DispatcherConfig,
 } from '../config/config.js';
+import { loadConfigWithBuiltins } from '../agent-runtime/load-config.js';
 import { logsRoot, stateRoot } from '../platform/paths.js';
 import { dispatcherWorkspaceSkillDirs } from '../agent-runtime/builtin/codex/paths.js';
 
@@ -105,7 +105,7 @@ async function warnIfConfigIsNotReadable(
   try {
     await assertNoLegacyTomlOnly({ configDir });
     if (!(await pathExists(globalConfigFile({ configDir })))) return;
-    await loadConfig({ configDir });
+    await loadConfigWithBuiltins({ configDir });
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
     warnings.push(
@@ -116,7 +116,7 @@ async function warnIfConfigIsNotReadable(
 
 async function collectWorkspaceSkillPaths(configDir: string): Promise<string[]> {
   try {
-    return (await loadConfig({ configDir })).config.dispatchers
+    return (await loadConfigWithBuiltins({ configDir })).config.dispatchers
       .flatMap(dispatcherWorkspaceSkillPathsFromConfig);
   } catch {
     return [];

--- a/packages/dreamux/tests/global-config.test.ts
+++ b/packages/dreamux/tests/global-config.test.ts
@@ -27,6 +27,10 @@ import {
   stringifyConfig,
 } from '../src/config/config.js';
 import {
+  loadConfigWithBuiltins,
+  loadOrInitConfigWithBuiltins,
+} from '../src/agent-runtime/load-config.js';
+import {
   adminSocketPath,
   resetRuntimeConfig,
   serverJsonPath,
@@ -124,11 +128,11 @@ describe('global config (~/.dreamux/config.json)', () => {
         feishu: { app_id: 'app-flow', app_secret: 'secret-flow' },
       }),
     );
-    const c1 = (await loadConfig({ configDir })).config;
+    const c1 = (await loadConfigWithBuiltins({ configDir })).config;
     // load -> stringify -> load must be a fixed point: the in-memory config
     // serialised back to the file shape and reloaded yields the same config.
     writeConfigText(globalConfigFile({ configDir }), stringifyConfig(c1));
-    const c2 = (await loadConfig({ configDir })).config;
+    const c2 = (await loadConfigWithBuiltins({ configDir })).config;
     expect(c2).toEqual(c1);
   });
 
@@ -179,7 +183,7 @@ describe('global config (~/.dreamux/config.json)', () => {
     )}\n`;
     writeConfigText(file, original);
 
-    const { config, createdOnThisBoot } = await loadOrInitConfig({ configDir });
+    const { config, createdOnThisBoot } = await loadOrInitConfigWithBuiltins({ configDir });
     expect(createdOnThisBoot).toBe(false);
     expect(config.agents['flow']).toMatchObject({
       provider: 'builtin:codex',
@@ -298,7 +302,7 @@ describe('global config (~/.dreamux/config.json)', () => {
     (fileObject['dispatchers'] as Record<string, unknown>[])[0]!['enabled'] =
       'yes';
     writeConfigObject(fileObject);
-    await expect(loadOrInitConfig({ configDir })).rejects.toThrow(
+    await expect(loadOrInitConfigWithBuiltins({ configDir })).rejects.toThrow(
       /enabled must be a boolean/,
     );
   });
@@ -387,7 +391,7 @@ describe('global config (~/.dreamux/config.json)', () => {
       ],
     });
 
-    await expect(loadConfig({ configDir })).rejects.toThrow(
+    await expect(loadConfigWithBuiltins({ configDir })).rejects.toThrow(
       /dispatchers\[0\]\.agentRuntime is required/,
     );
   });
@@ -400,10 +404,10 @@ describe('global config (~/.dreamux/config.json)', () => {
       }),
     );
 
-    await expect(loadConfig({ configDir })).rejects.toThrow(
+    await expect(loadConfigWithBuiltins({ configDir })).rejects.toThrow(
       /agentRuntime='does-not-exist' does not match any agents\[\]\.id/,
     );
-    await expect(loadConfig({ configDir })).rejects.toThrow(/Known agents: 'codex'/);
+    await expect(loadConfigWithBuiltins({ configDir })).rejects.toThrow(/Known agents: 'codex'/);
   });
 
   it('fails loud on a duplicate agents[].id', async () => {
@@ -417,7 +421,7 @@ describe('global config (~/.dreamux/config.json)', () => {
       }),
     );
 
-    await expect(loadConfig({ configDir })).rejects.toThrow(
+    await expect(loadConfigWithBuiltins({ configDir })).rejects.toThrow(
       /agents\[1\]\.id duplicates agent 'codex'/,
     );
   });
@@ -458,7 +462,7 @@ describe('global config (~/.dreamux/config.json)', () => {
       }),
     );
 
-    const { config } = await loadConfig({ configDir });
+    const { config } = await loadConfigWithBuiltins({ configDir });
     expect(Object.keys(config.agents)).toEqual(['shared-codex']);
     expect(dispatcherCodexConfig(config.dispatchers[0]!).sandbox_mode).toBe(
       'read-only',
@@ -487,7 +491,7 @@ describe('global config (~/.dreamux/config.json)', () => {
       }),
     );
 
-    const { config } = await loadConfig({ configDir });
+    const { config } = await loadConfigWithBuiltins({ configDir });
     expect(config.agents['codex']?.provider).toBe('builtin:codex');
     expect(config.agents['claude']?.provider).toBe('builtin:claude-code');
     expect(config.dispatchers[0]?.runtime.provider).toBe('builtin:codex');
@@ -526,7 +530,7 @@ describe('global config (~/.dreamux/config.json)', () => {
       }),
     );
 
-    const { config } = await loadConfig({ configDir });
+    const { config } = await loadConfigWithBuiltins({ configDir });
     // Both agents map to the same provider …
     expect(config.agents['codex-safe']?.provider).toBe('builtin:codex');
     expect(config.agents['codex-yolo']?.provider).toBe('builtin:codex');
@@ -558,7 +562,7 @@ describe('global config (~/.dreamux/config.json)', () => {
         codex: { approval_policy: 'ask-every-time' },
       }),
     );
-    await expect(loadOrInitConfig({ configDir })).rejects.toThrow(
+    await expect(loadOrInitConfigWithBuiltins({ configDir })).rejects.toThrow(
       /agents\[0\]\.config\.approval_policy='ask-every-time'/,
     );
   });
@@ -567,7 +571,7 @@ describe('global config (~/.dreamux/config.json)', () => {
     writeConfigObject(
       testSingleDispatcherFileObject({ id: 'flow', codex: {} }),
     );
-    const { config } = await loadConfig({ configDir });
+    const { config } = await loadConfigWithBuiltins({ configDir });
     const codex = dispatcherCodexConfig(config.dispatchers[0]!);
     expect(codex.bin).toBe('codex');
     expect(codex.initialize_timeout_ms).toBe(10000);
@@ -580,7 +584,7 @@ describe('global config (~/.dreamux/config.json)', () => {
         codex: { bin: '/opt/custom-codex', initialize_timeout_ms: 30000 },
       }),
     );
-    const { config } = await loadConfig({ configDir });
+    const { config } = await loadConfigWithBuiltins({ configDir });
     const codex = dispatcherCodexConfig(config.dispatchers[0]!);
     expect(codex.bin).toBe('/opt/custom-codex');
     expect(codex.initialize_timeout_ms).toBe(30000);
@@ -593,7 +597,7 @@ describe('global config (~/.dreamux/config.json)', () => {
         codex: { bin: '   ' },
       }),
     );
-    await expect(loadConfig({ configDir })).rejects.toThrow(
+    await expect(loadConfigWithBuiltins({ configDir })).rejects.toThrow(
       /agents\[0\]\.config\.bin must be a non-empty string/,
     );
   });
@@ -605,7 +609,7 @@ describe('global config (~/.dreamux/config.json)', () => {
         codex: { initialize_timeout_ms: 0 },
       }),
     );
-    await expect(loadConfig({ configDir })).rejects.toThrow(
+    await expect(loadConfigWithBuiltins({ configDir })).rejects.toThrow(
       /agents\[0\]\.config\.initialize_timeout_ms must be > 0/,
     );
   });
@@ -643,7 +647,7 @@ describe('global config (~/.dreamux/config.json)', () => {
       }),
     );
 
-    const { config } = await loadConfig({ configDir });
+    const { config } = await loadConfigWithBuiltins({ configDir });
     const firstFeishu = dispatcherFeishuConfig(config.dispatchers[0]!);
     const firstCodex = dispatcherCodexConfig(config.dispatchers[0]!);
     expect(config.dispatchers[0]).toMatchObject({
@@ -686,7 +690,7 @@ describe('global config (~/.dreamux/config.json)', () => {
       }),
     );
 
-    await expect(loadConfig({ configDir })).rejects.toThrow(
+    await expect(loadConfigWithBuiltins({ configDir })).rejects.toThrow(
       /not a built-in Dreamux channel/,
     );
   });
@@ -699,7 +703,7 @@ describe('global config (~/.dreamux/config.json)', () => {
       }),
     );
 
-    await expect(loadConfig({ configDir })).rejects.toThrow(
+    await expect(loadConfigWithBuiltins({ configDir })).rejects.toThrow(
       /not a built-in Dreamux channel/,
     );
   });
@@ -712,7 +716,7 @@ describe('global config (~/.dreamux/config.json)', () => {
       }),
     );
 
-    await expect(loadConfig({ configDir })).rejects.toThrow(
+    await expect(loadConfigWithBuiltins({ configDir })).rejects.toThrow(
       /not a built-in Dreamux channel/,
     );
   });
@@ -826,7 +830,7 @@ describe('global config (~/.dreamux/config.json)', () => {
       }),
     );
 
-    const { config } = await loadConfig({ configDir });
+    const { config } = await loadConfigWithBuiltins({ configDir });
     expect(config.agents['flow']?.provider).toBe('builtin:claude-code');
     expect(config.dispatchers[0]?.runtime.provider).toBe('builtin:claude-code');
   });
@@ -847,7 +851,7 @@ describe('global config (~/.dreamux/config.json)', () => {
       }),
     );
 
-    await expect(loadConfig({ configDir })).rejects.toThrow(
+    await expect(loadConfigWithBuiltins({ configDir })).rejects.toThrow(
       /approval_policy is not supported/,
     );
   });
@@ -865,7 +869,7 @@ describe('global config (~/.dreamux/config.json)', () => {
     });
     writeConfigObject(fileObject);
 
-    await expect(loadConfig({ configDir })).rejects.toThrow(
+    await expect(loadConfigWithBuiltins({ configDir })).rejects.toThrow(
       /must contain exactly one channel in this phase/,
     );
   });
@@ -882,7 +886,7 @@ describe('global config (~/.dreamux/config.json)', () => {
       }),
     );
 
-    await expect(loadConfig({ configDir })).rejects.toThrow(
+    await expect(loadConfigWithBuiltins({ configDir })).rejects.toThrow(
       /callback_secret is not supported/,
     );
   });
@@ -891,7 +895,7 @@ describe('global config (~/.dreamux/config.json)', () => {
     const withAccess = testSingleDispatcherFileObject({ id: 'flow' });
     (withAccess['dispatchers'] as Record<string, unknown>[])[0]!['access'] = {};
     writeConfigObject(withAccess);
-    await expect(loadConfig({ configDir })).rejects.toThrow(
+    await expect(loadConfigWithBuiltins({ configDir })).rejects.toThrow(
       /access is not supported/,
     );
 
@@ -905,7 +909,7 @@ describe('global config (~/.dreamux/config.json)', () => {
         },
       }),
     );
-    await expect(loadConfig({ configDir })).rejects.toThrow(
+    await expect(loadConfigWithBuiltins({ configDir })).rejects.toThrow(
       /agents\[0\]\.config\.extra_env\.EXAMPLE_FLAG must be a string/,
     );
   });
@@ -933,7 +937,7 @@ describe('global config (~/.dreamux/config.json)', () => {
       }),
     );
 
-    await expect(loadConfig({ configDir })).rejects.toThrow(
+    await expect(loadConfigWithBuiltins({ configDir })).rejects.toThrow(
       /duplicates dispatcher 'flow'/,
     );
   });
@@ -952,8 +956,8 @@ describe('global config (~/.dreamux/config.json)', () => {
       }),
     );
 
-    await expect(loadConfig({ configDir })).rejects.toThrow(/dispatchers\[0\]\.id/);
-    await expect(loadConfig({ configDir })).rejects.toThrow(/ASCII letters/);
+    await expect(loadConfigWithBuiltins({ configDir })).rejects.toThrow(/dispatchers\[0\]\.id/);
+    await expect(loadConfigWithBuiltins({ configDir })).rejects.toThrow(/ASCII letters/);
   });
 
   it('requires non-empty Feishu app_id and app_secret values', async () => {
@@ -966,7 +970,7 @@ describe('global config (~/.dreamux/config.json)', () => {
         },
       }),
     );
-    await expect(loadConfig({ configDir })).rejects.toThrow(
+    await expect(loadConfigWithBuiltins({ configDir })).rejects.toThrow(
       /app_id must be a non-empty string/,
     );
 
@@ -979,7 +983,7 @@ describe('global config (~/.dreamux/config.json)', () => {
         },
       }),
     );
-    await expect(loadConfig({ configDir })).rejects.toThrow(
+    await expect(loadConfigWithBuiltins({ configDir })).rejects.toThrow(
       /app_secret must be a non-empty string/,
     );
   });
@@ -1112,7 +1116,7 @@ describe('sandbox_mode precedence', () => {
       configDir,
       testSingleDispatcherFileObject({ id: 'flow', codex: {} }),
     );
-    const { config } = await loadOrInitConfig({ configDir });
+    const { config } = await loadOrInitConfigWithBuiltins({ configDir });
     expect(dispatcherCodexConfig(config.dispatchers[0]!).sandbox_mode).toBe(
       'workspace-write',
     );
@@ -1126,7 +1130,7 @@ describe('sandbox_mode precedence', () => {
         codex: { sandbox_mode: 'danger-full-access' },
       }),
     );
-    const { config } = await loadOrInitConfig({ configDir });
+    const { config } = await loadOrInitConfigWithBuiltins({ configDir });
     expect(dispatcherCodexConfig(config.dispatchers[0]!).sandbox_mode).toBe(
       'danger-full-access',
     );
@@ -1140,7 +1144,7 @@ describe('sandbox_mode precedence', () => {
         codex: { sandbox_mode: 'not-a-mode' },
       }),
     );
-    await expect(loadOrInitConfig({ configDir })).rejects.toThrow(
+    await expect(loadOrInitConfigWithBuiltins({ configDir })).rejects.toThrow(
       /sandbox_mode='not-a-mode'/,
     );
   });

--- a/packages/dreamux/tests/onboard.test.ts
+++ b/packages/dreamux/tests/onboard.test.ts
@@ -20,7 +20,7 @@ import {
 } from '../src/onboard/wizard.js';
 import type { CommandRunner, OnboardAnswers } from '../src/onboard/types.js';
 import type { ServiceNodeProbe } from '../src/onboard/service.js';
-import { loadConfig } from '../src/config/config.js';
+import { loadConfigWithBuiltins } from '../src/agent-runtime/load-config.js';
 import {
   logsRoot,
   resetRuntimeConfig,
@@ -751,7 +751,7 @@ describe('dreamux onboard', () => {
     });
 
     // Now load the written config through the same parser.
-    const { config } = await loadConfig({ configDir });
+    const { config } = await loadConfigWithBuiltins({ configDir });
 
     // agents map must be populated with the 'flow' agent.
     expect(Object.keys(config.agents)).toEqual(['flow']);


### PR DESCRIPTION
## Problem

`#153` (the `#148` `agents[]` normalization) merged to `next` and broke the runtime: the built CLI crashes on cold start, before printing anything.

```
$ node packages/dreamux/dist/cli/dreamux.js --version
ReferenceError: Cannot access 'BUILT_IN_DEFAULTS' before initialization
    at platform/paths.js:35
```

## Root cause — a static ESM import cycle

`#148` made `config/config.ts` import `registerBuiltinAgentRuntimeProviders` from `agent-runtime/catalog.ts` so config could self-register the builtin providers for parsing. That closed a static import cycle:

```
config/config.ts → agent-runtime/catalog.ts → agent-runtime/builtin/* → platform/paths.ts → config/config.ts
```

`platform/paths.ts` reads `BUILT_IN_DEFAULTS` at module top level (`let currentConfig = BUILT_IN_DEFAULTS`), so under that cycle the binding is read in its temporal dead zone. `tsc` (hoisted, transpiled) and `vitest` never surfaced it — only the compiled artifact run in a fresh Node process did.

## Why not the minimal patch (#157)

#157 defers the TDZ read (lazy `BUILT_IN_DEFAULTS`) and re-exports without copying. By its own admission *"the import cycle still exists"*. That treats the symptom; the inverted dependency (a schema/parse leaf reaching up into the runtime catalog) remains a latent trap for the next top-level read. This PR removes the cycle at its root and **supersedes #157**, while keeping #157's genuinely useful `smoke-built-cli` gate.

## Fix — caller-composed builtins

`config/config.ts` becomes a true schema/parse leaf that never imports the catalog. Builtin registration moves to the composition layer, matching the provider-self-reported design and the seam `cli/server.ts` already used (it passes its own factory-bearing registry to `loadConfig`):

- New `agent-runtime/load-config.ts` exports `loadConfigWithBuiltins` / `loadOrInitConfigWithBuiltins`: build a registry, register the builtins idempotently, then delegate to `config`.
- `doctor` / `daemon` / `onboard` switch to the wrapper; `cli/server.ts` is unchanged (already composes).
- A bare `loadConfig` against a registered-but-unimplemented builtin now fails loud in `readAgents` ("registered but not runnable"), with a hint pointing at `loadConfigWithBuiltins`.
- External `npm:` providers still load inside `readConfigFile` via the dynamic-import loader (unchanged).

**Invariant established:** `config/config.ts` and `platform/paths.ts` must never statically import `agent-runtime/catalog.ts` or any `agent-runtime/builtin/*`; `agent-runtime/load-config.ts` must never be imported by `platform/paths.ts` or a builtin. Documented in `.agents/decisions/agents-config-normalization.md`.

## Regression guard

Adopts #157's `smoke-built-cli` Rush command — a fresh-Node `bin/dreamux --version` run wired into CI (after `rush build`) and before release publish. This exercises the compiled cold-start path that unit tests structurally cannot. ESLint enforces the sync-IO ban, not cycles; `madge` is noisy on pre-existing type-only cycles, so the smoke gate is the practical guard.

## Verification

- `node packages/dreamux/dist/cli/dreamux.js --version` → `0.0.0` (was a crash); `serve` and `doctor` load all modules cleanly and fail-loud on missing config rather than TDZ.
- `madge --circular dist/` (runtime truth, types erased): config↔paths cycle **gone**; only the 2 pre-existing intra-`builtin/codex/` cycles (`provider↔diagnostic`, `provider↔runtime`) remain — neither touches `config`/`paths`, neither TDZs. The `provider↔diagnostic` one is `#148`-introduced and tracked for separate follow-up.
- `rush smoke-built-cli` passes.
- Full suite: **518 passed, 1 skipped** (live-codex opt-in). Test migration was suite-classified: only call sites that parse a builtin agent moved to the wrapper; pre-`readAgents` error-path tests and the deliberate injected-registry tests stay on bare `loadConfig`.
- `rush lint`, `rush typecheck` clean.

Refs #148. Supersedes #157.
