### PR TITLE
Fix duplicate TeamMate completion delivery

### DIFF
--- a/common/changes/@excitedjs/dreamux/fix-teammate-completion-idempotent_2026-06-09-06-21.json
+++ b/common/changes/@excitedjs/dreamux/fix-teammate-completion-idempotent_2026-06-09-06-21.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Fix duplicate TeamMate reverse-completion delivery so repeated settled events and concurrent retries are idempotent.",
+      "type": "patch",
+      "packageName": "@excitedjs/dreamux"
+    }
+  ],
+  "packageName": "@excitedjs/dreamux",
+  "email": "053700@gmail.com"
+}

--- a/common/changes/@excitedjs/dreamux/fix-teammate-completion-idempotent_2026-06-09-06-21.json
+++ b/common/changes/@excitedjs/dreamux/fix-teammate-completion-idempotent_2026-06-09-06-21.json
@@ -1,7 +1,7 @@
 {
   "changes": [
     {
-      "comment": "Fix duplicate TeamMate reverse-completion delivery so repeated settled events and concurrent retries are idempotent.",
+      "comment": "Fix TeamMate reverse-completion delivery so duplicate/retried completions are idempotent and multi-send steering shares one current-turn completion.",
       "type": "patch",
       "packageName": "@excitedjs/dreamux"
     }

--- a/packages/dreamux/src/agent-runtime/builtin/claude-code/rpc.ts
+++ b/packages/dreamux/src/agent-runtime/builtin/claude-code/rpc.ts
@@ -22,6 +22,9 @@ interface PendingTurn {
   reject: (err: Error) => void;
   aggregator: TurnAggregator;
   timer: NodeJS.Timeout | null;
+  settleImmediate: NodeJS.Immediate | null;
+  steered: boolean;
+  deferredOutcome: TurnOutcome | null;
 }
 
 export interface ClaudeCodeStreamRpcOptions {
@@ -57,6 +60,9 @@ export class ClaudeCodeStreamRpc {
         reject,
         aggregator: new TurnAggregator(),
         timer: null,
+        settleImmediate: null,
+        steered: false,
+        deferredOutcome: null,
       };
       this.pending = pending;
       // Arm the idle deadline (reset on every inbound stream line in `onLine`).
@@ -81,6 +87,8 @@ export class ClaudeCodeStreamRpc {
     if (this.pending === null) {
       return Promise.reject(new Error('claude resident session has no active turn'));
     }
+    const pending = this.pending;
+    pending.steered = true;
     return new Promise<void>((resolve, reject) => {
       this.stdin.write(
         `${buildUserMessage(prompt, { priority: 'now', ...options })}\n`,
@@ -111,6 +119,7 @@ export class ClaudeCodeStreamRpc {
     const pending = this.pending;
     if (pending === null) return null;
     if (pending.timer !== null) clearTimeout(pending.timer);
+    if (pending.settleImmediate !== null) clearImmediate(pending.settleImmediate);
     this.pending = null;
     return pending;
   }
@@ -154,6 +163,10 @@ export class ClaudeCodeStreamRpc {
         if (this.pending === null) break;
         this.pending.aggregator.accept(line);
         const outcome = this.pending.aggregator.outcome();
+        if (this.pending.steered) {
+          this.deferSteeredResult(this.pending, outcome);
+          break;
+        }
         const pending = this.settlePending();
         if (pending === null) break;
         if (outcome !== null) pending.resolve(outcome);
@@ -172,6 +185,26 @@ export class ClaudeCodeStreamRpc {
       default:
         break;
     }
+  }
+
+  private deferSteeredResult(
+    pending: PendingTurn,
+    outcome: TurnOutcome | null,
+  ): void {
+    pending.deferredOutcome = outcome;
+    if (pending.settleImmediate !== null) return;
+    // A stream-json `priority` steer can cause Claude Code to close the
+    // interrupted run and immediately drain the queued steer in the same stdout
+    // flush. Resolve on the next tick so those follow-up lines are still folded
+    // into this one Dreamux logical turn instead of becoming a silent late result.
+    pending.settleImmediate = setImmediate(() => {
+      if (this.pending !== pending) return;
+      const finalOutcome = pending.deferredOutcome;
+      const settled = this.settlePending();
+      if (settled === null) return;
+      if (finalOutcome !== null) settled.resolve(finalOutcome);
+      else settled.reject(new Error('claude turn ended without a result'));
+    });
   }
 
   private onControlRequest(

--- a/packages/dreamux/src/agent-runtime/builtin/claude-code/rpc.ts
+++ b/packages/dreamux/src/agent-runtime/builtin/claude-code/rpc.ts
@@ -71,6 +71,30 @@ export class ClaudeCodeStreamRpc {
     });
   }
 
+  async steerTurn(
+    prompt: string,
+    options: TurnSubmitOptions = {},
+  ): Promise<void> {
+    if (!this.stdin.writable) {
+      return Promise.reject(new Error('claude resident child is not running'));
+    }
+    if (this.pending === null) {
+      return Promise.reject(new Error('claude resident session has no active turn'));
+    }
+    return new Promise<void>((resolve, reject) => {
+      this.stdin.write(
+        `${buildUserMessage(prompt, { priority: 'now', ...options })}\n`,
+        (err) => {
+          if (err != null) {
+            reject(err instanceof Error ? err : new Error(String(err)));
+            return;
+          }
+          resolve();
+        },
+      );
+    });
+  }
+
   onStdoutChunk(chunk: string): void {
     for (const line of this.lineBuf.push(chunk)) this.onLine(parseLine(line));
   }

--- a/packages/dreamux/src/agent-runtime/builtin/claude-code/runtime.ts
+++ b/packages/dreamux/src/agent-runtime/builtin/claude-code/runtime.ts
@@ -431,7 +431,7 @@ export class ClaudeCodeRuntime implements AgentRuntime {
       return;
     }
     const steer = active.steerQueue.then(() =>
-      session.steerTurn(prompt, { priority: 'now' }),
+      session.steerTurn(prompt, { priority: 'next' }),
     );
     active.steerQueue = steer.then(
       () => undefined,

--- a/packages/dreamux/src/agent-runtime/builtin/claude-code/runtime.ts
+++ b/packages/dreamux/src/agent-runtime/builtin/claude-code/runtime.ts
@@ -80,6 +80,7 @@ import {
   createDefaultClaudeCodeSession,
   type ClaudeCodeSession,
   type ClaudeCodeSessionFactory,
+  type TurnOutcome,
   type TurnSubmitOptions,
 } from './supervisor.js';
 import type {
@@ -110,7 +111,7 @@ export interface ClaudeCodeAgentRuntimeProviderOptions {
 
 export const CLAUDE_CODE_AGENT_RUNTIME_CAPABILITIES: AgentRuntimeCapabilities = {
   resume: { supported: true, checkpoint: 'claudeCodeSession' },
-  steer: { supported: false },
+  steer: { supported: true },
   events: { kind: 'synthesized' },
   last: { supported: true },
   context: { supported: false },
@@ -128,6 +129,15 @@ interface ClaudeCodeRuntimeDeps {
   sessionFactory: ClaudeCodeSessionFactory;
   resolveBinPath: (bin: string) => string;
 }
+
+interface ActiveChannelTurn {
+  turnId: string;
+  pendingSteers: string[];
+  session: ClaudeCodeSession | null;
+  steerQueue: Promise<void>;
+}
+
+let nextRuntimeInstanceId = 0;
 
 /**
  * Format a TeamMate completion as a Claude Code `<task-notification>` — the
@@ -178,9 +188,11 @@ export class ClaudeCodeRuntime implements AgentRuntime {
   private stopped = false;
   private readonly seen = new Set<string>();
   private queue: Promise<void> = Promise.resolve();
+  private readonly runtimeInstanceId = ++nextRuntimeInstanceId;
   private turnCounter = 0;
   private session: ClaudeCodeSession | null = null;
   private lastResult: AgentRuntimeLastResult | null = null;
+  private activeChannelTurn: ActiveChannelTurn | null = null;
 
   constructor(
     private readonly context: AgentRuntimeCreateContext,
@@ -276,7 +288,7 @@ export class ClaudeCodeRuntime implements AgentRuntime {
 
   async systemInput(notice: AgentRuntimeSystemInput): Promise<AgentRuntimeTurnResult> {
     if (this.stopped) return { status: 'stopped' };
-    const turnId = `claude-system-${++this.turnCounter}`;
+    const turnId = this.nextTurnId('system');
     void this.runTurnOnQueue(notice.text, turnId).then(
       () => this.markTurnSucceeded(turnId),
       (err) => this.markTurnFailed(turnId, err),
@@ -299,13 +311,32 @@ export class ClaudeCodeRuntime implements AgentRuntime {
       // failure there must not drop the turn.
       this.log('warn', 'claude-code onAccepted hook failed', err);
     }
-    const turnId = `claude-turn-${++this.turnCounter}`;
+    const active = this.activeChannelTurn;
+    if (active !== null) {
+      try {
+        await this.steerChannelTurn(active, input.text);
+        return { status: 'submitted', turnId: active.turnId };
+      } catch (err) {
+        return {
+          status: 'failed',
+          error: err instanceof Error ? err : new Error(String(err)),
+        };
+      }
+    }
+    const turnId = this.nextTurnId('turn');
+    const channelTurn: ActiveChannelTurn = {
+      turnId,
+      pendingSteers: [],
+      session: null,
+      steerQueue: Promise.resolve(),
+    };
+    this.activeChannelTurn = channelTurn;
     // Submit-then-serialize: return after accept (so the channel can ack
     // promptly), run the turn on the serial queue. A turn failure cannot be
     // returned to this caller without blocking the channel ack on full turn
     // completion. Instead, a failed turn drives the runtime to `degraded` with a
     // persisted `last_error` (visible via status/doctor) — never swallowed.
-    void this.runTurnOnQueue(input.text, turnId).then(
+    void this.runChannelTurnOnQueue(input.text, channelTurn).then(
       () => this.markTurnSucceeded(turnId),
       (err) => this.markTurnFailed(turnId, err),
     );
@@ -357,6 +388,56 @@ export class ClaudeCodeRuntime implements AgentRuntime {
       () => undefined,
     );
     return run;
+  }
+
+  private runChannelTurnOnQueue(
+    prompt: string,
+    active: ActiveChannelTurn,
+  ): Promise<void> {
+    const run = this.queue.then(() => this.runChannelTurn(prompt, active));
+    this.queue = run.then(
+      () => undefined,
+      () => undefined,
+    );
+    return run;
+  }
+
+  private async runChannelTurn(
+    prompt: string,
+    active: ActiveChannelTurn,
+  ): Promise<void> {
+    const session = await this.ensureSession();
+    const steers = active.pendingSteers.splice(0);
+    const fullPrompt =
+      steers.length === 0 ? prompt : [prompt, ...steers].join('\n\n');
+    const outcome = session.submitTurn(fullPrompt);
+    active.session = session;
+    try {
+      await this.applyTurnOutcome(await outcome, active.turnId);
+    } finally {
+      active.session = null;
+      if (this.activeChannelTurn === active) this.activeChannelTurn = null;
+      active.pendingSteers = [];
+    }
+  }
+
+  private async steerChannelTurn(
+    active: ActiveChannelTurn,
+    prompt: string,
+  ): Promise<void> {
+    const session = active.session;
+    if (session === null) {
+      active.pendingSteers.push(prompt);
+      return;
+    }
+    const steer = active.steerQueue.then(() =>
+      session.steerTurn(prompt, { priority: 'now' }),
+    );
+    active.steerQueue = steer.then(
+      () => undefined,
+      () => undefined,
+    );
+    await steer;
   }
 
   private async markTurnSucceeded(turnId: string): Promise<void> {
@@ -426,7 +507,23 @@ export class ClaudeCodeRuntime implements AgentRuntime {
     options?: TurnSubmitOptions,
   ): Promise<void> {
     const session = await this.ensureSession();
+    await this.runTurnWithSession(session, prompt, turnId, options);
+  }
+
+  private async runTurnWithSession(
+    session: ClaudeCodeSession,
+    prompt: string,
+    turnId: string,
+    options?: TurnSubmitOptions,
+  ): Promise<void> {
     const outcome = await session.submitTurn(prompt, options);
+    await this.applyTurnOutcome(outcome, turnId);
+  }
+
+  private async applyTurnOutcome(
+    outcome: TurnOutcome,
+    turnId: string,
+  ): Promise<void> {
     if (
       outcome.sessionId !== null &&
       outcome.sessionId !== '' &&
@@ -447,6 +544,10 @@ export class ClaudeCodeRuntime implements AgentRuntime {
       throw new Error(`claude turn ${turnId} returned an error result: ${detail}`);
     }
     this.log('info', `claude-code turn ${turnId} completed`);
+  }
+
+  private nextTurnId(kind: 'system' | 'turn'): string {
+    return `claude-${kind}-${this.runtimeInstanceId}-${++this.turnCounter}`;
   }
 
   private async setStatus(

--- a/packages/dreamux/src/agent-runtime/builtin/claude-code/supervisor.ts
+++ b/packages/dreamux/src/agent-runtime/builtin/claude-code/supervisor.ts
@@ -117,6 +117,19 @@ class LiveClaudeCodeSession implements ClaudeCodeSession {
     return this.rpc.submitTurn(prompt, options);
   }
 
+  async steerTurn(
+    prompt: string,
+    options: TurnSubmitOptions = {},
+  ): Promise<void> {
+    if (this.stopped) {
+      return Promise.reject(new Error('claude resident session is stopped'));
+    }
+    if (this.child === null || this.exited || this.rpc === null) {
+      return Promise.reject(new Error('claude resident child is not running'));
+    }
+    return this.rpc.steerTurn(prompt, options);
+  }
+
   async stop(): Promise<void> {
     if (this.stopped) return;
     this.stopped = true;

--- a/packages/dreamux/src/agent-runtime/builtin/claude-code/types.ts
+++ b/packages/dreamux/src/agent-runtime/builtin/claude-code/types.ts
@@ -100,14 +100,17 @@ export interface ClaudeCodeSessionSpec {
 }
 
 /**
- * A resident Claude Code session. Turns are serialized by the caller; the
- * session itself rejects a concurrent `submitTurn` defensively.
+ * A resident Claude Code session. Full turns are serialized by the caller;
+ * `steerTurn` is the one allowed concurrent write, used to steer the active
+ * turn without creating a second completion subscription.
  */
 export interface ClaudeCodeSession {
   /** Spawn the child and resolve once it is up (reject on spawn error). */
   start(): Promise<void>;
   /** Submit one user turn; resolve with the outcome when `result` lands. */
   submitTurn(prompt: string, options?: TurnSubmitOptions): Promise<TurnOutcome>;
+  /** Send a user message into the active turn without awaiting a separate result. */
+  steerTurn(prompt: string, options?: TurnSubmitOptions): Promise<void>;
   /** Whether the child is currently alive. */
   isAlive(): boolean;
   /**

--- a/packages/dreamux/src/agent-runtime/builtin/codex/events.ts
+++ b/packages/dreamux/src/agent-runtime/builtin/codex/events.ts
@@ -24,7 +24,7 @@ export interface CollectedTurn {
 }
 
 export interface TurnCollector {
-  awaitTurn(): Promise<CollectedTurn>;
+  awaitTurn(turnId?: string): Promise<CollectedTurn>;
 }
 
 /**
@@ -77,21 +77,61 @@ export function subscribeTurnCollection(
 ): TurnCollector {
   const acceptAnyThread = options.acceptAnyThread === true;
   const itemsByTurn = new Map<string, ThreadItem[]>();
-  let cached: CollectedTurn | null = null;
-  let failure: Error | null = null;
-  let awaiting: Promise<CollectedTurn> | null = null;
-  let resolveTurn: ((turn: CollectedTurn) => void) | null = null;
-  let rejectTurn: ((err: Error) => void) | null = null;
-  let done = false;
+  const completedByTurn = new Map<string, CollectedTurn>();
+  const failuresByTurn = new Map<string, Error>();
+  let firstCompleted: CollectedTurn | null = null;
+  let firstFailure: Error | null = null;
+  let unscopedFailure: Error | null = null;
+  let closed = false;
+  let awaiting:
+    | {
+        turnId: string | null;
+        promise: Promise<CollectedTurn>;
+        resolve: (turn: CollectedTurn) => void;
+        reject: (err: Error) => void;
+      }
+    | null = null;
 
-  const settleFailure = (err: Error): void => {
-    if (done) return;
-    done = true;
-    failure = err;
-    if (rejectTurn !== null) {
-      rejectTurn(err);
-      rejectTurn = null;
-      resolveTurn = null;
+  const closeCollector = (): void => {
+    closed = true;
+    itemsByTurn.clear();
+  };
+
+  const resolveAwaiting = (): void => {
+    if (awaiting === null) return;
+    const expectedTurnId = awaiting.turnId;
+    if (unscopedFailure !== null) {
+      awaiting.reject(unscopedFailure);
+      awaiting = null;
+      closeCollector();
+      return;
+    }
+    if (expectedTurnId !== null) {
+      const failure = failuresByTurn.get(expectedTurnId);
+      if (failure !== undefined) {
+        awaiting.reject(failure);
+        awaiting = null;
+        closeCollector();
+        return;
+      }
+      const completed = completedByTurn.get(expectedTurnId);
+      if (completed !== undefined) {
+        awaiting.resolve(completed);
+        awaiting = null;
+        closeCollector();
+      }
+      return;
+    }
+    if (firstFailure !== null) {
+      awaiting.reject(firstFailure);
+      awaiting = null;
+      closeCollector();
+      return;
+    }
+    if (firstCompleted !== null) {
+      awaiting.resolve(firstCompleted);
+      awaiting = null;
+      closeCollector();
     }
   };
 
@@ -108,7 +148,7 @@ export function subscribeTurnCollection(
         matched: matches,
       });
     }
-    if (done || !matches) return;
+    if (closed || !matches) return;
     if (notif.method === 'item/completed') {
       const params = notif.params as ItemCompletedNotification;
       const bucket = itemsByTurn.get(params.turnId) ?? [];
@@ -117,38 +157,74 @@ export function subscribeTurnCollection(
     } else if (notif.method === 'turn/completed') {
       const params = notif.params as TurnCompletedNotification;
       if (params.turn.error != null) {
-        settleFailure(new Error(params.turn.error.message || 'codex turn failed'));
+        const failure = new Error(params.turn.error.message || 'codex turn failed');
+        failuresByTurn.set(params.turn.id, failure);
+        firstFailure ??= failure;
+        resolveAwaiting();
         return;
       }
-      done = true;
       const items = itemsByTurn.get(params.turn.id) ?? params.turn.items ?? [];
-      cached = { threadId, turnId: params.turn.id, items };
-      if (resolveTurn !== null) {
-        resolveTurn(cached);
-        resolveTurn = null;
-        rejectTurn = null;
-      }
+      const completed = { threadId, turnId: params.turn.id, items };
+      completedByTurn.set(params.turn.id, completed);
+      firstCompleted ??= completed;
+      resolveAwaiting();
     } else if (notif.method === 'error') {
       const params = notif.params as TurnErrorNotification;
       // Only a fatal (non-retried) error terminates the turn. A transient
       // `willRetry: true` error is followed by codex's own retry and an
       // eventual `turn/completed`, so we ignore it here.
       if (params.willRetry === false) {
-        settleFailure(new Error(params.error?.message ?? 'codex turn error'));
+        const failure = new Error(params.error?.message ?? 'codex turn error');
+        if (typeof params.turnId === 'string') failuresByTurn.set(params.turnId, failure);
+        else unscopedFailure = failure;
+        firstFailure ??= failure;
+        resolveAwaiting();
       }
     }
   });
 
   return {
-    awaitTurn(): Promise<CollectedTurn> {
-      if (cached !== null) return Promise.resolve(cached);
-      if (failure !== null) return Promise.reject(failure);
-      if (awaiting !== null) return awaiting;
-      awaiting = new Promise<CollectedTurn>((res, rej) => {
+    awaitTurn(turnId?: string): Promise<CollectedTurn> {
+      const expectedTurnId = turnId ?? null;
+      if (unscopedFailure !== null) {
+        closeCollector();
+        return Promise.reject(unscopedFailure);
+      }
+      if (expectedTurnId !== null) {
+        const failure = failuresByTurn.get(expectedTurnId);
+        if (failure !== undefined) {
+          closeCollector();
+          return Promise.reject(failure);
+        }
+        const completed = completedByTurn.get(expectedTurnId);
+        if (completed !== undefined) {
+          closeCollector();
+          return Promise.resolve(completed);
+        }
+      } else {
+        if (firstFailure !== null) {
+          closeCollector();
+          return Promise.reject(firstFailure);
+        }
+        if (firstCompleted !== null) {
+          closeCollector();
+          return Promise.resolve(firstCompleted);
+        }
+      }
+      if (awaiting !== null) return awaiting.promise;
+      let resolveTurn!: (turn: CollectedTurn) => void;
+      let rejectTurn!: (err: Error) => void;
+      const promise = new Promise<CollectedTurn>((res, rej) => {
         resolveTurn = res;
         rejectTurn = rej;
       });
-      return awaiting;
+      awaiting = {
+        turnId: expectedTurnId,
+        promise,
+        resolve: resolveTurn,
+        reject: rejectTurn,
+      };
+      return promise;
     },
   };
 }
@@ -212,8 +288,8 @@ export async function runTurn(
   cwd: string | null,
 ): Promise<CollectedTurn> {
   const collector = subscribeTurnCollection(client, threadId);
-  await submitTurnStart(client, threadId, prompt, cwd);
-  return collector.awaitTurn();
+  const res = await submitTurnStart(client, threadId, prompt, cwd);
+  return collector.awaitTurn(res.turn.id);
 }
 
 /**

--- a/packages/dreamux/src/agent-runtime/builtin/codex/runtime.ts
+++ b/packages/dreamux/src/agent-runtime/builtin/codex/runtime.ts
@@ -119,6 +119,8 @@ export interface CodexRuntimeDeps {
   log?: (level: 'info' | 'warn' | 'error', msg: string, err?: unknown) => void;
 }
 
+const COMPLETION_ID_CACHE_LIMIT = 256;
+
 export class CodexRuntime implements AgentRuntime {
   readonly providerRef = BUILTIN_CODEX_PROVIDER_REF;
 
@@ -136,6 +138,21 @@ export class CodexRuntime implements AgentRuntime {
   private status: DispatcherStatus = 'declared';
   /** Monotonic per-attempt suffix for TeamMate delivery turn dedup ids (#110 PR8). */
   private teammateDeliverySeq = 0;
+  /**
+   * Completion deliveries currently being processed. Duplicate settled events can
+   * race into `completionInput`; coalescing by completion id keeps one logical
+   * completion from injecting or triggering more than once concurrently.
+   */
+  private readonly inFlightCompletionDeliveries = new Map<
+    string,
+    Promise<TeamMateCompletionDeliveryResult>
+  >();
+  /**
+   * Completion ids whose trigger turn has already been accepted. A later replay
+   * of the same settled teammate turn is an idempotent success, not a new wake-up.
+   */
+  private readonly acceptedCompletionIds = new Set<string>();
+  private readonly acceptedCompletionOrder: string[] = [];
   /**
    * Completion ids whose item has already been injected into the thread. The
    * Dispatcher Service retries `completionInput` on `failed`; if the inject
@@ -449,6 +466,28 @@ export class CodexRuntime implements AgentRuntime {
   async completionInput(
     completion: CompletionEnvelope,
   ): Promise<TeamMateCompletionDeliveryResult> {
+    if (this.acceptedCompletionIds.has(completion.id)) {
+      return { status: 'accepted' };
+    }
+    const inFlight = this.inFlightCompletionDeliveries.get(completion.id);
+    if (inFlight !== undefined) return inFlight;
+
+    const delivery = this.deliverCompletionInput(completion);
+    this.inFlightCompletionDeliveries.set(completion.id, delivery);
+    try {
+      const outcome = await delivery;
+      if (outcome.status === 'accepted') {
+        this.rememberAcceptedCompletion(completion.id);
+      }
+      return outcome;
+    } finally {
+      this.inFlightCompletionDeliveries.delete(completion.id);
+    }
+  }
+
+  private async deliverCompletionInput(
+    completion: CompletionEnvelope,
+  ): Promise<TeamMateCompletionDeliveryResult> {
     if (this.client === null || this.turnManager === null || this.stopping) {
       return { status: 'unsupported', reason: 'dispatcher runtime stopped' };
     }
@@ -459,7 +498,6 @@ export class CodexRuntime implements AgentRuntime {
         error: new Error('teammate completion delivery has no thread id'),
       };
     }
-    this.teammateDeliverySeq += 1;
     // Inject the completion item at most once per completion id. On a retry
     // (trigger turn failed last time) the item is already in the thread, so we
     // skip straight to re-triggering instead of persisting a duplicate.
@@ -482,8 +520,9 @@ export class CodexRuntime implements AgentRuntime {
       }
       this.rememberInjectedCompletion(completion.id);
     }
+    const deliverySeq = ++this.teammateDeliverySeq;
     const delivery = await this.channelInput({
-      sourceId: `teammate:${completion.id}#${this.teammateDeliverySeq}`,
+      sourceId: `teammate:${completion.id}#${deliverySeq}`,
       text: CODEX_COMPLETION_TRIGGER_TEXT,
     });
     switch (delivery.status) {
@@ -662,9 +701,20 @@ export class CodexRuntime implements AgentRuntime {
     if (this.injectedCompletionIds.has(id)) return;
     this.injectedCompletionIds.add(id);
     this.injectedCompletionOrder.push(id);
-    while (this.injectedCompletionOrder.length > 256) {
+    while (this.injectedCompletionOrder.length > COMPLETION_ID_CACHE_LIMIT) {
       const evicted = this.injectedCompletionOrder.shift();
       if (evicted !== undefined) this.injectedCompletionIds.delete(evicted);
+    }
+  }
+
+  /** Record a completion id as fully accepted, evicting the oldest past a cap. */
+  private rememberAcceptedCompletion(id: string): void {
+    if (this.acceptedCompletionIds.has(id)) return;
+    this.acceptedCompletionIds.add(id);
+    this.acceptedCompletionOrder.push(id);
+    while (this.acceptedCompletionOrder.length > COMPLETION_ID_CACHE_LIMIT) {
+      const evicted = this.acceptedCompletionOrder.shift();
+      if (evicted !== undefined) this.acceptedCompletionIds.delete(evicted);
     }
   }
 

--- a/packages/dreamux/src/agent-runtime/builtin/codex/turn-manager.ts
+++ b/packages/dreamux/src/agent-runtime/builtin/codex/turn-manager.ts
@@ -61,6 +61,7 @@ export class TurnManager {
    * in-flight inbound and skip rather than wake the thread twice (issue #78).
    */
   private inboundSubmitted = false;
+  private activeTurnId: string | null = null;
   /**
    * Turn ids submitted to Codex that have not yet reached `turn/completed`. On
    * `stop()` each still-pending turn is settled as `stopped` so a teammate turn
@@ -108,6 +109,16 @@ export class TurnManager {
     }
 
     try {
+      const activeTurnId = this.activeTurnId;
+      if (activeTurnId !== null) {
+        await submitTurnStart(
+          this.opts.client,
+          threadId,
+          input.text,
+          this.opts.turnCwd ?? null,
+        );
+        return { status: 'submitted', turnId: activeTurnId };
+      }
       const collector = subscribeTurnCollection(this.opts.client, threadId);
       const res = await submitTurnStart(
         this.opts.client,
@@ -176,6 +187,7 @@ export class TurnManager {
       this.opts.onTurnSettled?.({ turnId, status: 'stopped' });
     }
     this.pendingTurnIds.clear();
+    this.activeTurnId = null;
   }
 
   /**
@@ -188,18 +200,24 @@ export class TurnManager {
    * is delivered with a status instead of hanging until teardown.
    */
   private trackTurn(turnId: string, collector: TurnCollector): void {
+    if (this.pendingTurnIds.has(turnId)) return;
     this.pendingTurnIds.add(turnId);
-    void collector.awaitTurn().then(
+    this.activeTurnId = turnId;
+    void collector.awaitTurn(turnId).then(
       (turn) => {
         // Only forward completion if this turn was still pending. If `stop()`
         // already settled it as `stopped`, the delete returns false and we drop
         // the late completion so a turn is never settled twice.
-        if (this.pendingTurnIds.delete(turnId)) this.opts.onTurnCompleted?.(turn);
+        if (this.pendingTurnIds.delete(turnId)) {
+          if (this.activeTurnId === turnId) this.activeTurnId = null;
+          this.opts.onTurnCompleted?.(turn);
+        }
       },
       (err) => {
         // Same mutual-exclusion guard as the completed path: only settle as
         // `failed` if `stop()` did not already settle it as `stopped`.
         if (this.pendingTurnIds.delete(turnId)) {
+          if (this.activeTurnId === turnId) this.activeTurnId = null;
           this.opts.onTurnSettled?.({
             turnId,
             status: 'failed',

--- a/packages/dreamux/src/agent-runtime/builtin/codex/turn-manager.ts
+++ b/packages/dreamux/src/agent-runtime/builtin/codex/turn-manager.ts
@@ -24,6 +24,17 @@ import {
   type TurnSettledSignal,
 } from '../../turn.js';
 
+interface ActiveTurnSlot {
+  collector: TurnCollector;
+  turnId: string | null;
+  candidateTurnId: string | null;
+  primaryFailed: boolean;
+  pendingSubmissions: number;
+  turnIdPromise: Promise<string>;
+  resolveTurnId: (turnId: string) => void;
+  rejectTurnId: (err: Error) => void;
+}
+
 export interface TurnManagerOptions {
   dispatcherId: string;
   /** Lazily resolved Codex thread id (set after thread/start | resume). */
@@ -61,6 +72,7 @@ export class TurnManager {
    * in-flight inbound and skip rather than wake the thread twice (issue #78).
    */
   private inboundSubmitted = false;
+  private activeTurnSlot: ActiveTurnSlot | null = null;
   private activeTurnId: string | null = null;
   /**
    * Turn ids submitted to Codex that have not yet reached `turn/completed`. On
@@ -99,42 +111,48 @@ export class TurnManager {
     // that a real inbound is in flight and skips itself.
     this.inboundSubmitted = true;
 
-    await this.notifyAccepted(input, hooks);
-
     const threadId = this.opts.getThreadId();
     if (threadId === null) {
+      await this.notifyAccepted(input, hooks);
       const error = new Error('inbound submitted without thread_id');
       this.log('error', error.message);
       return { status: 'failed', error };
     }
 
+    const activeTurn = this.claimActiveTurnSlot(threadId);
+    activeTurn.slot.pendingSubmissions += 1;
+    await this.notifyAccepted(input, hooks);
+
+    let res: Awaited<ReturnType<typeof submitTurnStart>>;
     try {
-      const activeTurnId = this.activeTurnId;
-      if (activeTurnId !== null) {
-        await submitTurnStart(
-          this.opts.client,
-          threadId,
-          input.text,
-          this.opts.turnCwd ?? null,
-        );
-        return { status: 'submitted', turnId: activeTurnId };
-      }
-      const collector = subscribeTurnCollection(this.opts.client, threadId);
-      const res = await submitTurnStart(
+      res = await submitTurnStart(
         this.opts.client,
         threadId,
         input.text,
         this.opts.turnCwd ?? null,
       );
-      this.trackTurn(res.turn.id, collector);
-      return { status: 'submitted', turnId: res.turn.id };
     } catch (err) {
       const error = err instanceof Error ? err : new Error(String(err));
+      this.recordTurnStartFailure(activeTurn.slot, error, activeTurn.primary);
       this.log(
         'error',
         `turn/start submission failed for message ${input.sourceId === '' ? '<none>' : input.sourceId}: ${error.message}`,
         error,
       );
+      return { status: 'failed', error };
+    }
+    const turnId = this.recordTurnStartSuccess(
+      activeTurn.slot,
+      res.turn.id,
+      activeTurn.primary,
+    );
+    try {
+      return {
+        status: 'submitted',
+        turnId: turnId ?? await activeTurn.slot.turnIdPromise,
+      };
+    } catch (err) {
+      const error = err instanceof Error ? err : new Error(String(err));
       return { status: 'failed', error };
     }
   }
@@ -180,6 +198,11 @@ export class TurnManager {
 
   async stop(): Promise<void> {
     this.stopped = true;
+    const activeSlot = this.activeTurnSlot;
+    this.activeTurnSlot = null;
+    if (activeSlot !== null && activeSlot.turnId === null) {
+      activeSlot.rejectTurnId(new Error('codex turn stopped before acceptance'));
+    }
     // Any turn still in flight at teardown will never reach `turn/completed`
     // (the WS is closing). Settle each as `stopped` so an interrupted teammate
     // turn is delivered with a status rather than vanishing.
@@ -188,6 +211,81 @@ export class TurnManager {
     }
     this.pendingTurnIds.clear();
     this.activeTurnId = null;
+  }
+
+  private claimActiveTurnSlot(threadId: string): {
+    slot: ActiveTurnSlot;
+    primary: boolean;
+  } {
+    const active = this.activeTurnSlot;
+    if (active !== null) return { slot: active, primary: false };
+
+    let resolveTurnId!: (turnId: string) => void;
+    let rejectTurnId!: (err: Error) => void;
+    const turnIdPromise = new Promise<string>((resolve, reject) => {
+      resolveTurnId = resolve;
+      rejectTurnId = reject;
+    });
+    // The primary submitter returns its own failure directly. The shared promise
+    // only exists for concurrent followers waiting for that primary turn id, so
+    // reject it without producing an unhandled rejection when there are none.
+    turnIdPromise.catch(() => undefined);
+    const slot: ActiveTurnSlot = {
+      collector: subscribeTurnCollection(this.opts.client, threadId),
+      turnId: null,
+      candidateTurnId: null,
+      primaryFailed: false,
+      pendingSubmissions: 0,
+      turnIdPromise,
+      resolveTurnId,
+      rejectTurnId,
+    };
+    this.activeTurnSlot = slot;
+    return { slot, primary: true };
+  }
+
+  private recordTurnStartSuccess(
+    slot: ActiveTurnSlot,
+    turnId: string,
+    primary: boolean,
+  ): string | null {
+    slot.pendingSubmissions = Math.max(0, slot.pendingSubmissions - 1);
+    if (slot.turnId !== null) return slot.turnId;
+    if (this.stopped) {
+      slot.rejectTurnId(new Error('codex turn stopped before acceptance'));
+      return null;
+    }
+    if (primary || slot.primaryFailed) {
+      this.activateTurnSlot(slot, turnId);
+      return turnId;
+    }
+    slot.candidateTurnId ??= turnId;
+    return null;
+  }
+
+  private recordTurnStartFailure(
+    slot: ActiveTurnSlot,
+    error: Error,
+    primary: boolean,
+  ): void {
+    slot.pendingSubmissions = Math.max(0, slot.pendingSubmissions - 1);
+    if (slot.turnId !== null) return;
+    if (primary) slot.primaryFailed = true;
+    if (slot.primaryFailed && slot.candidateTurnId !== null) {
+      this.activateTurnSlot(slot, slot.candidateTurnId);
+      return;
+    }
+    if (slot.primaryFailed && slot.pendingSubmissions === 0) {
+      if (this.activeTurnSlot === slot) this.activeTurnSlot = null;
+      slot.rejectTurnId(error);
+    }
+  }
+
+  private activateTurnSlot(slot: ActiveTurnSlot, turnId: string): void {
+    if (slot.turnId !== null) return;
+    slot.turnId = turnId;
+    this.trackTurn(turnId, slot.collector, slot);
+    slot.resolveTurnId(turnId);
   }
 
   /**
@@ -199,7 +297,11 @@ export class TurnManager {
    * settled as `failed` here, so a teammate turn that errors at the model level
    * is delivered with a status instead of hanging until teardown.
    */
-  private trackTurn(turnId: string, collector: TurnCollector): void {
+  private trackTurn(
+    turnId: string,
+    collector: TurnCollector,
+    slot?: ActiveTurnSlot,
+  ): void {
     if (this.pendingTurnIds.has(turnId)) return;
     this.pendingTurnIds.add(turnId);
     this.activeTurnId = turnId;
@@ -209,6 +311,7 @@ export class TurnManager {
         // already settled it as `stopped`, the delete returns false and we drop
         // the late completion so a turn is never settled twice.
         if (this.pendingTurnIds.delete(turnId)) {
+          if (this.activeTurnSlot === slot) this.activeTurnSlot = null;
           if (this.activeTurnId === turnId) this.activeTurnId = null;
           this.opts.onTurnCompleted?.(turn);
         }
@@ -217,6 +320,7 @@ export class TurnManager {
         // Same mutual-exclusion guard as the completed path: only settle as
         // `failed` if `stop()` did not already settle it as `stopped`.
         if (this.pendingTurnIds.delete(turnId)) {
+          if (this.activeTurnSlot === slot) this.activeTurnSlot = null;
           if (this.activeTurnId === turnId) this.activeTurnId = null;
           this.opts.onTurnSettled?.({
             turnId,

--- a/packages/dreamux/src/dispatcher-service/dispatcher/service.ts
+++ b/packages/dreamux/src/dispatcher-service/dispatcher/service.ts
@@ -68,6 +68,8 @@ export interface FeishuChannelToolCall {
   arguments: unknown;
 }
 
+const COMPLETION_DELIVERY_CACHE_LIMIT = 512;
+
 /**
  * Owns live dispatcher agents and their built-in Feishu channel sessions.
  *
@@ -78,6 +80,9 @@ export interface FeishuChannelToolCall {
 export class DispatcherAgentService {
   private readonly slots = new Map<string, DispatcherAgentSlot>();
   private readonly starting = new Map<string, Promise<void>>();
+  private readonly inFlightCompletionDeliveries = new Map<string, Promise<void>>();
+  private readonly deliveredCompletionIds = new Set<string>();
+  private readonly deliveredCompletionOrder: string[] = [];
   private restartIntent: RestartIntentConsumer | null = null;
 
   constructor(private readonly opts: DispatcherAgentServiceOptions) {}
@@ -135,6 +140,25 @@ export class DispatcherAgentService {
     dispatcherId: string,
     completion: CompletionEnvelope,
   ): Promise<void> {
+    const completionKey = completionDeliveryKey(dispatcherId, completion.id);
+    if (this.deliveredCompletionIds.has(completionKey)) return;
+    const inFlight = this.inFlightCompletionDeliveries.get(completionKey);
+    if (inFlight !== undefined) return inFlight;
+
+    const delivery = this.doDeliverCompletion(dispatcherId, completion, completionKey);
+    this.inFlightCompletionDeliveries.set(completionKey, delivery);
+    try {
+      await delivery;
+    } finally {
+      this.inFlightCompletionDeliveries.delete(completionKey);
+    }
+  }
+
+  private async doDeliverCompletion(
+    dispatcherId: string,
+    completion: CompletionEnvelope,
+    completionKey: string,
+  ): Promise<void> {
     const slot = this.slots.get(dispatcherId);
     if (slot === undefined) {
       this.opts.log.warn(
@@ -163,7 +187,10 @@ export class DispatcherAgentService {
         );
         return;
       }
-      if (outcome.status === 'accepted') return;
+      if (outcome.status === 'accepted') {
+        this.rememberDeliveredCompletion(completionKey);
+        return;
+      }
       if (outcome.status === 'unsupported') {
         slot.log.warn(
           { dispatcher_id: dispatcherId, source: completion.source, reason: outcome.reason },
@@ -357,6 +384,20 @@ export class DispatcherAgentService {
     }
     return slot;
   }
+
+  private rememberDeliveredCompletion(key: string): void {
+    if (this.deliveredCompletionIds.has(key)) return;
+    this.deliveredCompletionIds.add(key);
+    this.deliveredCompletionOrder.push(key);
+    while (this.deliveredCompletionOrder.length > COMPLETION_DELIVERY_CACHE_LIMIT) {
+      const evicted = this.deliveredCompletionOrder.shift();
+      if (evicted !== undefined) this.deliveredCompletionIds.delete(evicted);
+    }
+  }
+}
+
+function completionDeliveryKey(dispatcherId: string, completionId: string): string {
+  return JSON.stringify([dispatcherId, completionId]);
 }
 
 function errInfo(err: unknown): { message: string; stack?: string } {

--- a/packages/dreamux/src/dispatcher-service/teammate/service.ts
+++ b/packages/dreamux/src/dispatcher-service/teammate/service.ts
@@ -76,6 +76,7 @@ export interface TeamMateAgentServiceOptions {
 export class TeamMateAgentService {
   private readonly identities: TeamMateIdentityStore;
   private readonly live = new Map<string, LiveTeamMate>();
+  private submissionSeq = 0;
 
   constructor(private readonly opts: TeamMateAgentServiceOptions) {
     this.identities = new TeamMateIdentityStore({
@@ -368,8 +369,9 @@ export class TeamMateAgentService {
     prompt: string,
   ): Promise<TeamMateTurnResult> {
     const live = await this.ensureRuntime(dispatcherId, name);
+    const submissionSeq = ++this.submissionSeq;
     const result = await live.runtime.channelInput({
-      sourceId: `teammate:${name}:${Date.now()}`,
+      sourceId: `teammate:${name}:${submissionSeq}`,
       text: prompt,
     });
     return toTurnResult(result);

--- a/packages/dreamux/src/dispatcher-service/teammate/service.ts
+++ b/packages/dreamux/src/dispatcher-service/teammate/service.ts
@@ -380,9 +380,12 @@ export class TeamMateAgentService {
    * turn into a {@link CompletionEnvelope} and hand it to the sink. Reads the
    * teammate's final assistant-visible result via `getLast`. A `stopped` turn
    * maps to envelope status `failed` (the envelope carries only completed/failed)
-   * so a torn-down teammate still surfaces, never silently vanishing. Every step
-   * is error-isolated: this runs `void`-ed off the synchronous settle callback,
-   * so any escape would become an unhandled rejection.
+   * so a torn-down teammate still surfaces, never silently vanishing. Reverse
+   * delivery requires a stable non-null turn id because the completion id is the
+   * idempotency key; builtin runtimes only settle accepted turns after they have
+   * a turn id. Every step is error-isolated: this runs `void`-ed off the
+   * synchronous settle callback, so any escape would become an unhandled
+   * rejection.
    */
   private async deliverTurnSettled(
     dispatcherId: string,
@@ -392,6 +395,17 @@ export class TeamMateAgentService {
     sink: NonNullable<TeamMateAgentServiceOptions['onTeamMateCompletion']>,
   ): Promise<void> {
     try {
+      if (settled.turnId === null) {
+        this.opts.log.warn(
+          {
+            dispatcher_id: dispatcherId,
+            teammate: name,
+            status: settled.status,
+          },
+          'dropping teammate completion: settled turn has no turn id',
+        );
+        return;
+      }
       let result = '';
       try {
         const last = await runtime.getLast();
@@ -404,7 +418,7 @@ export class TeamMateAgentService {
       }
       const envelope: CompletionEnvelope = {
         source: name,
-        id: settled.turnId !== null ? `${name}:${settled.turnId}` : name,
+        id: `${name}:${settled.turnId}`,
         status: settled.status === 'completed' ? 'completed' : 'failed',
         result,
       };

--- a/packages/dreamux/tests/claude-code-rpc.test.ts
+++ b/packages/dreamux/tests/claude-code-rpc.test.ts
@@ -35,11 +35,11 @@ function assistantLine(text: string): string {
   })}\n`;
 }
 
-function resultLine(): string {
+function resultLine(text = 'final'): string {
   return `${JSON.stringify({
     type: 'result',
     subtype: 'success',
-    result: 'final',
+    result: text,
     session_id: 's1',
   })}\n`;
 }
@@ -118,3 +118,60 @@ describe('ClaudeCodeStreamRpc idle deadline (issue #156)', () => {
     expect(reap).toHaveBeenCalledTimes(1);
   });
 });
+
+describe('ClaudeCodeStreamRpc active steering', () => {
+  it('writes a stream-json user envelope while a turn is pending', async () => {
+    const stdin = new FakeStdin();
+    const rpc = new ClaudeCodeStreamRpc(stdin as unknown as Writable, {
+      turnTimeoutMs: 5_000,
+      reapOnTimeout: () => undefined,
+    });
+
+    const turn = rpc.submitTurn('first');
+    await rpc.steerTurn('second', { priority: 'next' });
+
+    expect(stdin.writes).toHaveLength(2);
+    expect(JSON.parse(stdin.writes[1] ?? '{}')).toEqual({
+      type: 'user',
+      message: {
+        role: 'user',
+        content: [{ type: 'text', text: 'second' }],
+      },
+      priority: 'next',
+    });
+
+    rpc.onStdoutChunk(resultLine('done'));
+    await flushImmediate();
+    await expect(turn).resolves.toMatchObject({ text: 'done', isError: false });
+  });
+
+  it('folds an immediate follow-up result from a steer into the pending turn', async () => {
+    const stdin = new FakeStdin();
+    const rpc = new ClaudeCodeStreamRpc(stdin as unknown as Writable, {
+      turnTimeoutMs: 5_000,
+      reapOnTimeout: () => undefined,
+    });
+
+    const turn = rpc.submitTurn('first');
+    await rpc.steerTurn('second', { priority: 'next' });
+
+    rpc.onStdoutChunk(
+      [
+        assistantLine('original answer'),
+        resultLine('original result'),
+        assistantLine('steered answer'),
+        resultLine('steered result'),
+      ].join(''),
+    );
+    await flushImmediate();
+
+    await expect(turn).resolves.toMatchObject({
+      text: 'steered result',
+      isError: false,
+    });
+  });
+});
+
+async function flushImmediate(): Promise<void> {
+  await new Promise<void>((resolve) => setImmediate(resolve));
+}

--- a/packages/dreamux/tests/claude-code-runtime.test.ts
+++ b/packages/dreamux/tests/claude-code-runtime.test.ts
@@ -127,6 +127,10 @@ function fakeFleet(
         if (outcome instanceof Error) throw outcome;
         return outcome as TurnOutcome;
       },
+      async steerTurn(prompt, options) {
+        prompts.push(prompt);
+        submitOptions.push(options);
+      },
       async stop() {
         alive = false;
       },
@@ -139,6 +143,71 @@ function fakeFleet(
     return session;
   };
   return { factory, sessions };
+}
+
+function controllableFleet(): FakeFleet & {
+  resolveNext(outcome?: TurnOutcome): void;
+  rejectNext(error: Error): void;
+} {
+  const sessions: FakeSession[] = [];
+  let pendingResolve: ((outcome: TurnOutcome) => void) | null = null;
+  let pendingReject: ((error: Error) => void) | null = null;
+  const factory: ClaudeCodeSessionFactory = (spec) => {
+    let alive = false;
+    let starts = 0;
+    let onExit: (() => void) | null = null;
+    const prompts: string[] = [];
+    const submitOptions: Array<TurnSubmitOptions | undefined> = [];
+    const session: FakeSession = {
+      spec,
+      prompts,
+      submitOptions,
+      startCount: () => starts,
+      async start() {
+        starts += 1;
+        alive = true;
+      },
+      isAlive: () => alive,
+      setOnExit(handler) {
+        onExit = handler;
+      },
+      async submitTurn(prompt, options) {
+        prompts.push(prompt);
+        submitOptions.push(options);
+        return new Promise<TurnOutcome>((resolve, reject) => {
+          pendingResolve = resolve;
+          pendingReject = reject;
+        });
+      },
+      async steerTurn(prompt, options) {
+        prompts.push(prompt);
+        submitOptions.push(options);
+      },
+      async stop() {
+        alive = false;
+      },
+      triggerExit() {
+        alive = false;
+        onExit?.();
+      },
+    };
+    sessions.push(session);
+    return session;
+  };
+  return {
+    factory,
+    sessions,
+    resolveNext(outcome = okOutcome()) {
+      pendingResolve?.(outcome);
+      pendingResolve = null;
+      pendingReject = null;
+    },
+    rejectNext(error: Error) {
+      pendingReject?.(error);
+      pendingResolve = null;
+      pendingReject = null;
+    },
+  };
 }
 
 async function waitFor(predicate: () => boolean, timeoutMs = 2000): Promise<void> {
@@ -399,6 +468,96 @@ describe('ClaudeCodeRuntime resident lifecycle (fake session)', () => {
     expect(fleet.sessions[0]?.prompts).toHaveLength(1);
   });
 
+  it('steers follow-up sends into the active channel turn and settles once', async () => {
+    const settled: TurnSettledSignal[] = [];
+    const fleet = controllableFleet();
+    const { runtime } = makeRuntime(fleet, {
+      onTurnSettled: (s) => settled.push(s),
+    });
+    await runtime.start();
+
+    const first = await runtime.channelInput({ sourceId: 'm1', text: 'first' });
+    expect(first.status).toBe('submitted');
+    await waitFor(() => fleet.sessions[0]?.prompts.length === 1);
+
+    const second = await runtime.channelInput({ sourceId: 'm2', text: 'second' });
+    const third = await runtime.channelInput({ sourceId: 'm3', text: 'third' });
+    expect(second).toEqual(first);
+    expect(third).toEqual(first);
+    expect(fleet.sessions[0]?.prompts).toEqual(['first', 'second', 'third']);
+    expect(fleet.sessions[0]?.submitOptions).toEqual([
+      undefined,
+      { priority: 'now' },
+      { priority: 'now' },
+    ]);
+
+    fleet.resolveNext(okOutcome('session-abc'));
+    await waitFor(() => settled.length === 1);
+    expect(settled).toEqual([
+      {
+        turnId: first.status === 'submitted' ? first.turnId : 'unreachable',
+        status: 'completed',
+      },
+    ]);
+  });
+
+  it('starts a fresh logical turn for a sequential send after the previous turn completed', async () => {
+    const settled: TurnSettledSignal[] = [];
+    const fleet = fakeFleet([okOutcome('session-abc'), okOutcome('session-abc')]);
+    const { runtime } = makeRuntime(fleet, {
+      onTurnSettled: (s) => settled.push(s),
+    });
+    await runtime.start();
+
+    const first = await runtime.channelInput({ sourceId: 'm1', text: 'first' });
+    await waitFor(() => settled.length === 1);
+    const second = await runtime.channelInput({ sourceId: 'm2', text: 'second' });
+    await waitFor(() => settled.length === 2);
+
+    expect(first.status).toBe('submitted');
+    expect(second.status).toBe('submitted');
+    if (first.status !== 'submitted' || second.status !== 'submitted') {
+      throw new Error('expected submitted turns');
+    }
+    expect(first.turnId).not.toBe(second.turnId);
+    expect(settled.map((s) => s.turnId)).toEqual([
+      first.turnId,
+      second.turnId,
+    ]);
+  });
+
+  it('does not reuse logical turn ids across resumed runtime instances', async () => {
+    const firstSettled: TurnSettledSignal[] = [];
+    const firstRuntime = makeRuntime(fakeFleet([okOutcome('session-abc')]), {
+      onTurnSettled: (s) => firstSettled.push(s),
+    });
+    await firstRuntime.runtime.start();
+    const first = await firstRuntime.runtime.channelInput({
+      sourceId: 'm1',
+      text: 'first',
+    });
+    await waitFor(() => firstSettled.length === 1);
+
+    const secondSettled: TurnSettledSignal[] = [];
+    const secondRuntime = makeRuntime(fakeFleet([okOutcome('session-abc')]), {
+      resumeSession: 'session-abc',
+      onTurnSettled: (s) => secondSettled.push(s),
+    });
+    await secondRuntime.runtime.start();
+    const second = await secondRuntime.runtime.channelInput({
+      sourceId: 'm2',
+      text: 'second',
+    });
+    await waitFor(() => secondSettled.length === 1);
+
+    expect(first.status).toBe('submitted');
+    expect(second.status).toBe('submitted');
+    if (first.status !== 'submitted' || second.status !== 'submitted') {
+      throw new Error('expected submitted turns');
+    }
+    expect(first.turnId).not.toBe(second.turnId);
+  });
+
   it('delivers a TeamMate completion via the task-notification entry', async () => {
     const fleet = fakeFleet([okOutcome('session-abc')]);
     const { runtime } = makeRuntime(fleet);
@@ -657,6 +816,9 @@ describe('ClaudeCodeRuntime resident lifecycle (fake session)', () => {
             releaseTurn = () =>
               reject(new Error('claude resident session stopped mid-turn'));
           });
+        },
+        async steerTurn() {
+          /* no-op: the turn is blocked until stop() */
         },
         async stop() {
           alive = false;

--- a/packages/dreamux/tests/claude-code-runtime.test.ts
+++ b/packages/dreamux/tests/claude-code-runtime.test.ts
@@ -487,8 +487,8 @@ describe('ClaudeCodeRuntime resident lifecycle (fake session)', () => {
     expect(fleet.sessions[0]?.prompts).toEqual(['first', 'second', 'third']);
     expect(fleet.sessions[0]?.submitOptions).toEqual([
       undefined,
-      { priority: 'now' },
-      { priority: 'now' },
+      { priority: 'next' },
+      { priority: 'next' },
     ]);
 
     fleet.resolveNext(okOutcome('session-abc'));

--- a/packages/dreamux/tests/codex-completion.test.ts
+++ b/packages/dreamux/tests/codex-completion.test.ts
@@ -154,6 +154,51 @@ describe('codex teammate completion delivery (native inject + trigger)', () => {
     expect(fake.injectItemsParams).toHaveLength(1);
   });
 
+  it('coalesces concurrent duplicate completions before inject and trigger', async () => {
+    const fake = await startFakeCodex();
+    fakes.push(fake);
+    const runtime = await makeRuntime(fake);
+    const completion = {
+      source: 'teammate',
+      id: 'mate-concurrent',
+      status: 'completed' as const,
+      result: 'done once',
+    };
+
+    await expect(
+      Promise.all([
+        runtime.completionInput!(completion),
+        runtime.completionInput!(completion),
+      ]),
+    ).resolves.toEqual([{ status: 'accepted' }, { status: 'accepted' }]);
+
+    expect(fake.injectItemsParams).toHaveLength(1);
+    expect(fake.methodLog.filter((method) => method === 'turn/start')).toHaveLength(1);
+    expect(fake.turnsHandled).toBe(1);
+  });
+
+  it('treats already accepted completion ids as delivered', async () => {
+    const fake = await startFakeCodex();
+    fakes.push(fake);
+    const runtime = await makeRuntime(fake);
+    const completion = {
+      source: 'teammate',
+      id: 'mate-accepted',
+      status: 'completed' as const,
+      result: 'done once',
+    };
+
+    await expect(runtime.completionInput!(completion)).resolves.toEqual({
+      status: 'accepted',
+    });
+    await expect(runtime.completionInput!(completion)).resolves.toEqual({
+      status: 'accepted',
+    });
+
+    expect(fake.injectItemsParams).toHaveLength(1);
+    expect(fake.methodLog.filter((method) => method === 'turn/start')).toHaveLength(1);
+  });
+
   it('reports unsupported once the runtime is stopped', async () => {
     const fake = await startFakeCodex();
     fakes.push(fake);

--- a/packages/dreamux/tests/codex-completion.test.ts
+++ b/packages/dreamux/tests/codex-completion.test.ts
@@ -154,6 +154,31 @@ describe('codex teammate completion delivery (native inject + trigger)', () => {
     expect(fake.injectItemsParams).toHaveLength(1);
   });
 
+  it('retries a previously failed completion call without accepted-cache suppression', async () => {
+    const fake = await startFakeCodex({ failTurnStartAttempts: 1 });
+    fakes.push(fake);
+    const runtime = await makeRuntime(fake);
+    const completion = {
+      source: 'teammate',
+      id: 'mate-retry-then-accept',
+      status: 'completed' as const,
+      result: 'done after retry',
+    };
+
+    await expect(runtime.completionInput!(completion)).resolves.toMatchObject({
+      status: 'failed',
+    });
+    await expect(runtime.completionInput!(completion)).resolves.toEqual({
+      status: 'accepted',
+    });
+    await expect(runtime.completionInput!(completion)).resolves.toEqual({
+      status: 'accepted',
+    });
+
+    expect(fake.injectItemsParams).toHaveLength(1);
+    expect(fake.methodLog.filter((method) => method === 'turn/start')).toHaveLength(2);
+  });
+
   it('coalesces concurrent duplicate completions before inject and trigger', async () => {
     const fake = await startFakeCodex();
     fakes.push(fake);

--- a/packages/dreamux/tests/fake-codex.ts
+++ b/packages/dreamux/tests/fake-codex.ts
@@ -24,6 +24,8 @@ export interface FakeCodexOptions {
   failResume?: boolean;
   /** Force turn/start to throw. */
   failTurnStart?: boolean;
+  /** Force the first N turn/start requests to throw. */
+  failTurnStartAttempts?: number;
   /** Force codex to issue a server-request that the dispatcher must reject. */
   triggerApprovalOnTurn?: boolean;
   /** Delay between turn/start ack and the eventual turn/completed (ms). */
@@ -74,6 +76,8 @@ export async function startFakeCodex(opts: FakeCodexOptions = {}): Promise<FakeC
   let turnsCompleted = 0;
   let nextSrvReqId = 100;
   let initializedAt: number | null = null;
+  let remainingTurnStartFailures =
+    opts.failTurnStartAttempts ?? (opts.failTurnStart === true ? Infinity : 0);
   const methodLog: string[] = [];
   const threadStartParams: Array<Record<string, unknown>> = [];
   const threadResumeParams: Array<Record<string, unknown>> = [];
@@ -169,7 +173,8 @@ export async function startFakeCodex(opts: FakeCodexOptions = {}): Promise<FakeC
       return;
     }
     if (method === 'turn/start') {
-      if (opts.failTurnStart === true) {
+      if (remainingTurnStartFailures > 0) {
+        remainingTurnStartFailures -= 1;
         send(ws, {
           id,
           error: { code: -32000, message: 'fake codex: turn/start refused' },

--- a/packages/dreamux/tests/teammate-agent-service.test.ts
+++ b/packages/dreamux/tests/teammate-agent-service.test.ts
@@ -612,7 +612,7 @@ describe('TeamMateAgentService', () => {
     });
 
     provider.runtimes[0]?.settle('failed', 'turn-7');
-    provider.runtimes[0]?.settle('stopped', null);
+    provider.runtimes[0]?.settle('stopped', 'turn-8');
     await flush();
 
     expect(received).toEqual([
@@ -624,11 +624,38 @@ describe('TeamMateAgentService', () => {
       },
       {
         source: 'breaker',
-        id: 'breaker',
+        id: 'breaker:turn-8',
         status: 'failed',
         result: 'last fake result',
       },
     ]);
+  });
+
+  it('drops null-turn settlements rather than fabricating a completion id', async () => {
+    const { catalog, provider } = providerCatalog();
+    const config = testDreamuxConfig();
+    const received: CompletionEnvelope[] = [];
+    const service = new TeamMateAgentService({
+      config,
+      dispatchers: new DispatcherStore(config),
+      agentRuntimeProviders: catalog,
+      onTeamMateCompletion: (_id, env) => {
+        received.push(env);
+      },
+      log: noopLog(),
+    });
+
+    await service.spawn({
+      dispatcherId: 'flow',
+      name: 'breaker',
+      prompt: 'Run.',
+      cwd: root,
+    });
+
+    provider.runtimes[0]?.settle('stopped', null);
+    await flush();
+
+    expect(received).toEqual([]);
   });
 
   it('delivers concurrent teammate completions without dropping any', async () => {

--- a/packages/dreamux/tests/teammate-completion-delivery.test.ts
+++ b/packages/dreamux/tests/teammate-completion-delivery.test.ts
@@ -202,6 +202,33 @@ describe('DispatcherAgentService.deliverCompletion (Seam ③)', () => {
     await service.shutdown();
   });
 
+  it('retries a completion id on a later call after an exhausted failed call', async () => {
+    const behavior: DeliveryBehavior = {
+      results: [
+        { status: 'failed', error: new Error('boom 1') },
+        { status: 'failed', error: new Error('boom 2') },
+        { status: 'failed', error: new Error('boom 3') },
+        { status: 'accepted' },
+      ],
+      calls: 0,
+      omitCompletionInput: false,
+    };
+    const service = buildService(behavior, adminSocketPath);
+    await service.startDispatcher('flow');
+    const completion = envelope();
+
+    await service.deliverCompletion('flow', completion);
+    expect(behavior.calls).toBe(3);
+
+    await service.deliverCompletion('flow', completion);
+    expect(behavior.calls).toBe(4);
+
+    await service.deliverCompletion('flow', completion);
+    expect(behavior.calls).toBe(4);
+
+    await service.shutdown();
+  });
+
   it('stops after exhausting retries without throwing', async () => {
     const behavior: DeliveryBehavior = {
       results: [

--- a/packages/dreamux/tests/teammate-completion-delivery.test.ts
+++ b/packages/dreamux/tests/teammate-completion-delivery.test.ts
@@ -164,6 +164,44 @@ describe('DispatcherAgentService.deliverCompletion (Seam ③)', () => {
     await service.shutdown();
   });
 
+  it('coalesces duplicate completion delivery calls while one is in flight', async () => {
+    const behavior: DeliveryBehavior = {
+      results: [{ status: 'accepted' }],
+      calls: 0,
+      omitCompletionInput: false,
+    };
+    const service = buildService(behavior, adminSocketPath);
+    await service.startDispatcher('flow');
+    const completion = envelope();
+
+    await expect(
+      Promise.all([
+        service.deliverCompletion('flow', completion),
+        service.deliverCompletion('flow', completion),
+      ]),
+    ).resolves.toEqual([undefined, undefined]);
+    expect(behavior.calls).toBe(1);
+
+    await service.shutdown();
+  });
+
+  it('does not redeliver a completion id after acceptance', async () => {
+    const behavior: DeliveryBehavior = {
+      results: [{ status: 'accepted' }, { status: 'accepted' }],
+      calls: 0,
+      omitCompletionInput: false,
+    };
+    const service = buildService(behavior, adminSocketPath);
+    await service.startDispatcher('flow');
+    const completion = envelope();
+
+    await service.deliverCompletion('flow', completion);
+    await service.deliverCompletion('flow', completion);
+    expect(behavior.calls).toBe(1);
+
+    await service.shutdown();
+  });
+
   it('stops after exhausting retries without throwing', async () => {
     const behavior: DeliveryBehavior = {
       results: [

--- a/packages/dreamux/tests/teammate-completion-e2e.test.ts
+++ b/packages/dreamux/tests/teammate-completion-e2e.test.ts
@@ -267,7 +267,7 @@ describe('reverse delivery end-to-end (Seam ①→②→③ through the facade)'
     const teammateRuntime = provider.runtimes[1]!;
 
     teammateRuntime.settle('failed', 'turn-3');
-    teammateRuntime.settle('stopped', null);
+    teammateRuntime.settle('stopped', 'turn-4');
     await flush();
 
     expect(dispatcherRuntime.delivered).toEqual([
@@ -279,7 +279,7 @@ describe('reverse delivery end-to-end (Seam ①→②→③ through the facade)'
       },
       {
         source: 'breaker',
-        id: 'breaker',
+        id: 'breaker:turn-4',
         status: 'failed',
         result: 'reviewer final answer',
       },

--- a/packages/dreamux/tests/teammate-completion-e2e.test.ts
+++ b/packages/dreamux/tests/teammate-completion-e2e.test.ts
@@ -216,6 +216,40 @@ describe('reverse delivery end-to-end (Seam ①→②→③ through the facade)'
     await facade.shutdown();
   });
 
+  it('coalesces duplicate settled events for the same teammate turn', async () => {
+    const descriptor = createBuiltinProviderRegistry().resolve('builtin:codex');
+    const provider = new FakeProvider(descriptor);
+    const facade = buildFacade(provider, adminSocketPath);
+
+    await facade.startDispatcher('flow');
+    await facade.spawnTeamMate({
+      dispatcherId: 'flow',
+      name: 'reviewer',
+      prompt: 'Review the change.',
+      cwd: root,
+    });
+
+    const dispatcherRuntime = provider.runtimes[0]!;
+    const teammateRuntime = provider.runtimes[1]!;
+
+    teammateRuntime.settle('completed', 'turn-duplicate');
+    teammateRuntime.settle('completed', 'turn-duplicate');
+    await flush();
+    teammateRuntime.settle('completed', 'turn-duplicate');
+    await flush();
+
+    expect(dispatcherRuntime.delivered).toEqual([
+      {
+        source: 'reviewer',
+        id: 'reviewer:turn-duplicate',
+        status: 'completed',
+        result: 'reviewer final answer',
+      },
+    ]);
+
+    await facade.shutdown();
+  });
+
   it('delivers a terminal failure/stop settlement to completionInput (not dropped)', async () => {
     const descriptor = createBuiltinProviderRegistry().resolve('builtin:codex');
     const provider = new FakeProvider(descriptor);

--- a/packages/dreamux/tests/teammate-completion-e2e.test.ts
+++ b/packages/dreamux/tests/teammate-completion-e2e.test.ts
@@ -50,9 +50,13 @@ class FakeRuntime implements AgentRuntime {
   private threadId: string | null = null;
   private resumed = false;
   private turns = 0;
+  private activeTurnId: string | null = null;
   readonly delivered: CompletionEnvelope[] = [];
 
-  constructor(private readonly context: AgentRuntimeCreateContext) {}
+  constructor(
+    private readonly context: AgentRuntimeCreateContext,
+    private readonly instanceId: number,
+  ) {}
 
   async start(): Promise<void> {
     this.status = 'ready';
@@ -74,8 +78,12 @@ class FakeRuntime implements AgentRuntime {
   }
 
   async channelInput(_input: InboundTurnInput): Promise<AgentRuntimeTurnResult> {
+    if (this.activeTurnId !== null) {
+      return { status: 'submitted', turnId: this.activeTurnId };
+    }
     this.turns += 1;
-    return { status: 'submitted', turnId: `turn-${this.turns}` };
+    this.activeTurnId = `runtime-${this.instanceId}-turn-${this.turns}`;
+    return { status: 'submitted', turnId: this.activeTurnId };
   }
 
   async systemInput(_notice: AgentRuntimeSystemInput): Promise<AgentRuntimeTurnResult> {
@@ -120,6 +128,7 @@ class FakeRuntime implements AgentRuntime {
 
   /** Simulate the runtime firing a terminal turn-settled signal. */
   settle(status: TurnSettledSignal['status'], turnId: string | null): void {
+    if (turnId !== null && this.activeTurnId === turnId) this.activeTurnId = null;
     this.context.onTurnSettled?.({ turnId, status });
   }
 }
@@ -135,7 +144,7 @@ class FakeProvider implements AgentRuntimeProvider {
   }
 
   createRuntime(context: AgentRuntimeCreateContext): AgentRuntime {
-    const runtime = new FakeRuntime(context);
+    const runtime = new FakeRuntime(context, this.runtimes.length + 1);
     this.runtimes.push(runtime);
     return runtime;
   }
@@ -187,7 +196,7 @@ describe('reverse delivery end-to-end (Seam ①→②→③ through the facade)'
     const facade = buildFacade(provider, adminSocketPath);
 
     await facade.startDispatcher('flow');
-    await facade.spawnTeamMate({
+    const spawned = await facade.spawnTeamMate({
       dispatcherId: 'flow',
       name: 'reviewer',
       prompt: 'Review the change.',
@@ -201,13 +210,16 @@ describe('reverse delivery end-to-end (Seam ①→②→③ through the facade)'
     expect(dispatcherRuntime.hasSettleHook()).toBe(false);
     expect(teammateRuntime.hasSettleHook()).toBe(true);
 
-    teammateRuntime.settle('completed', 'turn-1');
+    expect(spawned.turn.status).toBe('submitted');
+    const turnId =
+      spawned.turn.status === 'submitted' ? spawned.turn.turn_id : 'unreachable';
+    teammateRuntime.settle('completed', turnId);
     await flush();
 
     expect(dispatcherRuntime.delivered).toEqual([
       {
         source: 'reviewer',
-        id: 'reviewer:turn-1',
+        id: `reviewer:${turnId}`,
         status: 'completed',
         result: 'reviewer final answer',
       },
@@ -222,7 +234,7 @@ describe('reverse delivery end-to-end (Seam ①→②→③ through the facade)'
     const facade = buildFacade(provider, adminSocketPath);
 
     await facade.startDispatcher('flow');
-    await facade.spawnTeamMate({
+    const spawned = await facade.spawnTeamMate({
       dispatcherId: 'flow',
       name: 'reviewer',
       prompt: 'Review the change.',
@@ -232,16 +244,130 @@ describe('reverse delivery end-to-end (Seam ①→②→③ through the facade)'
     const dispatcherRuntime = provider.runtimes[0]!;
     const teammateRuntime = provider.runtimes[1]!;
 
-    teammateRuntime.settle('completed', 'turn-duplicate');
-    teammateRuntime.settle('completed', 'turn-duplicate');
+    const turnId =
+      spawned.turn.status === 'submitted' ? spawned.turn.turn_id : 'unreachable';
+    teammateRuntime.settle('completed', turnId);
+    teammateRuntime.settle('completed', turnId);
     await flush();
-    teammateRuntime.settle('completed', 'turn-duplicate');
+    teammateRuntime.settle('completed', turnId);
     await flush();
 
     expect(dispatcherRuntime.delivered).toEqual([
       {
         source: 'reviewer',
-        id: 'reviewer:turn-duplicate',
+        id: `reviewer:${turnId}`,
+        status: 'completed',
+        result: 'reviewer final answer',
+      },
+    ]);
+
+    await facade.shutdown();
+  });
+
+  it('reverse-delivers one completion for multiple sends steered into the current turn', async () => {
+    const descriptor = createBuiltinProviderRegistry().resolve('builtin:codex');
+    const provider = new FakeProvider(descriptor);
+    const facade = buildFacade(provider, adminSocketPath);
+
+    await facade.startDispatcher('flow');
+    const spawned = await facade.spawnTeamMate({
+      dispatcherId: 'flow',
+      name: 'reviewer',
+      prompt: 'Review the change.',
+      cwd: root,
+    });
+    const firstSend = await facade.sendTeamMate({
+      dispatcherId: 'flow',
+      name: 'reviewer',
+      prompt: 'Fold this into the active review.',
+    });
+    const secondSend = await facade.sendTeamMate({
+      dispatcherId: 'flow',
+      name: 'reviewer',
+      prompt: 'One more steering note.',
+    });
+
+    expect(spawned.turn.status).toBe('submitted');
+    expect(firstSend.turn).toEqual(spawned.turn);
+    expect(secondSend.turn).toEqual(spawned.turn);
+
+    const dispatcherRuntime = provider.runtimes[0]!;
+    const teammateRuntime = provider.runtimes[1]!;
+    const turnId =
+      spawned.turn.status === 'submitted' ? spawned.turn.turn_id : 'unreachable';
+    teammateRuntime.settle('completed', turnId);
+    await flush();
+
+    const last = await facade.getTeamMateLast('flow', 'reviewer');
+    expect(last.last).toEqual({ text: 'reviewer final answer' });
+    expect(dispatcherRuntime.delivered).toEqual([
+      {
+        source: 'reviewer',
+        id: `reviewer:${turnId}`,
+        status: 'completed',
+        result: 'reviewer final answer',
+      },
+    ]);
+
+    await facade.shutdown();
+  });
+
+  it('reverse-delivers a follow-up send after close/reopen with a fresh logical turn id', async () => {
+    const descriptor = createBuiltinProviderRegistry().resolve('builtin:codex');
+    const provider = new FakeProvider(descriptor);
+    const facade = buildFacade(provider, adminSocketPath);
+
+    await facade.startDispatcher('flow');
+    const spawned = await facade.spawnTeamMate({
+      dispatcherId: 'flow',
+      name: 'reviewer',
+      prompt: 'Review the change.',
+      cwd: root,
+    });
+
+    const dispatcherRuntime = provider.runtimes[0]!;
+    const firstTeammateRuntime = provider.runtimes[1]!;
+    const firstTurnId =
+      spawned.turn.status === 'submitted' ? spawned.turn.turn_id : 'unreachable';
+    firstTeammateRuntime.settle('completed', firstTurnId);
+    await flush();
+
+    await facade.closeTeamMate({
+      dispatcherId: 'flow',
+      name: 'reviewer',
+      note: 'done',
+    });
+    const sent = await facade.sendTeamMate({
+      dispatcherId: 'flow',
+      name: 'reviewer',
+      prompt: 'Follow up after reopen.',
+    });
+
+    const secondTeammateRuntime = provider.runtimes[2]!;
+    expect(secondTeammateRuntime.wasThreadResumed()).toBe(true);
+    expect(secondTeammateRuntime.hasSettleHook()).toBe(true);
+
+    const secondTurnId =
+      sent.turn.status === 'submitted' ? sent.turn.turn_id : 'unreachable';
+    expect(secondTurnId).not.toBe(firstTurnId);
+
+    // Duplicate settles for that reopened turn must still coalesce.
+    secondTeammateRuntime.settle('completed', secondTurnId);
+    secondTeammateRuntime.settle('completed', secondTurnId);
+    await flush();
+
+    const last = await facade.getTeamMateLast('flow', 'reviewer');
+    expect(last.last).toEqual({ text: 'reviewer final answer' });
+    expect(dispatcherRuntime.delivered).toEqual([
+      {
+        source: 'reviewer',
+        id: `reviewer:${firstTurnId}`,
+        status: 'completed',
+        result: 'reviewer final answer',
+      },
+      {
+        source: 'reviewer',
+        id: `reviewer:${secondTurnId}`,
         status: 'completed',
         result: 'reviewer final answer',
       },

--- a/packages/dreamux/tests/turn-manager.test.ts
+++ b/packages/dreamux/tests/turn-manager.test.ts
@@ -179,6 +179,36 @@ describe('TurnManager turn settlement', () => {
     expect(completed.map((turn) => turn.turnId)).toEqual(['turn-1']);
   });
 
+  it('coalesces concurrent cold-start submissions into one completion-producing turn', async () => {
+    const client = new DelayedFakeCodexClient();
+    const completed: CollectedTurn[] = [];
+    const manager = new TurnManager({
+      dispatcherId: 'flow',
+      getThreadId: () => 'thread-1',
+      client: client as never,
+      onTurnCompleted: (turn) => completed.push(turn),
+    });
+
+    const first = manager.enqueue(input('msg-1', 'first'));
+    const second = manager.enqueue(input('msg-2', 'second'));
+    await waitFor(() => client.inputs.length === 2);
+
+    expect(client.handlerCount).toBe(1);
+    client.resolveNext('turn-1');
+    client.resolveNext('turn-2');
+    await expect(Promise.all([first, second])).resolves.toEqual([
+      { status: 'submitted', turnId: 'turn-1' },
+      { status: 'submitted', turnId: 'turn-1' },
+    ]);
+
+    client.emitCompleted('thread-1', 'turn-1', 'folded result');
+    client.emitCompleted('thread-1', 'turn-2', 'extra physical result');
+    await waitFor(() => completed.length === 1);
+    await flush();
+
+    expect(completed.map((turn) => turn.turnId)).toEqual(['turn-1']);
+  });
+
   it('starts a fresh subscription for a sequential send after the previous turn completed', async () => {
     const client = new FoldingFakeCodexClient(['turn-1', 'turn-2']);
     const completed: CollectedTurn[] = [];
@@ -391,6 +421,62 @@ class FoldingFakeCodexClient {
     const turnId = this.turnIds[this.nextIndex++];
     if (turnId === undefined) throw new Error('no scripted turn id');
     return { turn: { id: turnId } } as TurnStartResponse as R;
+  }
+
+  emitCompleted(threadId: string, turnId: string, text: string): void {
+    this.emit({
+      method: 'item/completed',
+      params: {
+        threadId,
+        turnId,
+        completedAtMs: Date.now(),
+        item: { type: 'agentMessage', id: `item-${turnId}`, text },
+      },
+    });
+    this.emit({
+      method: 'turn/completed',
+      params: {
+        threadId,
+        turn: { id: turnId, items: [] },
+      },
+    });
+  }
+
+  private emit(notification: ServerNotification): void {
+    for (const handler of this.handlers) handler(notification);
+  }
+}
+
+class DelayedFakeCodexClient {
+  readonly inputs: string[] = [];
+  private readonly handlers: NotificationHandler[] = [];
+  private readonly pending: Array<(turnId: string) => void> = [];
+
+  get handlerCount(): number {
+    return this.handlers.length;
+  }
+
+  onNotification(handler: NotificationHandler): void {
+    this.handlers.push(handler);
+  }
+
+  request<R>(method: string, params: unknown): Promise<R> {
+    if (method !== 'turn/start') throw new Error(`unexpected method ${method}`);
+    const p = params as {
+      input: Array<{ text: string }>;
+    };
+    this.inputs.push(p.input[0]?.text ?? '');
+    return new Promise<R>((resolve) => {
+      this.pending.push((turnId) => {
+        resolve({ turn: { id: turnId } } as TurnStartResponse as R);
+      });
+    });
+  }
+
+  resolveNext(turnId: string): void {
+    const resolve = this.pending.shift();
+    if (resolve === undefined) throw new Error('no pending turn/start');
+    resolve(turnId);
   }
 
   emitCompleted(threadId: string, turnId: string, text: string): void {

--- a/packages/dreamux/tests/turn-manager.test.ts
+++ b/packages/dreamux/tests/turn-manager.test.ts
@@ -148,6 +148,65 @@ describe('TurnManager turn settlement', () => {
     expect(completed[0]?.turnId).toBe('turn-1');
   });
 
+  it('steers active submissions into the current turn and settles it once', async () => {
+    const client = new FoldingFakeCodexClient(['turn-1', 'turn-2', 'turn-3']);
+    const completed: CollectedTurn[] = [];
+    const manager = new TurnManager({
+      dispatcherId: 'flow',
+      getThreadId: () => 'thread-1',
+      client: client as never,
+      onTurnCompleted: (turn) => completed.push(turn),
+    });
+
+    await expect(manager.enqueue(input('msg-1', 'first'))).resolves.toEqual({
+      status: 'submitted',
+      turnId: 'turn-1',
+    });
+    await expect(manager.enqueue(input('msg-2', 'second steered'))).resolves.toEqual({
+      status: 'submitted',
+      turnId: 'turn-1',
+    });
+    await expect(manager.enqueue(input('msg-3', 'third steered'))).resolves.toEqual({
+      status: 'submitted',
+      turnId: 'turn-1',
+    });
+    expect(client.inputs).toEqual(['first', 'second steered', 'third steered']);
+
+    client.emitCompleted('thread-1', 'turn-1', 'folded result');
+    await waitFor(() => completed.length === 1);
+    await flush();
+
+    expect(completed.map((turn) => turn.turnId)).toEqual(['turn-1']);
+  });
+
+  it('starts a fresh subscription for a sequential send after the previous turn completed', async () => {
+    const client = new FoldingFakeCodexClient(['turn-1', 'turn-2']);
+    const completed: CollectedTurn[] = [];
+    const manager = new TurnManager({
+      dispatcherId: 'flow',
+      getThreadId: () => 'thread-1',
+      client: client as never,
+      onTurnCompleted: (turn) => completed.push(turn),
+    });
+
+    await expect(manager.enqueue(input('msg-1', 'first'))).resolves.toEqual({
+      status: 'submitted',
+      turnId: 'turn-1',
+    });
+
+    client.emitCompleted('thread-1', 'turn-1', 'first result');
+    await waitFor(() => completed.length === 1);
+    expect(completed.map((turn) => turn.turnId)).toEqual(['turn-1']);
+
+    await expect(manager.enqueue(input('msg-2', 'second'))).resolves.toEqual({
+      status: 'submitted',
+      turnId: 'turn-2',
+    });
+    client.emitCompleted('thread-1', 'turn-2', 'second result');
+    await waitFor(() => completed.length === 2);
+    expect(completed.map((turn) => turn.turnId)).toEqual(['turn-1', 'turn-2']);
+  });
+
   it('settles each still-pending turn as stopped on stop()', async () => {
     // A manual client never emits turn/completed, so the submitted turn stays
     // in flight until stop() tears it down.
@@ -238,6 +297,10 @@ async function waitFor(predicate: () => boolean, timeoutMs = 2000): Promise<void
   throw new Error('waitFor timed out');
 }
 
+async function flush(): Promise<void> {
+  await new Promise((resolve) => setImmediate(resolve));
+}
+
 function input(messageId: string, text: string) {
   return {
     sourceId: messageId,
@@ -301,6 +364,52 @@ class FakeCodexClient {
       });
     });
     return { turn: { id: turnId } } as TurnStartResponse as R;
+  }
+
+  private emit(notification: ServerNotification): void {
+    for (const handler of this.handlers) handler(notification);
+  }
+}
+
+class FoldingFakeCodexClient {
+  readonly inputs: string[] = [];
+  private readonly handlers: NotificationHandler[] = [];
+  private nextIndex = 0;
+
+  constructor(private readonly turnIds: string[]) {}
+
+  onNotification(handler: NotificationHandler): void {
+    this.handlers.push(handler);
+  }
+
+  async request<R>(method: string, params: unknown): Promise<R> {
+    if (method !== 'turn/start') throw new Error(`unexpected method ${method}`);
+    const p = params as {
+      input: Array<{ text: string }>;
+    };
+    this.inputs.push(p.input[0]?.text ?? '');
+    const turnId = this.turnIds[this.nextIndex++];
+    if (turnId === undefined) throw new Error('no scripted turn id');
+    return { turn: { id: turnId } } as TurnStartResponse as R;
+  }
+
+  emitCompleted(threadId: string, turnId: string, text: string): void {
+    this.emit({
+      method: 'item/completed',
+      params: {
+        threadId,
+        turnId,
+        completedAtMs: Date.now(),
+        item: { type: 'agentMessage', id: `item-${turnId}`, text },
+      },
+    });
+    this.emit({
+      method: 'turn/completed',
+      params: {
+        threadId,
+        turn: { id: turnId, items: [] },
+      },
+    });
   }
 
   private emit(notification: ServerNotification): void {


### PR DESCRIPTION
## Summary

- Coalesce dispatcher reverse-completion delivery by dispatcher/completion id so duplicate settled events or concurrent retries share one delivery.
- Make Codex `completionInput` idempotent per completion id: concurrent duplicates share one inject/trigger, accepted ids return accepted, and trigger source ids capture the per-attempt sequence.
- Normalize TeamMate `send` as active-turn steering inside the runtime layer: Codex keeps one current-turn collector while still forwarding active sends to `turn/start`, and Claude Code steers active stream-json turns without creating independent completion-producing turns.
- Close the Codex concurrent cold-start window with a synchronous active-turn slot before any await; concurrent cold-start sends now share one collector and return the same logical current turn id.
- Use Claude Code's queued stream-json priority for active sends and fold immediate follow-up results into the pending Dreamux logical turn, so steered output is not silently dropped at the RPC demux boundary.
- Give Claude Code logical turn ids a runtime-instance component so close/reopen follow-up rounds cannot reuse an earlier completion trigger id.
- Add regression coverage for folded/active sends, concurrent cold-start sends, sequential sends, close/reopen follow-ups, retry replay, duplicate settled events, and the Claude stream-json steer envelope/result path.

## Root Cause

`CodexRuntime.completionInput` checked `injectedCompletionIds` only after awaiting `thread/inject_items`, so concurrent calls for the same completion id could all pass the check and inject duplicate `<teammate_session_completion>` items. The trigger source id also read a mutable sequence field after that await, letting concurrent calls reuse the same source id and hit TurnManager dedupe.

`DispatcherAgentService.deliverCompletion` also did not coalesce by completion id, so duplicated settled events/replays could start independent delivery loops against the same dispatcher runtime.

A second issue lived at the runtime boundary: TeamMate `send` must steer the current runtime turn when one is active, not create an independent completion subscription per call. Codex collection was thread-scoped, so folded active sends could wake multiple collectors for one physical completion. The cold-start path also needed a synchronous current-turn slot before `turn/start` ack so two concurrent first sends could not both create completion-producing collectors.

Claude Code did not expose active-turn steering and reused instance-local logical ids after close/reopen, so follow-up rounds could collide with earlier completion ids. The runtime layer now owns current-turn identity and final-output normalization; dispatcher/TeamMate delivery remains runtime-agnostic after that boundary. The stream-json RPC path now has direct coverage that active steering writes the expected user envelope while a turn is pending and folds an immediate follow-up result into the pending logical turn.

## Notes

PR #160 is on the same `next` base but is scoped to Claude remote-control/config/capability surfaces. Its current head does not change `teammate/service.ts` completion id semantics or the runtime completion identity path, so no coordination conflict was found.

## Validation

- `./node_modules/.bin/vitest run tests/turn-manager.test.ts tests/codex-events.test.ts tests/claude-code-rpc.test.ts tests/claude-code-runtime.test.ts tests/teammate-completion-e2e.test.ts tests/codex-completion.test.ts tests/teammate-completion-delivery.test.ts tests/teammate-agent-service.test.ts`
- `./node_modules/.bin/vitest run tests/claude-code-rpc.test.ts tests/turn-manager.test.ts tests/codex-completion.test.ts`
- `./node_modules/.bin/vitest run tests/codex-completion.test.ts --sequence.concurrent false`
- `node common/scripts/install-run-rush.js lint --to @excitedjs/dreamux`
- `node common/scripts/install-run-rush.js build --to @excitedjs/dreamux`
- `node common/scripts/install-run-rush.js test --to @excitedjs/dreamux`
- `node common/scripts/install-run-rush.js change --verify --no-fetch`
- `git diff --check`
- `gitleaks protect --staged --verbose`