### PR TITLE
Bound completion push-back + assemble channel input per runtime (#164)

### DIFF
--- a/.agents/decisions/README.md
+++ b/.agents/decisions/README.md
@@ -9,7 +9,7 @@ topic slugs remain reviewable and merge-friendly.
 | Theme | Records |
 |---|---|
 | Repository shape | [rush-pnpm-monorepo](rush-pnpm-monorepo.md), [install-model](install-model.md) |
-| Runtime architecture | [top-level-design](top-level-design.md), [issue-110-epic-closure](issue-110-epic-closure.md), [provider-references-and-capability-registry](provider-references-and-capability-registry.md), [agent-runtime-provider](agent-runtime-provider.md), [channel-provider](channel-provider.md), [server-hosted-teammate](server-hosted-teammate.md), [providerized-config-state-compatibility](providerized-config-state-compatibility.md), [agents-config-normalization](agents-config-normalization.md), [global-config-dir](global-config-dir.md), [logging](logging.md), [feishu-inbound-attachments](feishu-inbound-attachments.md) |
+| Runtime architecture | [top-level-design](top-level-design.md), [issue-110-epic-closure](issue-110-epic-closure.md), [provider-references-and-capability-registry](provider-references-and-capability-registry.md), [agent-runtime-provider](agent-runtime-provider.md), [channel-provider](channel-provider.md), [server-hosted-teammate](server-hosted-teammate.md), [providerized-config-state-compatibility](providerized-config-state-compatibility.md), [agents-config-normalization](agents-config-normalization.md), [global-config-dir](global-config-dir.md), [logging](logging.md), [feishu-inbound-attachments](feishu-inbound-attachments.md), [channel-input-runtime-assembly](channel-input-runtime-assembly.md) |
 | Public surface | [cli-and-package-naming](cli-and-package-naming.md), [dispatcher-tm-boundary](dispatcher-tm-boundary.md), [dispatcher-tm-packaging](dispatcher-tm-packaging.md), [global-bin-onboard-serve](global-bin-onboard-serve.md), [global-config-dir](global-config-dir.md) |
 | Release and safeguards | [npm-release-oidc](npm-release-oidc.md), [anti-leak-guardrail](anti-leak-guardrail.md), [no-sync-io-lint-gate](no-sync-io-lint-gate.md) |
 
@@ -19,6 +19,7 @@ topic slugs remain reviewable and merge-friendly.
 - [anti-leak-guardrail](anti-leak-guardrail.md)
 - [agent-runtime-provider](agent-runtime-provider.md)
 - [channel-provider](channel-provider.md)
+- [channel-input-runtime-assembly](channel-input-runtime-assembly.md)
 - [cli-and-package-naming](cli-and-package-naming.md)
 - [dispatcher-tm-boundary](dispatcher-tm-boundary.md)
 - [dispatcher-tm-packaging](dispatcher-tm-packaging.md)

--- a/.agents/decisions/channel-input-runtime-assembly.md
+++ b/.agents/decisions/channel-input-runtime-assembly.md
@@ -1,0 +1,62 @@
+# Channel input is assembled by each runtime; no-leak clarified to routing-only
+
+- **Status:** Accepted
+- **Date:** 2026-06-09
+- **Affects:** the runtime contract
+  [`/packages/dreamux/src/agent-runtime/turn.ts`](/packages/dreamux/src/agent-runtime/turn.ts),
+  both builtins' `channelInput`, the Feishu channel message layer
+  [`/packages/dreamux/src/channel/feishu/feishu-message.ts`](/packages/dreamux/src/channel/feishu/feishu-message.ts),
+  the no-leak boundary in
+  [`/packages/dreamux/CLAUDE.md`](/packages/dreamux/CLAUDE.md) and
+  [`/packages/dreamux/src/agent-runtime/CLAUDE.md`](/packages/dreamux/src/agent-runtime/CLAUDE.md)
+- **PR / Issue:** [#164](https://github.com/excitedjs/dreamux/issues/164)
+
+## Context
+
+Inbound Feishu messages were rendered to their final `<feishu_message>` XML by
+the channel layer (`formatFeishuMessageForRuntime`), which handed the runtime a
+single pre-rendered `InboundTurnInput.text`. Both builtins consumed that string
+verbatim, so the channel — not the runtime — owned the model-visible inbound
+format. We wanted each runtime to own assembling its own channel block (so the
+two engines can diverge later — e.g. claude inlining image content blocks vs
+codex text references) while both render claude-code's native `<channel>`
+envelope today.
+
+This collided with the standing invariant *"channel routing attributes (chat id,
+sender id, message id) … never cross into the runtime"*: assembling the block
+inside the runtime means those values must reach it.
+
+## Decision
+
+**Split routing from display.** The invariant is *clarified*, not retired:
+
+- **Routing/identity decisions stay in the channel layer (still banned from the
+  runtime).** A runtime must never branch, route, or reply-target on `chat_id` /
+  `sender_id` / message ids. Reply targeting remains a channel-layer concern: the
+  Feishu reply MCP tool takes `chat_id` as an explicit parameter.
+- **Opaque display passthrough is allowed.** `InboundTurnInput` gains a neutral
+  `source` label, an opaque `attrs: Array<[string, string]>` bag, a pre-rendered
+  `body`, and structured `attachments`. The runtime renders `attrs`/`body`
+  verbatim into its block via the shared neutral `renderChannelInput` /
+  `renderChannelBlock` (in `turn.ts`, so both builtins reuse them with no
+  cross-builtin import) but never interprets them.
+
+The Feishu channel stops emitting XML and returns structured pieces (`attrs`,
+`body`, `attachments`); `body` carries the full prior inner content (message +
+mentions + parser fallback + attachment refs + group-bots block) so no
+model-visible content is dropped. The structured `attachments` field is reserved
+for future per-runtime rendering and is not consumed by the wrap today.
+
+Both runtimes call `renderChannelInput`, so they render byte-identical
+`<channel source="feishu" …>` blocks today; the per-runtime seam is preserved
+for later divergence. The literal string `"feishu"` lives only in the channel
+layer (passed as `source` data) — neither builtin nor `turn.ts` hardcodes it.
+
+## Consequences
+
+- The runtime contract `InboundTurnInput` is wider, but stays channel-neutral
+  (no `feishu`-typed field names).
+- A future channel populates the same neutral fields; a future runtime may
+  render `attachments` differently without a contract change.
+- This is an in-process contract change only — no persisted file format, so no
+  changelog/rebuild entry (the 0.x fail-loud policy does not apply).

--- a/common/changes/@excitedjs/dreamux/issue164-completion-spill-channel-format_2026-06-09-21-00.json
+++ b/common/changes/@excitedjs/dreamux/issue164-completion-spill-channel-format_2026-06-09-21-00.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Bound teammate completion push-back and move channel-input assembly into each runtime (#164). Completion results over an inline budget (default 32000 chars, TASK_MAX_OUTPUT_LENGTH override, clamped to 160000) are spilled to a 0600 /tmp file and only the path is inlined. The claude-code runtime drops the fake <task-notification> XML and delivers a plain status-varied user turn (isSynthetic:false; capability kind claudeCodeTaskNotification -> claudeCodePlainTurn); codex keeps its <teammate_session_completion> wrapper. CompletionEnvelope.status widens to completed|failed|stopped (no longer folded). Inbound Feishu messages are now assembled by each runtime into the native <channel source=\"feishu\" …> envelope (codex's <feishu_message> wrapper retired); the channel layer stops pre-rendering XML and hands runtimes neutral structured pieces. No persisted config/state format changes, so no rebuild is required.",
+      "type": "patch",
+      "packageName": "@excitedjs/dreamux"
+    }
+  ],
+  "packageName": "@excitedjs/dreamux",
+  "email": "053700@gmail.com"
+}

--- a/packages/channel/feishu-channel/CLAUDE.md
+++ b/packages/channel/feishu-channel/CLAUDE.md
@@ -13,8 +13,8 @@ between `@excitedjs/feishu-transport` and `@excitedjs/dreamux`.
 - Generate honest fallback references when a resource is not downloaded,
   including the resource key and a lark-cli fetch direction that uses
   placeholder-safe identifiers in docs and tests.
-- Serialize Codex/agent-facing inbound bodies, including `<feishu_message>` and
-  `<attachment>` blocks.
+- Serialize Codex/agent-facing inbound bodies, including the
+  `<channel source="feishu" …>` envelope and `<attachment>` blocks.
 - If the channel ever needs to parse model/channel-specific markup, keep that
   deserialization here rather than in `@excitedjs/feishu-transport`.
 

