### PR TITLE
Fix macOS CI: Codex socket path budget + symlinked tmpdir fixtures

### DIFF
--- a/.agents/decisions/top-level-design.md
+++ b/.agents/decisions/top-level-design.md
@@ -348,10 +348,18 @@ server-owned discovery state, safe to delete; it holds no credentials.
 dispatcher. It is not the Feishu MCP transport. The Feishu MCP default transport
 is stdio.
 
-Socket path builders must live in `src/runtime/paths.ts`. They must enforce a
-short Unix socket path budget before spawning child processes. Dispatcher ids are
-validated as stable path segments and length-checked so derived `admin.sock` and
-`codex.sock` paths stay within Linux and macOS `sun_path` limits.
+Socket path builders must live in `src/platform/paths.ts` (neutral) and each
+builtin's own `paths.ts` (runtime-specific, per the issue #143 de-leak). They
+must enforce a short Unix socket path budget before spawning child processes.
+Dispatcher ids are validated as stable path segments and length-checked so
+derived `admin.sock` and `codex.sock` paths stay within Linux and macOS
+`sun_path` limits. When a Codex socket's descriptive in-state path exceeds the
+budget (deep `$HOME`, long teammate runtime roots such as
+`state/<dispatcher>/teammate/runtime/<name>/`), the builtin falls back to a
+short deterministic digest-named socket under a private per-user runtime root —
+`XDG_RUNTIME_DIR`, or a non-shared os tmpdir such as macOS's per-user
+`$TMPDIR`. The shared `/tmp` is never used for sockets (see the global-bin
+decision record); with no private root available the start still fails loudly.
 
 There is no `runtime_dir`, no SQLite database, no persisted inbound message
 queue, and no persisted reaction ledger. `stateRoot()` is the single state root;

--- a/common/changes/@excitedjs/dreamux/fix-pr179-macos-ci_2026-06-10-06-50.json
+++ b/common/changes/@excitedjs/dreamux/fix-pr179-macos-ci_2026-06-10-06-50.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Fix Codex socket startup failure under deep state roots (long $HOME, long dispatcher/teammate names). When the descriptive socket path (state/<dispatcher>/.../codex.sock) exceeds the Unix sun_path budget, the socket now falls back to a short deterministic path under a private per-user runtime dir (XDG_RUNTIME_DIR, or a non-shared os tmpdir such as the macOS per-user $TMPDIR) instead of failing to start. The shared /tmp is never used; with no private root available the start still fails loudly. No action needed for existing installs whose paths fit the budget.",
+      "type": "patch",
+      "packageName": "@excitedjs/dreamux"
+    }
+  ],
+  "packageName": "@excitedjs/dreamux",
+  "email": "053700@gmail.com"
+}

