### PR TITLE
Add managed TeamMate worktrees

### DIFF
--- a/.agents/decisions/provider-architecture-realignment.md
+++ b/.agents/decisions/provider-architecture-realignment.md
@@ -115,10 +115,11 @@ see its `verbs/` (spawn/resume/history), `persistence/history-index.ts` and
   lifecycle verb. Per-runtime checkpoint mechanics are absorbed by the runtime
   implementation behind one `resume()` runtime surface.
 - **Identity and state location.** A teammate is a flat name plus a base record
-  (provider ref, cwd, checkpoint, status, close metadata). State is server-owned
+  (agent runtime id, dispatcher owner, source/runtime cwd, optional managed
+  worktree metadata, checkpoint, status, close metadata). State is server-owned
   under `~/.dreamux/state/<dispatcher>/teammate/` with `identities/`,
-  `history/`, and `runtime/` subtrees; paths go through
-  `/packages/dreamux/src/runtime/paths.ts`.
+  `history/`, `runtime/`, and managed `worktrees/` subtrees; paths go through
+  `/packages/dreamux/src/platform/paths.ts`.
 - **Ownership.** The Dispatcher Service owns TeamMate identity and history
   through focused modules under
   `/packages/dreamux/src/dispatcher-service/teammate/`.

--- a/.agents/decisions/top-level-design.md
+++ b/.agents/decisions/top-level-design.md
@@ -591,9 +591,16 @@ The dispatcher-facing tools are `spawn`, `send`, `close`, `history`,
 tools forward
 to `dreamux serve` over the local admin socket; the server owns the
 per-dispatcher TeamMate identities, runtime checkpoints, and forward-only
-history under `state/<dispatcher-id>/teammate/`. A caller marked as `teammate`
-does not receive lifecycle tools, so TeamMates cannot recursively spawn or close
-TeamMates.
+history under `state/<dispatcher-id>/teammate/`. Issue #169 made `spawn.cwd`
+required and added optional managed worktree isolation:
+`spawn({ name, prompt, cwd, worktree?, agent_runtime? })`. A reuse-cwd teammate
+runs in the caller-supplied `cwd`; a managed teammate runs only in its prepared
+worktree and persists source cwd/repo, runtime cwd, worktree branch/base ref,
+cleanup policy/state, and a default dispatcher `owner` field on the identity.
+Old identities without owner/worktree metadata read as dispatcher-owned
+reuse-cwd records until the next lifecycle mutation rewrites them. A caller
+marked as `teammate` does not receive lifecycle tools, so TeamMates cannot
+recursively spawn or close TeamMates.
 
 ## Reaction Ownership
 

--- a/common/changes/@excitedjs/dreamux/issue169-teammate-managed-worktree_2026-06-10-00-00.json
+++ b/common/changes/@excitedjs/dreamux/issue169-teammate-managed-worktree_2026-06-10-00-00.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "BREAKING: TeamMate MCP/admin spawn now requires `cwd`; the service no longer falls back to a dispatcher cwd or Dreamux runtime directory for native teammates. Call `spawn({ name, prompt, cwd, worktree?, agent_runtime? })` and pass either `worktree: { mode: \"reuse-cwd\" }` or `worktree: { mode: \"managed\", slug?, base_ref?, branch?, cleanup? }` for Dreamux-managed worktree isolation. TeamMate identities now persist dispatcher owner metadata plus source/runtime cwd and worktree cleanup metadata. Rebuild: respawn any caller-side TeamMate automation that omitted `cwd`; old identity files without owner/worktree metadata still read as dispatcher-owned reuse-cwd records and are rewritten only on later lifecycle mutation.",
+      "type": "minor",
+      "packageName": "@excitedjs/dreamux"
+    }
+  ],
+  "packageName": "@excitedjs/dreamux",
+  "email": "053700@gmail.com"
+}

--- a/packages/dreamux/src/admin/methods.ts
+++ b/packages/dreamux/src/admin/methods.ts
@@ -9,6 +9,7 @@
 import type { Server } from '../server.js';
 import { AdminError } from './protocol.js';
 import { validateDispatcherId } from '../state/dispatcher-id.js';