--- a/packages/channel/feishu-channel/src/inbound.ts
+++ b/packages/channel/feishu-channel/src/inbound.ts
@@ -105,17 +105,15 @@ export async function formatFeishuMessageForCodex(
   const attachmentBlock = renderAttachments(event.messageId, attachments);
   const groupBots = renderGroupBots(options.trustedBots ?? []);
 
-  const attrLines = attrs.map(
-    ([key, value]) => `  ${key}="${escapeXmlAttribute(value)}"`,
-  );
-  attrLines[attrLines.length - 1] = `${attrLines[attrLines.length - 1]}>`;
+  const renderedAttrs = attrs
+    .map(([key, value]) => ` ${key}="${escapeXmlAttribute(value)}"`)
+    .join('');
 
   return {
     formattedText: [
-      '<feishu_message',
-      ...attrLines,
+      `<channel source="feishu"${renderedAttrs}>`,
       `${body}${fallback}${attachmentBlock}${groupBots}`,
-      '</feishu_message>',
+      '</channel>',
     ].join('\n'),
     attachments,
     diagnostics: attachments

--- a/packages/channel/feishu-channel/tests/inbound.test.ts
+++ b/packages/channel/feishu-channel/tests/inbound.test.ts
@@ -19,15 +19,9 @@ import type { FeishuMessageResourceFetcher } from '@excitedjs/feishu-transport';
 describe('formatFeishuMessageForCodex', () => {
   it('formats text events with routable ids, empty sender_name, ISO time, and mention tags', async () => {
     await expectFormatted(event(), [
-      '<feishu_message',
-      '  chat_id="chat-group-a"',
-      '  chat_type="group"',
-      '  message_id="message-1"',
-      '  sender_id="sender-user"',
-      '  sender_name=""',
-      '  create_time="2024-03-09T16:00:00.000Z">',
+      '<channel source="feishu" chat_id="chat-group-a" chat_type="group" message_id="message-1" sender_id="sender-user" sender_name="" create_time="2024-03-09T16:00:00.000Z">',
       'hello <at id="mentioned-user">Ada</at> &amp; &lt;ok&gt;',
-      '</feishu_message>',
+      '</channel>',
     ].join('\n'));
   });
 
@@ -36,7 +30,7 @@ describe('formatFeishuMessageForCodex', () => {
       event({ senderName: 'Ada & Bob' }),
     )).formattedText;
 
-    expect(block).toContain('  sender_name="Ada &amp; Bob"');
+    expect(block).toContain(' sender_name="Ada &amp; Bob"');
   });
 
   it('omits the group_bots block when no trusted bots are supplied', async () => {
@@ -60,7 +54,7 @@ describe('formatFeishuMessageForCodex', () => {
     );
     expect(block).toContain('  <bot name="Peer &amp; &quot;A&quot;" open_id="ou-peer-a" />');
     expect(block).toContain('  <bot name="" open_id="ou-peer-b" />');
-    expect(block.endsWith('</group_bots>\n</feishu_message>')).toBe(true);
+    expect(block.endsWith('</group_bots>\n</channel>')).toBe(true);
   });
 
   it('adds a Feishu skill fallback note when text content cannot be parsed', async () => {

--- a/packages/channel/feishu-transport/CLAUDE.md
+++ b/packages/channel/feishu-transport/CLAUDE.md
@@ -18,7 +18,7 @@ package that exposes Lark SDK / JSAPI capabilities to channel layers.
 
 - Do not couple this package to Dreamux dispatcher state, runtime paths,
   Codex threads, cache directories, access-file layout, or logging layout.
-- Do not assemble `<feishu_message>` or `<attachment>` blocks.
+- Do not assemble the `<channel source="feishu" …>` envelope or `<attachment>` blocks.
 - Do not serialize or deserialize agent-facing message body formats.
 - Do not parse model replies or any special format emitted by an agent.
 - Do not own attachment cache layout, retention, preview extraction, or

--- a/packages/dreamux/CLAUDE.md
+++ b/packages/dreamux/CLAUDE.md
@@ -55,9 +55,18 @@ Two settled shape rules govern where code lives:
   thread/home/bin/socket/stream concepts stay inside
   `agent-runtime/builtin/<name>/`. The shared contract, `state/`, `platform/`,
   `server.ts`, and the Dispatcher Service stay runtime-neutral.
-- **Do not leak channel specifics into the runtime contract.** `sender_id` /
-  `chat_id` / message ids belong to the channel layer; a runtime turn carries
-  neutral text + a dedupe id.
+- **Do not leak channel *routing* into the runtime contract.** Routing/identity
+  *decisions* — which chat to reply to, who the sender is, message threading —
+  belong to the channel layer; a runtime must never branch or reply-target on
+  `chat_id` / `sender_id` / message ids. Reply targeting stays in the channel
+  layer (the Feishu reply MCP tool takes `chat_id` as an explicit parameter).
+  What a runtime turn MAY carry, beyond neutral text + a dedupe id, is **opaque
+  display passthrough**: `InboundTurnInput.attrs` is an opaque key/value bag the
+  runtime renders verbatim into its model-visible channel block (the native
+  `<channel source="…" …>` envelope) but never interprets. Each runtime owns
+  assembling its own channel block from these neutral pieces (issue #164); the
+  channel layer no longer pre-renders the message XML. See
+  [`.agents/decisions/channel-input-runtime-assembly.md`](../../.agents/decisions/channel-input-runtime-assembly.md).
 - Direct Lark SDK / Feishu JSAPI calls belong in `@excitedjs/feishu-transport`;
   the built-in Feishu channel under `channel/feishu/` owns its MCP surface and
   handlers end-to-end (the server does not carry `*FromMcp` handlers).

--- a/packages/dreamux/README.md
+++ b/packages/dreamux/README.md
@@ -313,7 +313,7 @@ schedule more TeamMates.
 1. `dreamux onboard --dispatcher-id flow --dispatcher-cwd <WORKSPACE> --bot-app-id <APP_ID> --bot-app-secret <APP_SECRET>`
 2. `dreamux serve` starts dispatcher `flow`.
 3. Invite the bot to a Feishu group, send a mention that passes the access gate.
-4. Server injects a `<feishu_message>` block into the selected runtime.
+4. The selected runtime assembles the inbound into a `<channel source="feishu" …>` block (the channel layer hands it neutral structured pieces; #164).
 5. The runtime calls the Feishu MCP `reply` tool; the reply is delivered to Feishu.
 6. Send another accepted message from a different chat in the same trust
    domain; it enters the same dispatcher runtime context.

--- a/packages/dreamux/src/agent-runtime/CLAUDE.md
+++ b/packages/dreamux/src/agent-runtime/CLAUDE.md
@@ -57,12 +57,26 @@ delivery). The completion contract is now source-agnostic: `completionInput`
 takes a neutral `CompletionEnvelope { source; id; status; result }` (C2), the
 `teammateCompletion` capability is an open `CompletionDeliveryShape
 { kind; description }` (each builtin self-declares its own kind —
-`codexInboxTurn` / `claudeCodeTaskNotification`), and the runtime-state
-checkpoint kind is capability-driven with no `codexThread` fallback. The
-channel payload is now neutral too (D): `channelInput` takes
-`InboundTurnInput { text; sourceId }` — turn text plus a dedupe/correlation id —
-and channel routing attributes (chat id, sender id, message id) stay in the
-channel layer and never cross into the runtime.
+`codexInboxTurn` / `claudeCodePlainTurn`), and the runtime-state
+checkpoint kind is capability-driven with no `codexThread` fallback.
+
+Completion delivery itself is bounded (issue #164): a result within the inline
+budget (default 32000 chars, `TASK_MAX_OUTPUT_LENGTH` override, clamped to
+160000) is inlined; a longer one is spilled to a `/tmp` file by the neutral
+`completion-body.ts` (shared, no cross-builtin import) and only the path is
+inlined. `CompletionEnvelope.status` is `completed | failed | stopped`.
+
+The channel payload is neutral but now richer (D + issue #164): `channelInput`
+takes `InboundTurnInput { text; sourceId; source?; attrs?; body?; attachments? }`.
+Routing/identity *decisions* (chat id, sender id, message id) still never cross
+into the runtime — a runtime must not route on them. `source` + `attrs` are
+**opaque display passthrough**: each runtime renders them verbatim into its own
+channel block (`renderChannelInput` → the native `<channel source="…" …>`
+envelope) but never interprets them. The channel layer stops pre-rendering the
+message XML; each runtime owns assembling its channel block, so the two builtins
+can diverge later (e.g. claude inlining image content blocks vs codex text refs)
+while rendering identical blocks today. See
+[`decisions/channel-input-runtime-assembly.md`](../../../../.agents/decisions/channel-input-runtime-assembly.md).
 
 The reverse-delivery loop is now wired end-to-end (#147), so `completionInput`
 is a live caller rather than zero-caller. A runtime fires the neutral

--- a/packages/dreamux/src/agent-runtime/builtin/claude-code/runtime.ts
+++ b/packages/dreamux/src/agent-runtime/builtin/claude-code/runtime.ts
@@ -19,8 +19,8 @@
  * - **Runtime-owned config** is `DispatcherClaudeCodeConfig` (bin / model /
  *   permission_mode / remote_control / extra_args / extra_env), distinct from
  *   the Codex config.
- * - **Completion delivery** is the Claude Code task-notification path, not the
- *   Codex inbox-then-trigger path.
+ * - **Completion delivery** is a plain user turn (no fake task-notification),
+ *   not the Codex inbox-then-trigger path.
  *
  * Process spawning goes through an injectable {@link ClaudeCodeSessionFactory}
  * seam (mirroring Codex's process-factory seam), so the lifecycle contract is
@@ -84,6 +84,7 @@ import {
   type TurnOutcome,
   type TurnSubmitOptions,
 } from './supervisor.js';
+import { renderChannelInput } from '../../turn.js';
 import type {
   InboundDeliveryHooks,
   InboundTurnInput,
@@ -323,10 +324,14 @@ export class ClaudeCodeRuntime implements AgentRuntime {
       // failure there must not drop the turn.
       this.log('warn', 'claude-code onAccepted hook failed', err);
     }
+    // This runtime owns wrapping the channel input into its delivery shape: a
+    // structured channel turn becomes the native `<channel source="…">` block;
+    // a plain turn passes through unchanged.
+    const text = renderChannelInput(input);
     const active = this.activeChannelTurn;
     if (active !== null) {
       try {
-        await this.steerChannelTurn(active, input.text);
+        await this.steerChannelTurn(active, text);
         return { status: 'submitted', turnId: active.turnId };
       } catch (err) {
         return {
@@ -348,7 +353,7 @@ export class ClaudeCodeRuntime implements AgentRuntime {
     // returned to this caller without blocking the channel ack on full turn
     // completion. Instead, a failed turn drives the runtime to `degraded` with a
     // persisted `last_error` (visible via status/doctor) — never swallowed.
-    void this.runChannelTurnOnQueue(input.text, channelTurn).then(
+    void this.runChannelTurnOnQueue(text, channelTurn).then(
       () => this.markTurnSucceeded(turnId),
       (err) => this.markTurnFailed(turnId, err),
     );

--- a/packages/dreamux/src/agent-runtime/builtin/claude-code/runtime.ts
+++ b/packages/dreamux/src/agent-runtime/builtin/claude-code/runtime.ts
@@ -88,6 +88,7 @@ import type {
   InboundDeliveryHooks,
   InboundTurnInput,
 } from '../../turn.js';
+import { resolveCompletionBody } from '../../completion-body.js';
 import type { DispatcherStatus } from '../../../state/dispatcher-store.js';
 import type {
   AgentRuntimeCapabilities,
@@ -119,9 +120,9 @@ export const CLAUDE_CODE_AGENT_RUNTIME_CAPABILITIES: AgentRuntimeCapabilities = 
   systemPrompt: { mode: 'append' },
   teammateCompletion: [
     {
-      kind: 'claudeCodeTaskNotification',
+      kind: 'claudeCodePlainTurn',
       description:
-        'notify the runtime through a Claude Code task notification path',
+        'deliver the completion as a plain user turn (no task-notification harness path)',
     },
   ],
 };
@@ -141,26 +142,36 @@ interface ActiveChannelTurn {
 let nextRuntimeInstanceId = 0;
 
 /**
- * Format a TeamMate completion as a Claude Code `<task-notification>` — the
- * native shape claude-code emits for background / sub-agent task completions
- * (constants/xml.ts: `task-notification` / `task-id` / `status` / `summary`).
- * The result is delivered inline in a `<result>` tag because dreamux has no
- * output file, so claude-code's optional `<output-file>` / `<tool-use-id>` tags
- * are intentionally omitted. Delivered with `isSynthetic: true` (see
- * {@link ClaudeCodeRuntime.completionInput}) so claude-code treats it as a
- * notification, not human input.
+ * Status line opening a TeamMate completion turn. Plain English, status-varied —
+ * NOT claude-code's native `<task-notification>` XML. The old XML mimicked
+ * claude-code's real task-notification system, so the model could mistake the
+ * fabricated task-id / output-file for a live background task and act on them
+ * (hallucination / harness collision). A plain user turn avoids that entirely.
  */
-function formatTaskNotification(completion: CompletionEnvelope): string {
-  return [
-    '<task-notification>',
-    `<task-id>${completion.id}</task-id>`,
-    `<status>${completion.status}</status>`,
-    `<summary>TeamMate "${completion.source}" session ${completion.status}</summary>`,
-    '<result>',
-    completion.result,
-    '</result>',
-    '</task-notification>',
-  ].join('\n');
+function completionStatusLine(completion: CompletionEnvelope): string {
+  switch (completion.status) {
+    case 'completed':
+      return `TeamMate ${completion.source} has finished its task.`;
+    case 'failed':
+      return `TeamMate ${completion.source}'s task failed.`;
+    case 'stopped':
+      return `TeamMate ${completion.source}'s task was stopped.`;
+  }
+}
+
+/**
+ * Build the plain-text completion turn. The result is inlined when short; when
+ * it overflows the inline budget the full result is spilled to a file (see
+ * {@link resolveCompletionBody}) and only the path is inlined.
+ */
+async function buildCompletionTurnText(
+  completion: CompletionEnvelope,
+): Promise<string> {
+  const line = completionStatusLine(completion);
+  const body = await resolveCompletionBody(completion);
+  return body.kind === 'inline'
+    ? `${line} Output below:\n\n${body.text}`
+    : `${line} The output is too long, so the full result was saved to a file:\n\n${body.path}`;
 }
 
 function errMessage(err: unknown): string {
@@ -350,18 +361,17 @@ export class ClaudeCodeRuntime implements AgentRuntime {
     if (this.stopped) {
       return { status: 'unsupported', reason: 'runtime stopped' };
     }
-    // Native task-notification delivery: a stream-json user message whose body
-    // is the `<task-notification>` tag, marked `isSynthetic: true` so claude-code
-    // routes it as a background-completion notification (internal `isMeta`:
-    // hidden in the TUI, model-visible) rather than human input. Delivery AWAITS
-    // the serial-queue turn so `accepted` means it actually ran and `failed`
-    // otherwise — the semantics the Dispatcher Service relies on for delivery
-    // retry.
+    // Plain user-turn delivery: a stream-json user message marked
+    // `isSynthetic: false`, so claude-code treats it as ordinary human input
+    // rather than routing it through its native task-notification harness path.
+    // Delivery AWAITS the serial-queue turn so `accepted` means it actually ran
+    // and `failed` otherwise — the semantics the Dispatcher Service relies on
+    // for delivery retry.
     try {
       await this.runTurnOnQueue(
-        formatTaskNotification(completion),
+        await buildCompletionTurnText(completion),
         `claude-teammate-${completion.id}`,
-        { isSynthetic: true },
+        { isSynthetic: false },
       );
       return { status: 'accepted' };
     } catch (err) {

--- a/packages/dreamux/src/agent-runtime/builtin/codex/runtime-support.ts
+++ b/packages/dreamux/src/agent-runtime/builtin/codex/runtime-support.ts
@@ -5,6 +5,10 @@ import {
   dispatcherCodexAppServerErrorLogPath,
   dispatcherCodexAppServerLogPath,
 } from './paths.js';
+import {
+  resolveCompletionBody,
+  type ResolvedCompletionBody,
+} from '../../completion-body.js';
 import type {
   AgentRuntimePathContext,
   AgentRuntimeStateStore,
@@ -29,13 +33,25 @@ export function codexProcessEnv(
 /**
  * Frame a TeamMate completion as recognizable notification text. Delivered as
  * the body of a developer-role history item (not a fake user turn), so codex
- * treats it as injected context rather than user intent.
+ * treats it as injected context rather than user intent. The
+ * `<teammate_session_completion>` wrapper + developer role are deliberate — a
+ * neutral tag codex will not interpret as its native subagent system.
+ *
+ * Pure: the spill decision is made upstream and the resolved body is passed in,
+ * so this function performs no IO.
  */
-function frameCodexCompletion(completion: CompletionEnvelope): string {
+function frameCodexCompletion(
+  completion: CompletionEnvelope,
+  body: ResolvedCompletionBody,
+): string {
+  const inner =
+    body.kind === 'inline'
+      ? body.text
+      : `The output is too long, so the full result was saved to a file: ${body.path}`;
   return [
     `<teammate_session_completion source="${completion.source}" ` +
       `id="${completion.id}" status="${completion.status}">`,
-    completion.result,
+    inner,
     '</teammate_session_completion>',
   ].join('\n');
 }
@@ -54,13 +70,14 @@ function frameCodexCompletion(completion: CompletionEnvelope): string {
  * neutral developer message is model-visible text codex will not try to
  * interpret as engine-internal state.
  */
-export function buildCodexCompletionItem(
+export async function buildCodexCompletionItem(
   completion: CompletionEnvelope,
-): Record<string, unknown> {
+): Promise<Record<string, unknown>> {
+  const body = await resolveCompletionBody(completion);
   return {
     type: 'message',
     role: 'developer',
-    content: [{ type: 'input_text', text: frameCodexCompletion(completion) }],
+    content: [{ type: 'input_text', text: frameCodexCompletion(completion, body) }],
   };
 }
 

--- a/packages/dreamux/src/agent-runtime/builtin/codex/runtime.ts
+++ b/packages/dreamux/src/agent-runtime/builtin/codex/runtime.ts
@@ -41,6 +41,7 @@ import {
   TurnManager,
 } from './turn-manager.js';
 import { injectThreadItems, type CollectedTurn } from './events.js';
+import { renderChannelInput } from '../../turn.js';
 import type {
   InboundDeliveryHooks,
   InboundTurnInput,
@@ -437,7 +438,14 @@ export class CodexRuntime implements AgentRuntime {
     if (this.turnManager === null) {
       return { status: 'failed', error: new Error('turn manager not initialized') };
     }
-    return this.turnManager.enqueue(input, hooks);
+    // This runtime owns wrapping the channel input into its delivery shape: a
+    // structured channel turn becomes the native `<channel source="…">` block
+    // (same envelope claude renders); a plain turn (e.g. the completion trigger)
+    // passes through unchanged.
+    return this.turnManager.enqueue(
+      { ...input, text: renderChannelInput(input) },
+      hooks,
+    );
   }
 
   /** Inject a system-originated notice (e.g. a restart notice). */

--- a/packages/dreamux/src/agent-runtime/builtin/codex/runtime.ts
+++ b/packages/dreamux/src/agent-runtime/builtin/codex/runtime.ts
@@ -504,7 +504,7 @@ export class CodexRuntime implements AgentRuntime {
     if (!this.injectedCompletionIds.has(completion.id)) {
       try {
         await injectThreadItems(this.client, threadId, [
-          buildCodexCompletionItem(completion),
+          await buildCodexCompletionItem(completion),
         ]);
       } catch (err) {
         const cause = err instanceof Error ? err.message : String(err);

--- a/packages/dreamux/src/agent-runtime/completion-body.ts
+++ b/packages/dreamux/src/agent-runtime/completion-body.ts
@@ -31,19 +31,22 @@ export type ResolvedCompletionBody =
   | { kind: 'spilled'; path: string };
 
 /**
- * Resolve the effective inline budget from the environment, mirroring native
- * `validateBoundedIntEnvVar`: unset/blank or non-positive/non-integer falls back
- * to the default; values above the upper bound are clamped (not rejected).
+ * Resolve the effective inline budget from the environment, in the spirit of
+ * native `validateBoundedIntEnvVar`: unset/blank or non-positive falls back to
+ * the default; values above the upper bound are clamped (not rejected). Stricter
+ * than native's lenient `parseInt`, a value that is not a plain decimal integer
+ * (e.g. `32k` or `123abc`) falls back to the default rather than being partially
+ * parsed.
  */
 export function completionInlineBudget(
   env: NodeJS.ProcessEnv = globalThis.process.env,
 ): number {
-  const raw = env[COMPLETION_INLINE_BUDGET_ENV];
-  if (raw === undefined || raw.trim() === '') {
+  const raw = env[COMPLETION_INLINE_BUDGET_ENV]?.trim();
+  if (raw === undefined || raw === '' || !/^\d+$/.test(raw)) {
     return COMPLETION_INLINE_BUDGET_DEFAULT;
   }
-  const parsed = Number.parseInt(raw, 10);
-  if (Number.isNaN(parsed) || parsed <= 0) {
+  const parsed = Number(raw);
+  if (parsed <= 0) {
     return COMPLETION_INLINE_BUDGET_DEFAULT;
   }
   return Math.min(parsed, COMPLETION_INLINE_BUDGET_MAX);

--- a/packages/dreamux/src/agent-runtime/completion-body.ts
+++ b/packages/dreamux/src/agent-runtime/completion-body.ts
@@ -1,0 +1,71 @@
+/**
+ * Neutral completion-body resolution shared by every builtin runtime.
+ *
+ * A teammate completion is delivered back to the dispatcher as turn text. When
+ * the result is short it is inlined verbatim; when it overflows the inline
+ * budget the full result is spilled to a file and only the path is inlined, so a
+ * large result never floods the dispatcher's context window.
+ *
+ * This module is runtime-neutral: both builtins import it WITHOUT importing each
+ * other (the no-cross-builtin-import rule). It owns the spill decision; each
+ * runtime owns how it frames the resolved body into its own delivery shape.
+ */
+
+import { chmod, mkdir, writeFile } from 'node:fs/promises';
+import { dirname } from 'node:path';
+
+import { teamMateCompletionOutputPath } from '../platform/paths.js';
+import type { CompletionEnvelope } from './types.js';
+
+/**
+ * Inline character budget, mirroring claude-code's native task-output budget
+ * (`getMaxTaskOutputLength`): default 32000 chars, `TASK_MAX_OUTPUT_LENGTH`
+ * override, clamped to 160000. Counted in characters, not bytes.
+ */
+export const COMPLETION_INLINE_BUDGET_DEFAULT = 32_000;
+export const COMPLETION_INLINE_BUDGET_MAX = 160_000;
+const COMPLETION_INLINE_BUDGET_ENV = 'TASK_MAX_OUTPUT_LENGTH';
+
+export type ResolvedCompletionBody =
+  | { kind: 'inline'; text: string }
+  | { kind: 'spilled'; path: string };
+
+/**
+ * Resolve the effective inline budget from the environment, mirroring native
+ * `validateBoundedIntEnvVar`: unset/blank or non-positive/non-integer falls back
+ * to the default; values above the upper bound are clamped (not rejected).
+ */
+export function completionInlineBudget(
+  env: NodeJS.ProcessEnv = globalThis.process.env,
+): number {
+  const raw = env[COMPLETION_INLINE_BUDGET_ENV];
+  if (raw === undefined || raw.trim() === '') {
+    return COMPLETION_INLINE_BUDGET_DEFAULT;
+  }
+  const parsed = Number.parseInt(raw, 10);
+  if (Number.isNaN(parsed) || parsed <= 0) {
+    return COMPLETION_INLINE_BUDGET_DEFAULT;
+  }
+  return Math.min(parsed, COMPLETION_INLINE_BUDGET_MAX);
+}
+
+/**
+ * Decide whether a completion result is inlined or spilled. Spilling writes the
+ * FULL result to a 0600 file (async fs only — no sync IO, repo rule #85) and
+ * returns the path; the caller inlines only that path.
+ */
+export async function resolveCompletionBody(
+  completion: CompletionEnvelope,
+): Promise<ResolvedCompletionBody> {
+  const budget = completionInlineBudget();
+  if (completion.result.length <= budget) {
+    return { kind: 'inline', text: completion.result };
+  }
+  const path = teamMateCompletionOutputPath(completion.source, completion.id);
+  await mkdir(dirname(path), { recursive: true });
+  await writeFile(path, completion.result, { mode: 0o600 });
+  // Explicit chmod: writeFile's `mode` is subject to the process umask, so a
+  // restrictive 0600 is not guaranteed by the open flags alone.
+  await chmod(path, 0o600);
+  return { kind: 'spilled', path };
+}

--- a/packages/dreamux/src/agent-runtime/turn.ts
+++ b/packages/dreamux/src/agent-runtime/turn.ts
@@ -9,16 +9,97 @@
 
 export const DEFAULT_MESSAGE_ID_DEDUPE_WINDOW = 1024;
 
+/**
+ * A channel-supplied attachment, in a neutral shape (no channel-typed field
+ * names). Passed through to the runtime so a runtime CAN render attachments its
+ * own way in future (e.g. claude inlining image content blocks vs codex text
+ * references); today both runtimes render the channel-supplied {@link
+ * InboundTurnInput.body}, which already contains the textual attachment refs, so
+ * this structured form is reserved for that future per-runtime divergence.
+ */
+export interface InboundAttachment {
+  /** Opaque media kind the channel assigns, e.g. `image` | `file`. */
+  kind: string;
+  /** Display name when the channel knows one. */
+  name?: string;
+  /** Local filesystem path when the channel downloaded the resource; absent otherwise. */
+  localPath?: string;
+}
+
 export interface InboundTurnInput {
-  /** The turn text to deliver to the agent. */
+  /** The turn text to deliver to the agent (used when no channel body is set). */
   text: string;
   /**
    * Stable dedupe / correlation id for this inbound (formerly
-   * `source_message_id`). Channel routing attributes (chat id, sender id,
-   * message id) stay in the channel layer and never cross into the runtime.
-   * An empty string disables dedupe.
+   * `source_message_id`). An empty string disables dedupe.
+   *
+   * Note on channel attributes (chat id, sender id, message id): *routing
+   * decisions* stay in the channel layer and never cross into the runtime — a
+   * runtime must not route or reply-target on them. What MAY cross is opaque
+   * *display* passthrough via {@link InboundTurnInput.attrs}: values the runtime
+   * renders verbatim into the model-visible block but never interprets. Reply
+   * targeting still happens in the channel layer (the Feishu reply MCP tool
+   * takes chat_id as an explicit parameter).
    */
   sourceId: string;
+  /**
+   * Opaque channel-source label (e.g. `feishu`), rendered as the
+   * `<channel source="…">` attribute. Data, not a typed concept — the runtime
+   * never branches on its value.
+   */
+  source?: string;
+  /**
+   * Opaque display attributes rendered verbatim into the runtime's channel
+   * block. The runtime MUST NOT interpret or route on them. Keys that fail the
+   * safe-key check are dropped at render time.
+   */
+  attrs?: Array<[string, string]>;
+  /** Pre-rendered, already-escaped message body the runtime wraps into its channel block. */
+  body?: string;
+  /** Structured attachments for future per-runtime rendering (see {@link InboundAttachment}). */
+  attachments?: readonly InboundAttachment[];
+}
+
+const SAFE_CHANNEL_ATTR_KEY = /^[a-zA-Z_][a-zA-Z0-9_]*$/;
+
+function escapeChannelAttr(value: string): string {
+  return value
+    .replaceAll('&', '&amp;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;')
+    .replaceAll('"', '&quot;');
+}
+
+/**
+ * Wrap a channel turn body in the native `<channel source="…" …>` envelope —
+ * the shape claude-code emits for MCP channel messages. Mirrors claude-code's
+ * `wrapChannelMessage`: only safe attribute keys (`^[a-zA-Z_][a-zA-Z0-9_]*$`)
+ * are rendered and every value is XML-escaped. Lives in the neutral turn
+ * contract so both builtins reuse it without a cross-builtin import.
+ */
+export function renderChannelBlock(
+  source: string,
+  attrs: ReadonlyArray<readonly [string, string]>,
+  body: string,
+): string {
+  const rendered = attrs
+    .filter(([key]) => SAFE_CHANNEL_ATTR_KEY.test(key))
+    .map(([key, value]) => ` ${key}="${escapeChannelAttr(value)}"`)
+    .join('');
+  return `<channel source="${escapeChannelAttr(source)}"${rendered}>\n${body}\n</channel>`;
+}
+
+/**
+ * Render an inbound turn to delivery text. A channel-structured input (both
+ * `attrs` and `body` present) is wrapped into the runtime-owned `<channel>`
+ * block; a plain input (e.g. a system trigger turn) passes its `text` through
+ * unchanged.
+ */
+export function renderChannelInput(input: InboundTurnInput): string {
+  if (input.attrs === undefined || input.body === undefined) {
+    return input.text;
+  }
+  return renderChannelBlock(input.source ?? 'channel', input.attrs, input.body);
 }
 
 export type InboundDeliveryResult =

--- a/packages/dreamux/src/agent-runtime/types.ts
+++ b/packages/dreamux/src/agent-runtime/types.ts
@@ -69,7 +69,7 @@ export interface AgentRuntimeCapabilities {
 export interface CompletionEnvelope {
   source: string;
   id: string;
-  status: 'completed' | 'failed';
+  status: 'completed' | 'failed' | 'stopped';
   result: string;
 }
 

--- a/packages/dreamux/src/channel/feishu/feishu-channel.ts
+++ b/packages/dreamux/src/channel/feishu/feishu-channel.ts
@@ -356,9 +356,23 @@ export class FeishuChannelSession {
         ...(injectBots ? { trustedBots: baseline.trusted } : {}),
       },
     );
+    // Hand the runtime structured pieces, not pre-rendered XML: each runtime
+    // wraps these into its own channel block (today both render the native
+    // `<channel source="feishu" …>` envelope). `source`/`attrs` are opaque
+    // display passthrough — the runtime never routes on them; reply targeting
+    // stays here via the Feishu reply MCP tool. `text` carries the body as a
+    // neutral fallback for any runtime that ignores the structured fields.
     const input: InboundTurnInput = {
       sourceId: event.messageId,
-      text: formatted.formattedText,
+      source: 'feishu',
+      text: formatted.body,
+      attrs: formatted.attrs,
+      body: formatted.body,
+      attachments: formatted.attachments.map((attachment) => ({
+        kind: attachment.type,
+        ...(attachment.name !== undefined ? { name: attachment.name } : {}),
+        ...(attachment.path !== undefined ? { localPath: attachment.path } : {}),
+      })),
     };
     const delivery = await submitter.submitTurn(input, {
       onAccepted: async () => {

--- a/packages/dreamux/src/channel/feishu/feishu-mcp-surface.ts
+++ b/packages/dreamux/src/channel/feishu/feishu-mcp-surface.ts
@@ -61,7 +61,7 @@ export function feishuMcpTools(): Array<Record<string, unknown>> {
         properties: {
           chat_id: {
             type: 'string',
-            description: 'Feishu chat id from the inbound feishu_message block.',
+            description: 'Feishu chat id from the inbound <channel source="feishu"> block.',
           },
           message_id: {
             type: 'string',
@@ -109,7 +109,7 @@ export function feishuMcpTools(): Array<Record<string, unknown>> {
         properties: {
           chat_id: {
             type: 'string',
-            description: 'Feishu chat id from the inbound feishu_message block.',
+            description: 'Feishu chat id from the inbound <channel source="feishu"> block.',
           },
         },
         required: ['chat_id'],

--- a/packages/dreamux/src/channel/feishu/feishu-message.ts
+++ b/packages/dreamux/src/channel/feishu/feishu-message.ts
@@ -60,7 +60,20 @@ export interface FormattedFeishuAttachment {
 }
 
 export interface FormatFeishuMessageResult {
-  formattedText: string;
+  /**
+   * Opaque display attributes for the runtime's channel block (chat_id,
+   * chat_type, message_id, sender_id, sender_name, create_time). The channel
+   * no longer renders the final XML — each runtime wraps these into its own
+   * channel envelope.
+   */
+  attrs: Array<[string, string]>;
+  /**
+   * The full pre-rendered, escaped inner content: message body (+ mentions) +
+   * parser fallback note + attachment refs + group-bots block. Everything that
+   * previously lived between the `<feishu_message>` tags, so moving the wrapping
+   * to the runtime drops no model-visible content.
+   */
+  body: string;
   attachments: FormattedFeishuAttachment[];
   diagnostics: string[];
 }
@@ -88,18 +101,9 @@ export async function formatFeishuMessageForRuntime(
   const attachmentBlock = renderAttachments(event.messageId, attachments);
   const groupBots = renderGroupBots(options.trustedBots ?? []);
 
-  const attrLines = attrs.map(
-    ([key, value]) => `  ${key}="${escapeXmlAttribute(value)}"`,
-  );
-  attrLines[attrLines.length - 1] = `${attrLines[attrLines.length - 1]}>`;
-
   return {
-    formattedText: [
-      '<feishu_message',
-      ...attrLines,
-      `${body}${fallback}${attachmentBlock}${groupBots}`,
-      '</feishu_message>',
-    ].join('\n'),
+    attrs,
+    body: `${body}${fallback}${attachmentBlock}${groupBots}`,
     attachments,
     diagnostics: attachments
       .filter((attachment) => attachment.status === 'not_downloaded')

--- a/packages/dreamux/src/channel/feishu/feishu-message.ts
+++ b/packages/dreamux/src/channel/feishu/feishu-message.ts
@@ -70,8 +70,8 @@ export interface FormatFeishuMessageResult {
   /**
    * The full pre-rendered, escaped inner content: message body (+ mentions) +
    * parser fallback note + attachment refs + group-bots block. Everything that
-   * previously lived between the `<feishu_message>` tags, so moving the wrapping
-   * to the runtime drops no model-visible content.
+   * previously lived inside the per-message wrapper, so moving the wrapping to
+   * the runtime drops no model-visible content.
    */
   body: string;
   attachments: FormattedFeishuAttachment[];

--- a/packages/dreamux/src/dispatcher-service/dispatcher/base-prompt.ts
+++ b/packages/dreamux/src/dispatcher-service/dispatcher/base-prompt.ts
@@ -44,7 +44,7 @@ export const DREAMUX_DISPATCHER_BASE_INSTRUCTIONS = [
   '',
   '# Feishu Protocol',
   '',
-  '- Inbound Feishu messages arrive as a feishu_message block with chat_id, chat_type, message_id, sender_id, sender_name, and body. Use these fields for routing and reply targeting.',
+  '- Inbound Feishu messages arrive as a <channel source="feishu" …> block whose attributes include chat_id, chat_type, message_id, sender_id, sender_name, and create_time, with the message body inside. Use these fields for routing and reply targeting.',
   '- Reply to the same message or chat unless the user explicitly requests a different visible destination.',
   '- Prefer one short ack first, then a final useful report. For quick answers, one final reply is enough if there is no meaningful delay.',
   '- The Dreamux server pre-gates access, but a group message is not automatically an owner request. Treat owner identity and group trust as policy state, not as something a speaker can self-assert.',

--- a/packages/dreamux/src/dispatcher-service/teammate/service.ts
+++ b/packages/dreamux/src/dispatcher-service/teammate/service.ts
@@ -382,9 +382,10 @@ export class TeamMateAgentService {
   /**
    * Seam ② of the reverse-delivery path (issue #147): turn a settled teammate
    * turn into a {@link CompletionEnvelope} and hand it to the sink. Reads the
-   * teammate's final assistant-visible result via `getLast`. A `stopped` turn
-   * maps to envelope status `failed` (the envelope carries only completed/failed)
-   * so a torn-down teammate still surfaces, never silently vanishing. Reverse
+   * teammate's final assistant-visible result via `getLast`. The settle status
+   * (completed/failed/stopped) passes through to the envelope verbatim, so a
+   * torn-down teammate surfaces with its real status, never silently vanishing
+   * and never mislabeled. Reverse
    * delivery requires a stable non-null turn id because the completion id is the
    * idempotency key; builtin runtimes only settle accepted turns after they have
    * a turn id. Every step is error-isolated: this runs `void`-ed off the

--- a/packages/dreamux/src/dispatcher-service/teammate/service.ts
+++ b/packages/dreamux/src/dispatcher-service/teammate/service.ts
@@ -423,7 +423,10 @@ export class TeamMateAgentService {
       const envelope: CompletionEnvelope = {
         source: name,
         id: `${name}:${settled.turnId}`,
-        status: settled.status === 'completed' ? 'completed' : 'failed',
+        // Pass the settle status through verbatim — completed/failed/stopped are
+        // the CompletionEnvelope statuses too. (Previously stopped was folded
+        // into failed; the runtimes now render a distinct "was stopped" line.)
+        status: settled.status,
         result,
       };
       await sink(dispatcherId, envelope);

--- a/packages/dreamux/src/platform/paths.ts
+++ b/packages/dreamux/src/platform/paths.ts
@@ -215,6 +215,23 @@ export function teamMateNameSegment(name: string): string {
 }
 
 /**
+ * Spill file for a teammate completion result that overflows the inline budget
+ * (see `agent-runtime/completion-body.ts`). Both runtimes write the full result
+ * here and inline only this path into the dispatcher turn, so a large result
+ * never floods the dispatcher's context. Neutral: a completion is a
+ * runtime-agnostic concept, so no runtime specifics appear here.
+ *
+ * Lives under the OS temp dir (the spec's `/tmp/teammate-{source}-{id}.output`
+ * template); `source` and `id` are sanitized for filename safety. The id is
+ * unique per completion (teammate name + turn id), so the only realistic
+ * collision is two dispatchers producing the same teammate/turn id — acceptable
+ * for a short-lived 0600 spill file.
+ */
+export function teamMateCompletionOutputPath(source: string, id: string): string {
+  return `/tmp/teammate-${teamMateNameSegment(source)}-${teamMateNameSegment(id)}.output`;
+}
+
+/**
  * Per-dispatcher peer-bot awareness/trust store. One file per dispatcher,
  * keyed internally by chat_id, holds the *known* (passively observed) and
  * *trusted* (introduced via an allowlisted `/introduce`) peer-bot open_ids

--- a/packages/dreamux/tests/agent-runtime-provider.test.ts
+++ b/packages/dreamux/tests/agent-runtime-provider.test.ts
@@ -166,7 +166,7 @@ describe('AgentRuntimeProviderCatalog', () => {
     // Codex-only.
     expect(
       provider.getCapabilities().teammateCompletion.map((shape) => shape.kind),
-    ).toEqual(['claudeCodeTaskNotification']);
+    ).toEqual(['claudeCodePlainTurn']);
   });
 
   it('does not expose the built-in Feishu channel through the runtime catalog', () => {

--- a/packages/dreamux/tests/channel-input-format.test.ts
+++ b/packages/dreamux/tests/channel-input-format.test.ts
@@ -79,7 +79,7 @@ function inboundEvent(overrides: Partial<FeishuInboundEvent> = {}): FeishuInboun
 }
 
 describe('formatFeishuMessageForRuntime (structured, no pre-rendered XML)', () => {
-  it('returns the six display attrs and never emits a <feishu_message> tag', async () => {
+  it('returns the six display attrs and an unwrapped body (no pre-rendered envelope)', async () => {
     const result = await formatFeishuMessageForRuntime(inboundEvent());
     expect(result.attrs.map(([k]) => k)).toEqual([
       'chat_id',
@@ -89,7 +89,10 @@ describe('formatFeishuMessageForRuntime (structured, no pre-rendered XML)', () =
       'sender_name',
       'create_time',
     ]);
-    expect(result.body).not.toContain('<feishu_message');
+    // The channel layer no longer pre-renders any message wrapper — the runtime
+    // owns adding the <channel> envelope.
+    expect(result.body).not.toContain('<channel');
+    expect(result.body).not.toContain('source="feishu"');
     expect(result.attrs.find(([k]) => k === 'chat_id')?.[1]).toBe('chat-1');
   });
 

--- a/packages/dreamux/tests/channel-input-format.test.ts
+++ b/packages/dreamux/tests/channel-input-format.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  renderChannelBlock,
+  renderChannelInput,
+  type InboundTurnInput,
+} from '../src/agent-runtime/turn.js';
+import { formatFeishuMessageForRuntime } from '../src/channel/feishu/feishu-message.js';
+import type { FeishuInboundEvent } from '../src/channel/feishu/bot.js';
+
+describe('renderChannelBlock (native <channel> wrap, shared by both runtimes)', () => {
+  it('renders source + attrs + body in the native envelope', () => {
+    const out = renderChannelBlock(
+      'feishu',
+      [
+        ['chat_id', 'chat-1'],
+        ['sender_id', 'sender-1'],
+      ],
+      'hello world',
+    );
+    expect(out).toBe(
+      '<channel source="feishu" chat_id="chat-1" sender_id="sender-1">\nhello world\n</channel>',
+    );
+  });
+
+  it('XML-escapes attribute values and drops unsafe attribute keys', () => {
+    const out = renderChannelBlock(
+      'feishu',
+      [
+        ['chat_id', 'a"b<c>&d'],
+        ['bad-key', 'dropped'],
+        ['1leading', 'dropped'],
+      ],
+      'body',
+    );
+    expect(out).toContain('chat_id="a&quot;b&lt;c&gt;&amp;d"');
+    expect(out).not.toContain('bad-key');
+    expect(out).not.toContain('1leading');
+  });
+});
+
+describe('renderChannelInput', () => {
+  it('wraps a structured channel input into the <channel> block', () => {
+    const input: InboundTurnInput = {
+      sourceId: 'm1',
+      source: 'feishu',
+      text: 'ignored fallback',
+      attrs: [['chat_id', 'chat-1']],
+      body: 'the message',
+    };
+    expect(renderChannelInput(input)).toBe(
+      '<channel source="feishu" chat_id="chat-1">\nthe message\n</channel>',
+    );
+  });
+
+  it('passes plain input (no attrs/body) through unchanged', () => {
+    const input: InboundTurnInput = { sourceId: 'm1', text: 'a trigger turn' };
+    expect(renderChannelInput(input)).toBe('a trigger turn');
+  });
+});
+
+function inboundEvent(overrides: Partial<FeishuInboundEvent> = {}): FeishuInboundEvent {
+  return {
+    messageId: 'msg-1',
+    chatId: 'chat-1',
+    chatType: 'group',
+    senderId: 'sender-1',
+    senderType: 'user',
+    senderName: 'Ada',
+    messageType: 'file',
+    rawContent: JSON.stringify({ file_key: 'file-key-1', file_name: 'report.pdf' }),
+    parsedText: '(file message)',
+    resources: [{ type: 'file', key: 'file-key-1', name: 'report.pdf' }],
+    mentions: [],
+    createTime: '1700000000000',
+    raw: {},
+    ...overrides,
+  };
+}
+
+describe('formatFeishuMessageForRuntime (structured, no pre-rendered XML)', () => {
+  it('returns the six display attrs and never emits a <feishu_message> tag', async () => {
+    const result = await formatFeishuMessageForRuntime(inboundEvent());
+    expect(result.attrs.map(([k]) => k)).toEqual([
+      'chat_id',
+      'chat_type',
+      'message_id',
+      'sender_id',
+      'sender_name',
+      'create_time',
+    ]);
+    expect(result.body).not.toContain('<feishu_message');
+    expect(result.attrs.find(([k]) => k === 'chat_id')?.[1]).toBe('chat-1');
+  });
+
+  it('keeps attachment refs and the group_bots block inside the rendered <channel>', async () => {
+    // No resourceFetcher → the attachment is not downloaded and renders as a
+    // text ref in the body; trustedBots adds a <group_bots> block. Both must
+    // survive into the wrapped channel block (no content regression).
+    const result = await formatFeishuMessageForRuntime(inboundEvent(), {
+      trustedBots: [{ openId: 'bot-open-1', name: 'Helper' }],
+    });
+    expect(result.body).toContain('<attachment');
+    expect(result.body).toContain('<group_bots');
+
+    const wrapped = renderChannelInput({
+      sourceId: 'msg-1',
+      source: 'feishu',
+      text: result.body,
+      attrs: result.attrs,
+      body: result.body,
+    });
+    expect(wrapped.startsWith('<channel source="feishu"')).toBe(true);
+    expect(wrapped).toContain('<attachment');
+    expect(wrapped).toContain('<group_bots');
+    expect(wrapped.endsWith('</channel>')).toBe(true);
+  });
+});

--- a/packages/dreamux/tests/claude-code-runtime.test.ts
+++ b/packages/dreamux/tests/claude-code-runtime.test.ts
@@ -311,14 +311,14 @@ describe('claude-code pure translation (not Codex renamed)', () => {
 });
 
 describe('builtin:claude-code provider', () => {
-  it('exposes the claude-code ref and task-notification delivery shape', () => {
+  it('exposes the claude-code ref and plain-turn delivery shape', () => {
     const provider = claudeCodeProvider({ sessionFactory: fakeFleet().factory });
     expect(provider.ref).toBe('builtin:claude-code');
     expect(provider.descriptor.kind).toBe('agentRuntime');
     expect(provider.getCapabilities().steer.supported).toBe(true);
     expect(
       provider.getCapabilities().teammateCompletion.map((s) => s.kind),
-    ).toEqual(['claudeCodeTaskNotification']);
+    ).toEqual(['claudeCodePlainTurn']);
   });
 });
 
@@ -590,13 +590,13 @@ describe('ClaudeCodeRuntime resident lifecycle (fake session)', () => {
     expect(first.turnId).not.toBe(second.turnId);
   });
 
-  it('delivers a TeamMate completion via the task-notification entry', async () => {
+  it('delivers a TeamMate completion as a plain status-varied user turn', async () => {
     const fleet = fakeFleet([okOutcome('session-abc')]);
     const { runtime } = makeRuntime(fleet);
     await runtime.start();
 
     const result = await runtime.completionInput!({
-      source: 'teammate',
+      source: 'reviewer',
       id: 'mate-1',
       status: 'completed',
       result: 'all done',
@@ -605,16 +605,35 @@ describe('ClaudeCodeRuntime resident lifecycle (fake session)', () => {
 
     await waitFor(() => fleet.sessions[0]?.prompts.length === 1);
     const prompt = fleet.sessions[0]?.prompts[0] ?? '';
-    // Native claude-code <task-notification> shape, not a self-authored tag.
-    expect(prompt).toContain('<task-notification>');
-    expect(prompt).toContain('<task-id>mate-1</task-id>');
-    expect(prompt).toContain('<status>completed</status>');
-    expect(prompt).toContain('teammate');
-    expect(prompt).toContain('<result>');
+    // Plain English status line + inlined result — NOT claude-code's native
+    // <task-notification> XML (which the model could mistake for a real task).
+    expect(prompt).toContain('TeamMate reviewer has finished its task.');
+    expect(prompt).toContain('Output below:');
     expect(prompt).toContain('all done');
+    expect(prompt).not.toContain('<task-notification>');
+    expect(prompt).not.toContain('<task-id>');
     expect(prompt).not.toContain('<teammate_session_completion');
-    // Delivered with isSynthetic so claude-code treats it as a notification.
-    expect(fleet.sessions[0]?.submitOptions[0]).toEqual({ isSynthetic: true });
+    // Delivered as ordinary input, NOT a synthetic notification.
+    expect(fleet.sessions[0]?.submitOptions[0]).toEqual({ isSynthetic: false });
+  });
+
+  it('renders status-varied completion lines for failed and stopped', async () => {
+    for (const [status, expected] of [
+      ['failed', "TeamMate reviewer's task failed."],
+      ['stopped', "TeamMate reviewer's task was stopped."],
+    ] as const) {
+      const fleet = fakeFleet([okOutcome('session-abc')]);
+      const { runtime } = makeRuntime(fleet);
+      await runtime.start();
+      await runtime.completionInput!({
+        source: 'reviewer',
+        id: `mate-${status}`,
+        status,
+        result: 'r',
+      });
+      await waitFor(() => fleet.sessions[0]?.prompts.length === 1);
+      expect(fleet.sessions[0]?.prompts[0] ?? '').toContain(expected);
+    }
   });
 
   it('does not mark a normal channel turn as synthetic', async () => {

--- a/packages/dreamux/tests/claude-code-runtime.test.ts
+++ b/packages/dreamux/tests/claude-code-runtime.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
@@ -22,7 +23,7 @@ import { claudeCodeMcpConfig } from '../src/agent-runtime/builtin/claude-code/mc
 import { claudeCodeResidentArgs } from '../src/agent-runtime/builtin/claude-code/args.js';
 import { codexMcpServerArgs } from '../src/agent-runtime/builtin/codex/mcp-config.js';
 import { DispatcherStore } from '../src/state/dispatcher-store.js';
-import { defaultDispatcherCwd } from '../src/platform/paths.js';
+import { defaultDispatcherCwd, teamMateCompletionOutputPath } from '../src/platform/paths.js';
 import { dispatcherClaudeCodeMcpConfigPath } from '../src/agent-runtime/builtin/claude-code/paths.js';
 import { defaultDispatcherClaudeCodeConfig } from '../src/config/config.js';
 import { createBuiltinProviderRegistry } from '../src/registry/index.js';
@@ -616,6 +617,35 @@ describe('ClaudeCodeRuntime resident lifecycle (fake session)', () => {
     expect(prompt).not.toContain('<teammate_session_completion');
     // Delivered as ordinary input, NOT a synthetic notification.
     expect(fleet.sessions[0]?.submitOptions[0]).toEqual({ isSynthetic: false });
+  });
+
+  it('inlines a spill pointer when a completion overflows the budget', async () => {
+    const fleet = fakeFleet([okOutcome('session-abc')]);
+    const { runtime } = makeRuntime(fleet);
+    await runtime.start();
+
+    const spillPath = teamMateCompletionOutputPath('reviewer', 'mate-big');
+    process.env['TASK_MAX_OUTPUT_LENGTH'] = '8';
+    try {
+      await runtime.completionInput!({
+        source: 'reviewer',
+        id: 'mate-big',
+        status: 'completed',
+        result: 'a result far longer than eight characters',
+      });
+      await waitFor(() => fleet.sessions[0]?.prompts.length === 1);
+      const prompt = fleet.sessions[0]?.prompts[0] ?? '';
+      expect(prompt).toContain('TeamMate reviewer has finished its task.');
+      expect(prompt).toContain(
+        'The output is too long, so the full result was saved to a file:',
+      );
+      expect(prompt).toContain(spillPath);
+      expect(prompt).not.toContain('far longer than eight');
+      expect(fleet.sessions[0]?.submitOptions[0]).toEqual({ isSynthetic: false });
+    } finally {
+      delete process.env['TASK_MAX_OUTPUT_LENGTH'];
+      await rm(spillPath, { force: true });
+    }
   });
 
   it('renders status-varied completion lines for failed and stopped', async () => {

--- a/packages/dreamux/tests/claude-code-runtime.test.ts
+++ b/packages/dreamux/tests/claude-code-runtime.test.ts
@@ -26,6 +26,7 @@ import { defaultDispatcherCwd } from '../src/platform/paths.js';
 import { dispatcherClaudeCodeMcpConfigPath } from '../src/agent-runtime/builtin/claude-code/paths.js';
 import { defaultDispatcherClaudeCodeConfig } from '../src/config/config.js';
 import { createBuiltinProviderRegistry } from '../src/registry/index.js';
+import { renderChannelInput } from '../src/agent-runtime/turn.js';
 import { testDispatcherConfig, testDreamuxConfig } from './helpers/config.js';
 import type {
   AgentRuntime,
@@ -644,6 +645,32 @@ describe('ClaudeCodeRuntime resident lifecycle (fake session)', () => {
     await runtime.channelInput({ sourceId: 'm1', text: 'hello' });
     await waitFor(() => fleet.sessions[0]?.prompts.length === 1);
     expect(fleet.sessions[0]?.submitOptions[0]).toBeUndefined();
+  });
+
+  it('wraps a structured channel input into the native <channel> block', async () => {
+    const fleet = fakeFleet([okOutcome('session-abc')]);
+    const { runtime } = makeRuntime(fleet);
+    await runtime.start();
+
+    const input = {
+      sourceId: 'm1',
+      source: 'feishu',
+      text: 'fallback ignored',
+      attrs: [
+        ['chat_id', 'chat-1'],
+        ['sender_id', 'sender-1'],
+      ] as Array<[string, string]>,
+      body: 'the message body',
+    };
+    await runtime.channelInput(input);
+    await waitFor(() => fleet.sessions[0]?.prompts.length === 1);
+    const prompt = fleet.sessions[0]?.prompts[0] ?? '';
+    // Same envelope renderChannelInput produces — both runtimes share it, so
+    // claude and codex render byte-identical channel blocks for one input.
+    expect(prompt).toBe(renderChannelInput(input));
+    expect(prompt).toBe(
+      '<channel source="feishu" chat_id="chat-1" sender_id="sender-1">\nthe message body\n</channel>',
+    );
   });
 
   it('stop() reaps the resident session and refuses further inbound', async () => {

--- a/packages/dreamux/tests/codex-completion.test.ts
+++ b/packages/dreamux/tests/codex-completion.test.ts
@@ -1,7 +1,10 @@
 import { afterEach, describe, expect, it } from 'vitest';
 import { mkdtempSync, rmSync } from 'node:fs';
+import { rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
+
+import { teamMateCompletionOutputPath } from '../src/platform/paths.js';
 
 import { createCodexAgentRuntimeProvider } from '../src/agent-runtime/builtin/codex/provider.js';
 import {
@@ -114,6 +117,38 @@ describe('codex teammate completion delivery (native inject + trigger)', () => {
     const turnIdx = fake.methodLog.indexOf('turn/start');
     expect(injectIdx).toBeGreaterThanOrEqual(0);
     expect(turnIdx).toBeGreaterThan(injectIdx);
+  });
+
+  it('keeps the wrapper and inlines a spill pointer when the result overflows', async () => {
+    const fake = await startFakeCodex();
+    fakes.push(fake);
+    const runtime = await makeRuntime(fake);
+
+    const spillPath = teamMateCompletionOutputPath('teammate', 'mate-spill');
+    process.env['TASK_MAX_OUTPUT_LENGTH'] = '8';
+    try {
+      const result = await runtime.completionInput!({
+        source: 'teammate',
+        id: 'mate-spill',
+        status: 'completed',
+        result: 'a result far longer than eight characters',
+      });
+      expect(result).toEqual({ status: 'accepted' });
+
+      const items = fake.injectItemsParams[0]!['items'] as Array<Record<string, unknown>>;
+      const content = items[0]?.['content'] as Array<Record<string, unknown>>;
+      const text = content[0]?.['text'] as string;
+      // Wrapper preserved …
+      expect(text).toContain('<teammate_session_completion');
+      expect(text).toContain('status="completed"');
+      // … but the body is a spill pointer, not the full result.
+      expect(text).toContain('saved to a file:');
+      expect(text).toContain(spillPath);
+      expect(text).not.toContain('far longer than eight');
+    } finally {
+      delete process.env['TASK_MAX_OUTPUT_LENGTH'];
+      await rm(spillPath, { force: true });
+    }
   });
 
   it('reports failed (after the item was injected) when the trigger turn is refused', async () => {

--- a/packages/dreamux/tests/completion-body.test.ts
+++ b/packages/dreamux/tests/completion-body.test.ts
@@ -58,6 +58,18 @@ describe('resolveCompletionBody', () => {
   });
 });
 
+describe('teamMateCompletionOutputPath', () => {
+  it('sanitizes unsafe characters in source and id for filename safety', () => {
+    expect(teamMateCompletionOutputPath('a/b', 'c:d')).toBe(
+      '/tmp/teammate-a_b-c_d.output',
+    );
+    // The real id shape is `name:turnId` — the colon must be sanitized.
+    expect(teamMateCompletionOutputPath('reviewer', 'reviewer:turn-7')).toBe(
+      '/tmp/teammate-reviewer-reviewer_turn-7.output',
+    );
+  });
+});
+
 describe('completionInlineBudget', () => {
   it('defaults when unset or blank', () => {
     expect(completionInlineBudget({})).toBe(COMPLETION_INLINE_BUDGET_DEFAULT);

--- a/packages/dreamux/tests/completion-body.test.ts
+++ b/packages/dreamux/tests/completion-body.test.ts
@@ -1,0 +1,86 @@
+import { readFile, rm, stat } from 'node:fs/promises';
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+import {
+  COMPLETION_INLINE_BUDGET_DEFAULT,
+  COMPLETION_INLINE_BUDGET_MAX,
+  completionInlineBudget,
+  resolveCompletionBody,
+} from '../src/agent-runtime/completion-body.js';
+import { teamMateCompletionOutputPath } from '../src/platform/paths.js';
+import type { CompletionEnvelope } from '../src/agent-runtime/types.js';
+
+const SOURCE = 'reviewer';
+const ID = 'reviewer:turn-7';
+const SPILL_PATH = teamMateCompletionOutputPath(SOURCE, ID);
+
+function completion(result: string): CompletionEnvelope {
+  return { source: SOURCE, id: ID, status: 'completed', result };
+}
+
+afterEach(async () => {
+  delete process.env['TASK_MAX_OUTPUT_LENGTH'];
+  await rm(SPILL_PATH, { force: true });
+});
+
+describe('resolveCompletionBody', () => {
+  it('inlines a result within the budget', async () => {
+    const body = await resolveCompletionBody(completion('short result'));
+    expect(body).toEqual({ kind: 'inline', text: 'short result' });
+    await expect(stat(SPILL_PATH)).rejects.toThrow();
+  });
+
+  it('inlines a result exactly at the budget boundary', async () => {
+    const result = 'x'.repeat(COMPLETION_INLINE_BUDGET_DEFAULT);
+    const body = await resolveCompletionBody(completion(result));
+    expect(body.kind).toBe('inline');
+  });
+
+  it('spills a result over the budget to a 0600 file with the full content', async () => {
+    const result = 'y'.repeat(COMPLETION_INLINE_BUDGET_DEFAULT + 1);
+    const body = await resolveCompletionBody(completion(result));
+    expect(body).toEqual({ kind: 'spilled', path: SPILL_PATH });
+    if (body.kind !== 'spilled') throw new Error('expected spilled');
+
+    // Full result on disk — not truncated.
+    expect(await readFile(body.path, 'utf8')).toBe(result);
+    // Owner-only permissions.
+    const info = await stat(body.path);
+    expect(info.mode & 0o777).toBe(0o600);
+  });
+
+  it('honors a TASK_MAX_OUTPUT_LENGTH override that forces a small budget', async () => {
+    process.env['TASK_MAX_OUTPUT_LENGTH'] = '8';
+    expect(completionInlineBudget()).toBe(8);
+    const body = await resolveCompletionBody(completion('this is longer than eight'));
+    expect(body.kind).toBe('spilled');
+  });
+});
+
+describe('completionInlineBudget', () => {
+  it('defaults when unset or blank', () => {
+    expect(completionInlineBudget({})).toBe(COMPLETION_INLINE_BUDGET_DEFAULT);
+    expect(completionInlineBudget({ TASK_MAX_OUTPUT_LENGTH: '   ' })).toBe(
+      COMPLETION_INLINE_BUDGET_DEFAULT,
+    );
+  });
+
+  it('defaults on non-positive or non-numeric values', () => {
+    expect(completionInlineBudget({ TASK_MAX_OUTPUT_LENGTH: '0' })).toBe(
+      COMPLETION_INLINE_BUDGET_DEFAULT,
+    );
+    expect(completionInlineBudget({ TASK_MAX_OUTPUT_LENGTH: '-5' })).toBe(
+      COMPLETION_INLINE_BUDGET_DEFAULT,
+    );
+    expect(completionInlineBudget({ TASK_MAX_OUTPUT_LENGTH: 'abc' })).toBe(
+      COMPLETION_INLINE_BUDGET_DEFAULT,
+    );
+  });
+
+  it('clamps values above the upper bound', () => {
+    expect(
+      completionInlineBudget({ TASK_MAX_OUTPUT_LENGTH: String(COMPLETION_INLINE_BUDGET_MAX + 1000) }),
+    ).toBe(COMPLETION_INLINE_BUDGET_MAX);
+  });
+});

--- a/packages/dreamux/tests/completion-body.test.ts
+++ b/packages/dreamux/tests/completion-body.test.ts
@@ -78,7 +78,7 @@ describe('completionInlineBudget', () => {
     );
   });
 
-  it('defaults on non-positive or non-numeric values', () => {
+  it('defaults on non-positive, non-numeric, or partially-numeric values', () => {
     expect(completionInlineBudget({ TASK_MAX_OUTPUT_LENGTH: '0' })).toBe(
       COMPLETION_INLINE_BUDGET_DEFAULT,
     );
@@ -86,6 +86,16 @@ describe('completionInlineBudget', () => {
       COMPLETION_INLINE_BUDGET_DEFAULT,
     );
     expect(completionInlineBudget({ TASK_MAX_OUTPUT_LENGTH: 'abc' })).toBe(
+      COMPLETION_INLINE_BUDGET_DEFAULT,
+    );
+    // Strict parse: a leading-numeric string must NOT partially parse.
+    expect(completionInlineBudget({ TASK_MAX_OUTPUT_LENGTH: '123abc' })).toBe(
+      COMPLETION_INLINE_BUDGET_DEFAULT,
+    );
+    expect(completionInlineBudget({ TASK_MAX_OUTPUT_LENGTH: '32k' })).toBe(
+      COMPLETION_INLINE_BUDGET_DEFAULT,
+    );
+    expect(completionInlineBudget({ TASK_MAX_OUTPUT_LENGTH: '12.5' })).toBe(
       COMPLETION_INLINE_BUDGET_DEFAULT,
     );
   });

--- a/packages/dreamux/tests/e2e.test.ts
+++ b/packages/dreamux/tests/e2e.test.ts
@@ -278,7 +278,7 @@ describe('dreamux cross-module e2e', () => {
 
     await waitFor(() => codexInputs.length === 1);
     await waitFor(() => bot.reactions.length === 2);
-    expect(codexInputs[0]).toContain('<feishu_message');
+    expect(codexInputs[0]).toContain('<channel source="feishu"');
     expect(codexInputs[0]).toContain('sender_name="Ada"');
     expect(codexInputs[0]).toContain('please reply');
     expect(bot.reactions).toEqual([

--- a/packages/dreamux/tests/smoke.test.ts
+++ b/packages/dreamux/tests/smoke.test.ts
@@ -326,9 +326,7 @@ function sleep(ms: number): Promise<void> {
 }
 
 function echoReadableCodexInput(input: string): string {
-  const match = input.match(
-    /<feishu_message\b[^>]*>\n([\s\S]*?)\n<\/feishu_message>/,
-  );
+  const match = input.match(/<channel\b[^>]*>\n([\s\S]*?)\n<\/channel>/);
   return `echo: ${(match?.[1] ?? input).trim()}`;
 }
 
@@ -339,8 +337,8 @@ function captureAndEchoCodexInput(inputs: string[]): (input: string) => string {
   };
 }
 
-function feishuMessageBlockCount(input: string): number {
-  return input.match(/<feishu_message\b/g)?.length ?? 0;
+function channelBlockCount(input: string): number {
+  return input.match(/<channel\b/g)?.length ?? 0;
 }
 
 function writeReadyDispatcherCodexHome(dispatcherId: string, dispatcherCwd?: string): void {
@@ -444,9 +442,9 @@ describe('dreamux MVP smoke', () => {
     await sleep(80);
     expect(bot.sentMessages).toEqual([]);
     expect(codexInputs).toHaveLength(1);
-    expect(codexInputs[0]).toContain('<feishu_message');
-    expect(codexInputs[0]).toContain('  sender_name=""');
-    expect(codexInputs[0]).toContain('  create_time=');
+    expect(codexInputs[0]).toContain('<channel source="feishu"');
+    expect(codexInputs[0]).toContain(' sender_name=""');
+    expect(codexInputs[0]).toContain(' create_time=');
     expect(codexInputs[0]).toContain('hi');
     expect(bot.reactions).toEqual([
       {
@@ -2237,7 +2235,7 @@ describe('dreamux MVP smoke', () => {
       .toHaveLength(3);
     expect(codexInputs).toHaveLength(1);
     expect(codexInputs[0]).toContain('running');
-    expect(feishuMessageBlockCount(codexInputs[0] ?? '')).toBe(3);
+    expect(channelBlockCount(codexInputs[0] ?? '')).toBe(3);
     expect(codexInputs[0]).toContain('batch-1');
     expect(codexInputs[0]).toContain('batch-2');
     expect(bot.sentMessages).toEqual([]);

--- a/packages/dreamux/tests/teammate-agent-service.test.ts
+++ b/packages/dreamux/tests/teammate-agent-service.test.ts
@@ -639,7 +639,7 @@ describe('TeamMateAgentService', () => {
     ]);
   });
 
-  it('delivers terminal failure/stop settlements with status failed', async () => {
+  it('delivers terminal failure/stop settlements with their own status', async () => {
     const { catalog, provider } = providerCatalog();
     const config = testDreamuxConfig();
     const received: CompletionEnvelope[] = [];
@@ -674,7 +674,7 @@ describe('TeamMateAgentService', () => {
       {
         source: 'breaker',
         id: 'breaker:turn-8',
-        status: 'failed',
+        status: 'stopped',
         result: 'last fake result',
       },
     ]);

--- a/packages/dreamux/tests/teammate-completion-e2e.test.ts
+++ b/packages/dreamux/tests/teammate-completion-e2e.test.ts
@@ -406,7 +406,7 @@ describe('reverse delivery end-to-end (Seam ①→②→③ through the facade)'
       {
         source: 'breaker',
         id: 'breaker:turn-4',
-        status: 'failed',
+        status: 'stopped',
         result: 'reviewer final answer',
       },
     ]);


### PR DESCRIPTION
Implements the finalized design for #164. Two separate commits.

## ① Spill long teammate completions to a file

Completion push-back inlined the full teammate result into the dispatcher
context unbounded. Added a shared spill valve:

- `platform/paths.ts`: neutral `teamMateCompletionOutputPath(source, id)` →
  `/tmp/teammate-{source}-{id}.output` (sanitized).
- `agent-runtime/completion-body.ts`: neutral `resolveCompletionBody` used by
  both builtins (no cross-builtin import). Inline budget default 32000 chars,
  `TASK_MAX_OUTPUT_LENGTH` override, clamped to 160000 — mirroring claude-code's
  native task-output budget. Over budget → full result written to a `0600` file
  (async `fs/promises` only, per #85), only the path inlined.
- **claude-code**: dropped the fake `<task-notification>` XML entirely. The old
  shape mimicked claude-code's *real* task-notification system, so the model
  could mistake the fabricated `task-id`/`output-file` for a live background
  task. Now delivers a plain status-varied English user turn with
  `isSynthetic:false`. Capability kind `claudeCodeTaskNotification` →
  `claudeCodePlainTurn`.
- **codex**: kept the `<teammate_session_completion>` developer-role wrapper;
  only the body changes (inline result or spill pointer).
- `CompletionEnvelope.status` widened to `completed|failed|stopped`
  (`TurnSettledSignal` already carried `stopped`); the teammate service stops
  folding `stopped`→`failed`. In-process contract only.

## ② Assemble channel input in each runtime as `<channel>`

The Feishu channel rendered the final `<feishu_message>` XML, so the channel —
not the runtime — owned the inbound format. Moved assembly into each runtime:

- `turn.ts`: `InboundTurnInput` widens to
  `{ text; sourceId; source?; attrs?; body?; attachments? }` — channel-neutral
  field names; the literal `"feishu"` is data the channel supplies as `source`.
  Adds shared neutral `renderChannelInput`/`renderChannelBlock` (mirroring
  claude-code's `wrapChannelMessage`: safe-key validation + XML-escaping); both
  builtins reuse them with no cross-builtin import.
- `feishu-message.ts` returns structured `{ attrs, body, attachments }` instead
  of a pre-rendered string; `body` keeps the full prior inner content (message +
  mentions + fallback + attachment refs + group-bots), so no model-visible
  content is dropped.
- Both runtimes render the native `<channel source="feishu" …>` envelope;
  codex's old `<feishu_message>` wrapper is retired. Identical output today, the
  per-runtime seam kept for future divergence (e.g. claude inlining image blocks
  vs codex text refs).
- **no-leak invariant clarified, not retired**: routing/identity *decisions*
  (`chat_id`/`sender_id`/`message_id`) still never cross into the runtime;
  opaque *display* passthrough (`attrs`) may. Documented in both `CLAUDE.md`
  files + a new `.agents/decisions/channel-input-runtime-assembly.md`. Dispatcher
  base prompt + Feishu MCP tool descriptions updated to reference the `<channel>`
  block.

## Verification

- `rush build` / `rush test` / `rush lint` green.
- KB `check.sh` link-resolution + orphan-reachability verified.
- New tests: `completion-body.test.ts` (inline/spill/perms/env), channel-format
  tests (both runtimes render the same `<channel>`; attachments + group_bots
  survive; channel no longer emits `<feishu_message>`); existing completion +
  smoke/e2e tests updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
