### PR TITLE
Route TeamLeader completions by turn origin

### DIFF
--- a/common/changes/@excitedjs/dreamux/fix-team-mode-completion-routing_2026-06-10-04-30.json
+++ b/common/changes/@excitedjs/dreamux/fix-team-mode-completion-routing_2026-06-10-04-30.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "TeamLeader completion routing is now per turn instead of per role: bound-channel leader turns stay pull-only (team ledger), while dispatcher-initiated leader send/control turns return to the dispatcher as completions; removes the redundant getLast-polling completion path that double-delivered leader ledger rows and team-member completions",
+      "type": "patch",
+      "packageName": "@excitedjs/dreamux"
+    }
+  ],
+  "packageName": "@excitedjs/dreamux",
+  "email": "053700@gmail.com"
+}

--- a/packages/dreamux/src/dispatcher-service/service.ts
+++ b/packages/dreamux/src/dispatcher-service/service.ts
@@ -28,6 +28,7 @@ import type {
   SendTeamMateInput,
   SpawnTeamMateInput,
   TeamMateIdentity,
+  TeamMateTurnOrigin,
 } from './teammate/types.js';
 import type {
   TeamBindChannelInput,
@@ -104,8 +105,8 @@ export class DispatcherService {
       // Reverse delivery (issue #147): a settled teammate turn bridges here to
       // the dispatcher runtime's completionInput, becoming a fresh dispatcher
       // turn. The facade is where both services meet.
-      onTeamMateCompletion: (id, identity, completion) =>
-        this.deliverTeamMateCompletion(id, identity, completion),
+      onTeamMateCompletion: (id, identity, completion, origin) =>
+        this.deliverTeamMateCompletion(id, identity, completion, origin),
       log: opts.log,
     });
     this.teams = new TeamService({
@@ -176,8 +177,15 @@ export class DispatcherService {
     dispatcherId: string,
     identity: TeamMateIdentity,
     completion: CompletionEnvelope,
+    origin: TeamMateTurnOrigin | null = null,
   ): Promise<void> {
-    if (identity.role === 'team_leader') {
+    // Routing is per turn, not per role: a TeamLeader turn fed by its bound
+    // channel stays pull-only (ledger), but a dispatcher-initiated send/control
+    // turn to that same leader returns to the dispatcher like any teammate.
+    // An unattributed leader turn (origin null, e.g. settled after a restart
+    // lost the in-memory origin map) defaults to the ledger so it can never
+    // inject channel traffic into dispatcher context.
+    if (identity.role === 'team_leader' && origin !== 'dispatcher') {
       await this.teams.recordLeaderTurn({
         dispatcherId,
         leaderName: identity.name,

--- a/packages/dreamux/src/dispatcher-service/teammate/service.ts
+++ b/packages/dreamux/src/dispatcher-service/teammate/service.ts
@@ -50,6 +50,7 @@ import {
   type TeamMateRuntimeStatus,
   type TeamMateSendResult,
   type TeamMateSpawnResult,
+  type TeamMateTurnOrigin,
   type TeamMateTurnResult,
   type TeamMateWorktreeIdentity,
   type TeamMateWorktreeRequest,
@@ -60,8 +61,17 @@ import {
 interface LiveTeamMate {
   runtime: AgentRuntime;
   state: TeamMateRuntimeStateStore;
-  identity: TeamMateIdentity;
+  /**
+   * Per-turn submission origin, keyed by runtime turn id. First-writer-wins:
+   * a later input steered into an already-active turn never re-targets that
+   * turn's completion. Bounded FIFO (see {@link TURN_ORIGIN_CACHE_LIMIT});
+   * entries are kept after settle so duplicate settles of the same turn route
+   * consistently.
+   */
+  turnOrigins: Map<string, TeamMateTurnOrigin>;
 }
+
+const TURN_ORIGIN_CACHE_LIMIT = 256;
 
 export interface TeamMateAgentServiceOptions {
   config: DreamuxConfig;
@@ -84,6 +94,11 @@ export interface TeamMateAgentServiceOptions {
     dispatcherId: string,
     identity: TeamMateIdentity,
     completion: CompletionEnvelope,
+    /**
+     * The settled turn's submission origin, or `null` when the turn id was
+     * never recorded by this process (the sink picks the role's safe default).
+     */
+    origin: TeamMateTurnOrigin | null,
   ) => void | Promise<void>;
   log: DreamuxLogger;
 }
@@ -434,8 +449,8 @@ export class TeamMateAgentService {
       reopenClosed: true,
     });
     const result = await live.runtime.channelInput(input);
-    if (result.status === 'submitted' && this.opts.onTeamMateCompletion !== undefined) {
-      this.armTurnCompletion(deliverableTurnId(result), live.runtime, dispatcherId, name, live.identity);
+    if (result.status === 'submitted') {
+      recordTurnOrigin(live, result.turnId, 'channel');
     }
     return result;
   }
@@ -623,8 +638,9 @@ export class TeamMateAgentService {
     // Bound late so the settle handler closes over the runtime instance directly
     // rather than re-reading the live map: close() deletes the live entry right
     // after stop() fires its terminal `stopped` settles, which would otherwise
-    // race the lookup.
+    // race the lookup. The origin map is closed over for the same reason.
     let liveRuntime: AgentRuntime | null = null;
+    const turnOrigins = new Map<string, TeamMateTurnOrigin>();
     // The teammate's runtime config comes from its own resolved agent (the
     // agents[].id it was spawned with), never inherited from the dispatcher.
     // Hand the provider a create-context dispatcher whose `runtime` is the
@@ -668,6 +684,7 @@ export class TeamMateAgentService {
                 identity,
                 settledRuntime,
                 settled,
+                turnOrigins,
                 onTeamMateCompletion,
               );
             },
@@ -689,7 +706,7 @@ export class TeamMateAgentService {
     } else {
       await runtime.start();
     }
-    const live = { runtime, state, identity };
+    const live = { runtime, state, turnOrigins };
     this.live.set(liveKey(dispatcherId, identity.name), live);
     return live;
   }
@@ -706,29 +723,10 @@ export class TeamMateAgentService {
       sourceId: `teammate:${name}:${submissionSeq}`,
       text: prompt,
     });
-    if (result.status === 'submitted' && this.opts.onTeamMateCompletion !== undefined) {
-      this.armTurnCompletion(deliverableTurnId(result), live.runtime, dispatcherId, name, live.identity);
+    if (result.status === 'submitted') {
+      recordTurnOrigin(live, result.turnId, principalTurnOrigin(opts.principal));
     }
     return toTurnResult(result);
-  }
-
-  private armTurnCompletion(
-    turnId: string,
-    runtime: AgentRuntime,
-    dispatcherId: string,
-    name: string,
-    identity: TeamMateIdentity,
-  ): void {
-    void waitForCompletion(runtime, turnId).then((status) =>
-      this.deliverTurnSettled(
-        dispatcherId,
-        name,
-        identity,
-        runtime,
-        { turnId, status },
-        this.opts.onTeamMateCompletion!,
-      ),
-    );
   }
 
   /**
@@ -740,7 +738,9 @@ export class TeamMateAgentService {
    * and never mislabeled. Reverse
    * delivery requires a stable non-null turn id because the completion id is the
    * idempotency key; builtin runtimes only settle accepted turns after they have
-   * a turn id. Every step is error-isolated: this runs `void`-ed off the
+   * a turn id. The settled turn's recorded submission origin rides along so the
+   * sink can route per turn (channel-origin TeamLeader turns stay pull-only).
+   * Every step is error-isolated: this runs `void`-ed off the
    * synchronous settle callback, so any escape would become an unhandled
    * rejection.
    */
@@ -750,6 +750,7 @@ export class TeamMateAgentService {
     identity: TeamMateIdentity,
     runtime: AgentRuntime,
     settled: TurnSettledSignal,
+    turnOrigins: ReadonlyMap<string, TeamMateTurnOrigin>,
     sink: NonNullable<TeamMateAgentServiceOptions['onTeamMateCompletion']>,
   ): Promise<void> {
     try {
@@ -783,7 +784,12 @@ export class TeamMateAgentService {
         status: settled.status,
         result,
       };
-      await sink(dispatcherId, identity, envelope);
+      await sink(
+        dispatcherId,
+        identity,
+        envelope,
+        turnOrigins.get(settled.turnId) ?? null,
+      );
     } catch (err) {
       this.opts.log.warn(
         { dispatcher_id: dispatcherId, teammate: name, err: errInfo(err) },
@@ -1107,23 +1113,33 @@ function toTurnResult(result: AgentRuntimeTurnResult): TeamMateTurnResult {
   }
 }
 
-function deliverableTurnId(
-  result: Extract<AgentRuntimeTurnResult, { status: 'submitted' }>,
-): string {
-  return result.turnId;
+/**
+ * The completion origin a submitting principal implies: a TeamLeader-submitted
+ * turn (member spawn/send) answers to that leader; everything else — including
+ * the principal-less `createTeamLeader` bootstrap prompt — answers to the
+ * dispatcher. Channel-delivered turns never come through here; they are
+ * recorded as `channel` at the `channelInputScoped` seam.
+ */
+function principalTurnOrigin(
+  principal: TeamMateCallerPrincipal | undefined,
+): TeamMateTurnOrigin {
+  return principal?.kind === 'team_leader' ? 'team_leader' : 'dispatcher';
 }
 
-async function waitForCompletion(
-  runtime: AgentRuntime,
-  _turnId: string,
-): Promise<'completed' | 'failed' | 'stopped'> {
-  for (let i = 0; i < 200; i += 1) {
-    await new Promise((resolve) => setTimeout(resolve, 25));
-    const last = await runtime.getLast();
-    if (last !== null) return 'completed';
-    if (runtime.getStatus() === 'stopped') return 'stopped';
+function recordTurnOrigin(
+  live: LiveTeamMate,
+  turnId: string,
+  origin: TeamMateTurnOrigin,
+): void {
+  // First-writer-wins: a send steered into an already-active turn must not
+  // re-target the completion of the turn that absorbed it.
+  if (live.turnOrigins.has(turnId)) return;
+  live.turnOrigins.set(turnId, origin);
+  while (live.turnOrigins.size > TURN_ORIGIN_CACHE_LIMIT) {
+    const oldest = live.turnOrigins.keys().next().value;
+    if (oldest === undefined) break;
+    live.turnOrigins.delete(oldest);
   }
-  return runtime.getStatus() === 'stopped' ? 'stopped' : 'completed';
 }
 
 function ownerForPrincipal(principal: TeamMateCallerPrincipal): TeamMateIdentity['owner'] {

--- a/packages/dreamux/src/dispatcher-service/teammate/types.ts
+++ b/packages/dreamux/src/dispatcher-service/teammate/types.ts
@@ -135,6 +135,17 @@ export interface TeamMateDispatcherOwner {
   dispatcher_id: string;
 }
 
+/**
+ * Where a teammate turn was submitted from, recorded per turn id at submit
+ * time and resolved again when the turn settles. This is what decides where
+ * the completion is delivered: a `channel` turn on a TeamLeader stays
+ * pull-only (team ledger), while a `dispatcher`-initiated turn returns to the
+ * dispatcher runtime as a completion. A settle whose turn id was never
+ * recorded (e.g. submitted before a server restart) resolves to `null` and
+ * the facade picks the safe default for the role.
+ */
+export type TeamMateTurnOrigin = 'channel' | 'dispatcher' | 'team_leader';
+
 export interface SpawnTeamMateInput {
   dispatcherId: string;
   name: string;

--- a/packages/dreamux/tests/teammate-completion-e2e.test.ts
+++ b/packages/dreamux/tests/teammate-completion-e2e.test.ts
@@ -266,6 +266,9 @@ describe('reverse delivery end-to-end (Seam ①→②→③ through the facade)'
       spawned.turn.status === 'submitted' ? spawned.turn.turn_id : 'unreachable';
     memberRuntime.settle('completed', turnId);
     await flush();
+    // Wait past the removed 25ms poller's interval: a duplicate delivery path
+    // would have pushed a second envelope into the leader runtime by now.
+    await sleep(150);
 
     expect(leaderRuntime.delivered).toEqual([
       {
@@ -280,14 +283,14 @@ describe('reverse delivery end-to-end (Seam ①→②→③ through the facade)'
     await facade.shutdown();
   });
 
-  it('records TeamLeader bound-channel completions in the team ledger only', async () => {
+  it('records a bound-channel TeamLeader completion as exactly one ledger row, never a dispatcher push', async () => {
     await initGitRepo(workspace(root));
     const descriptor = createBuiltinProviderRegistry().resolve('builtin:codex');
     const provider = new FakeProvider(descriptor);
     const facade = buildFacade(provider, adminSocketPath);
 
     await facade.startDispatcher('flow');
-    await facade.createTeam({
+    const created = await facade.createTeam({
       dispatcherId: 'flow',
       name: 'alpha',
       repoCwd: workspace(root),
@@ -296,23 +299,80 @@ describe('reverse delivery end-to-end (Seam ①→②→③ through the facade)'
 
     const dispatcherRuntime = provider.runtimes[0]!;
     const leaderRuntime = provider.runtimes[1]!;
+    // Settle the dispatcher-initiated bootstrap turn first so the channel turn
+    // below gets its own turn id instead of being steered into the bootstrap.
+    const bootstrapTurnId =
+      created.turn.status === 'submitted' ? created.turn.turn_id : 'unreachable';
+    leaderRuntime.settle('completed', bootstrapTurnId);
+    await flush();
+
     const submitted = await facade.teams.deliverToLeader({
       dispatcherId: 'flow',
       teamId: 'alpha',
       turn: { sourceId: 'msg-team', text: 'team asks' },
     });
     const turnId = submitted.status === 'submitted' ? submitted.turnId : 'unreachable';
+    expect(turnId).not.toBe(bootstrapTurnId);
     leaderRuntime.settle('completed', turnId);
     await waitFor(async () =>
       (await facade.getTeamLedger('flow', 'alpha')).events
         .some((event) => event.type === 'leader_turn'),
     );
+    // Wait past the removed 25ms poller's interval: a second (duplicate)
+    // delivery path would have appended a second leader_turn row by now.
+    await sleep(150);
 
-    expect(dispatcherRuntime.delivered).toEqual([]);
-    expect((await facade.getTeamLedger('flow', 'alpha')).events.at(-1)).toMatchObject({
-      type: 'leader_turn',
+    const leaderTurnRows = (await facade.getTeamLedger('flow', 'alpha')).events
+      .filter((event) => event.type === 'leader_turn');
+    expect(leaderTurnRows).toHaveLength(1);
+    expect(leaderTurnRows[0]).toMatchObject({
       summary: expect.stringContaining('TeamLeader turn completed'),
     });
+    // The bound-channel turn never reaches dispatcher context.
+    expect(dispatcherRuntime.delivered.map((env) => env.id)).not.toContain(
+      `alpha-leader:${turnId}`,
+    );
+
+    await facade.shutdown();
+  });
+
+  it('pushes a dispatcher-initiated TeamLeader turn back to the dispatcher, not the ledger', async () => {
+    await initGitRepo(workspace(root));
+    const descriptor = createBuiltinProviderRegistry().resolve('builtin:codex');
+    const provider = new FakeProvider(descriptor);
+    const facade = buildFacade(provider, adminSocketPath);
+
+    await facade.startDispatcher('flow');
+    const created = await facade.createTeam({
+      dispatcherId: 'flow',
+      name: 'alpha',
+      repoCwd: workspace(root),
+      leaderAgentRuntime: 'flow',
+    });
+
+    const dispatcherRuntime = provider.runtimes[0]!;
+    const leaderRuntime = provider.runtimes[1]!;
+    const bootstrapTurnId =
+      created.turn.status === 'submitted' ? created.turn.turn_id : 'unreachable';
+    leaderRuntime.settle('completed', bootstrapTurnId);
+    await flush();
+
+    const sent = await facade.sendTeamMate({
+      dispatcherId: 'flow',
+      name: 'alpha-leader',
+      prompt: 'Status check from the dispatcher.',
+    });
+    const turnId =
+      sent.turn.status === 'submitted' ? sent.turn.turn_id : 'unreachable';
+    leaderRuntime.settle('completed', turnId);
+    await flush();
+
+    expect(dispatcherRuntime.delivered.map((env) => env.id)).toContain(
+      `alpha-leader:${turnId}`,
+    );
+    const leaderTurnRows = (await facade.getTeamLedger('flow', 'alpha')).events
+      .filter((event) => event.type === 'leader_turn');
+    expect(leaderTurnRows).toEqual([]);
 
     await facade.shutdown();
   });
@@ -556,6 +616,10 @@ function noopLog(): {
 /** Drain the macrotask the void-ed settle handler runs on. */
 async function flush(): Promise<void> {
   await new Promise((resolve) => setImmediate(resolve));
+}
+
+async function sleep(ms: number): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, ms));
 }
 
 async function waitFor(predicate: () => Promise<boolean>): Promise<void> {


### PR DESCRIPTION
修复 PR #177 当前 head（5a7066e）被 CX/CL BLOCK 的两个 P1。

## 问题 1：按角色路由过宽

`deliverTeamMateCompletion` 把所有 `role === 'team_leader'` 的 completion 一律写入 team ledger 并 return。但 Dispatcher 对 TeamLeader 的 send/控制回合（dispatcher principal 对 leader 合法可达，因 leader 的 `owner.kind === 'dispatcher'`）的 completion 也被吞进 ledger，Dispatcher 永远收不到回包。

**修复：按回合（per-turn）记录提交来源，而非按角色路由。** TeamMate 服务在提交时按 turnId 记录来源（`channel` / `dispatcher` / `team_leader`，定义于 `teammate/types.ts` 的 `TeamMateTurnOrigin`）：

- `channelInputScoped`（绑定群消息 → leader）记 `channel`；
- `submitPrompt`（spawn / send / createTeamLeader 引导词）按 principal 记 `dispatcher` 或 `team_leader`；
- 先写者优先：后续输入被折叠（steer）进活跃回合时不改写该回合的响应目标；
- 有界 FIFO（256 条/runtime），settle 后保留以保证重复 settle 路由一致。

settle 时 origin 随 completion 传给 facade，路由规则：

| 回合 | 去向 |
|---|---|
| 绑定频道 → TeamLeader（origin=`channel`） | team ledger（pull-only），不进 Dispatcher context |
| Dispatcher 发起的 TeamLeader send/控制回合（origin=`dispatcher`） | Dispatcher runtime completion |
| Dispatcher 拥有的普通 TeamMate | Dispatcher runtime completion（不变） |
| TeamLeader 拥有的 member | 所属 TeamLeader runtime（不变） |
| leader 回合 origin 未知（如重启后内存 map 丢失） | ledger（安全默认：绝不把频道流量注入 Dispatcher context） |

## 问题 2：轮询路径导致双投递

`armTurnCompletion` / `waitForCompletion` 与既有 `onTurnSettled` 钩子并存，两路都调 `deliverTurnSettled`：Dispatcher 路径被 completion id 去重掩盖，但 leader ledger 行和 member→leader 投递会重复（未修复前实测一次绑定频道回合产生多条 `leader_turn`）。且 `waitForCompletion` 忽略 turnId、用非回合作用域的 `getLast()` 判断完成，超时 5 秒后还无条件返回 `completed`。

**修复：整段删除轮询路径**，`onTurnSettled` 是唯一 completion 信号（两个 builtin runtime 都会对每个已投递回合触发 settle，轮询纯属冗余）。

## 测试（均在未修复 head 上失败，已验证）

- 绑定频道 leader 回合：等待超过旧轮询间隔后，ledger 中 `leader_turn` 行**恰好一条**，且该回合不进 Dispatcher；
- Dispatcher 发起的 leader send 回合：completion 到达 Dispatcher，且不写 ledger；
- TeamLeader 拥有的 member：completion **恰好一次**送达 leader。

## 验证

- `vitest run tests/teammate-completion-e2e.test.ts`：9/9 通过（stash 修复后 3 个新断言按预期失败）
- 全量 `vitest run`（`DREAMUX_SKIP_LIVE_CODEX=1`）：589 通过 / 2 跳过
- `rush build`、`rush lint`：通过
- `rush change --verify`：已附 change 文件

## 残余风险

- origin map 是进程内状态：服务重启丢失后，在途 leader 回合的 completion 会落 ledger 而非 Dispatcher（安全方向的降级，Dispatcher 可经 `tm last` 拉取）。
- 折叠进活跃回合的输入不改写响应目标（先写者优先）：若 Dispatcher 的控制消息被 steer 进正在进行的频道回合，该回合结果仍只进 ledger。