+import type { TeamMateWorktreeRequest } from '../dispatcher-service/teammate/types.js';
 
 export type AdminHandler = (
   server: Server,
@@ -127,14 +128,18 @@ export const adminMethods: Record<string, AdminHandler> = {
     const name = mustString(params, 'name');
     const prompt = mustString(params, 'prompt');
     const agentRuntime = optionalString(params, 'agent_runtime');
-    const cwd = optionalString(params, 'cwd');
+    const cwd = mustString(params, 'cwd');
+    const worktree = optionalWorktreeRequest(params, 'worktree');
+    const intent = optionalString(params, 'intent');
     try {
       return await server.dispatcherService.spawnTeamMate({
         dispatcherId: id,
         name,
         prompt,
+        cwd,
         ...(agentRuntime !== null ? { agentRuntime } : {}),
-        ...(cwd !== null ? { cwd } : {}),
+        ...(worktree !== null ? { worktree } : {}),
+        ...(intent !== null ? { intent } : {}),
       });
     } catch (err) {
       throw new AdminError('TEAMMATE_SPAWN_FAILED', parseMessage(err));
@@ -246,6 +251,52 @@ function optionalString(
     throw new AdminError('BAD_REQUEST', `param '${key}' must be a string`);
   }
   return v;
+}
+
+function optionalWorktreeRequest(
+  params: Record<string, unknown> | undefined,
+  key: string,
+): TeamMateWorktreeRequest | null {
+  if (params === undefined) return null;
+  const value = params[key];
+  if (value === undefined || value === null) return null;
+  if (typeof value !== 'object' || Array.isArray(value)) {
+    throw new AdminError('BAD_REQUEST', `param '${key}' must be an object`);
+  }
+  const obj = value as Record<string, unknown>;
+  const mode = mustString(obj, 'mode');
+  if (mode !== 'reuse-cwd' && mode !== 'managed') {
+    throw new AdminError(
+      'BAD_REQUEST',
+      `param '${key}.mode' must be 'reuse-cwd' or 'managed'`,
+    );
+  }
+  const cleanup = optionalString(obj, 'cleanup');
+  if (
+    cleanup !== null &&
+    cleanup !== 'keep' &&
+    cleanup !== 'delete-on-close'
+  ) {
+    throw new AdminError(
+      'BAD_REQUEST',
+      `param '${key}.cleanup' must be 'keep' or 'delete-on-close'`,
+    );
+  }
+  return {
+    mode,
+    ...optionalStringProp(obj, 'slug'),
+    ...optionalStringProp(obj, 'base_ref'),
+    ...optionalStringProp(obj, 'branch'),
+    ...(cleanup !== null ? { cleanup } : {}),
+  };
+}
+
+function optionalStringProp(
+  params: Record<string, unknown>,
+  key: string,
+): Record<string, string> {
+  const value = optionalString(params, key);
+  return value === null ? {} : { [key]: value };
 }
 
 function mustExistingDispatcher(server: Server, id: string): void {

--- a/packages/dreamux/src/dispatcher-service/teammate/identity-store.ts
+++ b/packages/dreamux/src/dispatcher-service/teammate/identity-store.ts
@@ -12,6 +12,8 @@ import {
   type TeamMateHistoryEventType,
   type TeamMateIdentity,
   type TeamMateIdentityStatus,
+  type TeamMateOwner,
+  type TeamMateWorktreeIdentity,
 } from './types.js';
 import type { AgentRuntimeResumeCheckpoint } from '../../agent-runtime/index.js';
 
@@ -23,14 +25,22 @@ export interface TeamMateIdentityCreateInput {
   dispatcherId: string;
   name: string;
   agentRuntime: string;
+  sourceCwd: string;
+  sourceRepo: string | null;
   cwd: string;
+  runtimeCwd: string;
+  worktree: TeamMateWorktreeIdentity;
   checkpoint?: AgentRuntimeResumeCheckpoint | null;
   status?: TeamMateIdentityStatus;
 }
 
 export interface TeamMateIdentityUpdateInput {
   agentRuntime?: string;
+  sourceCwd?: string;
+  sourceRepo?: string | null;
   cwd?: string;
+  runtimeCwd?: string;
+  worktree?: TeamMateWorktreeIdentity;
   checkpoint?: AgentRuntimeResumeCheckpoint | null;
   status?: TeamMateIdentityStatus;
   lastError?: string | null;
@@ -98,8 +108,13 @@ export class TeamMateIdentityStore {
       version: 1,
       dispatcher_id: input.dispatcherId,
       name: input.name,
+      owner: dispatcherOwner(input.dispatcherId),
       agent_runtime: input.agentRuntime,
+      source_cwd: input.sourceCwd,
+      source_repo: input.sourceRepo,
       cwd: input.cwd,
+      runtime_cwd: input.runtimeCwd,
+      worktree: input.worktree,
       created_at: now,
       updated_at: now,
       status: input.status ?? 'starting',
@@ -119,7 +134,11 @@ export class TeamMateIdentityStore {
     const updated: TeamMateIdentity = {
       ...identity,
       ...(input.agentRuntime !== undefined ? { agent_runtime: input.agentRuntime } : {}),
+      ...(input.sourceCwd !== undefined ? { source_cwd: input.sourceCwd } : {}),
+      ...(input.sourceRepo !== undefined ? { source_repo: input.sourceRepo } : {}),
       ...(input.cwd !== undefined ? { cwd: input.cwd } : {}),
+      ...(input.runtimeCwd !== undefined ? { runtime_cwd: input.runtimeCwd } : {}),
+      ...(input.worktree !== undefined ? { worktree: input.worktree } : {}),
       ...(input.checkpoint !== undefined ? { checkpoint: input.checkpoint } : {}),
       ...(input.status !== undefined ? { status: input.status } : {}),
       ...(input.lastError !== undefined ? { last_error: input.lastError } : {}),
@@ -142,9 +161,14 @@ export class TeamMateIdentityStore {
         timestamp: Date.now(),
         dispatcher_id: identity.dispatcher_id,
         name: identity.name,
+        owner: identity.owner,
         type: input.type,
         agent_runtime: identity.agent_runtime,
+        source_cwd: identity.source_cwd,
+        source_repo: identity.source_repo,
         cwd: identity.cwd,
+        runtime_cwd: identity.runtime_cwd,
+        worktree: identity.worktree,
         checkpoint: identity.checkpoint,
         prompt_preview:
           input.prompt !== undefined && input.prompt !== null
@@ -231,7 +255,84 @@ function readIdentity(
   ) {
     throw new Error(`invalid TeamMate identity ${JSON.stringify(name)}`);
   }
-  return value as unknown as TeamMateIdentity;
+  const record = value as Record<string, unknown>;
+  const sourceCwd =
+    typeof record['source_cwd'] === 'string'
+      ? record['source_cwd']
+      : (record['cwd'] as string);
+  const sourceRepo =
+    typeof record['source_repo'] === 'string' ? record['source_repo'] : null;
+  const runtimeCwd =
+    typeof record['runtime_cwd'] === 'string'
+      ? record['runtime_cwd']
+      : (record['cwd'] as string);
+  const worktree = readWorktreeIdentity(record['worktree'], runtimeCwd);
+  return {
+    ...(value as unknown as TeamMateIdentity),
+    owner: readOwner(record['owner'], dispatcherId),
+    source_cwd: sourceCwd,
+    source_repo: sourceRepo,
+    runtime_cwd: runtimeCwd,
+    worktree,
+  };
+}
+
+function readOwner(value: unknown, dispatcherId: string): TeamMateOwner {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+    return dispatcherOwner(dispatcherId);
+  }
+  const record = value as Record<string, unknown>;
+  if (
+    record['kind'] !== 'dispatcher' ||
+    typeof record['dispatcher_id'] !== 'string'
+  ) {
+    return dispatcherOwner(dispatcherId);
+  }
+  return { kind: 'dispatcher', dispatcher_id: record['dispatcher_id'] };
+}
+
+function dispatcherOwner(dispatcherId: string): TeamMateOwner {
+  return { kind: 'dispatcher', dispatcher_id: dispatcherId };
+}
+
+function readWorktreeIdentity(
+  value: unknown,
+  runtimeCwd: string,
+): TeamMateWorktreeIdentity {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+    return {
+      mode: 'reuse-cwd',
+      slug: null,
+      path: runtimeCwd,
+      branch: null,
+      base_ref: null,
+      cleanup: 'keep',
+      cleanup_state: 'not-managed',
+      cleanup_error: null,
+    };
+  }
+  const record = value as Record<string, unknown>;
+  const mode = record['mode'] === 'managed' ? 'managed' : 'reuse-cwd';
+  return {
+    mode,
+    slug: typeof record['slug'] === 'string' ? record['slug'] : null,
+    path: typeof record['path'] === 'string' ? record['path'] : runtimeCwd,
+    branch: typeof record['branch'] === 'string' ? record['branch'] : null,
+    base_ref:
+      typeof record['base_ref'] === 'string' ? record['base_ref'] : null,
+    cleanup:
+      record['cleanup'] === 'delete-on-close' ? 'delete-on-close' : 'keep',
+    cleanup_state:
+      typeof record['cleanup_state'] === 'string'
+        ? (record['cleanup_state'] as TeamMateWorktreeIdentity['cleanup_state'])
+        : mode === 'managed'
+          ? 'managed-active'
+          : 'not-managed',
+    cleanup_error:
+      typeof record['cleanup_error'] === 'string'
+        ? record['cleanup_error']
+        : null,
+  };
 }
 
 function readHistoryEvent(

--- a/packages/dreamux/src/dispatcher-service/teammate/service.ts
+++ b/packages/dreamux/src/dispatcher-service/teammate/service.ts
@@ -28,6 +28,7 @@ import { dispatcherTeamMateRuntimeDir } from '../../platform/paths.js';
 import { validateDispatcherId } from '../../state/dispatcher-id.js';
 import { TeamMateIdentityStore } from './identity-store.js';
 import { TeamMateRuntimeStateStore } from './runtime-state.js';
+import { WorktreeManager } from './worktree-manager.js';
 import {
   validateTeamMateName,
   type CloseTeamMateInput,
@@ -76,6 +77,7 @@ export interface TeamMateAgentServiceOptions {
 
 export class TeamMateAgentService {
   private readonly identities: TeamMateIdentityStore;
+  private readonly worktrees = new WorktreeManager();
   private readonly live = new Map<string, LiveTeamMate>();
   private submissionSeq = 0;
 
@@ -87,6 +89,9 @@ export class TeamMateAgentService {
 
   async spawn(input: SpawnTeamMateInput): Promise<TeamMateSpawnResult> {
     const name = validateTeamMateName(input.name);
+    if (typeof input.cwd !== 'string' || input.cwd.trim() === '') {
+      throw new Error('TeamMate spawn requires cwd');
+    }
     const existing = await this.identities.get(input.dispatcherId, name);
     if (existing !== null && existing.status !== 'closed') {
       throw new Error(`TeamMate ${JSON.stringify(name)} already exists; use send`);
@@ -95,18 +100,31 @@ export class TeamMateAgentService {
       input.agentRuntime ?? this.defaultAgentRuntime(input.dispatcherId);
     const agent = this.resolveAgent(input.dispatcherId, agentRuntimeId);
     const provider = this.opts.agentRuntimeProviders.resolve(agent.provider);
-    const cwd = this.resolveCwd(input.dispatcherId, input.cwd);
+    const workspace = await this.worktrees.prepare({
+      dispatcherId: input.dispatcherId,
+      teammateName: name,
+      cwd: input.cwd,
+      request: input.worktree,
+    });
     let identity =
       existing ??
       (await this.identities.create({
         dispatcherId: input.dispatcherId,
         name,
         agentRuntime: agentRuntimeId,
-        cwd,
+        sourceCwd: workspace.sourceCwd,
+        sourceRepo: workspace.sourceRepo,
+        cwd: workspace.runtimeCwd,
+        runtimeCwd: workspace.runtimeCwd,
+        worktree: workspace.worktree,
       }));
     identity = await this.identities.update(identity, {
       agentRuntime: agentRuntimeId,
-      cwd,
+      sourceCwd: workspace.sourceCwd,
+      sourceRepo: workspace.sourceRepo,
+      cwd: workspace.runtimeCwd,
+      runtimeCwd: workspace.runtimeCwd,
+      worktree: workspace.worktree,
       status: 'starting',
       closedAt: null,
       closeNote: null,
@@ -155,6 +173,7 @@ export class TeamMateAgentService {
       status: 'closed',
       closedAt: Date.now(),
       closeNote: input.note ?? null,
+      worktree: await this.worktrees.cleanup(identity),
     });
     await this.identities.appendHistory(closed, {
       type: 'close',
@@ -557,22 +576,19 @@ export class TeamMateAgentService {
     );
   }
 
-  private resolveCwd(dispatcherId: string, input: string | undefined): string {
-    if (input !== undefined && input !== '') return input;
-    return (
-      this.dispatcherConfig(dispatcherId)?.cwd ??
-      dispatcherTeamMateRuntimeDir(dispatcherId, 'default')
-    );
-  }
-
   private toStatus(
     identity: TeamMateIdentity,
     runtime: AgentRuntime | null,
   ): TeamMateRuntimeStatus {
     return {
       name: identity.name,
+      owner: identity.owner,
       agent_runtime: identity.agent_runtime,
+      source_cwd: identity.source_cwd,
+      source_repo: identity.source_repo,
       cwd: identity.cwd,
+      runtime_cwd: identity.runtime_cwd,
+      worktree: identity.worktree,
       status: identity.status,
       runtime_status: runtime?.getStatus() ?? null,
       checkpoint: identity.checkpoint,

--- a/packages/dreamux/src/dispatcher-service/teammate/service.ts
+++ b/packages/dreamux/src/dispatcher-service/teammate/service.ts
@@ -106,6 +106,7 @@ export class TeamMateAgentService {
       cwd: input.cwd,
       request: input.worktree,
     });
+    await this.assertManagedWorktreeAvailable(input.dispatcherId, name, workspace.worktree);
     let identity =
       existing ??
       (await this.identities.create({
@@ -283,6 +284,7 @@ export class TeamMateAgentService {
       if (opts.reopenClosed !== true) {
         throw new Error(`TeamMate ${JSON.stringify(teammateName)} is closed`);
       }
+      identity = await this.reprepareDeletedManagedWorktree(identity);
       identity = await this.identities.update(identity, {
         status: 'starting',
         closedAt: null,
@@ -296,6 +298,43 @@ export class TeamMateAgentService {
     const agent = this.resolveAgent(dispatcherId, identity.agent_runtime);
     const provider = this.opts.agentRuntimeProviders.resolve(agent.provider);
     return this.startRuntime(dispatcherId, identity, provider, agent);
+  }
+
+  private async reprepareDeletedManagedWorktree(
+    identity: TeamMateIdentity,
+  ): Promise<TeamMateIdentity> {
+    if (
+      identity.worktree.mode !== 'managed' ||
+      identity.worktree.cleanup_state !== 'deleted'
+    ) {
+      return identity;
+    }
+    const workspace = await this.worktrees.prepare({
+      dispatcherId: identity.dispatcher_id,
+      teammateName: identity.name,
+      cwd: identity.source_cwd,
+      request: {
+        mode: 'managed',
+        ...(identity.worktree.slug !== null ? { slug: identity.worktree.slug } : {}),
+        ...(identity.worktree.base_ref !== null
+          ? { base_ref: identity.worktree.base_ref }
+          : {}),
+        ...(identity.worktree.branch !== null ? { branch: identity.worktree.branch } : {}),
+        cleanup: identity.worktree.cleanup,
+      },
+    });
+    await this.assertManagedWorktreeAvailable(
+      identity.dispatcher_id,
+      identity.name,
+      workspace.worktree,
+    );
+    return this.identities.update(identity, {
+      sourceCwd: workspace.sourceCwd,
+      sourceRepo: workspace.sourceRepo,
+      cwd: workspace.runtimeCwd,
+      runtimeCwd: workspace.runtimeCwd,
+      worktree: workspace.worktree,
+    });
   }
 
   private async startRuntime(
@@ -596,6 +635,27 @@ export class TeamMateAgentService {
       closed_at: identity.closed_at,
       close_note: identity.close_note,
     };
+  }
+
+  private async assertManagedWorktreeAvailable(
+    dispatcherId: string,
+    name: string,
+    worktree: TeamMateIdentity['worktree'],
+  ): Promise<void> {
+    if (worktree.mode !== 'managed') return;
+    const identities = await this.identities.list(dispatcherId);
+    const collision = identities.find(
+      (identity) =>
+        identity.name !== name &&
+        identity.worktree.mode === 'managed' &&
+        identity.worktree.path === worktree.path,
+    );
+    if (collision !== undefined) {
+      throw new Error(
+        `managed worktree path ${JSON.stringify(worktree.path)} is already ` +
+          `owned by TeamMate ${JSON.stringify(collision.name)}`,
+      );
+    }
   }
 
   private agentRuntimeCapability(

--- a/packages/dreamux/src/dispatcher-service/teammate/types.ts
+++ b/packages/dreamux/src/dispatcher-service/teammate/types.ts
@@ -19,13 +19,23 @@ export interface TeamMateIdentity {
   version: 1;
   dispatcher_id: string;
   name: string;
+  owner: TeamMateOwner;
   /**
    * The `agents[].id` this teammate runs (persisted so resume re-resolves the
    * runtime config from `DreamuxConfig.agents`). Replaces the former
    * `provider_ref`: a teammate references an agent, not a provider directly.
    */
   agent_runtime: string;
+  /**
+   * The caller-supplied workspace cwd. `cwd` remains the runtime cwd for
+   * compatibility with pre-#169 clients and equals either this value
+   * (`reuse-cwd`) or the prepared managed worktree path.
+   */
+  source_cwd: string;
+  source_repo: string | null;
   cwd: string;
+  runtime_cwd: string;
+  worktree: TeamMateWorktreeIdentity;
   created_at: number;
   updated_at: number;
   status: TeamMateIdentityStatus;
@@ -50,9 +60,14 @@ export interface TeamMateHistoryEvent {
   timestamp: number;
   dispatcher_id: string;
   name: string;
+  owner: TeamMateOwner;
   type: TeamMateHistoryEventType;
   agent_runtime: string;
+  source_cwd: string;
+  source_repo: string | null;
   cwd: string;
+  runtime_cwd: string;
+  worktree: TeamMateWorktreeIdentity;
   checkpoint: AgentRuntimeResumeCheckpoint | null;
   prompt_preview: string | null;
   turn_id: string | null;
@@ -62,14 +77,24 @@ export interface TeamMateHistoryEvent {
 
 export interface TeamMateRuntimeStatus {
   name: string;
+  owner: TeamMateOwner;
   agent_runtime: string;
+  source_cwd: string;
+  source_repo: string | null;
   cwd: string;
+  runtime_cwd: string;
+  worktree: TeamMateWorktreeIdentity;
   status: TeamMateIdentityStatus;
   runtime_status: DispatcherStatus | null;
   checkpoint: AgentRuntimeResumeCheckpoint | null;
   last_error: string | null;
   closed_at: number | null;
   close_note: string | null;
+}
+
+export interface TeamMateOwner {
+  kind: 'dispatcher';
+  dispatcher_id: string;
 }
 
 export interface SpawnTeamMateInput {
@@ -84,7 +109,40 @@ export interface SpawnTeamMateInput {
    * dispatcher) — its config comes from that agent, never inherited.
    */
   agentRuntime?: string;
-  cwd?: string;
+  cwd: string;
+  worktree?: TeamMateWorktreeRequest;
+  intent?: string;
+}
+
+export interface TeamMateWorktreeRequest {
+  mode: 'reuse-cwd' | 'managed';
+  slug?: string;
+  base_ref?: string;
+  branch?: string;
+  cleanup?: 'keep' | 'delete-on-close';
+}
+
+export type TeamMateWorktreeCleanupPolicy = 'keep' | 'delete-on-close';
+
+export type TeamMateWorktreeCleanupState =
+  | 'not-managed'
+  | 'managed-active'
+  | 'kept'
+  | 'deleted'
+  | 'retained-dirty'
+  | 'retained-unmerged'
+  | 'retained-unique-commits'
+  | 'retained-error';
+
+export interface TeamMateWorktreeIdentity {
+  mode: 'reuse-cwd' | 'managed';
+  slug: string | null;
+  path: string;
+  branch: string | null;
+  base_ref: string | null;
+  cleanup: TeamMateWorktreeCleanupPolicy;
+  cleanup_state: TeamMateWorktreeCleanupState;
+  cleanup_error: string | null;
 }
 
 export interface SendTeamMateInput {

--- a/packages/dreamux/src/dispatcher-service/teammate/worktree-manager.ts
+++ b/packages/dreamux/src/dispatcher-service/teammate/worktree-manager.ts
@@ -1,4 +1,4 @@
-import { access, mkdir, stat } from 'node:fs/promises';
+import { access, mkdir, realpath, stat } from 'node:fs/promises';
 import { dirname, resolve } from 'node:path';
 
 import { execa } from 'execa';
@@ -66,6 +66,12 @@ export class WorktreeManager {
         path,
         branchExists ? branch : baseRef,
       ]);
+    } else {
+      await assertRegisteredWorktree({
+        repo: sourceRepo,
+        path,
+        branch,
+      });
     }
     return {
       sourceCwd,
@@ -199,6 +205,46 @@ async function revParseOrNull(cwd: string, ref: string): Promise<string | null> 
   } catch {
     return null;
   }
+}
+
+async function assertRegisteredWorktree(input: {
+  repo: string;
+  path: string;
+  branch: string;
+}): Promise<void> {
+  const entries = await listWorktrees(input.repo);
+  const expectedPath = await realpath(input.path);
+  const matched = entries.find((entry) => entry.path === expectedPath);
+  if (matched === undefined) {
+    throw new Error(
+      `managed worktree path already exists but is not registered for source repo: ${input.path}`,
+    );
+  }
+  const expectedBranch = `refs/heads/${input.branch}`;
+  if (matched.branch !== expectedBranch) {
+    throw new Error(
+      `managed worktree path already exists with unexpected branch: ` +
+        `${input.path} has ${matched.branch ?? 'detached HEAD'}, expected ${expectedBranch}`,
+    );
+  }
+}
+
+async function listWorktrees(
+  repo: string,
+): Promise<Array<{ path: string; branch: string | null }>> {
+  const result = await git(repo, ['worktree', 'list', '--porcelain']);
+  const entries: Array<{ path: string; branch: string | null }> = [];
+  let current: { path: string; branch: string | null } | null = null;
+  for (const line of result.stdout.split('\n')) {
+    if (line.startsWith('worktree ')) {
+      if (current !== null) entries.push(current);
+      current = { path: await realpath(line.slice('worktree '.length)), branch: null };
+    } else if (line.startsWith('branch ') && current !== null) {
+      current.branch = line.slice('branch '.length);
+    }
+  }
+  if (current !== null) entries.push(current);
+  return entries;
 }
 
 async function git(cwd: string, args: string[]): Promise<{ stdout: string }> {

--- a/packages/dreamux/src/dispatcher-service/teammate/worktree-manager.ts
+++ b/packages/dreamux/src/dispatcher-service/teammate/worktree-manager.ts
@@ -90,8 +90,11 @@ export class WorktreeManager {
     worktree: TeamMateWorktreeIdentity;
   }): Promise<TeamMateWorktreeIdentity> {
     const worktree = identity.worktree;
-    if (worktree.mode !== 'managed' || worktree.cleanup !== 'delete-on-close') {
+    if (worktree.mode !== 'managed') {
       return worktree;
+    }
+    if (worktree.cleanup !== 'delete-on-close') {
+      return { ...worktree, cleanup_state: 'kept', cleanup_error: null };
     }
     try {
       const repo = identity.source_repo ?? (await this.repoRoot(identity.source_cwd));
@@ -136,31 +139,66 @@ async function retainedState(
   if (unmerged.stdout.trim() !== '') return 'retained-unmerged';
   const status = await git(worktree.path, ['status', '--porcelain=v1', '-uall']);
   if (status.stdout.trim() !== '') return 'retained-dirty';
-  if (worktree.branch === null) return null;
+  const head = await git(worktree.path, ['rev-parse', '--verify', 'HEAD']);
+  const headSha = head.stdout.trim();
+  const safeRefs = await safeReachabilityRefs(repo, worktree);
+  if (safeRefs.length === 0) return 'retained-unique-commits';
+  const containsHead = await git(repo, [
+    'branch',
+    '--contains',
+    headSha,
+    '--format=%(refname:short)',
+  ]);
+  const containingRefs = new Set(
+    containsHead.stdout
+      .split('\n')
+      .map((line) => line.replace(/^\*\s*/, '').trim())
+      .filter((line) => line !== ''),
+  );
+  if (!safeRefs.some((ref) => containingRefs.has(ref))) {
+    return 'retained-unique-commits';
+  }
+  return null;
+}
+
+async function safeReachabilityRefs(
+  repo: string,
+  worktree: TeamMateWorktreeIdentity,
+): Promise<string[]> {
   const refs = await git(repo, [
     'for-each-ref',
     '--format=%(refname:short)',
     'refs/heads',
     'refs/remotes',
   ]);
-  const otherRefs = refs.stdout
+  const allRefs = refs.stdout
     .split('\n')
     .map((line) => line.trim())
-    .filter((ref) => ref !== '' && ref !== worktree.branch);
-  const unique =
-    otherRefs.length === 0
-      ? await git(repo, ['rev-parse', '--verify', worktree.branch])
-      : await git(repo, [
-          'log',
-          '--format=%H',
-          '--max-count=1',
-          worktree.branch,
-          '--not',
-          ...otherRefs,
-          '--',
-        ]);
-  if (unique.stdout.trim() !== '') return 'retained-unique-commits';
-  return null;
+    .filter((ref) => ref !== '');
+  const candidates = new Set<string>();
+  for (const ref of allRefs) {
+    if (worktree.branch === null || ref !== worktree.branch) candidates.add(ref);
+  }
+  if (worktree.base_ref !== null) {
+    const baseSha = await revParseOrNull(repo, worktree.base_ref);
+    if (baseSha !== null) {
+      for (const ref of allRefs) {
+        if (await gitOk(repo, ['merge-base', '--is-ancestor', baseSha, ref])) {
+          candidates.add(ref);
+        }
+      }
+    }
+  }
+  return [...candidates];
+}
+
+async function revParseOrNull(cwd: string, ref: string): Promise<string | null> {
+  try {
+    const result = await git(cwd, ['rev-parse', '--verify', ref]);
+    return result.stdout.trim();
+  } catch {
+    return null;
+  }
 }
 
 async function git(cwd: string, args: string[]): Promise<{ stdout: string }> {

--- a/packages/dreamux/src/dispatcher-service/teammate/worktree-manager.ts
+++ b/packages/dreamux/src/dispatcher-service/teammate/worktree-manager.ts
@@ -1,0 +1,213 @@
+import { access, mkdir, stat } from 'node:fs/promises';
+import { dirname, resolve } from 'node:path';
+
+import { execa } from 'execa';
+
+import { dispatcherTeamMateWorktreePath } from '../../platform/paths.js';
+import { teamMateNameSegment } from '../../platform/paths.js';
+import type {
+  TeamMateWorktreeCleanupState,
+  TeamMateWorktreeIdentity,
+  TeamMateWorktreeRequest,
+} from './types.js';
+
+export interface PreparedTeamMateWorkspace {
+  sourceCwd: string;
+  sourceRepo: string | null;
+  runtimeCwd: string;
+  worktree: TeamMateWorktreeIdentity;
+}
+
+export class WorktreeManager {
+  async prepare(input: {
+    dispatcherId: string;
+    teammateName: string;
+    cwd: string;
+    request?: TeamMateWorktreeRequest;
+  }): Promise<PreparedTeamMateWorkspace> {
+    const sourceCwd = resolve(input.cwd);
+    const mode = input.request?.mode ?? 'reuse-cwd';
+    if (mode === 'reuse-cwd') {
+      await assertDirectory(sourceCwd);
+      return {
+        sourceCwd,
+        sourceRepo: await this.tryRepoRoot(sourceCwd),
+        runtimeCwd: sourceCwd,
+        worktree: {
+          mode: 'reuse-cwd',
+          slug: null,
+          path: sourceCwd,
+          branch: null,
+          base_ref: null,
+          cleanup: input.request?.cleanup ?? 'keep',
+          cleanup_state: 'not-managed',
+          cleanup_error: null,
+        },
+      };
+    }
+
+    const sourceRepo = await this.repoRoot(sourceCwd);
+    const slug = validateWorktreeSlug(input.request?.slug ?? input.teammateName);
+    const branch = input.request?.branch ?? `dreamux/${teamMateNameSegment(slug)}`;
+    const baseRef = input.request?.base_ref ?? 'HEAD';
+    const path = dispatcherTeamMateWorktreePath(input.dispatcherId, slug);
+    await mkdir(dirname(path), { recursive: true });
+    const exists = await pathExists(path);
+    if (!exists) {
+      const branchExists = await gitOk(sourceRepo, [
+        'rev-parse',
+        '--verify',
+        `refs/heads/${branch}`,
+      ]);
+      await git(sourceRepo, [
+        'worktree',
+        'add',
+        ...(branchExists ? [] : ['-b', branch]),
+        path,
+        branchExists ? branch : baseRef,
+      ]);
+    }
+    return {
+      sourceCwd,
+      sourceRepo,
+      runtimeCwd: path,
+      worktree: {
+        mode: 'managed',
+        slug,
+        path,
+        branch,
+        base_ref: baseRef,
+        cleanup: input.request?.cleanup ?? 'keep',
+        cleanup_state: 'managed-active',
+        cleanup_error: null,
+      },
+    };
+  }
+
+  async cleanup(identity: {
+    source_cwd: string;
+    source_repo: string | null;
+    worktree: TeamMateWorktreeIdentity;
+  }): Promise<TeamMateWorktreeIdentity> {
+    const worktree = identity.worktree;
+    if (worktree.mode !== 'managed' || worktree.cleanup !== 'delete-on-close') {
+      return worktree;
+    }
+    try {
+      const repo = identity.source_repo ?? (await this.repoRoot(identity.source_cwd));
+      const retain = await retainedState(repo, worktree);
+      if (retain !== null) {
+        return {
+          ...worktree,
+          cleanup_state: retain,
+          cleanup_error: null,
+        };
+      }
+      await git(repo, ['worktree', 'remove', worktree.path]);
+      return { ...worktree, cleanup_state: 'deleted', cleanup_error: null };
+    } catch (err) {
+      return {
+        ...worktree,
+        cleanup_state: 'retained-error',
+        cleanup_error: err instanceof Error ? err.message : String(err),
+      };
+    }
+  }
+
+  private async repoRoot(cwd: string): Promise<string> {
+    const result = await git(cwd, ['rev-parse', '--show-toplevel']);
+    return result.stdout.trim();
+  }
+
+  private async tryRepoRoot(cwd: string): Promise<string | null> {
+    try {
+      return await this.repoRoot(cwd);
+    } catch {
+      return null;
+    }
+  }
+}
+
+async function retainedState(
+  repo: string,
+  worktree: TeamMateWorktreeIdentity,
+): Promise<TeamMateWorktreeCleanupState | null> {
+  const unmerged = await git(worktree.path, ['ls-files', '-u']);
+  if (unmerged.stdout.trim() !== '') return 'retained-unmerged';
+  const status = await git(worktree.path, ['status', '--porcelain=v1', '-uall']);
+  if (status.stdout.trim() !== '') return 'retained-dirty';
+  if (worktree.branch === null) return null;
+  const refs = await git(repo, [
+    'for-each-ref',
+    '--format=%(refname:short)',
+    'refs/heads',
+    'refs/remotes',
+  ]);
+  const otherRefs = refs.stdout
+    .split('\n')
+    .map((line) => line.trim())
+    .filter((ref) => ref !== '' && ref !== worktree.branch);
+  const unique =
+    otherRefs.length === 0
+      ? await git(repo, ['rev-parse', '--verify', worktree.branch])
+      : await git(repo, [
+          'log',
+          '--format=%H',
+          '--max-count=1',
+          worktree.branch,
+          '--not',
+          ...otherRefs,
+          '--',
+        ]);
+  if (unique.stdout.trim() !== '') return 'retained-unique-commits';
+  return null;
+}
+
+async function git(cwd: string, args: string[]): Promise<{ stdout: string }> {
+  return execa('git', args, { cwd });
+}
+
+async function gitOk(cwd: string, args: string[]): Promise<boolean> {
+  try {
+    await git(cwd, args);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function pathExists(path: string): Promise<boolean> {
+  try {
+    await access(path);
+    return true;
+  } catch (err) {
+    if (isNotFound(err)) return false;
+    throw err;
+  }
+}
+
+async function assertDirectory(path: string): Promise<void> {
+  const info = await stat(path);
+  if (!info.isDirectory()) {
+    throw new Error(`cwd is not a directory: ${path}`);
+  }
+}
+
+function validateWorktreeSlug(slug: string): string {
+  if (!/^[A-Za-z0-9][A-Za-z0-9._-]{0,63}$/.test(slug)) {
+    throw new Error(
+      'worktree slug must be 1-64 ASCII letters, digits, dots, underscores, ' +
+        `or dashes, starting with a letter or digit: ${slug}`,
+    );
+  }
+  return slug;
+}
+
+function isNotFound(err: unknown): boolean {
+  return (
+    typeof err === 'object' &&
+    err !== null &&
+    'code' in err &&
+    (err as { code?: unknown }).code === 'ENOENT'
+  );
+}

--- a/packages/dreamux/src/mcp/teammate-mcp.ts
+++ b/packages/dreamux/src/mcp/teammate-mcp.ts
@@ -156,8 +156,21 @@ function teammateTools(callerKind: 'dispatcher' | 'teammate'): Array<Record<stri
             'Spawnable agents[].id returned by get_capabilities.agent_runtimes[].id.',
         },
         cwd: { type: 'string', minLength: 1, maxLength: 4096 },
+        worktree: {
+          type: 'object',
+          additionalProperties: false,
+          properties: {
+            mode: { type: 'string', enum: ['reuse-cwd', 'managed'] },
+            slug: { type: 'string', minLength: 1, maxLength: 64 },
+            base_ref: { type: 'string', minLength: 1, maxLength: 256 },
+            branch: { type: 'string', minLength: 1, maxLength: 256 },
+            cleanup: { type: 'string', enum: ['keep', 'delete-on-close'] },
+          },
+          required: ['mode'],
+        },
+        intent: { type: 'string', maxLength: 2000 },
       },
-      ['name', 'prompt'],
+      ['name', 'prompt', 'cwd'],
     ),
     tool('send', 'Send a turn to a TeamMate agent; reopens a closed one from its checkpoint first.', {
       name: { type: 'string', minLength: 1, maxLength: 64 },
@@ -290,13 +303,52 @@ function asToolCallParams(params: unknown): ToolCall {
 function spawnArgs(value: unknown): Record<string, unknown> {
   const obj = asRecord(value, 'spawn arguments');
   const agentRuntime = optionalString(obj, 'agent_runtime');
-  const cwd = optionalString(obj, 'cwd');
+  const worktree = optionalWorktree(obj, 'worktree');
+  const intent = optionalString(obj, 'intent');
   return {
     name: requireString(obj, 'name'),
     prompt: requireString(obj, 'prompt'),
+    cwd: requireString(obj, 'cwd'),
     ...(agentRuntime !== null ? { agent_runtime: agentRuntime } : {}),
-    ...(cwd !== null ? { cwd } : {}),
+    ...(worktree !== null ? { worktree } : {}),
+    ...(intent !== null ? { intent } : {}),
   };
+}
+
+function optionalWorktree(
+  obj: Record<string, unknown>,
+  key: string,
+): Record<string, unknown> | null {
+  const value = obj[key];
+  if (value === undefined || value === null) return null;
+  const worktree = asRecord(value, key);
+  const mode = requireString(worktree, 'mode');
+  if (mode !== 'reuse-cwd' && mode !== 'managed') {
+    throw new Error(`${key}.mode must be 'reuse-cwd' or 'managed'`);
+  }
+  const cleanup = optionalString(worktree, 'cleanup');
+  if (
+    cleanup !== null &&
+    cleanup !== 'keep' &&
+    cleanup !== 'delete-on-close'
+  ) {
+    throw new Error(`${key}.cleanup must be 'keep' or 'delete-on-close'`);
+  }
+  return {
+    mode,
+    ...optionalProp(worktree, 'slug'),
+    ...optionalProp(worktree, 'base_ref'),
+    ...optionalProp(worktree, 'branch'),
+    ...(cleanup !== null ? { cleanup } : {}),
+  };
+}
+
+function optionalProp(
+  obj: Record<string, unknown>,
+  key: string,
+): Record<string, string> {
+  const value = optionalString(obj, key);
+  return value === null ? {} : { [key]: value };
 }
 
 function sendArgs(value: unknown): Record<string, unknown> {

--- a/packages/dreamux/src/platform/paths.ts
+++ b/packages/dreamux/src/platform/paths.ts
@@ -206,6 +206,16 @@ export function dispatcherTeamMateRuntimeDir(
   return join(dispatcherTeamMateDir(id), 'runtime', teamMateNameSegment(teammateName));
 }
 
+/** Dreamux-managed Git worktrees for one dispatcher. */
+export function dispatcherTeamMateWorktreesDir(id: string): string {
+  return join(dispatcherTeamMateDir(id), 'worktrees');
+}
+
+/** One Dreamux-managed Git worktree path for a teammate slug. */
+export function dispatcherTeamMateWorktreePath(id: string, slug: string): string {
+  return join(dispatcherTeamMateWorktreesDir(id), teamMateNameSegment(slug));
+}
+
 /**
  * Neutral teammate-name path segment sanitizer. Shared by the neutral
  * teammate-state builders here and by each builtin's teammate log-path builders.

--- a/packages/dreamux/tests/teammate-agent-service.test.ts
+++ b/packages/dreamux/tests/teammate-agent-service.test.ts
@@ -657,6 +657,53 @@ describe('TeamMateAgentService', () => {
     expect(existsSync(spawned.teammate.worktree.path)).toBe(false);
   });
 
+  it('recreates a deleted managed worktree when send reopens a closed teammate', async () => {
+    const repo = await initGitRepo(join(root, 'reopen-repo'));
+    const { catalog, provider } = providerCatalog();
+    const config = testDreamuxConfig();
+    const service = new TeamMateAgentService({
+      config,
+      dispatchers: new DispatcherStore(config),
+      agentRuntimeProviders: catalog,
+      log: noopLog(),
+    });
+
+    const spawned = await service.spawn({
+      dispatcherId: 'flow',
+      name: 'reopen-managed',
+      prompt: 'go',
+      cwd: repo,
+      worktree: {
+        mode: 'managed',
+        slug: 'reopen-managed',
+        branch: 'dreamux/reopen-managed',
+        cleanup: 'delete-on-close',
+      },
+    });
+    const worktreePath = spawned.teammate.worktree.path;
+    await service.close({
+      dispatcherId: 'flow',
+      name: 'reopen-managed',
+    });
+    expect(existsSync(worktreePath)).toBe(false);
+
+    const sent = await service.send({
+      dispatcherId: 'flow',
+      name: 'reopen-managed',
+      prompt: 'continue',
+    });
+    expect(sent.turn).toEqual({ status: 'submitted', turn_id: 'turn-1' });
+    expect(sent.teammate.worktree).toMatchObject({
+      mode: 'managed',
+      path: worktreePath,
+      cleanup_state: 'managed-active',
+    });
+    expect(existsSync(worktreePath)).toBe(true);
+    expect(provider.runtimes).toHaveLength(2);
+    expect(provider.runtimes[1]?.wasThreadResumed()).toBe(true);
+    expect(provider.contexts[1]?.cwd).toBe(worktreePath);
+  });
+
   it('marks intentionally retained managed worktrees as kept on close', async () => {
     const repo = await initGitRepo(join(root, 'kept-repo'));
     const { catalog } = providerCatalog();
@@ -759,6 +806,85 @@ describe('TeamMateAgentService', () => {
       'retained-unique-commits',
     );
     expect(existsSync(worktreePath)).toBe(true);
+  });
+
+  it('rejects a managed path that exists for a different source repository', async () => {
+    const firstRepo = await initGitRepo(join(root, 'slug-a'));
+    const secondRepo = await initGitRepo(join(root, 'slug-b'));
+    const { catalog } = providerCatalog();
+    const config = testDreamuxConfig();
+    const service = new TeamMateAgentService({
+      config,
+      dispatchers: new DispatcherStore(config),
+      agentRuntimeProviders: catalog,
+      log: noopLog(),
+    });
+
+    await service.spawn({
+      dispatcherId: 'flow',
+      name: 'first-slug',
+      prompt: 'go',
+      cwd: firstRepo,
+      worktree: {
+        mode: 'managed',
+        slug: 'shared-slug',
+        branch: 'dreamux/shared-slug',
+        cleanup: 'keep',
+      },
+    });
+    await expect(
+      service.spawn({
+        dispatcherId: 'flow',
+        name: 'second-slug',
+        prompt: 'go',
+        cwd: secondRepo,
+        worktree: {
+          mode: 'managed',
+          slug: 'shared-slug',
+          branch: 'dreamux/shared-slug',
+          cleanup: 'keep',
+        },
+      }),
+    ).rejects.toThrow(/not registered for source repo|already owned/);
+  });
+
+  it('rejects two teammate identities using the same explicit managed slug', async () => {
+    const repo = await initGitRepo(join(root, 'same-slug-repo'));
+    const { catalog } = providerCatalog();
+    const config = testDreamuxConfig();
+    const service = new TeamMateAgentService({
+      config,
+      dispatchers: new DispatcherStore(config),
+      agentRuntimeProviders: catalog,
+      log: noopLog(),
+    });
+
+    await service.spawn({
+      dispatcherId: 'flow',
+      name: 'slug-one',
+      prompt: 'go',
+      cwd: repo,
+      worktree: {
+        mode: 'managed',
+        slug: 'same-slug',
+        branch: 'dreamux/same-slug',
+        cleanup: 'keep',
+      },
+    });
+    await expect(
+      service.spawn({
+        dispatcherId: 'flow',
+        name: 'slug-two',
+        prompt: 'go',
+        cwd: repo,
+        worktree: {
+          mode: 'managed',
+          slug: 'same-slug',
+          branch: 'dreamux/same-slug',
+          cleanup: 'keep',
+        },
+      }),
+    ).rejects.toThrow(/already owned by TeamMate "slug-one"/);
   });
 
   it('fails loud on a legacy provider_ref teammate identity (pre-#148)', async () => {

--- a/packages/dreamux/tests/teammate-agent-service.test.ts
+++ b/packages/dreamux/tests/teammate-agent-service.test.ts
@@ -657,6 +657,38 @@ describe('TeamMateAgentService', () => {
     expect(existsSync(spawned.teammate.worktree.path)).toBe(false);
   });
 
+  it('marks intentionally retained managed worktrees as kept on close', async () => {
+    const repo = await initGitRepo(join(root, 'kept-repo'));
+    const { catalog } = providerCatalog();
+    const config = testDreamuxConfig();
+    const service = new TeamMateAgentService({
+      config,
+      dispatchers: new DispatcherStore(config),
+      agentRuntimeProviders: catalog,
+      log: noopLog(),
+    });
+
+    const spawned = await service.spawn({
+      dispatcherId: 'flow',
+      name: 'keeper',
+      prompt: 'go',
+      cwd: repo,
+      worktree: {
+        mode: 'managed',
+        slug: 'keeper',
+        branch: 'dreamux/keeper',
+        cleanup: 'keep',
+      },
+    });
+
+    const closed = await service.close({
+      dispatcherId: 'flow',
+      name: 'keeper',
+    });
+    expect(closed.teammate.worktree.cleanup_state).toBe('kept');
+    expect(existsSync(spawned.teammate.worktree.path)).toBe(true);
+  });
+
   it('retains dirty managed worktrees on close', async () => {
     const repo = await initGitRepo(join(root, 'dirty-repo'));
     const { catalog } = providerCatalog();
@@ -688,6 +720,45 @@ describe('TeamMateAgentService', () => {
     });
     expect(closed.teammate.worktree.cleanup_state).toBe('retained-dirty');
     expect(existsSync(spawned.teammate.worktree.path)).toBe(true);
+  });
+
+  it('retains clean detached managed worktrees with unique commits', async () => {
+    const repo = await initGitRepo(join(root, 'detached-repo'));
+    const { catalog } = providerCatalog();
+    const config = testDreamuxConfig();
+    const service = new TeamMateAgentService({
+      config,
+      dispatchers: new DispatcherStore(config),
+      agentRuntimeProviders: catalog,
+      log: noopLog(),
+    });
+
+    const spawned = await service.spawn({
+      dispatcherId: 'flow',
+      name: 'detached',
+      prompt: 'go',
+      cwd: repo,
+      worktree: {
+        mode: 'managed',
+        slug: 'detached',
+        branch: 'dreamux/detached',
+        cleanup: 'delete-on-close',
+      },
+    });
+    const worktreePath = spawned.teammate.worktree.path;
+    await execa('git', ['switch', '--detach'], { cwd: worktreePath });
+    await writeFile(join(worktreePath, 'detached.txt'), 'detached\n');
+    await execa('git', ['add', 'detached.txt'], { cwd: worktreePath });
+    await execa('git', ['commit', '-m', 'Detached work'], { cwd: worktreePath });
+
+    const closed = await service.close({
+      dispatcherId: 'flow',
+      name: 'detached',
+    });
+    expect(closed.teammate.worktree.cleanup_state).toBe(
+      'retained-unique-commits',
+    );
+    expect(existsSync(worktreePath)).toBe(true);
   });
 
   it('fails loud on a legacy provider_ref teammate identity (pre-#148)', async () => {

--- a/packages/dreamux/tests/teammate-agent-service.test.ts
+++ b/packages/dreamux/tests/teammate-agent-service.test.ts
@@ -1,7 +1,8 @@
-import { mkdtempSync, rmSync } from 'node:fs';
+import { existsSync, mkdtempSync, rmSync } from 'node:fs';
 import { mkdir, readFile, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
+import { execa } from 'execa';
 
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
@@ -368,7 +369,15 @@ describe('TeamMateAgentService', () => {
     expect(spawned.turn).toEqual({ status: 'submitted', turn_id: 'turn-1' });
     expect(spawned.teammate).toMatchObject({
       name: 'reviewer',
+      owner: { kind: 'dispatcher', dispatcher_id: 'flow' },
       agent_runtime: 'flow',
+      source_cwd: root,
+      runtime_cwd: root,
+      worktree: {
+        mode: 'reuse-cwd',
+        path: root,
+        cleanup_state: 'not-managed',
+      },
       status: 'running',
       checkpoint: { kind: 'codexThread', id: expect.stringContaining('thread') },
     });
@@ -536,6 +545,149 @@ describe('TeamMateAgentService', () => {
         cwd: root,
       }),
     ).rejects.toThrow(/'no-such-agent', which matches no agents\[\]\.id/);
+  });
+
+  it('requires cwd for native teammate spawn', async () => {
+    const { catalog } = providerCatalog();
+    const config = testDreamuxConfig();
+    const service = new TeamMateAgentService({
+      config,
+      dispatchers: new DispatcherStore(config),
+      agentRuntimeProviders: catalog,
+      log: noopLog(),
+    });
+    await expect(
+      service.spawn({
+        dispatcherId: 'flow',
+        name: 'no-cwd',
+        prompt: 'go',
+      } as Parameters<TeamMateAgentService['spawn']>[0]),
+    ).rejects.toThrow(/cwd/);
+  });
+
+  it('reads old identities without owner as dispatcher-owned until mutated', async () => {
+    const { catalog } = providerCatalog();
+    const config = testDreamuxConfig();
+    const service = new TeamMateAgentService({
+      config,
+      dispatchers: new DispatcherStore(config),
+      agentRuntimeProviders: catalog,
+      log: noopLog(),
+    });
+    const dir = join(
+      root,
+      'home',
+      '.dreamux',
+      'state',
+      'flow',
+      'teammate',
+      'identities',
+    );
+    const path = join(dir, 'oldie.json');
+    await mkdir(dir, { recursive: true });
+    await writeFile(
+      path,
+      JSON.stringify({
+        version: 1,
+        dispatcher_id: 'flow',
+        name: 'oldie',
+        agent_runtime: 'flow',
+        cwd: root,
+        created_at: 1,
+        updated_at: 1,
+        status: 'stopped',
+        checkpoint: null,
+        last_error: null,
+        closed_at: null,
+        close_note: null,
+      }),
+      { mode: 0o600 },
+    );
+
+    expect((await service.status('flow', 'oldie')).owner).toEqual({
+      kind: 'dispatcher',
+      dispatcher_id: 'flow',
+    });
+    expect(await readFile(path, 'utf8')).not.toContain('"owner"');
+  });
+
+  it('prepares managed worktrees, persists metadata, and deletes clean worktrees on close', async () => {
+    const repo = await initGitRepo(join(root, 'repo'));
+    const { catalog, provider } = providerCatalog();
+    const config = testDreamuxConfig();
+    const service = new TeamMateAgentService({
+      config,
+      dispatchers: new DispatcherStore(config),
+      agentRuntimeProviders: catalog,
+      log: noopLog(),
+    });
+
+    const spawned = await service.spawn({
+      dispatcherId: 'flow',
+      name: 'managed',
+      prompt: 'go',
+      cwd: repo,
+      worktree: {
+        mode: 'managed',
+        slug: 'managed',
+        branch: 'dreamux/managed',
+        cleanup: 'delete-on-close',
+      },
+    });
+
+    expect(spawned.teammate.source_cwd).toBe(repo);
+    expect(spawned.teammate.source_repo).toBe(repo);
+    expect(spawned.teammate.worktree).toMatchObject({
+      mode: 'managed',
+      slug: 'managed',
+      branch: 'dreamux/managed',
+      base_ref: 'HEAD',
+      cleanup: 'delete-on-close',
+      cleanup_state: 'managed-active',
+    });
+    expect(provider.contexts[0]?.cwd).toBe(spawned.teammate.worktree.path);
+    expect(existsSync(spawned.teammate.worktree.path)).toBe(true);
+
+    const closed = await service.close({
+      dispatcherId: 'flow',
+      name: 'managed',
+      note: 'done',
+    });
+    expect(closed.teammate.worktree.cleanup_state).toBe('deleted');
+    expect(existsSync(spawned.teammate.worktree.path)).toBe(false);
+  });
+
+  it('retains dirty managed worktrees on close', async () => {
+    const repo = await initGitRepo(join(root, 'dirty-repo'));
+    const { catalog } = providerCatalog();
+    const config = testDreamuxConfig();
+    const service = new TeamMateAgentService({
+      config,
+      dispatchers: new DispatcherStore(config),
+      agentRuntimeProviders: catalog,
+      log: noopLog(),
+    });
+
+    const spawned = await service.spawn({
+      dispatcherId: 'flow',
+      name: 'dirty',
+      prompt: 'go',
+      cwd: repo,
+      worktree: {
+        mode: 'managed',
+        slug: 'dirty',
+        branch: 'dreamux/dirty',
+        cleanup: 'delete-on-close',
+      },
+    });
+    await writeFile(join(spawned.teammate.worktree.path, 'dirty.txt'), 'dirty');
+
+    const closed = await service.close({
+      dispatcherId: 'flow',
+      name: 'dirty',
+    });
+    expect(closed.teammate.worktree.cleanup_state).toBe('retained-dirty');
+    expect(existsSync(spawned.teammate.worktree.path)).toBe(true);
   });
 
   it('fails loud on a legacy provider_ref teammate identity (pre-#148)', async () => {
@@ -758,4 +910,17 @@ function noopLog(): {
 /** Drain the microtask/macrotask the void-ed settle handler runs on. */
 async function flush(): Promise<void> {
   await new Promise((resolve) => setImmediate(resolve));
+}
+
+async function initGitRepo(path: string): Promise<string> {
+  await mkdir(path, { recursive: true });
+  await execa('git', ['init', '-b', 'main'], { cwd: path });
+  await execa('git', ['config', 'user.name', 'Dreamux Test'], { cwd: path });
+  await execa('git', ['config', 'user.email', 'dreamux-test@example.com'], {
+    cwd: path,
+  });
+  await writeFile(join(path, 'README.md'), 'test\n');
+  await execa('git', ['add', 'README.md'], { cwd: path });
+  await execa('git', ['commit', '-m', 'Initial test commit'], { cwd: path });
+  return path;
 }

--- a/packages/dreamux/tests/teammate-completion-e2e.test.ts
+++ b/packages/dreamux/tests/teammate-completion-e2e.test.ts
@@ -1,4 +1,5 @@
 import { mkdtempSync, rmSync } from 'node:fs';
+import { mkdir } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
@@ -175,8 +176,9 @@ describe('reverse delivery end-to-end (Seam ①→②→③ through the facade)'
   let adminSocketPath: string;
   let previousHome: string | undefined;
 
-  beforeEach(() => {
+  beforeEach(async () => {
     root = mkdtempSync(join(tmpdir(), 'dx-reverse-e2e-'));
+    await mkdir(join(root, 'workspace'));
     adminSocketPath = join(root, 'a.sock');
     previousHome = process.env['HOME'];
     process.env['HOME'] = join(root, 'home');
@@ -200,7 +202,7 @@ describe('reverse delivery end-to-end (Seam ①→②→③ through the facade)'
       dispatcherId: 'flow',
       name: 'reviewer',
       prompt: 'Review the change.',
-      cwd: root,
+      cwd: workspace(root),
     });
 
     const dispatcherRuntime = provider.runtimes[0]!;
@@ -238,7 +240,7 @@ describe('reverse delivery end-to-end (Seam ①→②→③ through the facade)'
       dispatcherId: 'flow',
       name: 'reviewer',
       prompt: 'Review the change.',
-      cwd: root,
+      cwd: workspace(root),
     });
 
     const dispatcherRuntime = provider.runtimes[0]!;
@@ -274,7 +276,7 @@ describe('reverse delivery end-to-end (Seam ①→②→③ through the facade)'
       dispatcherId: 'flow',
       name: 'reviewer',
       prompt: 'Review the change.',
-      cwd: root,
+      cwd: workspace(root),
     });
     const firstSend = await facade.sendTeamMate({
       dispatcherId: 'flow',
@@ -322,7 +324,7 @@ describe('reverse delivery end-to-end (Seam ①→②→③ through the facade)'
       dispatcherId: 'flow',
       name: 'reviewer',
       prompt: 'Review the change.',
-      cwd: root,
+      cwd: workspace(root),
     });
 
     const dispatcherRuntime = provider.runtimes[0]!;
@@ -386,7 +388,7 @@ describe('reverse delivery end-to-end (Seam ①→②→③ through the facade)'
       dispatcherId: 'flow',
       name: 'breaker',
       prompt: 'Run.',
-      cwd: root,
+      cwd: workspace(root),
     });
 
     const dispatcherRuntime = provider.runtimes[0]!;
@@ -424,13 +426,13 @@ describe('reverse delivery end-to-end (Seam ①→②→③ through the facade)'
       dispatcherId: 'flow',
       name: 'one',
       prompt: 'A.',
-      cwd: root,
+      cwd: workspace(root),
     });
     await facade.spawnTeamMate({
       dispatcherId: 'flow',
       name: 'two',
       prompt: 'B.',
-      cwd: root,
+      cwd: workspace(root),
     });
 
     const dispatcherRuntime = provider.runtimes[0]!;
@@ -467,4 +469,8 @@ function noopLog(): {
 /** Drain the macrotask the void-ed settle handler runs on. */
 async function flush(): Promise<void> {
   await new Promise((resolve) => setImmediate(resolve));
+}
+
+function workspace(root: string): string {
+  return join(root, 'workspace');
 }

--- a/packages/dreamux/tests/teammate-mcp.test.ts
+++ b/packages/dreamux/tests/teammate-mcp.test.ts
@@ -125,6 +125,29 @@ async function listTools(callerKind: 'dispatcher' | 'teammate'): Promise<string[
   return response.result.tools.map((tool) => tool.name);
 }
 
+async function toolSchemas(
+  callerKind: 'dispatcher' | 'teammate',
+): Promise<Array<Record<string, unknown>>> {
+  const input = new PassThrough();
+  const output = new PassThrough();
+  const reader = new JsonLineReader(output);
+  const run = runTeamMateMcp({
+    dispatcherId: 'dispatcher-a',
+    callerKind,
+    adminSocketPath: '/tmp/not-used.sock',
+    input,
+    output,
+    log: () => {},
+  });
+  writeJson(input, { jsonrpc: '2.0', id: 1, method: 'tools/list' });
+  const response = (await reader.next()) as {
+    result: { tools: Array<Record<string, unknown>> };
+  };
+  input.end();
+  await run;
+  return response.result.tools;
+}
+
 describe('teammate-mcp stdio shim', () => {
   it('exposes agent-centric lifecycle tools to dispatchers only', async () => {
     await expect(listTools('dispatcher')).resolves.toEqual([
@@ -147,6 +170,21 @@ describe('teammate-mcp stdio shim', () => {
       'ctx',
       'get_capabilities',
     ]);
+  });
+
+  it('marks spawn cwd as required and advertises managed worktree options', async () => {
+    const tools = await toolSchemas('dispatcher');
+    const spawn = tools.find((entry) => entry['name'] === 'spawn') as {
+      inputSchema: {
+        required: string[];
+        properties: Record<string, unknown>;
+      };
+    };
+    expect(spawn.inputSchema.required).toEqual(['name', 'prompt', 'cwd']);
+    expect(spawn.inputSchema.properties).toHaveProperty('worktree');
+    expect(JSON.stringify(spawn.inputSchema.properties['worktree'])).toContain(
+      'delete-on-close',
+    );
   });
 
   it('forwards spawn to the dispatcher-scoped admin method', async () => {
@@ -182,6 +220,14 @@ describe('teammate-mcp stdio shim', () => {
             prompt: 'Review the change.',
             agent_runtime: 'codex',
             cwd: '/workspace',
+            worktree: {
+              mode: 'managed',
+              slug: 'reviewer',
+              base_ref: 'origin/main',
+              branch: 'dreamux/reviewer',
+              cleanup: 'delete-on-close',
+            },
+            intent: 'review',
           },
         },
       });
@@ -206,9 +252,66 @@ describe('teammate-mcp stdio shim', () => {
             prompt: 'Review the change.',
             agent_runtime: 'codex',
             cwd: '/workspace',
+            worktree: {
+              mode: 'managed',
+              slug: 'reviewer',
+              base_ref: 'origin/main',
+              branch: 'dreamux/reviewer',
+              cleanup: 'delete-on-close',
+            },
+            intent: 'review',
           },
         },
       ]);
+
+      input.end();
+      await run;
+    } finally {
+      await admin.close();
+    }
+  });
+
+  it('rejects spawn without cwd before admin IPC', async () => {
+    const admin = await startFakeAdminServer((request) => ({
+      id: request.id,
+      ok: true,
+      result: {},
+    }));
+    try {
+      const input = new PassThrough();
+      const output = new PassThrough();
+      const reader = new JsonLineReader(output);
+      const run = runTeamMateMcp({
+        dispatcherId: 'dispatcher-a',
+        callerKind: 'dispatcher',
+        adminSocketPath: admin.socketPath,
+        input,
+        output,
+        log: () => {},
+      });
+
+      writeJson(input, {
+        jsonrpc: '2.0',
+        id: 1,
+        method: 'tools/call',
+        params: {
+          name: 'spawn',
+          arguments: {
+            name: 'reviewer',
+            prompt: 'Review the change.',
+          },
+        },
+      });
+
+      expect(await reader.next()).toMatchObject({
+        jsonrpc: '2.0',
+        id: 1,
+        result: {
+          isError: true,
+          content: [{ text: 'cwd must be a non-empty string' }],
+        },
+      });
+      expect(admin.requests).toEqual([]);
 
       input.end();
       await run;


### PR DESCRIPTION
## Summary

- require `cwd` for TeamMate spawn across the MCP/admin/service path
- add managed TeamMate worktree preparation with conservative cleanup
- persist source/runtime cwd, source repo, worktree metadata, and dispatcher-owner compatibility on TeamMate identities
- re-prepare deleted managed worktrees when `send` reopens a closed TeamMate
- reject managed worktree path/slug collisions unless ownership can be proven safe

## Notes

Managed worktree cleanup is intentionally conservative: dirty, unmerged, unique-commit, detached/uncertain, or mismatched ownership cases are retained or rejected instead of being deleted or reused unsafely.

## Validation

- `pnpm --dir packages/dreamux exec vitest run tests/teammate-agent-service.test.ts`
- `pnpm --dir packages/dreamux exec vitest run tests/teammate-agent-service.test.ts tests/teammate-mcp.test.ts tests/teammate-completion-e2e.test.ts`
- `node common/scripts/install-run-rush.js typecheck --to @excitedjs/dreamux`
- `node common/scripts/install-run-rush.js lint --to @excitedjs/dreamux`
- `node common/scripts/install-run-rush.js build --to @excitedjs/dreamux`
- `git diff --check`
