### PR TITLE
Add Team Mode channel binding

### DIFF
--- a/.agents/components/dispatcher-skill.md
+++ b/.agents/components/dispatcher-skill.md
@@ -16,9 +16,9 @@ ships in the npm package:
 - `team-dev-workflow` covers multi-teammate review, design, merge, and unblock
   coordination.
 - `team` MCP is injected for dispatcher-only Team Mode lifecycle: create a
-  TeamLeader, read Team status/ledger, and dissolve a Team. TeamLeader member
-  work still uses the caller-scoped TeamMate MCP; channel binding/routing is not
-  part of the first Team Mode slice.
+  TeamLeader, read Team status/ledger, bind or transfer back Feishu group
+  channels, and dissolve a Team. TeamLeader member work still uses the
+  caller-scoped TeamMate MCP.
 - `dreamux-maintenance` covers installed Dreamux diagnosis and safe operation.
 
 They are not installed through Codex plugin marketplaces. `dreamux onboard` and

--- a/.agents/decisions/top-level-design.md
+++ b/.agents/decisions/top-level-design.md
@@ -613,20 +613,28 @@ recursively spawn or close TeamMates.
 
 ## Team Mode Core
 
-Issue #171 starts Team Mode without Feishu channel routing. Dispatcher runtimes
-receive a `team` MCP server for dispatcher-only team lifecycle: `create`,
-`list`, `status`, `ledger`, and `dissolve`. `create` requires `repo_cwd` and
-`leader_agent_runtime`; Dreamux does not infer a default TeamLeader runtime. A
-TeamLeader is a TeamMate identity with `role: "team_leader"` and dispatcher
-owner. Team-owned members are normal TeamMate identities with `role:
-"team_member"` and `owner.kind: "team"`.
+Issue #171 starts Team Mode. Dispatcher runtimes receive a `team` MCP server for
+dispatcher-only team lifecycle: `create`, `list`, `status`, `ledger`,
+`bind_channel`, `transfer_channel_back`, and `dissolve`. `create` requires
+`repo_cwd` and `leader_agent_runtime`; Dreamux does not infer a default
+TeamLeader runtime. A TeamLeader is a TeamMate identity with `role:
+"team_leader"` and dispatcher owner. Team-owned members are normal TeamMate
+identities with `role: "team_member"` and `owner.kind: "team"`.
 
 The same `teammate` MCP surface is caller-scoped by server-derived principal,
 not by tool arguments. Dispatcher callers see dispatcher-owned TeamMates and
 TeamLeaders. TeamLeader callers see only members owned by their own team and
 spawn members into the shared Team managed worktree. Ordinary TeamMate callers
-still do not receive lifecycle tools. Channel binding and Feishu routing remain
-out of scope for this first Team Mode slice.
+still do not receive lifecycle tools.
+
+Channel binding is persisted under `state/<dispatcher-id>/team/` and is scoped
+to group chats only. Bound Feishu group inbound is gated and formatted by the
+Feishu channel exactly as before, then routed by Dispatcher Service to the
+owning TeamLeader runtime. Unbound and P2P inbound still route to the
+dispatcher. `transfer_channel_back` deactivates a binding; `dissolve` transfers
+active bindings back before closing the team. TeamLeader Feishu MCP calls carry
+their server-derived team principal and can reply/react only in bound team
+channels; the dispatcher keeps the global Feishu management surface.
 
 ## Reaction Ownership
 

--- a/common/changes/@excitedjs/dreamux/issue171-channel-binding_2026-06-10-00-00.json
+++ b/common/changes/@excitedjs/dreamux/issue171-channel-binding_2026-06-10-00-00.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "BREAKING: Team Mode adds persistent Feishu group channel binding. Dispatcher-scoped `team` MCP/admin now includes `bind_channel` and `transfer_channel_back`; bound group inbound is routed to the TeamLeader after the normal Feishu gate/format path, while unbound and P2P inbound continue to the dispatcher. TeamLeader Feishu reply/react calls are scoped to bound team channels. Rebuild: update Team Mode dispatcher automation to call `team.bind_channel({ team_id, chat_id, chat_type: \"group\" })` for group handoff and `team.transfer_channel_back({ chat_id, chat_type: \"group\" })` before returning a group to the dispatcher.",
+      "type": "minor",
+      "packageName": "@excitedjs/dreamux"
+    }
+  ],
+  "packageName": "@excitedjs/dreamux",
+  "email": "053700@gmail.com"
+}

--- a/packages/dreamux/skills/dispatcher/SKILL.md
+++ b/packages/dreamux/skills/dispatcher/SKILL.md
@@ -61,8 +61,12 @@ repo directly from the dispatcher.
   `leader_agent_runtime`; no default leader runtime is inferred.
 - `list`, `status`, `ledger` — read dispatcher-owned Team records and lifecycle
   ledger rows.
+- `bind_channel` — bind a Feishu group chat to a TeamLeader. P2P binding is
+  rejected.
+- `transfer_channel_back` — return a bound Feishu group chat to the dispatcher.
 - `dissolve` — close the TeamLeader and team-owned members, then conservatively
-  clean up the shared managed worktree.
+  clean up the shared managed worktree. Active channel bindings are transferred
+  back first.
 
 **Control and inspect.**
 