--- a/packages/dreamux/src/agent-runtime/builtin/codex/paths.ts
+++ b/packages/dreamux/src/agent-runtime/builtin/codex/paths.ts
@@ -64,22 +64,32 @@ export function dispatcherAppServerControlDir(id: string): string {
 
 /**
  * Short private root for over-budget Codex socket fallbacks, or null when no
- * private root exists. The shared world-writable `/tmp` is never used — the
- * global-bin decision record rejects `/tmp` app-server sockets (control state
- * must be private and owner-writable). `XDG_RUNTIME_DIR` is the canonical
- * private per-user runtime dir on Linux; on macOS `os.tmpdir()` is the
- * per-user 0700 `$TMPDIR` confinement dir, which qualifies.
+ * private root exists. The shared world-writable tmp roots are never used —
+ * the global-bin decision record rejects `/tmp` app-server sockets (control
+ * state must be private and owner-writable). `XDG_RUNTIME_DIR` is the
+ * canonical private per-user runtime dir on Linux, but it is operator input,
+ * so the shared-tmp rejection applies to it too; on macOS `os.tmpdir()` is
+ * the per-user 0700 `$TMPDIR` confinement dir, which qualifies.
  */
 export function codexSocketFallbackDir(): string | null {
   const xdg = process.env['XDG_RUNTIME_DIR'];
-  if (xdg !== undefined && xdg.trim() !== '') return xdg;
+  if (xdg !== undefined && xdg.trim() !== '' && !isSharedTmp(xdg)) return xdg;
   const tmp = tmpdir();
   return isSharedTmp(tmp) ? null : tmp;
 }
 
+/**
+ * Shared world-writable system tmp roots. `/private/tmp` and
+ * `/private/var/tmp` are the macOS symlink-resolved spellings of `/tmp` and
+ * `/var/tmp`, so a canonicalized path must not slip past the guard.
+ */
+const SHARED_TMP_ROOTS = ['/tmp', '/var/tmp', '/private/tmp', '/private/var/tmp'];
+
 function isSharedTmp(path: string): boolean {
   const normalized = normalize(path);
-  return normalized === '/tmp' || normalized.startsWith(`/tmp${sep}`);
+  return SHARED_TMP_ROOTS.some(
+    (root) => normalized === root || normalized.startsWith(`${root}${sep}`),
+  );
 }
 
 /**

--- a/packages/dreamux/src/agent-runtime/builtin/codex/paths.ts
+++ b/packages/dreamux/src/agent-runtime/builtin/codex/paths.ts
@@ -6,8 +6,9 @@
  * string here is byte-identical to its former `platform/paths.ts` output.
  */
 
-import { homedir } from 'node:os';
-import { join } from 'node:path';
+import { createHash } from 'node:crypto';
+import { homedir, tmpdir } from 'node:os';
+import { join, normalize, sep } from 'node:path';
 
 import {
   BUNDLED_SKILL_NAMES,
@@ -16,6 +17,7 @@ import {
   dispatcherPathSegment,
   logsRoot,
   teamMateNameSegment,
+  unixSocketPathFitsBudget,
   type BundledSkillName,
 } from '../../../platform/paths.js';
 
@@ -61,14 +63,57 @@ export function dispatcherAppServerControlDir(id: string): string {
 }
 
 /**
- * Codex app-server Unix socket inside the given per-dispatcher runtime root.
- * The runtime derives its socket from the neutral `dispatcherDir` accessor; this
- * helper applies the socket-path byte budget assertion.
+ * Short private root for over-budget Codex socket fallbacks, or null when no
+ * private root exists. The shared world-writable `/tmp` is never used — the
+ * global-bin decision record rejects `/tmp` app-server sockets (control state
+ * must be private and owner-writable). `XDG_RUNTIME_DIR` is the canonical
+ * private per-user runtime dir on Linux; on macOS `os.tmpdir()` is the
+ * per-user 0700 `$TMPDIR` confinement dir, which qualifies.
+ */
+export function codexSocketFallbackDir(): string | null {
+  const xdg = process.env['XDG_RUNTIME_DIR'];
+  if (xdg !== undefined && xdg.trim() !== '') return xdg;
+  const tmp = tmpdir();
+  return isSharedTmp(tmp) ? null : tmp;
+}
+
+function isSharedTmp(path: string): boolean {
+  const normalized = normalize(path);
+  return normalized === '/tmp' || normalized.startsWith(`/tmp${sep}`);
+}
+
+/**
+ * Codex app-server Unix socket for the given per-dispatcher runtime root.
+ *
+ * The descriptive in-tree path (`<dir>/codex.sock`) is used whenever it fits
+ * the `sun_path` byte budget. A deep runtime root (long $HOME, long dispatcher
+ * or teammate names — e.g. the teammate tree
+ * `state/<dispatcher>/teammate/runtime/<name>/`) can blow that budget; in that
+ * case the socket falls back to a short *private* per-user runtime path (see
+ * `codexSocketFallbackDir`) whose name is a digest of the descriptive path.
+ * The fallback is a pure function of the runtime root, so it keeps the
+ * contract the supervisor relies on:
+ *  - unique: the digest covers the full state-root + dispatcher + teammate dir;
+ *  - stable across restart/resume: same root → same socket path;
+ *  - cleanup unchanged: the supervisor removes `socketPath` before bind and on
+ *    stop, wherever it lives.
+ * When no private fallback root exists the original fail-loud budget assertion
+ * stands.
  */
 export function codexSocketPathIn(dir: string, id: string): string {
+  const descriptive = join(dir, 'codex.sock');
+  if (unixSocketPathFitsBudget(descriptive)) return descriptive;
+  const fallbackDir = codexSocketFallbackDir();
+  if (fallbackDir === null) {
+    return assertUnixSocketPathBudget(
+      descriptive,
+      `dispatcher '${id}' Codex socket path`,
+    );
+  }
+  const digest = createHash('sha256').update(descriptive).digest('hex').slice(0, 16);
   return assertUnixSocketPathBudget(
-    join(dir, 'codex.sock'),
-    `dispatcher '${id}' Codex socket path`,
+    join(fallbackDir, `dreamux-codex-${digest}.sock`),
+    `dispatcher '${id}' Codex socket fallback path`,
   );
 }
 

--- a/packages/dreamux/tests/claude-code-runtime.test.ts
+++ b/packages/dreamux/tests/claude-code-runtime.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
 import { rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
@@ -212,7 +212,15 @@ function controllableFleet(): FakeFleet & {
   };
 }
 
-async function waitFor(predicate: () => boolean, timeoutMs = 2000): Promise<void> {
+// 10s, not 2s: loaded shared CI runners (macOS especially) can stall a forked
+// worker past 2s and flake these purely-fake lifecycle tests (CI run
+// 27259524760 failed, then passed on a same-commit rerun). The poll returns as
+// soon as the predicate holds, so the ceiling costs nothing on the happy path.
+// The test timeout must stay above the waitFor ceiling or vitest's 5s default
+// would undercut it.
+vi.setConfig({ testTimeout: 15_000 });
+
+async function waitFor(predicate: () => boolean, timeoutMs = 10_000): Promise<void> {
   const deadline = Date.now() + timeoutMs;
   while (Date.now() < deadline) {
     if (predicate()) return;

--- a/packages/dreamux/tests/dispatcher-codex-home.test.ts
+++ b/packages/dreamux/tests/dispatcher-codex-home.test.ts
@@ -99,12 +99,43 @@ describe('global Codex home doctor', () => {
     expect(result.ok).toBe(true);
   });
 
-  it('rejects too-long app-server socket paths before bind', async () => {
+  it('rejects too-long app-server socket paths when no private fallback root exists', async () => {
+    const previousXdg = process.env['XDG_RUNTIME_DIR'];
+    const previousTmpdir = process.env['TMPDIR'];
     process.env['HOME'] = join(runtimeDir, 'h'.repeat(90));
+    // With a private runtime root the socket falls back instead of failing
+    // (see codexSocketPathIn); the fail-loud contract holds only when the
+    // sole candidate is the shared /tmp, which is banned for sockets.
+    delete process.env['XDG_RUNTIME_DIR'];
+    process.env['TMPDIR'] = '/tmp';
 
-    await expect(
-      validateDispatcherCodexHome('dispatcher-with-long-id', { env: {} }),
-    ).rejects.toThrow(/Codex socket path is too long/);
+    try {
+      await expect(
+        validateDispatcherCodexHome('dispatcher-with-long-id', { env: {} }),
+      ).rejects.toThrow(/Codex socket path is too long/);
+    } finally {
+      if (previousXdg === undefined) delete process.env['XDG_RUNTIME_DIR'];
+      else process.env['XDG_RUNTIME_DIR'] = previousXdg;
+      if (previousTmpdir === undefined) delete process.env['TMPDIR'];
+      else process.env['TMPDIR'] = previousTmpdir;
+    }
+  });
+
+  it('falls back to a private socket path for deep runtime roots instead of failing', async () => {
+    const previousXdg = process.env['XDG_RUNTIME_DIR'];
+    process.env['HOME'] = join(runtimeDir, 'h'.repeat(90));
+    process.env['XDG_RUNTIME_DIR'] = join(runtimeDir, 'xdg');
+
+    try {
+      const socket = dispatcherSocketPath('dispatcher-with-long-id');
+      expect(socket.startsWith(join(runtimeDir, 'xdg', 'dreamux-codex-'))).toBe(true);
+      expect(Buffer.byteLength(socket, 'utf8')).toBeLessThanOrEqual(
+        DISPATCHER_APP_SERVER_SOCKET_PATH_MAX_BYTES,
+      );
+    } finally {
+      if (previousXdg === undefined) delete process.env['XDG_RUNTIME_DIR'];
+      else process.env['XDG_RUNTIME_DIR'] = previousXdg;
+    }
   });
 
   it('requires auth environment variables to be non-empty and accepts CODEX_ACCESS_TOKEN', async () => {

--- a/packages/dreamux/tests/runtime-paths.test.ts
+++ b/packages/dreamux/tests/runtime-paths.test.ts
@@ -207,15 +207,16 @@ describe('runtime paths', () => {
     // A deep teammate runtime root (the macOS CI shape: long tmp HOME +
     // state/<dispatcher>/teammate/runtime/<name>/) exceeds the budget; the
     // socket must move to the short private fallback root instead of failing.
+    // Pure path derivation — the XDG dir does not need to exist.
     process.env['HOME'] = join(root, 'h'.repeat(90));
-    process.env['XDG_RUNTIME_DIR'] = join(root, 'xdg');
+    process.env['XDG_RUNTIME_DIR'] = '/run/user/424242';
     const longDir = dispatcherTeamMateRuntimeDir('dispatcher-a', 'alpha-leader');
     expect(
       unixSocketPathFitsBudget(join(longDir, 'codex.sock')),
     ).toBe(false);
     const fallback = codexSocketPathIn(longDir, 'dispatcher-a');
     expect(unixSocketPathFitsBudget(fallback)).toBe(true);
-    expect(fallback.startsWith(join(root, 'xdg', 'dreamux-codex-'))).toBe(true);
+    expect(fallback.startsWith('/run/user/424242/dreamux-codex-')).toBe(true);
     expect(fallback.endsWith('.sock')).toBe(true);
 
     // Deterministic across restart/resume, unique per runtime root.
@@ -224,7 +225,7 @@ describe('runtime paths', () => {
     expect(codexSocketPathIn(otherDir, 'dispatcher-a')).not.toBe(fallback);
   });
 
-  it('never places the Codex socket fallback in the shared /tmp', () => {
+  it('never places the Codex socket fallback in a shared tmp root', () => {
     // The global-bin decision record rejects /tmp app-server sockets: with no
     // private runtime root available, the budget assertion stays fail-loud.
     delete process.env['XDG_RUNTIME_DIR'];
@@ -237,9 +238,24 @@ describe('runtime paths', () => {
       /too long for Unix sockets/,
     );
 
-    // A private (non-/tmp) tmpdir — the macOS per-user $TMPDIR shape — is an
-    // acceptable fallback root. Pure env/path resolution; no fs access.
+    // XDG_RUNTIME_DIR is operator input: a shared-tmp value must not bypass
+    // the guard, whether it is the root itself or a subdirectory.
+    for (const sharedXdg of ['/tmp', '/tmp/xdg', '/private/tmp', '/var/tmp/xdg']) {
+      process.env['XDG_RUNTIME_DIR'] = sharedXdg;
+      expect(codexSocketFallbackDir()).toBe(null);
+      expect(() => codexSocketPathIn(longDir, 'dispatcher-a')).toThrow(
+        /too long for Unix sockets/,
+      );
+    }
+
+    // A shared-tmp XDG still allows a private tmpdir to serve as the root.
+    process.env['XDG_RUNTIME_DIR'] = '/tmp/xdg';
     process.env['TMPDIR'] = '/var/folders/zz/zyzzyva/T';
+    expect(codexSocketFallbackDir()).toBe('/var/folders/zz/zyzzyva/T');
+
+    // A private (non-shared-tmp) tmpdir — the macOS per-user $TMPDIR shape —
+    // is an acceptable fallback root. Pure env/path resolution; no fs access.
+    delete process.env['XDG_RUNTIME_DIR'];
     expect(codexSocketFallbackDir()).toBe('/var/folders/zz/zyzzyva/T');
   });
 });

--- a/packages/dreamux/tests/runtime-paths.test.ts
+++ b/packages/dreamux/tests/runtime-paths.test.ts
@@ -32,6 +32,8 @@ import {
 } from '../src/platform/paths.js';
 import {
   codexAppServerLogDir,
+  codexSocketFallbackDir,
+  codexSocketPathIn,
   dispatcherCodexAppServerErrorLogPath,
   dispatcherCodexAppServerLogPath,
   dispatcherSocketPath,
@@ -45,10 +47,14 @@ import {
 describe('runtime paths', () => {
   let root: string;
   let previousHome: string | undefined;
+  let previousXdgRuntimeDir: string | undefined;
+  let previousTmpdir: string | undefined;
 
   beforeEach(() => {
     root = mkdtempSync(join('/tmp', 'dreamux-paths-'));
     previousHome = process.env['HOME'];
+    previousXdgRuntimeDir = process.env['XDG_RUNTIME_DIR'];
+    previousTmpdir = process.env['TMPDIR'];
     process.env['HOME'] = join(root, 'home');
     delete process.env['CODEX_HOST_RUNTIME_DIR'];
     delete process.env['CODEX_HOST_ADMIN_SOCKET'];
@@ -58,6 +64,10 @@ describe('runtime paths', () => {
   afterEach(() => {
     if (previousHome === undefined) delete process.env['HOME'];
     else process.env['HOME'] = previousHome;
+    if (previousXdgRuntimeDir === undefined) delete process.env['XDG_RUNTIME_DIR'];
+    else process.env['XDG_RUNTIME_DIR'] = previousXdgRuntimeDir;
+    if (previousTmpdir === undefined) delete process.env['TMPDIR'];
+    else process.env['TMPDIR'] = previousTmpdir;
     resetRuntimeConfig();
     rmSync(root, { recursive: true, force: true });
   });
@@ -185,8 +195,51 @@ describe('runtime paths', () => {
 
     process.env['HOME'] = join(root, 'h'.repeat(90));
     expect(() => adminSocketPath()).toThrow(/too long for Unix sockets/);
-    expect(() => dispatcherSocketPath('dispatcher-a')).toThrow(
+  });
+
+  it('falls back to a short deterministic Codex socket when the runtime root blows the budget', () => {
+    // The descriptive in-tree socket survives short roots untouched.
+    const shortDir = dispatcherTeamMateRuntimeDir('dispatcher-a', 'reviewer-1');
+    expect(codexSocketPathIn(shortDir, 'dispatcher-a')).toBe(
+      join(shortDir, 'codex.sock'),
+    );
+
+    // A deep teammate runtime root (the macOS CI shape: long tmp HOME +
+    // state/<dispatcher>/teammate/runtime/<name>/) exceeds the budget; the
+    // socket must move to the short private fallback root instead of failing.
+    process.env['HOME'] = join(root, 'h'.repeat(90));
+    process.env['XDG_RUNTIME_DIR'] = join(root, 'xdg');
+    const longDir = dispatcherTeamMateRuntimeDir('dispatcher-a', 'alpha-leader');
+    expect(
+      unixSocketPathFitsBudget(join(longDir, 'codex.sock')),
+    ).toBe(false);
+    const fallback = codexSocketPathIn(longDir, 'dispatcher-a');
+    expect(unixSocketPathFitsBudget(fallback)).toBe(true);
+    expect(fallback.startsWith(join(root, 'xdg', 'dreamux-codex-'))).toBe(true);
+    expect(fallback.endsWith('.sock')).toBe(true);
+
+    // Deterministic across restart/resume, unique per runtime root.
+    expect(codexSocketPathIn(longDir, 'dispatcher-a')).toBe(fallback);
+    const otherDir = dispatcherTeamMateRuntimeDir('dispatcher-a', 'beta-leader');
+    expect(codexSocketPathIn(otherDir, 'dispatcher-a')).not.toBe(fallback);
+  });
+
+  it('never places the Codex socket fallback in the shared /tmp', () => {
+    // The global-bin decision record rejects /tmp app-server sockets: with no
+    // private runtime root available, the budget assertion stays fail-loud.
+    delete process.env['XDG_RUNTIME_DIR'];
+    process.env['TMPDIR'] = '/tmp';
+    expect(codexSocketFallbackDir()).toBe(null);
+
+    process.env['HOME'] = join(root, 'h'.repeat(90));
+    const longDir = dispatcherTeamMateRuntimeDir('dispatcher-a', 'alpha-leader');
+    expect(() => codexSocketPathIn(longDir, 'dispatcher-a')).toThrow(
       /too long for Unix sockets/,
     );
+
+    // A private (non-/tmp) tmpdir — the macOS per-user $TMPDIR shape — is an
+    // acceptable fallback root. Pure env/path resolution; no fs access.
+    process.env['TMPDIR'] = '/var/folders/zz/zyzzyva/T';
+    expect(codexSocketFallbackDir()).toBe('/var/folders/zz/zyzzyva/T');
   });
 });

--- a/packages/dreamux/tests/team-service.test.ts
+++ b/packages/dreamux/tests/team-service.test.ts
@@ -1,4 +1,4 @@
-import { existsSync, mkdtempSync, rmSync } from 'node:fs';
+import { existsSync, mkdtempSync, realpathSync, rmSync } from 'node:fs';
 import { mkdir, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
@@ -158,7 +158,10 @@ describe('TeamService', () => {
   let previousHome: string | undefined;
 
   beforeEach(() => {
-    root = mkdtempSync(join(tmpdir(), 'dreamux-team-'));
+    // realpath: on macOS tmpdir() is a /var -> /private/var symlink, and git
+    // reports symlink-resolved repo roots (source_repo), so fixture paths must
+    // be canonical for path equality assertions.
+    root = realpathSync(mkdtempSync(join(tmpdir(), 'dreamux-team-')));
     previousHome = process.env['HOME'];
     process.env['HOME'] = join(root, 'home');
     resetRuntimeConfig();

--- a/packages/dreamux/tests/teammate-agent-service.test.ts
+++ b/packages/dreamux/tests/teammate-agent-service.test.ts
@@ -1,5 +1,5 @@
-import { existsSync, mkdtempSync, rmSync } from 'node:fs';
-import { mkdir, readFile, writeFile } from 'node:fs/promises';
+import { existsSync, mkdtempSync, realpathSync, rmSync } from 'node:fs';
+import { mkdir, readFile, symlink, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { execa } from 'execa';
@@ -175,7 +175,10 @@ describe('TeamMateAgentService', () => {
   let previousHome: string | undefined;
 
   beforeEach(() => {
-    root = mkdtempSync(join(tmpdir(), 'dreamux-teammate-agent-'));
+    // realpath: on macOS tmpdir() is a /var -> /private/var symlink, and git
+    // reports symlink-resolved repo roots (source_repo), so fixture paths must
+    // be canonical for path equality assertions.
+    root = realpathSync(mkdtempSync(join(tmpdir(), 'dreamux-teammate-agent-')));
     previousHome = process.env['HOME'];
     process.env['HOME'] = join(root, 'home');
     resetRuntimeConfig();
@@ -750,6 +753,35 @@ describe('TeamMateAgentService', () => {
     });
     expect(closed.teammate.worktree.cleanup_state).toBe('deleted');
     expect(existsSync(spawned.teammate.worktree.path)).toBe(false);
+  });
+
+  it('reports the git-canonical source_repo when cwd reaches the repo through a symlink', async () => {
+    // macOS regression guard: tmpdir() lives behind a /var -> /private/var
+    // symlink, so `git rev-parse --show-toplevel` reports the symlink-resolved
+    // repo root. Reproduce that shape on any OS with an explicit symlink:
+    // source_repo is the canonical root while source_cwd keeps the
+    // caller-supplied path.
+    const repo = await initGitRepo(join(root, 'real-repo'));
+    const linked = join(root, 'linked-repo');
+    await symlink(repo, linked);
+    const { catalog } = providerCatalog();
+    const config = testDreamuxConfig();
+    const service = new TeamMateAgentService({
+      config,
+      dispatchers: new DispatcherStore(config),
+      agentRuntimeProviders: catalog,
+      log: noopLog(),
+    });
+
+    const spawned = await service.spawn({
+      dispatcherId: 'flow',
+      name: 'symlinked',
+      prompt: 'go',
+      cwd: linked,
+    });
+
+    expect(spawned.teammate.source_cwd).toBe(linked);
+    expect(spawned.teammate.source_repo).toBe(repo);
   });
 
   it('recreates a deleted managed worktree when send reopens a closed teammate', async () => {


### PR DESCRIPTION
解除 #179（next → main 发布）阻塞：macOS CI（run 27256943541，rush job 80493235872）红、Ubuntu 绿。共 4 个失败用例，两类根因，均已从代码与日志逐一验证。

## 根因 1：Codex socket 路径超出 sun_path 预算（产品级问题，非仅测试）

Team Mode smoke 用例创建 TeamLeader 时，teammate 的 Codex socket 路径
`state/<dispatcher>/teammate/runtime/<name>/codex.sock` 在 macOS 的 per-user 临时 HOME 下达到 129 字节，超过 103 字节安全预算，`assertUnixSocketPathBudget` fail-loud 导致启动失败。真实环境中较深的 `$HOME` 或较长的 teammate 名同样会触发，不是测试专属问题。

**修复**（`agent-runtime/builtin/codex/paths.ts`）：描述性路径在预算内时行为完全不变；超预算时回退到一个短的、以描述性路径 sha256 摘要命名的 socket，回退根按序选择私有的 per-user 运行时目录——`XDG_RUNTIME_DIR`，其次是非共享 `/tmp` 的 `os.tmpdir()`（即 macOS 的 per-user 0700 `$TMPDIR`）。设计要点：

- **不使用共享 `/tmp`**：维持 global-bin 决策记录对 `/tmp` app-server socket 的否决；没有私有回退根时保留原有 fail-loud 行为；
- **唯一性**：摘要覆盖完整 state root + dispatcher + teammate 运行时目录；
- **重启/恢复稳定**：回退路径是运行时根目录的纯函数，同一根目录恒得同一 socket 路径；
- **清理语义不变**：supervisor 在 bind 前与 stop 时按 `socketPath` 删除文件，与位置无关。

## 根因 2：macOS `/var → /private/var` 符号链接规范化

`WorktreeManager` 经 `git rev-parse --show-toplevel` 取 `source_repo`，git 返回符号链接解析后的 `/private/var/...`；测试夹具用未解析的 `mkdtempSync` 路径做相等断言。

**修复**（仅测试侧，产品语义不变）：`team-service.test.ts` 与 `teammate-agent-service.test.ts` 的夹具根目录改为 `realpathSync(mkdtempSync(...))`，并新增一个跨平台回归用例：通过显式符号链接进入仓库时，`source_repo` 必须是 git 规范化根、`source_cwd` 保持调用方传入路径。

## 回归测试

- `runtime-paths.test.ts`：短根目录保持描述性路径不变；深根目录回退（预算内、确定性、按根目录唯一）；无私有根时 fail-loud；macOS 形 `$TMPDIR` 作为合法回退根。
- `dispatcher-codex-home.test.ts`：doctor 在有私有回退根时接受深 HOME，仅在唯一候选为共享 `/tmp` 时拒绝。
- `teammate-agent-service.test.ts`：符号链接 `source_repo` 规范化回归用例。

## 验证

- `rush build` / `rush lint` / `rush test` 全绿（Linux 本地）。
- 在 Linux 上以深 TMPDIR（非 `/tmp` 下、无 XDG，等价 macOS CI 形态）复现原失败：修复前精确复现 CI 报错（131 字节超预算），修复后该 smoke 用例通过。
- `.agents/scripts/check.sh` 通过（同步更新了 top-level-design 决策记录的 socket 预算契约，并修正其中过时的 `src/runtime/paths.ts` 引用）。

附 rush change file（patch）说明深路径安装的行为变化。

Unblocks #179.

🤖 Generated with [Claude Code](https://claude.com/claude-code)