### PR TITLE
Add Team worktree mode selection

### DIFF
--- a/common/changes/@excitedjs/dreamux/feature-team-worktree-mode-select_2026-06-10-07-03.json
+++ b/common/changes/@excitedjs/dreamux/feature-team-worktree-mode-select_2026-06-10-07-03.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Add an optional Team worktree mode parameter to team.create and team.create_group so callers can reuse the repository cwd while the default remains managed worktrees.",
+      "type": "minor",
+      "packageName": "@excitedjs/dreamux"
+    }
+  ],
+  "packageName": "@excitedjs/dreamux",
+  "email": "noreply@users.noreply.github.com"
+}

--- a/packages/dreamux/src/admin/methods.ts
+++ b/packages/dreamux/src/admin/methods.ts
@@ -322,11 +322,13 @@ export const adminMethods: Record<string, AdminHandler> = {
   'mcp.team.create_group': async (server, params) => {
     const id = mustDispatcherId(params);
     mustExistingDispatcher(server, id);
+    const worktree = optionalWorktreeRequest(params, 'worktree');
     return server.dispatcherService.createTeamGroup({
       dispatcherId: id,
       name: mustString(params, 'name'),
       repoCwd: mustString(params, 'repo_cwd'),
       leaderAgentRuntime: mustString(params, 'leader_agent_runtime'),
+      ...(worktree !== null ? { worktree } : {}),
       sourceChatId: mustString(params, 'source_chat_id'),
       sourceChatType: mustString(params, 'source_chat_type') === 'p2p' ? 'p2p' : 'group',
       requesterOpenId: mustString(params, 'requester_open_id'),

--- a/packages/dreamux/src/dispatcher-service/team/types.ts
+++ b/packages/dreamux/src/dispatcher-service/team/types.ts
@@ -64,6 +64,7 @@ export interface TeamCreateGroupInput {
   name: string;
   repoCwd: string;
   leaderAgentRuntime: string;
+  worktree?: TeamMateWorktreeRequest;
   sourceChatId: string;
   sourceChatType: 'p2p' | 'group';
   requesterOpenId: string;

--- a/packages/dreamux/src/mcp/team-mcp.ts
+++ b/packages/dreamux/src/mcp/team-mcp.ts
@@ -103,6 +103,7 @@ function teamTools(): Array<Record<string, unknown>> {
       name: { type: 'string', minLength: 1, maxLength: 64 },
       repo_cwd: { type: 'string', minLength: 1, maxLength: 4096 },
       leader_agent_runtime: { type: 'string', minLength: 1, maxLength: 128 },
+      worktree: worktreeSchema(),
       intent: { type: 'string', maxLength: 2000 },
       prompt: { type: 'string', maxLength: 20000 },
     }, ['name', 'repo_cwd', 'leader_agent_runtime']),
@@ -110,6 +111,7 @@ function teamTools(): Array<Record<string, unknown>> {
       name: { type: 'string', minLength: 1, maxLength: 64 },
       repo_cwd: { type: 'string', minLength: 1, maxLength: 4096 },
       leader_agent_runtime: { type: 'string', minLength: 1, maxLength: 128 },
+      worktree: worktreeSchema(),
       source_chat_id: { type: 'string', minLength: 1 },
       source_chat_type: { type: 'string', enum: ['p2p', 'group'] },
       requester_open_id: { type: 'string', minLength: 1 },
@@ -151,6 +153,21 @@ function tool(
     name,
     description,
     inputSchema: { type: 'object', additionalProperties: false, properties, required },
+  };
+}
+
+function worktreeSchema(): Record<string, unknown> {
+  return {
+    type: 'object',
+    additionalProperties: false,
+    properties: {
+      mode: { type: 'string', enum: ['reuse-cwd', 'managed'] },
+      slug: { type: 'string', minLength: 1, maxLength: 64 },
+      base_ref: { type: 'string', minLength: 1, maxLength: 256 },
+      branch: { type: 'string', minLength: 1, maxLength: 256 },
+      cleanup: { type: 'string', enum: ['keep', 'delete-on-close'] },
+    },
+    required: ['mode'],
   };
 }
 
@@ -201,14 +218,44 @@ function mapToolCall(call: ToolCall): { method: string; params: Record<string, u
 
 function createArgs(value: unknown): Record<string, unknown> {
   const obj = asRecord(value, 'create arguments');
+  const worktree = optionalWorktree(obj, 'worktree');
   const intent = optionalString(obj, 'intent');
   const prompt = optionalString(obj, 'prompt');
   return {
     name: requireString(obj, 'name'),
     repo_cwd: requireString(obj, 'repo_cwd'),
     leader_agent_runtime: requireString(obj, 'leader_agent_runtime'),
+    ...(worktree !== null ? { worktree } : {}),
     ...(intent !== null ? { intent } : {}),
     ...(prompt !== null ? { prompt } : {}),
+  };
+}
+
+function optionalWorktree(
+  obj: Record<string, unknown>,
+  key: string,
+): Record<string, unknown> | null {
+  const value = obj[key];
+  if (value === undefined || value === null) return null;
+  const worktree = asRecord(value, key);
+  const mode = requireString(worktree, 'mode');
+  if (mode !== 'reuse-cwd' && mode !== 'managed') {
+    throw new Error(`${key}.mode must be 'reuse-cwd' or 'managed'`);
+  }
+  const cleanup = optionalString(worktree, 'cleanup');
+  if (
+    cleanup !== null &&
+    cleanup !== 'keep' &&
+    cleanup !== 'delete-on-close'
+  ) {
+    throw new Error(`${key}.cleanup must be 'keep' or 'delete-on-close'`);
+  }
+  return {
+    mode,
+    ...optionalStringProp(worktree, 'slug'),
+    ...optionalStringProp(worktree, 'base_ref'),
+    ...optionalStringProp(worktree, 'branch'),
+    ...(cleanup !== null ? { cleanup } : {}),
   };
 }
 

--- a/packages/dreamux/tests/team-mcp.test.ts
+++ b/packages/dreamux/tests/team-mcp.test.ts
@@ -1,0 +1,251 @@
+import { createServer, type Server as NetServer } from 'node:net';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { PassThrough } from 'node:stream';
+
+import { describe, expect, it } from 'vitest';
+
+import type { AdminRequest, AdminResponse } from '../src/admin/protocol.js';
+import { runTeamMcp } from '../src/mcp/team-mcp.js';
+
+class JsonLineReader {
+  private buffer = '';
+  private waiters: Array<(value: unknown) => void> = [];
+
+  constructor(stream: PassThrough) {
+    stream.setEncoding('utf8');
+    stream.on('data', (chunk: string) => {
+      this.buffer += chunk;
+      this.drain();
+    });
+  }
+
+  next(): Promise<unknown> {
+    const line = this.shiftLine();
+    if (line !== null) return Promise.resolve(JSON.parse(line));
+    return new Promise((resolve) => {
+      this.waiters.push(resolve);
+    });
+  }
+
+  private drain(): void {
+    while (this.waiters.length > 0) {
+      const line = this.shiftLine();
+      if (line === null) return;
+      this.waiters.shift()!(JSON.parse(line));
+    }
+  }
+
+  private shiftLine(): string | null {
+    const idx = this.buffer.indexOf('\n');
+    if (idx === -1) return null;
+    const line = this.buffer.slice(0, idx);
+    this.buffer = this.buffer.slice(idx + 1);
+    return line;
+  }
+}
+
+interface FakeAdminServer {
+  socketPath: string;
+  requests: AdminRequest[];
+  close(): Promise<void>;
+}
+
+async function startFakeAdminServer(
+  respond: (request: AdminRequest) => AdminResponse,
+): Promise<FakeAdminServer> {
+  const dir = mkdtempSync(join(tmpdir(), 'dreamux-team-mcp-admin-'));
+  const socketPath = join(dir, 'admin.sock');
+  const requests: AdminRequest[] = [];
+  const server: NetServer = createServer((socket) => {
+    let buffer = '';
+    socket.setEncoding('utf8');
+    socket.on('data', (chunk) => {
+      buffer += chunk;
+      let idx: number;
+      while ((idx = buffer.indexOf('\n')) !== -1) {
+        const line = buffer.slice(0, idx).trim();
+        buffer = buffer.slice(idx + 1);
+        if (line === '') continue;
+        const request = JSON.parse(line) as AdminRequest;
+        requests.push(request);
+        socket.write(`${JSON.stringify(respond(request))}\n`);
+      }
+    });
+  });
+  await new Promise<void>((resolve, reject) => {
+    server.once('error', reject);
+    server.listen(socketPath, () => resolve());
+  });
+  return {
+    socketPath,
+    requests,
+    async close(): Promise<void> {
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+      rmSync(dir, { recursive: true, force: true });
+    },
+  };
+}
+
+function writeJson(input: PassThrough, value: unknown): void {
+  input.write(`${JSON.stringify(value)}\n`);
+}
+
+async function listToolSchemas(): Promise<Array<Record<string, unknown>>> {
+  const input = new PassThrough();
+  const output = new PassThrough();
+  const reader = new JsonLineReader(output);
+  const run = runTeamMcp({
+    dispatcherId: 'dispatcher-a',
+    adminSocketPath: 'unused-admin.sock',
+    input,
+    output,
+    log: () => {},
+  });
+  writeJson(input, { jsonrpc: '2.0', id: 1, method: 'tools/list' });
+  const response = (await reader.next()) as {
+    result: { tools: Array<Record<string, unknown>> };
+  };
+  input.end();
+  await run;
+  return response.result.tools;
+}
+
+async function callTool(
+  admin: FakeAdminServer,
+  name: string,
+  args: Record<string, unknown>,
+): Promise<unknown> {
+  const input = new PassThrough();
+  const output = new PassThrough();
+  const reader = new JsonLineReader(output);
+  const run = runTeamMcp({
+    dispatcherId: 'dispatcher-a',
+    adminSocketPath: admin.socketPath,
+    input,
+    output,
+    log: () => {},
+  });
+  writeJson(input, {
+    jsonrpc: '2.0',
+    id: 1,
+    method: 'tools/call',
+    params: { name, arguments: args },
+  });
+  const response = await reader.next();
+  input.end();
+  await run;
+  return response;
+}
+
+function schemaProperties(tool: Record<string, unknown>): Record<string, unknown> {
+  const schema = tool['inputSchema'] as Record<string, unknown>;
+  return schema['properties'] as Record<string, unknown>;
+}
+
+describe('team-mcp stdio shim', () => {
+  it('exposes the worktree parameter on create and create_group schemas', async () => {
+    const tools = await listToolSchemas();
+    const byName = new Map(tools.map((tool) => [tool['name'] as string, tool]));
+    for (const name of ['create', 'create_group']) {
+      const tool = byName.get(name);
+      expect(tool).toBeDefined();
+      const worktree = schemaProperties(tool!)['worktree'] as Record<string, unknown>;
+      expect(worktree).toMatchObject({ type: 'object', required: ['mode'] });
+      const properties = worktree['properties'] as Record<string, unknown>;
+      expect(properties['mode']).toMatchObject({ enum: ['reuse-cwd', 'managed'] });
+      expect(Object.keys(properties).sort()).toEqual([
+        'base_ref',
+        'branch',
+        'cleanup',
+        'mode',
+        'slug',
+      ]);
+    }
+  });
+
+  it('forwards worktree from create to mcp.team.create', async () => {
+    const admin = await startFakeAdminServer((request) => ({
+      id: request.id,
+      ok: true,
+      result: { team: { team_id: 'alpha' } },
+    }));
+    try {
+      const response = await callTool(admin, 'create', {
+        name: 'alpha',
+        repo_cwd: '/workspace/repo',
+        leader_agent_runtime: 'flow',
+        worktree: { mode: 'reuse-cwd' },
+      });
+      expect(response).toMatchObject({ id: 1, result: {} });
+      expect(admin.requests).toHaveLength(1);
+      expect(admin.requests[0]).toMatchObject({
+        method: 'mcp.team.create',
+        params: {
+          dispatcher_id: 'dispatcher-a',
+          name: 'alpha',
+          repo_cwd: '/workspace/repo',
+          leader_agent_runtime: 'flow',
+          worktree: { mode: 'reuse-cwd' },
+        },
+      });
+    } finally {
+      await admin.close();
+    }
+  });
+
+  it('forwards worktree from create_group to mcp.team.create_group', async () => {
+    const admin = await startFakeAdminServer((request) => ({
+      id: request.id,
+      ok: true,
+      result: { team: { team_id: 'gamma' } },
+    }));
+    try {
+      await callTool(admin, 'create_group', {
+        name: 'gamma',
+        repo_cwd: '/workspace/repo',
+        leader_agent_runtime: 'flow',
+        worktree: { mode: 'managed', slug: 'gamma', cleanup: 'delete-on-close' },
+        source_chat_id: 'p2p_control',
+        source_chat_type: 'p2p',
+        requester_open_id: 'requester-open-id',
+      });
+      expect(admin.requests).toHaveLength(1);
+      expect(admin.requests[0]).toMatchObject({
+        method: 'mcp.team.create_group',
+        params: {
+          dispatcher_id: 'dispatcher-a',
+          name: 'gamma',
+          worktree: { mode: 'managed', slug: 'gamma', cleanup: 'delete-on-close' },
+          source_chat_id: 'p2p_control',
+          source_chat_type: 'p2p',
+          requester_open_id: 'requester-open-id',
+        },
+      });
+    } finally {
+      await admin.close();
+    }
+  });
+
+  it('rejects an invalid worktree mode before forwarding', async () => {
+    const admin = await startFakeAdminServer((request) => ({
+      id: request.id,
+      ok: true,
+      result: {},
+    }));
+    try {
+      const response = (await callTool(admin, 'create', {
+        name: 'alpha',
+        repo_cwd: '/workspace/repo',
+        leader_agent_runtime: 'flow',
+        worktree: { mode: 'detached' },
+      })) as { result: { isError?: boolean; content: Array<{ text: string }> } };
+      expect(response.result.isError).toBe(true);
+      expect(response.result.content[0]?.text).toMatch(/worktree\.mode/);
+      expect(admin.requests).toHaveLength(0);
+    } finally {
+      await admin.close();
+    }
+  });
+});

--- a/packages/dreamux/tests/team-service.test.ts
+++ b/packages/dreamux/tests/team-service.test.ts
@@ -200,6 +200,8 @@ describe('TeamService', () => {
       owner: { kind: 'dispatcher', dispatcher_id: 'flow' },
       team_id: 'alpha',
     });
+    expect(created.team.worktree.mode).toBe('managed');
+    expect(created.team.runtime_cwd).not.toBe(repo);
     expect(existsSync(created.team.runtime_cwd)).toBe(true);
     expect((await teams.list('flow')).map((entry) => entry.team.team_id)).toEqual(['alpha']);
     expect((await teams.ledger('flow', 'alpha')).events.map((event) => event.type)).toEqual(['create']);
@@ -282,6 +284,96 @@ describe('TeamService', () => {
     ).rejects.toThrow(/does not exist/);
   });
 
+  it('runs the team in the repo cwd when worktree mode is reuse-cwd', async () => {
+    const repo = await initGitRepo(join(root, 'reuse-repo'));
+    const { teams, teammates, provider } = buildServices();
+
+    const created = await teams.create({
+      dispatcherId: 'flow',
+      name: 'alpha',
+      repoCwd: repo,
+      leaderAgentRuntime: 'flow',
+      worktree: { mode: 'reuse-cwd' },
+    });
+
+    expect(created.team).toMatchObject({
+      repo_cwd: repo,
+      source_repo: repo,
+      runtime_cwd: repo,
+    });
+    expect(created.team.worktree).toMatchObject({
+      mode: 'reuse-cwd',
+      slug: null,
+      path: repo,
+      branch: null,
+      base_ref: null,
+      cleanup_state: 'not-managed',
+    });
+    expect(created.leader).toMatchObject({
+      runtime_cwd: repo,
+      worktree: { mode: 'reuse-cwd', path: repo },
+    });
+    expect(provider.contexts.at(-1)?.cwd).toBe(repo);
+
+    const status = await teams.status('flow', 'alpha');
+    expect(status.team.worktree.mode).toBe('reuse-cwd');
+    const ledger = await teams.ledger('flow', 'alpha');
+    expect(ledger.team?.worktree.mode).toBe('reuse-cwd');
+    expect(ledger.events.map((event) => event.type)).toEqual(['create']);
+
+    const workspace = await teams.sharedWorkspace('flow', 'alpha');
+    expect(workspace).toMatchObject({
+      sourceCwd: repo,
+      sourceRepo: repo,
+      runtimeCwd: repo,
+    });
+    const member = await teammates.spawnScoped({
+      principal: teamLeaderPrincipal({
+        dispatcherId: 'flow',
+        teamId: 'alpha',
+        leaderName: 'alpha-leader',
+      }),
+      name: 'builder',
+      prompt: 'build',
+      sharedWorkspace: workspace,
+    });
+    expect(member.teammate).toMatchObject({
+      runtime_cwd: repo,
+      worktree: { mode: 'reuse-cwd', path: repo },
+    });
+    expect(provider.contexts.at(-1)?.cwd).toBe(repo);
+
+    const dissolved = await teams.dissolve({
+      dispatcherId: 'flow',
+      teamId: 'alpha',
+      note: 'done',
+    });
+    expect(dissolved.team.status).toBe('closed');
+    expect(dissolved.team.worktree.cleanup_state).toBe('not-managed');
+    expect(existsSync(repo)).toBe(true);
+    expect(existsSync(join(repo, 'README.md'))).toBe(true);
+  });
+
+  it('passes a reuse-cwd worktree request through createGroup', async () => {
+    const repo = await initGitRepo(join(root, 'group-reuse-repo'));
+    const { teams } = buildServices();
+
+    const result = await teams.createGroup({
+      dispatcherId: 'flow',
+      name: 'gamma',
+      repoCwd: repo,
+      leaderAgentRuntime: 'flow',
+      worktree: { mode: 'reuse-cwd' },
+      sourceChatId: 'p2p_control',
+      sourceChatType: 'p2p',
+      requesterOpenId: 'requester-open-id',
+    });
+
+    expect(result.team).toMatchObject({ runtime_cwd: repo, repo_cwd: repo });
+    expect(result.team.worktree).toMatchObject({ mode: 'reuse-cwd', path: repo });
+    expect(result.binding.team_id).toBe('gamma');
+  });
+
   it('creates a team group from P2P and binds the new group', async () => {
     const repo = await initGitRepo(join(root, 'group-repo'));
     const { teams, createdGroups } = buildServices();
@@ -293,15 +385,15 @@ describe('TeamService', () => {
       leaderAgentRuntime: 'flow',
       sourceChatId: 'p2p_control',
       sourceChatType: 'p2p',
-      requesterOpenId: 'ou_requester',
-      inviteOpenIds: ['ou_peer', 'ou_requester'],
+      requesterOpenId: 'requester-open-id',
+      inviteOpenIds: ['peer-open-id', 'requester-open-id'],
       groupName: 'Gamma Team',
     });
 
     expect(createdGroups).toEqual([
       {
         name: 'Gamma Team',
-        userOpenIds: ['ou_requester', 'ou_peer'],
+        userOpenIds: ['requester-open-id', 'peer-open-id'],
         chatId: 'fake_group_1',
       },
     ]);
@@ -345,7 +437,7 @@ describe('TeamService', () => {
         leaderAgentRuntime: 'flow',
         sourceChatId: 'p2p_control',
         sourceChatType: 'p2p',
-        requesterOpenId: 'ou_requester',
+        requesterOpenId: 'requester-open-id',
       }),
     ).rejects.toThrow(/missing Feishu chat permission/);
 
@@ -372,7 +464,7 @@ describe('TeamService', () => {
         leaderAgentRuntime: 'flow',
         sourceChatId: 'group_source',
         sourceChatType: 'group',
-        requesterOpenId: 'ou_requester',
+        requesterOpenId: 'requester-open-id',
       }),
     ).rejects.toThrow(/P2P control channel/);
   });


### PR DESCRIPTION
## Summary
- expose an optional `worktree` parameter on Team MCP `create` and `create_group`
- pass `worktree` through Team create-group admin/service paths while keeping the omitted default as managed worktrees
- cover reuse-cwd Team workspace semantics for leaders, members, status/ledger, and dissolve cleanup

## Tests
- `vitest run tests/team-service.test.ts tests/team-mcp.test.ts`
- `tsc -p tsconfig.json --noEmit`
- `.agents/scripts/check.sh`
- `git diff --check`
- `gitleaks protect --staged --no-banner`