--- a/packages/dreamux/src/admin/methods.ts
+++ b/packages/dreamux/src/admin/methods.ts
@@ -121,9 +121,10 @@ export const adminMethods: Record<string, AdminHandler> = {
   // Read-only: lists a chat's known + trusted peer bots (issue #69). Reads the
   // per-dispatcher chat-bots store, so it does not require a running slot — only
   // a declared dispatcher.
-  'mcp.list_chat_bots': (server, params) => {
+  'mcp.list_chat_bots': async (server, params) => {
     const id = mustDispatcherId(params);
     mustExistingDispatcher(server, id);
+    await assertFeishuScope(server, id, params);
     return server.dispatcherService.callFeishuMcpTool({
       dispatcherId: id,
       toolName: 'list_chat_bots',
@@ -351,7 +352,13 @@ async function assertFeishuScope(
 ): Promise<void> {
   const caller = callerPrincipal(dispatcherId, params);
   if (caller.kind !== 'team_leader') return;
-  const chatId = mustString(params, 'chat_id');
+  const chatId = optionalString(params, 'chat_id');
+  if (chatId === null) {
+    throw new AdminError(
+      'BAD_REQUEST',
+      "param 'chat_id' is required for TeamLeader Feishu tools",
+    );
+  }
   const allowed = await server.dispatcherService.teamLeaderCanUseChannel({
     dispatcherId,
     teamId: caller.teamId,

--- a/packages/dreamux/src/admin/methods.ts
+++ b/packages/dreamux/src/admin/methods.ts
@@ -90,6 +90,7 @@ export const adminMethods: Record<string, AdminHandler> = {
     const id = mustDispatcherId(params);
     mustExistingDispatcher(server, id);
     mustRunningDispatcher(server, id);
+    await assertFeishuScope(server, id, params);
     try {
       return await server.dispatcherService.callFeishuMcpTool({
         dispatcherId: id,
@@ -105,6 +106,7 @@ export const adminMethods: Record<string, AdminHandler> = {
     const id = mustDispatcherId(params);
     mustExistingDispatcher(server, id);
     mustRunningDispatcher(server, id);
+    await assertFeishuScope(server, id, params);
     try {
       return await server.dispatcherService.callFeishuMcpTool({
         dispatcherId: id,
@@ -304,6 +306,31 @@ export const adminMethods: Record<string, AdminHandler> = {
     return server.dispatcherService.getTeamLedger(id, teamId);
   },
 
+  'mcp.team.bind_channel': async (server, params) => {
+    const id = mustDispatcherId(params);
+    mustExistingDispatcher(server, id);
+    return server.dispatcherService.bindTeamChannel({
+      dispatcherId: id,
+      teamId: mustString(params, 'team_id'),
+      provider: 'builtin:feishu',
+      chatId: mustString(params, 'chat_id'),
+      chatType: mustString(params, 'chat_type') === 'group' ? 'group' : 'p2p',
+    });
+  },
+
+  'mcp.team.transfer_channel_back': async (server, params) => {
+    const id = mustDispatcherId(params);
+    mustExistingDispatcher(server, id);
+    return {
+      binding: await server.dispatcherService.transferTeamChannelBack({
+        dispatcherId: id,
+        provider: 'builtin:feishu',
+        chatId: mustString(params, 'chat_id'),
+        chatType: mustString(params, 'chat_type') === 'group' ? 'group' : 'p2p',
+      }),
+    };
+  },
+
   'mcp.team.dissolve': async (server, params) => {
     const id = mustDispatcherId(params);
     mustExistingDispatcher(server, id);
@@ -316,6 +343,29 @@ export const adminMethods: Record<string, AdminHandler> = {
     });
   },
 };
+
+async function assertFeishuScope(
+  server: Server,
+  dispatcherId: string,
+  params: Record<string, unknown> | undefined,
+): Promise<void> {
+  const caller = callerPrincipal(dispatcherId, params);
+  if (caller.kind !== 'team_leader') return;
+  const chatId = mustString(params, 'chat_id');
+  const allowed = await server.dispatcherService.teamLeaderCanUseChannel({
+    dispatcherId,
+    teamId: caller.teamId,
+    leaderName: caller.leaderName,
+    provider: 'builtin:feishu',
+    chatId,
+  });
+  if (!allowed) {
+    throw new AdminError(
+      'CHANNEL_SCOPE_DENIED',
+      'TeamLeader may use Feishu only for bound team channels',
+    );
+  }
+}
 
 function callerPrincipal(
   dispatcherId: string,

--- a/packages/dreamux/src/channel/feishu/feishu-channel.ts
+++ b/packages/dreamux/src/channel/feishu/feishu-channel.ts
@@ -96,8 +96,16 @@ export interface FeishuChannelSessionOptions {
 export interface FeishuInboundSubmitter {
   submitTurn(
     input: InboundTurnInput,
+    envelope: FeishuInboundEnvelope,
     hooks?: InboundDeliveryHooks,
   ): Promise<AgentRuntimeTurnResult>;
+}
+
+export interface FeishuInboundEnvelope {
+  provider: 'builtin:feishu';
+  chatId: string;
+  chatType: 'group' | 'p2p';
+  messageId: string;
 }
 
 export class FeishuChannelCapabilityError extends Error {
@@ -374,16 +382,26 @@ export class FeishuChannelSession {
         ...(attachment.path !== undefined ? { localPath: attachment.path } : {}),
       })),
     };
-    const delivery = await submitter.submitTurn(input, {
-      onAccepted: async () => {
-        await this.setInboundReaction(
-          event.messageId,
-          event.chatId,
-          RECEIVED_REACTION_EMOJI,
-          'received',
-        );
+    const envelope: FeishuInboundEnvelope = {
+      provider: BUILTIN_FEISHU_PROVIDER_REF,
+      chatId: event.chatId,
+      chatType: event.chatType === 'group' ? 'group' : 'p2p',
+      messageId: event.messageId,
+    };
+    const delivery = await submitter.submitTurn(
+      input,
+      envelope,
+      {
+        onAccepted: async () => {
+          await this.setInboundReaction(
+            event.messageId,
+            event.chatId,
+            RECEIVED_REACTION_EMOJI,
+            'received',
+          );
+        },
       },
-    });
+    );
     if (delivery.status === 'submitted') {
       this.opts.log.info(
         {

--- a/packages/dreamux/src/channel/feishu/feishu-mcp-surface.ts
+++ b/packages/dreamux/src/channel/feishu/feishu-mcp-surface.ts
@@ -6,6 +6,9 @@ export const FEISHU_MCP_SERVER_NAME = 'feishu';
 export interface FeishuMcpServerDescriptorOptions {
   dispatcherId: string;
   adminSocketPath: string;
+  callerKind?: 'dispatcher' | 'team_leader';
+  teamId?: string;
+  leaderName?: string;
   command?: string;
   env?: NodeJS.ProcessEnv;
 }
@@ -44,6 +47,9 @@ export function feishuMcpServerDescriptor(
       'feishu-mcp',
       '--dispatcher',
       opts.dispatcherId,
+      ...(opts.callerKind !== undefined ? ['--caller', opts.callerKind] : []),
+      ...(opts.teamId !== undefined ? ['--team-id', opts.teamId] : []),
+      ...(opts.leaderName !== undefined ? ['--leader-name', opts.leaderName] : []),
       '--admin-socket',
       opts.adminSocketPath,
     ],

--- a/packages/dreamux/src/channel/feishu/feishu-mcp-surface.ts
+++ b/packages/dreamux/src/channel/feishu/feishu-mcp-surface.ts
@@ -23,6 +23,7 @@ export interface FeishuMcpReplyInput {
 }
 
 export interface FeishuMcpReactInput {
+  chatId?: string;
   messageId: string;
   emoji: string;
 }
@@ -96,6 +97,10 @@ export function feishuMcpTools(): Array<Record<string, unknown>> {
           message_id: {
             type: 'string',
             description: 'Feishu message id to react to.',
+          },
+          chat_id: {
+            type: 'string',
+            description: 'Feishu chat id from the inbound <channel source="feishu"> block.',
           },
           emoji: {
             type: 'string',
@@ -175,6 +180,7 @@ export function feishuMcpAdminParams(
     case 'react':
       return {
         dispatcher_id: dispatcherId,
+        ...(parsed.input.chatId !== undefined ? { chat_id: parsed.input.chatId } : {}),
         message_id: parsed.input.messageId,
         emoji: parsed.input.emoji,
       };
@@ -202,7 +208,9 @@ function replyArgs(value: unknown): FeishuMcpReplyInput {
 
 function reactArgs(value: unknown): FeishuMcpReactInput {
   const obj = asRecord(value, 'react arguments');
+  const chatId = optionalString(obj, 'chat_id');
   return {
+    ...(chatId !== null ? { chatId } : {}),
     messageId: requireString(obj, 'message_id'),
     emoji: requireString(obj, 'emoji'),
   };

--- a/packages/dreamux/src/cli/dreamux.ts
+++ b/packages/dreamux/src/cli/dreamux.ts
@@ -474,7 +474,13 @@ function buildConfigCommands(y: Argv): Argv {
 
 function buildFeishuMcpCommand(
   y: Argv,
-): Argv<{ dispatcher: string; adminSocket?: string }> {
+): Argv<{
+  dispatcher: string;
+  caller?: 'dispatcher' | 'team_leader';
+  teamId?: string;
+  leaderName?: string;
+  adminSocket?: string;
+}> {
   return y
     .option('dispatcher', {
       type: 'string',
@@ -484,7 +490,27 @@ function buildFeishuMcpCommand(
     .option('admin-socket', {
       type: 'string',
       describe: 'dreamux serve admin socket path',
-    }) as Argv<{ dispatcher: string; adminSocket?: string }>;
+    })
+    .option('caller', {
+      type: 'string',
+      choices: ['dispatcher', 'team_leader'] as const,
+      default: 'dispatcher' as const,
+      describe: 'Dreamux-controlled caller kind for channel scope enforcement',
+    })
+    .option('team-id', {
+      type: 'string',
+      describe: 'Team id for team_leader caller scope',
+    })
+    .option('leader-name', {
+      type: 'string',
+      describe: 'Leader TeamMate identity name for team_leader caller scope',
+    }) as Argv<{
+      dispatcher: string;
+      caller?: 'dispatcher' | 'team_leader';
+      teamId?: string;
+      leaderName?: string;
+      adminSocket?: string;
+    }>;
 }
 
 function buildTeamMateMcpCommand(
@@ -613,6 +639,9 @@ async function main(): Promise<void> {
         });
         await runFeishuMcp({
           dispatcherId,
+          callerKind: argv.caller,
+          teamId: argv.teamId,
+          leaderName: argv.leaderName,
           adminSocketPath: argv.adminSocket,
           log: (message) => log.info(message),
         });

--- a/packages/dreamux/src/dispatcher-service/channel-binding/store.ts
+++ b/packages/dreamux/src/dispatcher-service/channel-binding/store.ts
@@ -1,0 +1,138 @@
+import { mkdir, readFile, writeFile } from 'node:fs/promises';
+import { dirname } from 'node:path';
+
+import { dispatcherChannelBindingsPath } from '../../platform/paths.js';
+
+export type ChannelProvider = 'builtin:feishu';
+export type ChannelChatType = 'group' | 'p2p';
+
+export interface ChannelBinding {
+  provider: ChannelProvider;
+  chat_id: string;
+  chat_type: 'group';
+  team_id: string;
+  leader_name: string;
+  active: boolean;
+  created_at: number;
+  updated_at: number;
+  deactivated_at: number | null;
+}
+
+interface ChannelBindingFile {
+  version: 1;
+  bindings: ChannelBinding[];
+}
+
+export interface BindChannelInput {
+  dispatcherId: string;
+  provider: ChannelProvider;
+  chatId: string;
+  chatType: ChannelChatType;
+  teamId: string;
+  leaderName: string;
+}
+
+export interface TransferChannelBackInput {
+  dispatcherId: string;
+  provider: ChannelProvider;
+  chatId: string;
+  chatType: ChannelChatType;
+}
+
+export class ChannelBindingStore {
+  async bind(input: BindChannelInput): Promise<ChannelBinding> {
+    if (input.chatType !== 'group') {
+      throw new Error('Team channel binding supports group chats only');
+    }
+    const file = await this.read(input.dispatcherId);
+    const now = Date.now();
+    const next: ChannelBinding = {
+      provider: input.provider,
+      chat_id: input.chatId,
+      chat_type: input.chatType,
+      team_id: input.teamId,
+      leader_name: input.leaderName,
+      active: true,
+      created_at: now,
+      updated_at: now,
+      deactivated_at: null,
+    };
+    const idx = file.bindings.findIndex((binding) =>
+      binding.provider === input.provider && binding.chat_id === input.chatId,
+    );
+    if (idx === -1) file.bindings.push(next);
+    else file.bindings[idx] = { ...next, created_at: file.bindings[idx]!.created_at };
+    await this.write(input.dispatcherId, file);
+    return idx === -1 ? next : file.bindings[idx]!;
+  }
+
+  async transferBack(input: TransferChannelBackInput): Promise<ChannelBinding | null> {
+    if (input.chatType !== 'group') {
+      throw new Error('Team channel transfer supports group chats only');
+    }
+    const file = await this.read(input.dispatcherId);
+    const binding = file.bindings.find((entry) =>
+      entry.provider === input.provider &&
+      entry.chat_id === input.chatId &&
+      entry.active,
+    );
+    if (binding === undefined) return null;
+    binding.active = false;
+    binding.updated_at = Date.now();
+    binding.deactivated_at = binding.updated_at;
+    await this.write(input.dispatcherId, file);
+    return binding;
+  }
+
+  async resolve(input: {
+    dispatcherId: string;
+    provider: ChannelProvider;
+    chatId: string;
+    chatType: ChannelChatType;
+  }): Promise<ChannelBinding | null> {
+    if (input.chatType !== 'group') return null;
+    const file = await this.read(input.dispatcherId);
+    return file.bindings.find((binding) =>
+      binding.provider === input.provider &&
+      binding.chat_id === input.chatId &&
+      binding.active,
+    ) ?? null;
+  }
+
+  async list(dispatcherId: string): Promise<ChannelBinding[]> {
+    return (await this.read(dispatcherId)).bindings;
+  }
+
+  private async read(dispatcherId: string): Promise<ChannelBindingFile> {
+    let raw: string;
+    try {
+      raw = await readFile(dispatcherChannelBindingsPath(dispatcherId), 'utf8');
+    } catch (err) {
+      if (isNotFound(err)) return { version: 1, bindings: [] };
+      throw err;
+    }
+    const value = JSON.parse(raw) as Record<string, unknown>;
+    if (value['version'] !== 1 || !Array.isArray(value['bindings'])) {
+      throw new Error(`invalid channel binding store for dispatcher ${dispatcherId}`);
+    }
+    return value as unknown as ChannelBindingFile;
+  }
+
+  private async write(
+    dispatcherId: string,
+    file: ChannelBindingFile,
+  ): Promise<void> {
+    const path = dispatcherChannelBindingsPath(dispatcherId);
+    await mkdir(dirname(path), { recursive: true });
+    await writeFile(path, `${JSON.stringify(file, null, 2)}\n`, { mode: 0o600 });
+  }
+}
+
+function isNotFound(err: unknown): boolean {
+  return (
+    typeof err === 'object' &&
+    err !== null &&
+    'code' in err &&
+    (err as { code?: unknown }).code === 'ENOENT'
+  );
+}

--- a/packages/dreamux/src/dispatcher-service/dispatcher/service.ts
+++ b/packages/dreamux/src/dispatcher-service/dispatcher/service.ts
@@ -7,6 +7,7 @@ import type {
 import type { FeishuBot } from '../../channel/feishu/bot.js';
 import {
   FeishuChannelSession,
+  type FeishuInboundEnvelope,
   handleFeishuListChatBots,
   type FeishuMcpListChatBotsResult,
 } from '../../channel/feishu/feishu-channel.js';
@@ -46,6 +47,12 @@ export interface DispatcherAgentServiceOptions {
   skipBotSecret?: boolean;
   channelLoggerFactory: (dispatcherId: string) => DreamuxLogger;
   log: DreamuxLogger;
+  routeChannelInput?: (
+    dispatcherId: string,
+    input: import('../../agent-runtime/turn.js').InboundTurnInput,
+    envelope: FeishuInboundEnvelope,
+    hooks?: import('../../agent-runtime/turn.js').InboundDeliveryHooks,
+  ) => Promise<import('../../agent-runtime/types.js').AgentRuntimeTurnResult>;
 }
 
 export interface DispatcherAgentSlot {
@@ -300,7 +307,9 @@ export class DispatcherAgentService {
     try {
       await runtime.start();
       await channel.start({
-        submitTurn: (turn, hooks) => runtime.channelInput(turn, hooks),
+        submitTurn: (turn, envelope, hooks) =>
+          this.opts.routeChannelInput?.(id, turn, envelope, hooks) ??
+          runtime.channelInput(turn, hooks),
       });
     } catch (err) {
       try {

--- a/packages/dreamux/src/dispatcher-service/service.ts
+++ b/packages/dreamux/src/dispatcher-service/service.ts
@@ -1,8 +1,11 @@
 import type {
   AgentRuntimeProviderCatalog,
   AgentRuntime,
+  AgentRuntimeTurnResult,
   CompletionEnvelope,
 } from '../agent-runtime/index.js';
+import type { InboundDeliveryHooks, InboundTurnInput } from '../agent-runtime/turn.js';
+import type { FeishuInboundEnvelope } from '../channel/feishu/feishu-channel.js';
 import type { DreamuxConfig } from '../config/config.js';
 import type { DispatcherStore } from '../state/dispatcher-store.js';
 import type { DreamuxLogger } from '../platform/logger.js';
@@ -18,6 +21,7 @@ import {
 import { TeamService } from './team/service.js';
 import { TeamMateAgentService } from './teammate/service.js';
 import { teammateMcpServerDescriptor } from './teammate/mcp-config.js';
+import { feishuMcpServerDescriptor } from '../channel/feishu/feishu-mcp-surface.js';
 import type {
   CloseTeamMateInput,
   TeamMateHistoryQuery,
@@ -25,7 +29,12 @@ import type {
   SpawnTeamMateInput,
   TeamMateIdentity,
 } from './teammate/types.js';
-import type { TeamCreateInput, TeamDissolveInput } from './team/types.js';
+import type {
+  TeamBindChannelInput,
+  TeamCreateInput,
+  TeamDissolveInput,
+  TeamTransferChannelBackInput,
+} from './team/types.js';
 
 export interface DispatcherServiceOptions {
   config: DreamuxConfig;
@@ -64,6 +73,8 @@ export class DispatcherService {
       ...(opts.skipBotSecret !== undefined
         ? { skipBotSecret: opts.skipBotSecret }
         : {}),
+      routeChannelInput: (id, turn, envelope, hooks) =>
+        this.routeChannelInput(id, turn, envelope, hooks),
     });
     this.teammates = new TeamMateAgentService({
       config: opts.config,
@@ -73,6 +84,13 @@ export class DispatcherService {
         identity.role === 'team_leader'
           ? [
               teammateMcpServerDescriptor({
+                dispatcherId,
+                callerKind: 'team_leader',
+                teamId: identity.team_id ?? '',
+                leaderName: identity.name,
+                adminSocketPath: opts.adminSocketPath ?? defaultAdminSocketPath(),
+              }),
+              feishuMcpServerDescriptor({
                 dispatcherId,
                 callerKind: 'team_leader',
                 teamId: identity.team_id ?? '',
@@ -113,6 +131,32 @@ export class DispatcherService {
 
   callFeishuMcpTool(input: FeishuChannelToolCall) {
     return this.dispatchers.callFeishuMcpTool(input);
+  }
+
+  async routeChannelInput(
+    dispatcherId: string,
+    input: InboundTurnInput,
+    envelope: FeishuInboundEnvelope,
+    hooks?: InboundDeliveryHooks,
+  ): Promise<AgentRuntimeTurnResult> {
+    const binding = await this.teams.resolveChannel({
+      dispatcherId,
+      provider: envelope.provider,
+      chatId: envelope.chatId,
+      chatType: envelope.chatType,
+    });
+    if (binding !== null) {
+      const result = await this.teams.deliverToLeader({
+        dispatcherId,
+        teamId: binding.team_id,
+        turn: input,
+      });
+      if (result.status === 'submitted') await hooks?.onAccepted?.(input);
+      return result;
+    }
+    const runtime = this.dispatchers.getRuntime(dispatcherId);
+    if (runtime === null) return { status: 'stopped' };
+    return runtime.channelInput(input, hooks);
   }
 
   async deliverTeamMateCompletion(
@@ -191,6 +235,24 @@ export class DispatcherService {
 
   dissolveTeam(input: TeamDissolveInput) {
     return this.teams.dissolve(input);
+  }
+
+  bindTeamChannel(input: TeamBindChannelInput) {
+    return this.teams.bindChannel(input);
+  }
+
+  transferTeamChannelBack(input: TeamTransferChannelBackInput) {
+    return this.teams.transferChannelBack(input);
+  }
+
+  teamLeaderCanUseChannel(input: {
+    dispatcherId: string;
+    teamId: string;
+    leaderName: string;
+    provider: 'builtin:feishu';
+    chatId: string;
+  }) {
+    return this.teams.teamLeaderCanUseChannel(input);
   }
 
   async shutdown(): Promise<void> {

--- a/packages/dreamux/src/dispatcher-service/team/service.ts
+++ b/packages/dreamux/src/dispatcher-service/team/service.ts
@@ -1,14 +1,18 @@
 import { WorktreeManager } from '../teammate/worktree-manager.js';
 import type { TeamMateAgentService, TeamMateSharedWorkspace } from '../teammate/service.js';
-import { teamLeaderPrincipal } from '../teammate/types.js';
+import { dispatcherPrincipal, teamLeaderPrincipal } from '../teammate/types.js';
+import { ChannelBindingStore } from '../channel-binding/store.js';
+import type { ChannelBinding } from '../channel-binding/store.js';
 import { TeamStore } from './store.js';
 import type {
+  TeamBindChannelInput,
   TeamCreateInput,
   TeamCreateResult,
   TeamDissolveInput,
   TeamLedgerResult,
   TeamRecord,
   TeamSummary,
+  TeamTransferChannelBackInput,
 } from './types.js';
 import { validateTeamId } from './types.js';
 
@@ -19,6 +23,7 @@ export interface TeamServiceOptions {
 export class TeamService {
   private readonly store = new TeamStore();
   private readonly worktrees = new WorktreeManager();
+  private readonly bindings = new ChannelBindingStore();
 
   constructor(private readonly opts: TeamServiceOptions) {}
 
@@ -110,6 +115,16 @@ export class TeamService {
 
   async dissolve(input: TeamDissolveInput): Promise<TeamSummary> {
     const team = await this.mustTeam(input.dispatcherId, input.teamId);
+    for (const binding of await this.bindings.list(input.dispatcherId)) {
+      if (binding.active && binding.team_id === team.team_id) {
+        await this.bindings.transferBack({
+          dispatcherId: input.dispatcherId,
+          provider: binding.provider,
+          chatId: binding.chat_id,
+          chatType: binding.chat_type,
+        });
+      }
+    }
     const members = await this.opts.teammates.listScoped(
       teamLeaderPrincipal({
         dispatcherId: input.dispatcherId,
@@ -148,6 +163,89 @@ export class TeamService {
       summary: input.note ?? 'team dissolved',
     });
     return this.summary(closed);
+  }
+
+  async bindChannel(input: TeamBindChannelInput): Promise<ChannelBinding> {
+    const team = await this.mustTeam(input.dispatcherId, input.teamId);
+    if (team.status === 'closed') {
+      throw new Error(`Team ${JSON.stringify(input.teamId)} is closed`);
+    }
+    const binding = await this.bindings.bind({
+      dispatcherId: input.dispatcherId,
+      provider: input.provider,
+      chatId: input.chatId,
+      chatType: input.chatType,
+      teamId: team.team_id,
+      leaderName: team.leader_name,
+    });
+    await this.store.appendLedger(team, {
+      type: 'bind_channel',
+      summary: `bound ${input.provider} ${input.chatType} ${input.chatId}`,
+    });
+    return binding;
+  }
+
+  async transferChannelBack(
+    input: TeamTransferChannelBackInput,
+  ): Promise<ChannelBinding | null> {
+    const binding = await this.bindings.transferBack(input);
+    if (binding !== null) {
+      const team = await this.store.get(input.dispatcherId, binding.team_id);
+      if (team !== null) {
+        await this.store.appendLedger(team, {
+          type: 'transfer_channel_back',
+          summary: `transferred ${input.provider} ${input.chatType} ${input.chatId} back to dispatcher`,
+        });
+      }
+    }
+    return binding;
+  }
+
+  async resolveChannel(input: {
+    dispatcherId: string;
+    provider: 'builtin:feishu';
+    chatId: string;
+    chatType: 'group' | 'p2p';
+  }): Promise<ChannelBinding | null> {
+    const binding = await this.bindings.resolve(input);
+    if (binding === null) return null;
+    const team = await this.store.get(input.dispatcherId, binding.team_id);
+    if (team === null || team.status === 'closed') return null;
+    return binding;
+  }
+
+  async teamLeaderCanUseChannel(input: {
+    dispatcherId: string;
+    teamId: string;
+    leaderName: string;
+    provider: 'builtin:feishu';
+    chatId: string;
+  }): Promise<boolean> {
+    const binding = await this.bindings.resolve({
+      dispatcherId: input.dispatcherId,
+      provider: input.provider,
+      chatId: input.chatId,
+      chatType: 'group',
+    });
+    return (
+      binding !== null &&
+      binding.team_id === input.teamId &&
+      binding.leader_name === input.leaderName
+    );
+  }
+
+  async deliverToLeader(input: {
+    dispatcherId: string;
+    teamId: string;
+    turn: import('../../agent-runtime/turn.js').InboundTurnInput;
+  }): Promise<import('../../agent-runtime/types.js').AgentRuntimeTurnResult> {
+    const team = await this.mustTeam(input.dispatcherId, input.teamId);
+    if (team.status === 'closed') return { status: 'stopped' };
+    return this.opts.teammates.channelInputScoped(
+      dispatcherPrincipal(input.dispatcherId),
+      team.leader_name,
+      input.turn,
+    );
   }
 
   async sharedWorkspace(

--- a/packages/dreamux/src/dispatcher-service/team/types.ts
+++ b/packages/dreamux/src/dispatcher-service/team/types.ts
@@ -44,11 +44,28 @@ export interface TeamDissolveInput {
   note?: string;
 }
 
+export interface TeamBindChannelInput {
+  dispatcherId: string;
+  teamId: string;
+  provider: 'builtin:feishu';
+  chatId: string;
+  chatType: 'group' | 'p2p';
+}
+
+export interface TeamTransferChannelBackInput {
+  dispatcherId: string;
+  provider: 'builtin:feishu';
+  chatId: string;
+  chatType: 'group' | 'p2p';
+}
+
 export type TeamLedgerEventType =
   | 'create'
   | 'status'
   | 'artifact'
   | 'decision'
+  | 'bind_channel'
+  | 'transfer_channel_back'
   | 'dissolve';
 
 export interface TeamLedgerEvent {

--- a/packages/dreamux/src/dispatcher-service/teammate/mcp-config.ts
+++ b/packages/dreamux/src/dispatcher-service/teammate/mcp-config.ts
@@ -9,6 +9,7 @@ export interface TeamMateMcpServerDescriptorOptions {
   callerKind: 'dispatcher' | 'team_leader' | 'teammate';
   teamId?: string;
   leaderName?: string;
+  feishuScope?: 'team';
   command?: string;
   env?: NodeJS.ProcessEnv;
 }
@@ -28,6 +29,7 @@ export function teammateMcpServerDescriptor(
       opts.callerKind,
       ...(opts.teamId !== undefined ? ['--team-id', opts.teamId] : []),
       ...(opts.leaderName !== undefined ? ['--leader-name', opts.leaderName] : []),
+      ...(opts.feishuScope !== undefined ? ['--feishu-scope', opts.feishuScope] : []),
       '--admin-socket',
       opts.adminSocketPath,
     ],

--- a/packages/dreamux/src/dispatcher-service/teammate/service.ts
+++ b/packages/dreamux/src/dispatcher-service/teammate/service.ts
@@ -422,6 +422,19 @@ export class TeamMateAgentService {
     };
   }
 
+  async channelInputScoped(
+    principal: TeamMateCallerPrincipal,
+    name: string,
+    input: import('../../agent-runtime/turn.js').InboundTurnInput,
+  ): Promise<AgentRuntimeTurnResult> {
+    const dispatcherId = principalDispatcherId(principal);
+    const live = await this.ensureRuntime(dispatcherId, name, {
+      principal,
+      reopenClosed: true,
+    });
+    return live.runtime.channelInput(input);
+  }
+
   async createTeamLeader(input: CreateTeamLeaderInput): Promise<TeamMateSpawnResult> {
     const name = validateTeamMateName(input.name);
     const existing = await this.identities.get(input.dispatcherId, name);

--- a/packages/dreamux/src/mcp/feishu-mcp.ts
+++ b/packages/dreamux/src/mcp/feishu-mcp.ts
@@ -17,6 +17,9 @@ import { validateDispatcherId } from '../state/dispatcher-id.js';
 
 export interface FeishuMcpOptions {
   dispatcherId: string;
+  callerKind?: 'dispatcher' | 'team_leader';
+  teamId?: string;
+  leaderName?: string;
   adminSocketPath?: string;
   input?: Readable;
   output?: Writable;
@@ -40,6 +43,7 @@ const SUPPORTED_MCP_PROTOCOL_VERSIONS = new Set([
 
 export async function runFeishuMcp(opts: FeishuMcpOptions): Promise<void> {
   const dispatcherId = validateDispatcherId(opts.dispatcherId);
+  const callerKind = opts.callerKind ?? 'dispatcher';
   const socketPath = opts.adminSocketPath ?? defaultAdminSocketPath();
   const input = opts.input ?? process.stdin;
   const output = opts.output ?? process.stdout;
@@ -59,6 +63,9 @@ export async function runFeishuMcp(opts: FeishuMcpOptions): Promise<void> {
     try {
       await handleRequest(request, {
         dispatcherId,
+        callerKind,
+        teamId: opts.teamId,
+        leaderName: opts.leaderName,
         socketPath,
         output,
       });
@@ -73,7 +80,14 @@ export async function runFeishuMcp(opts: FeishuMcpOptions): Promise<void> {
 
 async function handleRequest(
   request: JsonRpcRequest,
-  ctx: { dispatcherId: string; socketPath: string; output: Writable },
+  ctx: {
+    dispatcherId: string;
+    callerKind: 'dispatcher' | 'team_leader';
+    teamId?: string;
+    leaderName?: string;
+    socketPath: string;
+    output: Writable;
+  },
 ): Promise<void> {
   if (typeof request.method !== 'string') {
     if (request.id !== undefined) {
@@ -136,14 +150,25 @@ function initializeResult(params: unknown): Record<string, unknown> {
 
 async function callTool(
   params: unknown,
-  ctx: { dispatcherId: string; socketPath: string },
+  ctx: {
+    dispatcherId: string;
+    callerKind: 'dispatcher' | 'team_leader';
+    teamId?: string;
+    leaderName?: string;
+    socketPath: string;
+  },
 ): Promise<Record<string, unknown>> {
   try {
     const call = asToolCallParams(params);
     const parsed = parseFeishuMcpToolInput(call.name, call.arguments);
     return forwardToolCall(
       feishuMcpAdminMethod(parsed.toolName),
-      feishuMcpAdminParams(ctx.dispatcherId, parsed),
+      {
+        ...feishuMcpAdminParams(ctx.dispatcherId, parsed),
+        caller_kind: ctx.callerKind,
+        ...(ctx.teamId !== undefined ? { team_id: ctx.teamId } : {}),
+        ...(ctx.leaderName !== undefined ? { leader_name: ctx.leaderName } : {}),
+      },
       ctx.socketPath,
       feishuMcpAdminLabel(parsed.toolName),
     );

--- a/packages/dreamux/src/mcp/team-mcp.ts
+++ b/packages/dreamux/src/mcp/team-mcp.ts
@@ -113,6 +113,15 @@ function teamTools(): Array<Record<string, unknown>> {
     tool('ledger', 'Read one Team ledger.', {
       team_id: { type: 'string', minLength: 1, maxLength: 64 },
     }, ['team_id']),
+    tool('bind_channel', 'Bind a Feishu group chat to a TeamLeader.', {
+      team_id: { type: 'string', minLength: 1, maxLength: 64 },
+      chat_id: { type: 'string', minLength: 1 },
+      chat_type: { type: 'string', enum: ['group', 'p2p'] },
+    }, ['team_id', 'chat_id', 'chat_type']),
+    tool('transfer_channel_back', 'Transfer a bound Feishu group chat back to the dispatcher.', {
+      chat_id: { type: 'string', minLength: 1 },
+      chat_type: { type: 'string', enum: ['group', 'p2p'] },
+    }, ['chat_id', 'chat_type']),
     tool('dissolve', 'Close one Team and its agents.', {
       team_id: { type: 'string', minLength: 1, maxLength: 64 },
       note: { type: 'string', maxLength: 2000 },
@@ -165,6 +174,10 @@ function mapToolCall(call: ToolCall): { method: string; params: Record<string, u
       return { method: 'mcp.team.status', params: teamIdArgs(call.arguments) };
     case 'ledger':
       return { method: 'mcp.team.ledger', params: teamIdArgs(call.arguments) };
+    case 'bind_channel':
+      return { method: 'mcp.team.bind_channel', params: bindChannelArgs(call.arguments) };
+    case 'transfer_channel_back':
+      return { method: 'mcp.team.transfer_channel_back', params: channelArgs(call.arguments) };
     case 'dissolve':
       return { method: 'mcp.team.dissolve', params: dissolveArgs(call.arguments) };
     default:
@@ -196,6 +209,22 @@ function dissolveArgs(value: unknown): Record<string, unknown> {
   return {
     team_id: requireString(obj, 'team_id'),
     ...(note !== null ? { note } : {}),
+  };
+}
+
+function bindChannelArgs(value: unknown): Record<string, unknown> {
+  const obj = asRecord(value, 'bind_channel arguments');
+  return {
+    team_id: requireString(obj, 'team_id'),
+    ...channelArgs(value),
+  };
+}
+
+function channelArgs(value: unknown): Record<string, unknown> {
+  const obj = asRecord(value, 'channel arguments');
+  return {
+    chat_id: requireString(obj, 'chat_id'),
+    chat_type: requireString(obj, 'chat_type'),
   };
 }
 

--- a/packages/dreamux/src/platform/paths.ts
+++ b/packages/dreamux/src/platform/paths.ts
@@ -233,6 +233,10 @@ export function dispatcherTeamLedgerPath(id: string, teamId: string): string {
   return join(dispatcherTeamDir(id), 'ledger', `${teamMateNameSegment(teamId)}.jsonl`);
 }
 
+export function dispatcherChannelBindingsPath(id: string): string {
+  return join(dispatcherTeamDir(id), 'channel-bindings.json');
+}
+
 /**
  * Neutral teammate-name path segment sanitizer. Shared by the neutral
  * teammate-state builders here and by each builtin's teammate log-path builders.

--- a/packages/dreamux/tests/feishu-mcp.test.ts
+++ b/packages/dreamux/tests/feishu-mcp.test.ts
@@ -212,6 +212,7 @@ describe('feishu-mcp stdio shim', () => {
           method: 'mcp.reply',
           params: {
             dispatcher_id: 'dispatcher-a',
+            caller_kind: 'dispatcher',
             chat_id: 'chat-a',
             message_id: 'message-in',
             text: 'hello',
@@ -271,7 +272,11 @@ describe('feishu-mcp stdio shim', () => {
         {
           id: expect.any(String) as string,
           method: 'mcp.list_chat_bots',
-          params: { dispatcher_id: 'dispatcher-a', chat_id: 'chat-a' },
+          params: {
+            dispatcher_id: 'dispatcher-a',
+            caller_kind: 'dispatcher',
+            chat_id: 'chat-a',
+          },
         },
       ]);
 
@@ -363,6 +368,7 @@ describe('feishu-mcp stdio shim', () => {
         method: 'mcp.react',
         params: {
           dispatcher_id: 'dispatcher-a',
+          caller_kind: 'dispatcher',
           message_id: 'message-in',
           emoji: 'THUMBSUP',
         },

--- a/packages/dreamux/tests/smoke.test.ts
+++ b/packages/dreamux/tests/smoke.test.ts
@@ -1167,6 +1167,7 @@ describe('dreamux MVP smoke', () => {
       'mcp.react',
       {
         dispatcher_id: 'flow',
+        chat_id: 'chat-group-a',
         message_id: 'msg-model-react',
         emoji: 'THUMBSUP',
       },

--- a/packages/dreamux/tests/smoke.test.ts
+++ b/packages/dreamux/tests/smoke.test.ts
@@ -11,6 +11,8 @@
  */
 
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+// eslint-disable-next-line no-restricted-imports -- git worktree smoke fixture setup uses synchronous git commands to create a local repository before async server assertions begin (issue #85 test-scope carve-out).
+import { execFileSync } from 'node:child_process';
 import {
   existsSync,
   lstatSync,
@@ -63,8 +65,9 @@ import { writeRestartIntent } from '../src/daemon/restart-intent.js';
 import { dreamuxBinPath } from '../src/platform/package-bin.js';
 import { createLogger, type DreamuxLogger } from '../src/platform/logger.js';
 import { DREAMUX_DISPATCHER_BASE_INSTRUCTIONS } from '../src/dispatcher-service/dispatcher/base-prompt.js';
+import { TeamMateIdentityStore } from '../src/dispatcher-service/teammate/identity-store.js';
 import { startFakeCodex, type FakeCodex } from './fake-codex.js';
-import { testDispatcherConfig } from './helpers/config.js';
+import { testDispatcherConfig, testDreamuxConfig } from './helpers/config.js';
 import { Writable } from 'node:stream';
 import {
   loadExternalAgentRuntimeProviders,
@@ -349,6 +352,17 @@ function writeReadyDispatcherCodexHome(dispatcherId: string, dispatcherCwd?: str
   mkdirSync(dispatcherCwd ?? defaultDispatcherCwd(dispatcherId), { recursive: true });
 }
 
+function initGitRepoSync(path: string): string {
+  mkdirSync(path, { recursive: true });
+  execFileSync('git', ['init', '-b', 'main'], { cwd: path });
+  execFileSync('git', ['config', 'user.name', 'Dreamux Test'], { cwd: path });
+  execFileSync('git', ['config', 'user.email', 'dreamux-test@example.com'], { cwd: path });
+  writeFileSync(join(path, 'README.md'), 'test\n');
+  execFileSync('git', ['add', 'README.md'], { cwd: path });
+  execFileSync('git', ['commit', '-m', 'Initial test commit'], { cwd: path });
+  return path;
+}
+
 interface ConfigDispatcherOverrides {
   id?: string;
   cwd?: string | null;
@@ -358,28 +372,25 @@ interface ConfigDispatcherOverrides {
 }
 
 function configWithDispatcher(overrides: ConfigDispatcherOverrides = {}): DreamuxConfig {
-  return {
-    ...BUILT_IN_DEFAULTS,
-    dispatchers: [
-      testDispatcherConfig({
-        id: overrides.id ?? 'flow',
-        cwd: overrides.cwd ?? null,
-        enabled: overrides.enabled ?? true,
-        feishu: overrides.feishu ?? {
-          app_id: 'app-smoke',
-          app_secret: 'secret-server-only',
-        },
-        codex: overrides.codex ?? {
-          bin: 'codex',
-          approval_policy: 'never',
-          sandbox_mode: 'workspace-write',
-          extra_args: [],
-          extra_env: {},
-          initialize_timeout_ms: 10000,
-        },
-      }),
-    ],
-  };
+  return testDreamuxConfig([
+    testDispatcherConfig({
+      id: overrides.id ?? 'flow',
+      cwd: overrides.cwd ?? null,
+      enabled: overrides.enabled ?? true,
+      feishu: overrides.feishu ?? {
+        app_id: 'app-smoke',
+        app_secret: 'secret-server-only',
+      },
+      codex: overrides.codex ?? {
+        bin: 'codex',
+        approval_policy: 'never',
+        sandbox_mode: 'workspace-write',
+        extra_args: [],
+        extra_env: {},
+        initialize_timeout_ms: 10000,
+      },
+    }),
+  ]);
 }
 
 describe('dreamux MVP smoke', () => {
@@ -438,7 +449,7 @@ describe('dreamux MVP smoke', () => {
 
     await bot.inject(fakeInbound('chat-group-a', 'hi', 'msg-1-id'));
 
-    await waitFor(() => codexInputs.length === 1);
+    await waitFor(() => codexInputs.length === 1, 10000);
     await sleep(80);
     expect(bot.sentMessages).toEqual([]);
     expect(codexInputs).toHaveLength(1);
@@ -519,7 +530,7 @@ describe('dreamux MVP smoke', () => {
         mentions: atUs,
       }),
     );
-    await waitFor(() => codexInputs.length === 1);
+    await waitFor(() => codexInputs.length === 1, 10000);
     expect(codexInputs[0]).toContain('hello from bee');
 
     // 3) Trusted bot WITHOUT an @ → dropped (no new Codex turn).
@@ -819,6 +830,40 @@ describe('dreamux MVP smoke', () => {
       `mcp_servers.team.args=["team-mcp", "--dispatcher", "flow", "--admin-socket", "${join(runtimeDir, 'admin.sock')}"]`,
     );
   });
+
+  it('routes bound Feishu group inbound to the TeamLeader and transfers back', async () => {
+    const repo = initGitRepoSync(join(runtimeDir, 'team-repo'));
+    server = buildServer({ runtimeDir, fake, bot, config: configWithDispatcher() });
+    await server.start();
+
+    await server.dispatcherService.createTeam({
+      dispatcherId: 'flow',
+      name: 'alpha',
+      repoCwd: repo,
+      leaderAgentRuntime: 'flow',
+    });
+    await server.dispatcherService.bindTeamChannel({
+      dispatcherId: 'flow',
+      teamId: 'alpha',
+      provider: 'builtin:feishu',
+      chatId: 'chat-team',
+      chatType: 'group',
+    });
+    await bot.inject(fakeInbound('chat-team', 'team hello', 'msg-team'));
+    await waitFor(() => codexInputs.some((input) => input.includes('team hello')));
+    expect(codexInputs.some((input) => input.includes('team hello'))).toBe(true);
+    codexInputs.length = 0;
+
+    await server.dispatcherService.transferTeamChannelBack({
+      dispatcherId: 'flow',
+      provider: 'builtin:feishu',
+      chatId: 'chat-team',
+      chatType: 'group',
+    });
+    await bot.inject(fakeInbound('chat-team', 'dispatcher again', 'msg-back'));
+    await waitFor(() => codexInputs.length === 1);
+    expect(codexInputs[0]).toContain('dispatcher again');
+  }, 10000);
 
   it('launches a dispatcher with its own runtime.config.bin', async () => {
     const previousEnvBin = process.env['CODEX_HOST_CODEX_BIN'];


### PR DESCRIPTION
## Summary

- add persistent Feishu group channel bindings for Team Mode
- add team.bind_channel and team.transfer_channel_back MCP/admin surfaces
- route bound Feishu group inbound to the owning TeamLeader after existing Feishu gate/format
- keep unbound/P2P inbound on the dispatcher path
- scope TeamLeader Feishu reply/react to bound team channels

## Out of scope

- no P2P create-group/invite support
- no independent Feishu bot identities
- no ChannelBinding for non-Feishu providers

## Validation

- pnpm --dir packages/dreamux exec vitest run tests/smoke.test.ts tests/team-service.test.ts tests/teammate-mcp.test.ts
- node common/scripts/install-run-rush.js build --to @excitedjs/dreamux
- node common/scripts/install-run-rush.js lint --to @excitedjs/dreamux
- git diff --check
- .agents/scripts/check.sh