### PR TITLE
feat(state): cache/spill 迁出持久 state (#182 PR-2)

### DIFF
--- a/.agents/components/repo-structure.md
+++ b/.agents/components/repo-structure.md
@@ -140,11 +140,13 @@ multi-package release notes precise while still using Rush as the validator.
 | `~/.dreamux/state/` | Durable server-owned state: per-dispatcher status/access files and `teammate/` ledgers. | The server |
 | `~/.dreamux/state/<id>/status.json` | Dispatcher runtime status and saved Codex `thread_id`. | The server |
 | `~/.dreamux/state/<id>/access.json` | Dispatcher-local Feishu access gate state. | The server / operator tools |
+| `~/.dreamux/cache/<id>/` | Rebuildable cache: completion `spill/` files and `feishu-attachments/`. Not durable state; safe to clear while no server runs (issue #182 PR-2). | The server |
 | `~/.dreamux/logs/` | Server and per-dispatcher logs, including Codex app-server logs. | The server |
 | `~/.codex/` | Codex global default home: auth, memory, and config used by dispatcher app-server processes. | The operator / Codex |
 | `<dispatcher cwd>/.codex/skills/<skill-name>` | Workspace-local bundled skill symlink. | dreamux installer |
 
-The split is load-bearing: a `rm -rf ~/.dreamux/run ~/.dreamux/state ~/.dreamux/logs`
+The split is load-bearing: a
+`rm -rf ~/.dreamux/run ~/.dreamux/cache ~/.dreamux/state ~/.dreamux/logs`
 recovery (only while no server is running) never loses user-edited dreamux
 settings or global Codex auth.
 Dispatcher app-server processes do not set `CODEX_HOME`; they use Codex's

--- a/.agents/decisions/dispatcher-tm-packaging.md
+++ b/.agents/decisions/dispatcher-tm-packaging.md
@@ -54,7 +54,7 @@ must match for each shipped skill. Older package-specific source-directory names
 must be renamed away before this design is implemented.
 
 `dreamux uninstall` does not delete these workspace-local skills by default. It
-removes dreamux-owned config, state, logs, and service integration, then reports
+removes dreamux-owned config, run, cache, state, logs, and service integration, then reports
 the workspace skill paths created by Dreamux so the operator can remove them
 manually when desired. This avoids deleting files under arbitrary operator
 workspaces during a global uninstall.

--- a/.agents/decisions/feishu-inbound-attachments.md
+++ b/.agents/decisions/feishu-inbound-attachments.md
@@ -67,15 +67,17 @@ be refetched later.
 
 ## Cache Contract
 
-Dreamux provides the cache root through `dispatcherFeishuAttachmentCacheDir()`.
-The channel package creates a sanitized per-resource file under that root,
-never trusts raw filenames as paths, resolves the final path back under the
-cache root, writes a temp file first, and renames into place only after the
-download completes under the configured limits.
+Dreamux provides the cache root through `dispatcherFeishuAttachmentCacheDir()`,
+which lives under the dreamux cache tree `~/.dreamux/cache/<dispatcher-id>/
+feishu-attachments/` (issue #182 PR-2 moved it out of durable
+`state/<dispatcher-id>/`). The channel package creates a sanitized per-resource
+file under that root, never trusts raw filenames as paths, resolves the final
+path back under the cache root, writes a temp file first, and renames into place
+only after the download completes under the configured limits.
 
-The cache is server-owned state. It is safe to delete; deletion only turns a
-future duplicate delivery into another Feishu resource fetch or a fallback
-block.
+The cache is server-owned, rebuildable artifact data — not durable state. It is
+safe to delete; deletion only turns a future duplicate delivery into another
+Feishu resource fetch or a fallback block.
 
 ## Consequences
 

--- a/.agents/decisions/global-bin-onboard-serve.md
+++ b/.agents/decisions/global-bin-onboard-serve.md
@@ -207,7 +207,7 @@ narrow decisions above. Everything else in this record stands.
   `install`/`uninstall` reuse the onboard service slice
   ([`/packages/dreamux/src/daemon/install.ts`](/packages/dreamux/src/daemon/install.ts)).
   `daemon uninstall` removes only the service unit; top-level
-  `dreamux uninstall` still removes config/state/logs. Native `systemctl`/
+  `dreamux uninstall` still removes config/run/cache/state/logs. Native `systemctl`/
   `launchctl` remain valid; the group is a convenience and the home of the new
   `restart` verb (which did not exist before).
 - **`loginctl enable-linger` is enabled best-effort** by both `onboard` and

--- a/.agents/decisions/runtime-run-root.md
+++ b/.agents/decisions/runtime-run-root.md
@@ -5,12 +5,13 @@
   [top-level-design](top-level-design.md).
 - **Date:** 2026-06-10
 - **Affects:** `~/.dreamux` layout, admin IPC path contract, Codex app-server
-  socket placement, `dreamux serve` startup, `dreamux uninstall`
-- **PR / Issue:** Epic issue #182, PR-1
+  socket placement, completion spill + attachment cache placement,
+  `dreamux serve` startup, `dreamux uninstall`
+- **PR / Issue:** Epic issue #182, PR-1 (run/sockets) and PR-2 (cache/spill)
 
 ## Decision
 
-`~/.dreamux` splits volatile run files from durable state:
+`~/.dreamux` splits volatile run files and rebuildable cache from durable state:
 
 ```text
 ~/.dreamux/
@@ -18,13 +19,39 @@
     admin.sock             stable cross-process admin IPC endpoint (+ .lock)
     restart-intent.json    one-shot daemon restart marker
     sockets/               fallback root for runtime rendezvous sockets
+  cache/<dispatcher-id>/   rebuildable artifacts (PR-2); safe to clear
+    spill/                 over-budget teammate completion spill files
+    feishu-attachments/    inbound attachment downloads
   state/                   durable server-owned state only
 ```
 
 Path builders stay centralized: neutral builders in
 `/packages/dreamux/src/platform/paths.ts` (`runRoot()`, `adminSocketPath()`,
-`restartIntentPath()`); volatile socket allocation in
+`restartIntentPath()`, `cacheRoot()`, `dispatcherCompletionSpillDir()`,
+`dispatcherFeishuAttachmentCacheDir()`); volatile socket allocation in
 `/packages/dreamux/src/platform/runtime-sockets.ts`.
+
+### Cache tree (PR-2)
+
+Completion spill and the Feishu attachment cache are rebuildable artifacts, not
+durable state, so they live under `cache/`, not `state/`:
+
+- **Completion spill** moved out of shared `/tmp` (a path surfaced verbatim in
+  dispatcher-visible text should not be a world-writable temp file). The neutral
+  `agent-runtime/completion-body.ts` stays runtime-agnostic — it never names a
+  dispatcher id — and receives the owning dispatcher's spill dir through the
+  runtime's `AgentRuntimePathContext.completionSpillDir`. The launcher resolves
+  that to the **operator** dispatcher's cache even for a teammate/team-leader
+  runtime (whose own `dispatcher_id` is a composite runtime id), so one
+  operator's spill groups under one `cache/<id>/spill`. The spill file is read
+  by no process; only its path is inlined.
+- **Feishu attachment cache** moved out of `state/<id>/` into
+  `cache/<id>/feishu-attachments/` (see
+  [feishu-inbound-attachments](feishu-inbound-attachments.md)).
+
+`dreamux uninstall` removes `cache/` alongside `run/`, `state/`, and `logs/`.
+No automatic migration of the old `/tmp` spill files or `state/<id>/
+feishu-attachments/` dirs — the changelog notes them as manually deletable.
 
 ### Two socket classes, two contracts
 

--- a/.agents/decisions/top-level-design.md
+++ b/.agents/decisions/top-level-design.md
@@ -706,7 +706,7 @@ it to let startup recreate the bundled symlink. Custom symlinks in these
 bundled skill slots are treated as Dreamux-managed links and may be replaced;
 use a real file or directory to opt out.
 
-`uninstall` removes dreamux-owned config, state, logs, and service integration
+`uninstall` removes dreamux-owned config, run, cache, state, logs, and service integration
 by default. It reports workspace-local bundled skill paths, but it does not
 delete files under operator workspaces by default.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,7 +64,7 @@ information entry point for the 0.x fail-loud + rebuild policy (issue #98).
 `daemon` group wraps the native user-level service manager (Linux
 `systemctl --user`, macOS `launchctl`); `daemon uninstall` removes only the
 service unit, whereas top-level `dreamux uninstall` removes
-config/run/state/logs too. `daemon restart --notify-resumed --dispatcher <id>` drops a one-shot
+config/run/cache/state/logs too. `daemon restart --notify-resumed --dispatcher <id>` drops a one-shot
 restart marker before restarting, so a resumed dispatcher gets a
 `Restart completed.` turn injected — see issue #78. Do not reintroduce
 global aliases such as `dreamux-server` or `server-ctl`; issue #18 explicitly
@@ -102,6 +102,12 @@ That record wins over older runtime-dir / SQLite decisions.
   Runtime socket paths are random per start, live only in process memory, and
   are never persisted to durable state. Safe to clear while no server runs;
   see `.agents/decisions/runtime-run-root.md`.
+- `~/.dreamux/cache/<dispatcher-id>/` — rebuildable cache (issue #182 PR-2):
+  `spill/` for over-budget teammate completion results (only the path is
+  inlined into a dispatcher turn) and `feishu-attachments/` for inbound
+  attachment downloads. Not durable state; safe to delete while no server runs.
+  Completion spill was relocated out of shared `/tmp`, attachments out of
+  `state/<dispatcher-id>/`.
 - `~/.dreamux/logs/` — server-owned logs, split by component; Codex
   app-server logs use `~/.dreamux/logs/codex-app-server/<dispatcher>.log`, and
   MCP shim diagnostics use component directories such as `feishu-mcp/` and

--- a/common/changes/@excitedjs/dreamux/epic182-pr2-cache-spill_2026-06-11-00-00.json
+++ b/common/changes/@excitedjs/dreamux/epic182-pr2-cache-spill_2026-06-11-00-00.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "BREAKING: dreamux cache/spill artifacts moved into a new ~/.dreamux/cache tree (issue #182 PR-2). Teammate completion spill files moved from shared /tmp/teammate-<source>-<id>.output to ~/.dreamux/cache/<dispatcher-id>/spill/, and the Feishu inbound attachment cache moved from ~/.dreamux/state/<dispatcher-id>/feishu-attachments/ to ~/.dreamux/cache/<dispatcher-id>/feishu-attachments/. Both are rebuildable cache, not durable state: nothing reads a spill file back (only its path is inlined into a dispatcher turn) and attachments are re-fetchable. dreamux uninstall now also removes ~/.dreamux/cache. No automatic migration. Rebuild: nothing to rebuild; old leftovers may be deleted manually: stale /tmp/teammate-*.output files and the old ~/.dreamux/state/<dispatcher-id>/feishu-attachments/ directories.",
+      "type": "minor",
+      "packageName": "@excitedjs/dreamux"
+    }
+  ],
+  "packageName": "@excitedjs/dreamux",
+  "email": "053700@gmail.com"
+}

--- a/packages/dreamux/README.md
+++ b/packages/dreamux/README.md
@@ -105,15 +105,17 @@ logs:
 | `~/.dreamux/state/<id>/access.json` | Dispatcher-local access-gate state | the server |
 | `~/.dreamux/state/<id>/claude-code-mcp.json` | Claude Code MCP config generated from Dreamux-owned descriptors | the server |
 | `~/.dreamux/state/<id>/teammate/` | TeamMate task ledger, results, and delivery retry state | the server |
+| `~/.dreamux/cache/<id>/spill/` | Over-budget teammate completion spill files; rebuildable cache, only the path is inlined into a dispatcher turn | the server |
+| `~/.dreamux/cache/<id>/feishu-attachments/` | Feishu inbound attachment cache; re-fetchable, safe to delete | the server |
 | `~/.dreamux/logs/codex-app-server/<id>.log` | Codex app-server stdout/stderr | the server |
 | `~/.dreamux/logs/feishu-channel/<id>.log` | Feishu channel logs | the server |
 | `~/.dreamux/logs/teammate-mcp/<id>.log` | TeamMate MCP shim diagnostics | the server |
 | `~/.codex/` | Codex global default home: auth, memory, and config | the operator / Codex |
 | `<dispatcher cwd>/.codex/skills/dispatcher/SKILL.md` | Dispatcher skill copied by `dreamux onboard`; reported but not deleted by `dreamux uninstall` | dreamux installer |
 
-`rm -rf ~/.dreamux/run ~/.dreamux/state ~/.dreamux/logs` is a run/state/log
-recovery path (only while no server is running); dreamux config and global Codex
-auth survive.
+`rm -rf ~/.dreamux/run ~/.dreamux/cache ~/.dreamux/state ~/.dreamux/logs` is a
+run/cache/state/log recovery path (only while no server is running); dreamux
+config and global Codex auth survive.
 
 ## Configure dispatchers
 

--- a/packages/dreamux/src/agent-runtime/CLAUDE.md
+++ b/packages/dreamux/src/agent-runtime/CLAUDE.md
@@ -62,9 +62,13 @@ checkpoint kind is capability-driven with no `codexThread` fallback.
 
 Completion delivery itself is bounded (issue #164): a result within the inline
 budget (default 32000 chars, `TASK_MAX_OUTPUT_LENGTH` override, clamped to
-160000) is inlined; a longer one is spilled to a `/tmp` file by the neutral
+160000) is inlined; a longer one is spilled to a file by the neutral
 `completion-body.ts` (shared, no cross-builtin import) and only the path is
-inlined. `CompletionEnvelope.status` is `completed | failed | stopped`.
+inlined. The spill lives under the owning dispatcher's cache spill dir
+(`~/.dreamux/cache/<dispatcher-id>/spill/`, issue #182 PR-2 — moved out of
+shared `/tmp`), supplied by the runtime via
+`AgentRuntimePathContext.completionSpillDir` so the neutral module never names
+a dispatcher id. `CompletionEnvelope.status` is `completed | failed | stopped`.
 
 The channel payload is neutral but now richer (D + issue #164): `channelInput`
 takes `InboundTurnInput { text; sourceId; source?; attrs?; body?; attachments? }`.

--- a/packages/dreamux/src/agent-runtime/builtin/claude-code/runtime.ts
+++ b/packages/dreamux/src/agent-runtime/builtin/claude-code/runtime.ts
@@ -75,6 +75,7 @@ import {
   dispatcherClaudeCodeStreamLogPath,
 } from './paths.js';
 import { dispatcherProcessEnv } from '../../../platform/package-bin.js';
+import { dispatcherCompletionSpillDir } from '../../../platform/paths.js';
 import { claudeCodeResidentArgs } from './args.js';
 import { stringifyClaudeCodeMcpConfig } from './mcp-config.js';
 import {
@@ -167,9 +168,10 @@ function completionStatusLine(completion: CompletionEnvelope): string {
  */
 async function buildCompletionTurnText(
   completion: CompletionEnvelope,
+  spillDir: string,
 ): Promise<string> {
   const line = completionStatusLine(completion);
-  const body = await resolveCompletionBody(completion);
+  const body = await resolveCompletionBody(completion, spillDir);
   return body.kind === 'inline'
     ? `${line} Output below:\n\n${body.text}`
     : `${line} The output is too long, so the full result was saved to a file:\n\n${body.path}`;
@@ -195,6 +197,7 @@ export class ClaudeCodeRuntime implements AgentRuntime {
   private readonly mcpConfigPath: string;
   private readonly mcpConfigDoc: string;
   private readonly stderrLogPath: string;
+  private readonly completionSpillDir: string;
   private status: DispatcherStatus = 'declared';
   private threadId: string | null;
   private resumed: boolean;
@@ -226,6 +229,9 @@ export class ClaudeCodeRuntime implements AgentRuntime {
     this.stderrLogPath =
       context.paths?.stderrLogPath(this.dispatcherId) ??
       dispatcherClaudeCodeStreamLogPath(this.dispatcherId);
+    this.completionSpillDir =
+      context.paths?.completionSpillDir(this.dispatcherId) ??
+      dispatcherCompletionSpillDir(this.dispatcherId);
     this.threadId = context.row.thread_id;
     this.resumed = context.row.thread_id !== null;
   }
@@ -373,7 +379,7 @@ export class ClaudeCodeRuntime implements AgentRuntime {
     // is decoupled from model thinking time.
     let text: string;
     try {
-      text = await buildCompletionTurnText(completion);
+      text = await buildCompletionTurnText(completion, this.completionSpillDir);
     } catch (err) {
       return {
         status: 'failed',

--- a/packages/dreamux/src/agent-runtime/builtin/codex/runtime-support.ts
+++ b/packages/dreamux/src/agent-runtime/builtin/codex/runtime-support.ts
@@ -1,5 +1,8 @@
 import type { DispatcherStore } from '../../../state/dispatcher-store.js';
-import { dispatcherDir } from '../../../platform/paths.js';
+import {
+  dispatcherCompletionSpillDir,
+  dispatcherDir,
+} from '../../../platform/paths.js';
 import { dispatcherProcessEnv } from '../../../platform/package-bin.js';
 import {
   dispatcherCodexAppServerErrorLogPath,
@@ -72,8 +75,9 @@ function frameCodexCompletion(
  */
 export async function buildCodexCompletionItem(
   completion: CompletionEnvelope,
+  spillDir: string,
 ): Promise<Record<string, unknown>> {
-  const body = await resolveCompletionBody(completion);
+  const body = await resolveCompletionBody(completion, spillDir);
   return {
     type: 'message',
     role: 'developer',
@@ -95,6 +99,7 @@ export const defaultCodexRuntimePaths: AgentRuntimePathContext = {
   dispatcherDir,
   stdoutLogPath: dispatcherCodexAppServerLogPath,
   stderrLogPath: dispatcherCodexAppServerErrorLogPath,
+  completionSpillDir: dispatcherCompletionSpillDir,
 };
 
 export function codexRowStateStore(

--- a/packages/dreamux/src/agent-runtime/builtin/codex/runtime.ts
+++ b/packages/dreamux/src/agent-runtime/builtin/codex/runtime.ts
@@ -507,7 +507,10 @@ export class CodexRuntime implements AgentRuntime {
     if (!this.injectedCompletionIds.has(completion.id)) {
       try {
         await injectThreadItems(this.client, threadId, [
-          await buildCodexCompletionItem(completion),
+          await buildCodexCompletionItem(
+            completion,
+            this.paths.completionSpillDir(this.dispatcherId),
+          ),
         ]);
       } catch (err) {
         const cause = err instanceof Error ? err.message : String(err);

--- a/packages/dreamux/src/agent-runtime/completion-body.ts
+++ b/packages/dreamux/src/agent-runtime/completion-body.ts
@@ -11,10 +11,10 @@
  * runtime owns how it frames the resolved body into its own delivery shape.
  */
 
-import { chmod, mkdir, writeFile } from 'node:fs/promises';
-import { dirname } from 'node:path';
+import { chmod, writeFile } from 'node:fs/promises';
 
 import { teamMateCompletionOutputPath } from '../platform/paths.js';
+import { ensureOwnerOnlyDir } from '../platform/owner-only-dir.js';
 import type { CompletionEnvelope } from './types.js';
 
 /**
@@ -54,21 +54,31 @@ export function completionInlineBudget(
 
 /**
  * Decide whether a completion result is inlined or spilled. Spilling writes the
- * FULL result to a 0600 file (async fs only — no sync IO, repo rule #85) and
- * returns the path; the caller inlines only that path.
+ * FULL result to a 0600 file (async fs only — no sync IO, repo rule #85) under
+ * the owning dispatcher's `spillDir` (cache, not state — issue #182 PR-2) and
+ * returns the path; the caller inlines only that path. `spillDir` is supplied
+ * by the runtime's path context, so this module stays runtime-neutral and never
+ * names a dispatcher id.
  */
 export async function resolveCompletionBody(
   completion: CompletionEnvelope,
+  spillDir: string,
 ): Promise<ResolvedCompletionBody> {
   const budget = completionInlineBudget();
   if (completion.result.length <= budget) {
     return { kind: 'inline', text: completion.result };
   }
-  const path = teamMateCompletionOutputPath(completion.source, completion.id);
-  await mkdir(dirname(path), { recursive: true });
+  const path = teamMateCompletionOutputPath(
+    spillDir,
+    completion.source,
+    completion.id,
+  );
+  // Owner-only spill dir: the cache may hold full teammate output. Use the
+  // shared helper so a pre-existing permissive dir is tightened and a symlink /
+  // foreign-uid dir is rejected (issue #182 — same invariant as the run tree),
+  // then a 0600 file + explicit chmod (writeFile's `mode` honors the umask).
+  await ensureOwnerOnlyDir(spillDir);
   await writeFile(path, completion.result, { mode: 0o600 });
-  // Explicit chmod: writeFile's `mode` is subject to the process umask, so a
-  // restrictive 0600 is not guaranteed by the open flags alone.
   await chmod(path, 0o600);
   return { kind: 'spilled', path };
 }

--- a/packages/dreamux/src/agent-runtime/types.ts
+++ b/packages/dreamux/src/agent-runtime/types.ts
@@ -134,6 +134,13 @@ export interface AgentRuntimePathContext {
   stdoutLogPath(id: string): string;
   /** The runtime's primary-process stderr/diagnostic log file in the central logs tree. */
   stderrLogPath(id: string): string;
+  /**
+   * The owning dispatcher's completion-spill directory in the cache tree
+   * (issue #182 PR-2). Supplied by the launcher so a teammate runtime spills
+   * under its operator dispatcher, not its composite runtime id — the same
+   * launcher-resolves-the-real-dir pattern as the log paths above.
+   */
+  completionSpillDir(id: string): string;
 }
 
 export interface AgentRuntime {

--- a/packages/dreamux/src/channel/feishu/feishu-message.ts
+++ b/packages/dreamux/src/channel/feishu/feishu-message.ts
@@ -220,12 +220,16 @@ async function resolveAttachment(
 
   try {
     const cacheRoot = resolve(options.cacheDir);
+    // Owner-only cache dir (issue #182): tighten a pre-existing permissive dir
+    // and reject a symlink / foreign-uid dir, matching the run/spill trees.
+    // Done BEFORE the cache-hit fast path below, so a pre-existing file in a
+    // permissive/symlinked/foreign-owned dir is never returned as `downloaded`
+    // without the dir first passing (or being tightened to) the owner-only
+    // invariant.
+    await ensureOwnerOnlyDir(cacheRoot);
     const path = attachmentPath(cacheRoot, resource);
     if (await fileExists(path)) return { ...base, status: 'downloaded', path };
 
-    // Owner-only cache dir (issue #182): tighten a pre-existing permissive dir
-    // and reject a symlink / foreign-uid dir, matching the run/spill trees.
-    await ensureOwnerOnlyDir(cacheRoot);
     const response = await options.resourceFetcher.fetchMessageResource({
       messageId,
       fileKey: resource.key,

--- a/packages/dreamux/src/channel/feishu/feishu-message.ts
+++ b/packages/dreamux/src/channel/feishu/feishu-message.ts
@@ -1,7 +1,6 @@
 import { createHash } from 'node:crypto';
 import {
   chmod,
-  mkdir,
   rename,
   rm,
   stat,
@@ -9,6 +8,8 @@ import {
 } from 'node:fs/promises';
 import { basename, resolve } from 'node:path';
 import type { Readable } from 'node:stream';
+
+import { ensureOwnerOnlyDir } from '../../platform/owner-only-dir.js';
 
 import type {
   FeishuMessageResourceFetcher,
@@ -222,7 +223,9 @@ async function resolveAttachment(
     const path = attachmentPath(cacheRoot, resource);
     if (await fileExists(path)) return { ...base, status: 'downloaded', path };
 
-    await mkdir(cacheRoot, { recursive: true, mode: 0o700 });
+    // Owner-only cache dir (issue #182): tighten a pre-existing permissive dir
+    // and reject a symlink / foreign-uid dir, matching the run/spill trees.
+    await ensureOwnerOnlyDir(cacheRoot);
     const response = await options.resourceFetcher.fetchMessageResource({
       messageId,
       fileKey: resource.key,

--- a/packages/dreamux/src/cli/dreamux.ts
+++ b/packages/dreamux/src/cli/dreamux.ts
@@ -318,7 +318,7 @@ function buildDaemonCommands(y: Argv): Argv {
     )
     .command(
       'uninstall',
-      'Remove the user-level service unit only (keeps config, run, state, logs)',
+      'Remove the user-level service unit only (keeps config, run, cache, state, logs)',
       (yy) =>
         yy.option('dry-run', {
           type: 'boolean',

--- a/packages/dreamux/src/dispatcher-service/teammate/service.ts
+++ b/packages/dreamux/src/dispatcher-service/teammate/service.ts
@@ -25,7 +25,10 @@ import {
   teammateCodexAppServerErrorLogPath,
   teammateCodexAppServerLogPath,
 } from '../../agent-runtime/builtin/codex/paths.js';
-import { dispatcherTeamMateRuntimeDir } from '../../platform/paths.js';
+import {
+  dispatcherCompletionSpillDir,
+  dispatcherTeamMateRuntimeDir,
+} from '../../platform/paths.js';
 import { validateDispatcherId } from '../../state/dispatcher-id.js';
 import { TeamMateIdentityStore } from './identity-store.js';
 import { TeamMateRuntimeStateStore } from './runtime-state.js';
@@ -852,6 +855,11 @@ export class TeamMateAgentService {
     const runtimeIdentity = runtimeIdentityName(identity);
     const dispatcherDir = (): string =>
       dispatcherTeamMateRuntimeDir(identity.dispatcher_id, runtimeIdentity);
+    // Completion spill belongs to the OPERATOR dispatcher's cache, not the
+    // teammate's composite runtime id, so it groups with the rest of that
+    // dispatcher's ephemera (issue #182 PR-2).
+    const completionSpillDir = (): string =>
+      dispatcherCompletionSpillDir(identity.dispatcher_id);
     if (providerRef === BUILTIN_CLAUDE_CODE_PROVIDER_REF) {
       const streamLog = (): string =>
         teammateClaudeCodeStreamLogPath(
@@ -862,6 +870,7 @@ export class TeamMateAgentService {
         dispatcherDir,
         stdoutLogPath: streamLog,
         stderrLogPath: streamLog,
+        completionSpillDir,
       };
     }
     return {
@@ -876,6 +885,7 @@ export class TeamMateAgentService {
           identity.dispatcher_id,
           runtimeIdentity,
         ),
+      completionSpillDir,
     };
   }
 

--- a/packages/dreamux/src/onboard/uninstall.ts
+++ b/packages/dreamux/src/onboard/uninstall.ts
@@ -23,7 +23,7 @@ import {
   type DispatcherConfig,
 } from '../config/config.js';
 import { loadConfigWithBuiltins } from '../agent-runtime/load-config.js';
-import { logsRoot, runRoot, stateRoot } from '../platform/paths.js';
+import { cacheRoot, logsRoot, runRoot, stateRoot } from '../platform/paths.js';
 import { dispatcherWorkspaceSkillDirs } from '../agent-runtime/builtin/codex/paths.js';
 
 export type UninstallStatus = 'removed' | 'missing' | 'skipped';
@@ -63,10 +63,12 @@ export async function runUninstall(
   await warnIfConfigIsNotReadable(configDir, warnings);
   const stateDir = normalizePath(stateRoot());
   const runDir = normalizePath(runRoot());
+  const cacheDir = normalizePath(cacheRoot());
   const logDir = normalizePath(logsRoot());
 
   assertSafeOwnedDirectory(stateDir, 'dreamux state directory');
   assertSafeOwnedDirectory(runDir, 'dreamux run directory');
+  assertSafeOwnedDirectory(cacheDir, 'dreamux cache directory');
   assertSafeOwnedDirectory(logDir, 'dreamux logs directory');
   assertSafeOwnedDirectory(configDir, 'dreamux config directory');
   const workspaceSkillPaths = await collectWorkspaceSkillPaths(configDir);
@@ -88,6 +90,7 @@ export async function runUninstall(
   await reportWorkspaceSkills(workspaceSkillPaths, entries);
   await removeOwnedDirectory(stateDir, entries, 'dreamux state directory', dryRun);
   await removeOwnedDirectory(runDir, entries, 'dreamux run directory', dryRun);
+  await removeOwnedDirectory(cacheDir, entries, 'dreamux cache directory', dryRun);
   await removeOwnedDirectory(logDir, entries, 'dreamux logs directory', dryRun);
   await removeOwnedDirectory(configDir, entries, 'dreamux config directory', dryRun);
 

--- a/packages/dreamux/src/platform/paths.ts
+++ b/packages/dreamux/src/platform/paths.ts
@@ -100,6 +100,31 @@ export function logsRoot(): string {
 }
 
 /**
+ * Root for dreamux-owned cache: rebuildable, droppable artifacts that are
+ * neither durable state nor volatile run files (issue #182 PR-2). Holds
+ * per-dispatcher completion spill files and inbound attachment caches. Safe to
+ * remove while no server is running; nothing here is part of identity, status,
+ * history, or checkpoint recovery.
+ */
+export function cacheRoot(): string {
+  return join(dreamuxRoot(), 'cache');
+}
+
+export function dispatcherCacheDir(id: string): string {
+  return join(cacheRoot(), dispatcherPathSegment(id));
+}
+
+/**
+ * Per-dispatcher completion-spill directory (issue #182 PR-2): where an
+ * over-budget teammate completion result is written so only its path is inlined
+ * into the dispatcher turn. Cache, not state — the file is read by no process;
+ * it is surfaced to the dispatcher model as text and is safe to delete.
+ */
+export function dispatcherCompletionSpillDir(id: string): string {
+  return join(dispatcherCacheDir(id), 'spill');
+}
+
+/**
  * The stable cross-process admin IPC endpoint. Packaged CLI commands and MCP
  * shims resolve it through this builder only — it is a fixed path contract, so
  * an over-budget path (extreme $HOME length) fails loudly instead of moving.
@@ -279,14 +304,23 @@ export function teamMateNameSegment(name: string): string {
  * never floods the dispatcher's context. Neutral: a completion is a
  * runtime-agnostic concept, so no runtime specifics appear here.
  *
- * Lives under the OS temp dir (the spec's `/tmp/teammate-{source}-{id}.output`
- * template); `source` and `id` are sanitized for filename safety. The id is
- * unique per completion (teammate name + turn id), so the only realistic
- * collision is two dispatchers producing the same teammate/turn id — acceptable
- * for a short-lived 0600 spill file.
+ * Lives under the dispatcher's cache spill dir (issue #182 PR-2 moved it out of
+ * shared `/tmp`, which is not a good long-term contract for a path surfaced in
+ * dispatcher-visible text). `spillDir` is the owning dispatcher's
+ * `dispatcherCompletionSpillDir`, supplied by the runtime's path context so a
+ * teammate runtime spills under its operator dispatcher, not its composite
+ * runtime id. `source` and `id` are sanitized for filename safety; the id is
+ * unique per completion (teammate name + turn id).
  */
-export function teamMateCompletionOutputPath(source: string, id: string): string {
-  return `/tmp/teammate-${teamMateNameSegment(source)}-${teamMateNameSegment(id)}.output`;
+export function teamMateCompletionOutputPath(
+  spillDir: string,
+  source: string,
+  id: string,
+): string {
+  return join(
+    spillDir,
+    `teammate-${teamMateNameSegment(source)}-${teamMateNameSegment(id)}.output`,
+  );
 }
 
 /**
@@ -299,9 +333,13 @@ export function dispatcherChatBotsPath(id: string): string {
   return join(dispatcherDir(id), 'chat-bots.json');
 }
 
-/** Per-dispatcher Feishu inbound attachment cache, owned by the server. */
+/**
+ * Per-dispatcher Feishu inbound attachment cache, owned by the server. Cache,
+ * not durable state (issue #182 PR-2 moved it out of `state/<id>/` into
+ * `cache/<id>/`): inbound attachments are re-fetchable and safe to delete.
+ */
 export function dispatcherFeishuAttachmentCacheDir(id: string): string {
-  return join(dispatcherDir(id), 'feishu-attachments');
+  return join(dispatcherCacheDir(id), 'feishu-attachments');
 }
 
 export function unixSocketPathFitsBudget(path: string): boolean {

--- a/packages/dreamux/tests/channel-input-format.test.ts
+++ b/packages/dreamux/tests/channel-input-format.test.ts
@@ -1,4 +1,15 @@
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it } from 'vitest';
+import {
+  chmodSync,
+  lstatSync,
+  mkdtempSync,
+  rmSync,
+  statSync,
+  symlinkSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { Readable } from 'node:stream';
 
 import {
   renderChannelBlock,
@@ -117,5 +128,79 @@ describe('formatFeishuMessageForRuntime (structured, no pre-rendered XML)', () =
     expect(wrapped).toContain('<attachment');
     expect(wrapped).toContain('<group_bots');
     expect(wrapped.endsWith('</channel>')).toBe(true);
+  });
+});
+
+describe('attachment cache owner-only enforcement (issue #182 PR-2)', () => {
+  const dirs: string[] = [];
+
+  afterEach(() => {
+    for (const dir of dirs.splice(0)) rmSync(dir, { recursive: true, force: true });
+  });
+
+  function cacheDir(): string {
+    const dir = mkdtempSync(join(tmpdir(), 'dx-attach-cache-'));
+    dirs.push(dir);
+    return dir;
+  }
+
+  /** A fetcher that streams fixed bytes; counts how many times it was called. */
+  function countingFetcher(): {
+    fetchMessageResource: () => Promise<{ stream: Readable; headers: Record<string, unknown> }>;
+    calls: number;
+  } {
+    const f = {
+      calls: 0,
+      async fetchMessageResource() {
+        f.calls += 1;
+        return { stream: Readable.from([Buffer.from('pdf-bytes')]), headers: {} };
+      },
+    };
+    return f;
+  }
+
+  it('tightens a pre-existing permissive cache dir on a cache HIT, not only on a miss', async () => {
+    const cache = cacheDir();
+    const fetcher = countingFetcher();
+
+    // First call: cache miss populates the file and creates the dir 0700.
+    const miss = await formatFeishuMessageForRuntime(inboundEvent(), {
+      cacheDir: cache,
+      resourceFetcher: fetcher,
+    });
+    expect(miss.attachments[0]?.status).toBe('downloaded');
+    expect(fetcher.calls).toBe(1);
+
+    // Someone loosens the cache dir behind our back.
+    chmodSync(cache, 0o755);
+    expect(statSync(cache).mode & 0o777).toBe(0o755);
+
+    // Second call: cache HIT. The fix runs ensureOwnerOnlyDir BEFORE the
+    // fast-path return, so the dir is re-tightened and the fetcher is not hit.
+    const hit = await formatFeishuMessageForRuntime(inboundEvent(), {
+      cacheDir: cache,
+      resourceFetcher: fetcher,
+    });
+    expect(hit.attachments[0]?.status).toBe('downloaded');
+    expect(fetcher.calls).toBe(1);
+    expect(statSync(cache).mode & 0o777).toBe(0o700);
+  });
+
+  it('refuses a symlinked cache dir instead of returning a downloaded path', async () => {
+    const real = cacheDir();
+    const link = `${real}-link`;
+    symlinkSync(real, link);
+    dirs.push(link);
+    expect(lstatSync(link).isSymbolicLink()).toBe(true);
+
+    const fetcher = countingFetcher();
+    const result = await formatFeishuMessageForRuntime(inboundEvent(), {
+      cacheDir: link,
+      resourceFetcher: fetcher,
+    });
+    // ensureOwnerOnlyDir rejects the symlinked leaf; the attachment falls back
+    // to not_downloaded rather than exposing a path under an unverified dir.
+    expect(result.attachments[0]?.status).toBe('not_downloaded');
+    expect(fetcher.calls).toBe(0);
   });
 });

--- a/packages/dreamux/tests/claude-code-runtime.test.ts
+++ b/packages/dreamux/tests/claude-code-runtime.test.ts
@@ -23,7 +23,11 @@ import { claudeCodeMcpConfig } from '../src/agent-runtime/builtin/claude-code/mc
 import { claudeCodeResidentArgs } from '../src/agent-runtime/builtin/claude-code/args.js';
 import { codexMcpServerArgs } from '../src/agent-runtime/builtin/codex/mcp-config.js';
 import { DispatcherStore } from '../src/state/dispatcher-store.js';
-import { defaultDispatcherCwd, teamMateCompletionOutputPath } from '../src/platform/paths.js';
+import {
+  defaultDispatcherCwd,
+  dispatcherCompletionSpillDir,
+  teamMateCompletionOutputPath,
+} from '../src/platform/paths.js';
 import { dispatcherClaudeCodeMcpConfigPath } from '../src/agent-runtime/builtin/claude-code/paths.js';
 import { defaultDispatcherClaudeCodeConfig } from '../src/config/config.js';
 import { createBuiltinProviderRegistry } from '../src/registry/index.js';
@@ -653,7 +657,13 @@ describe('ClaudeCodeRuntime resident lifecycle (fake session)', () => {
     const { runtime } = makeRuntime(fleet);
     await runtime.start();
 
-    const spillPath = teamMateCompletionOutputPath('reviewer', 'mate-big');
+    // No path context → the runtime falls back to the operator dispatcher's
+    // cache spill dir under the (HOME-isolated) ~/.dreamux/cache/flow/spill.
+    const spillPath = teamMateCompletionOutputPath(
+      dispatcherCompletionSpillDir('flow'),
+      'reviewer',
+      'mate-big',
+    );
     process.env['TASK_MAX_OUTPUT_LENGTH'] = '8';
     try {
       await runtime.completionInput!({

--- a/packages/dreamux/tests/codex-completion.test.ts
+++ b/packages/dreamux/tests/codex-completion.test.ts
@@ -45,17 +45,21 @@ describe('codex teammate completion delivery (native inject + trigger)', () => {
     for (const dir of tmpDirs.splice(0)) rmSync(dir, { recursive: true, force: true });
   });
 
-  async function makeRuntime(fake: FakeCodex): Promise<AgentRuntime> {
+  async function makeRuntime(
+    fake: FakeCodex,
+  ): Promise<{ runtime: AgentRuntime; spillDir: string }> {
     const dispatcher = testDispatcherConfig({ id: 'flow' });
     const store = new DispatcherStore(testDreamuxConfig([dispatcher]));
     const row = store.get('flow');
     expect(row).not.toBeNull();
     const tmp = mkdtempSync(join(tmpdir(), 'dx-codex-completion-'));
     tmpDirs.push(tmp);
+    const spillDir = join(tmp, 'spill');
     const paths: AgentRuntimePathContext = {
       dispatcherDir: () => tmp,
       stdoutLogPath: () => join(tmp, 'out.log'),
       stderrLogPath: () => join(tmp, 'err.log'),
+      completionSpillDir: () => spillDir,
     };
     const provider = createCodexAgentRuntimeProvider({
       descriptor: createBuiltinProviderRegistry().resolve('builtin:codex'),
@@ -78,13 +82,13 @@ describe('codex teammate completion delivery (native inject + trigger)', () => {
     });
     runtimes.push(runtime);
     await runtime.start();
-    return runtime;
+    return { runtime, spillDir };
   }
 
   it('injects a developer item then triggers a turn, reporting accepted', async () => {
     const fake = await startFakeCodex();
     fakes.push(fake);
-    const runtime = await makeRuntime(fake);
+    const { runtime } = await makeRuntime(fake);
 
     const result = await runtime.completionInput!({
       source: 'teammate',
@@ -122,9 +126,13 @@ describe('codex teammate completion delivery (native inject + trigger)', () => {
   it('keeps the wrapper and inlines a spill pointer when the result overflows', async () => {
     const fake = await startFakeCodex();
     fakes.push(fake);
-    const runtime = await makeRuntime(fake);
+    const { runtime, spillDir } = await makeRuntime(fake);
 
-    const spillPath = teamMateCompletionOutputPath('teammate', 'mate-spill');
+    const spillPath = teamMateCompletionOutputPath(
+      spillDir,
+      'teammate',
+      'mate-spill',
+    );
     process.env['TASK_MAX_OUTPUT_LENGTH'] = '8';
     try {
       const result = await runtime.completionInput!({
@@ -154,7 +162,7 @@ describe('codex teammate completion delivery (native inject + trigger)', () => {
   it('reports failed (after the item was injected) when the trigger turn is refused', async () => {
     const fake = await startFakeCodex({ failTurnStart: true });
     fakes.push(fake);
-    const runtime = await makeRuntime(fake);
+    const { runtime } = await makeRuntime(fake);
 
     const result = await runtime.completionInput!({
       source: 'teammate',
@@ -171,7 +179,7 @@ describe('codex teammate completion delivery (native inject + trigger)', () => {
   it('does not re-inject the same completion on a retry (idempotent)', async () => {
     const fake = await startFakeCodex({ failTurnStart: true });
     fakes.push(fake);
-    const runtime = await makeRuntime(fake);
+    const { runtime } = await makeRuntime(fake);
 
     const completion = {
       source: 'teammate',
@@ -192,7 +200,7 @@ describe('codex teammate completion delivery (native inject + trigger)', () => {
   it('retries a previously failed completion call without accepted-cache suppression', async () => {
     const fake = await startFakeCodex({ failTurnStartAttempts: 1 });
     fakes.push(fake);
-    const runtime = await makeRuntime(fake);
+    const { runtime } = await makeRuntime(fake);
     const completion = {
       source: 'teammate',
       id: 'mate-retry-then-accept',
@@ -217,7 +225,7 @@ describe('codex teammate completion delivery (native inject + trigger)', () => {
   it('coalesces concurrent duplicate completions before inject and trigger', async () => {
     const fake = await startFakeCodex();
     fakes.push(fake);
-    const runtime = await makeRuntime(fake);
+    const { runtime } = await makeRuntime(fake);
     const completion = {
       source: 'teammate',
       id: 'mate-concurrent',
@@ -240,7 +248,7 @@ describe('codex teammate completion delivery (native inject + trigger)', () => {
   it('treats already accepted completion ids as delivered', async () => {
     const fake = await startFakeCodex();
     fakes.push(fake);
-    const runtime = await makeRuntime(fake);
+    const { runtime } = await makeRuntime(fake);
     const completion = {
       source: 'teammate',
       id: 'mate-accepted',
@@ -262,7 +270,7 @@ describe('codex teammate completion delivery (native inject + trigger)', () => {
   it('reports unsupported once the runtime is stopped', async () => {
     const fake = await startFakeCodex();
     fakes.push(fake);
-    const runtime = await makeRuntime(fake);
+    const { runtime } = await makeRuntime(fake);
     await runtime.stop();
 
     const result = await runtime.completionInput!({

--- a/packages/dreamux/tests/completion-body.test.ts
+++ b/packages/dreamux/tests/completion-body.test.ts
@@ -1,6 +1,9 @@
-import { readFile, rm, stat } from 'node:fs/promises';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { readFile, stat } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
 import {
   COMPLETION_INLINE_BUDGET_DEFAULT,
@@ -13,59 +16,73 @@ import type { CompletionEnvelope } from '../src/agent-runtime/types.js';
 
 const SOURCE = 'reviewer';
 const ID = 'reviewer:turn-7';
-const SPILL_PATH = teamMateCompletionOutputPath(SOURCE, ID);
 
 function completion(result: string): CompletionEnvelope {
   return { source: SOURCE, id: ID, status: 'completed', result };
 }
 
-afterEach(async () => {
-  delete process.env['TASK_MAX_OUTPUT_LENGTH'];
-  await rm(SPILL_PATH, { force: true });
-});
-
 describe('resolveCompletionBody', () => {
+  let spillDir: string;
+  let spillPath: string;
+
+  beforeEach(() => {
+    // A throwaway spill dir per test, standing in for a dispatcher's
+    // cache/<id>/spill — the dir need not pre-exist (resolveCompletionBody
+    // creates it owner-only).
+    spillDir = join(mkdtempSync(join(tmpdir(), 'dx-spill-')), 'spill');
+    spillPath = teamMateCompletionOutputPath(spillDir, SOURCE, ID);
+  });
+
+  afterEach(() => {
+    delete process.env['TASK_MAX_OUTPUT_LENGTH'];
+    rmSync(spillDir, { recursive: true, force: true });
+  });
+
   it('inlines a result within the budget', async () => {
-    const body = await resolveCompletionBody(completion('short result'));
+    const body = await resolveCompletionBody(completion('short result'), spillDir);
     expect(body).toEqual({ kind: 'inline', text: 'short result' });
-    await expect(stat(SPILL_PATH)).rejects.toThrow();
+    await expect(stat(spillPath)).rejects.toThrow();
   });
 
   it('inlines a result exactly at the budget boundary', async () => {
     const result = 'x'.repeat(COMPLETION_INLINE_BUDGET_DEFAULT);
-    const body = await resolveCompletionBody(completion(result));
+    const body = await resolveCompletionBody(completion(result), spillDir);
     expect(body.kind).toBe('inline');
   });
 
   it('spills a result over the budget to a 0600 file with the full content', async () => {
     const result = 'y'.repeat(COMPLETION_INLINE_BUDGET_DEFAULT + 1);
-    const body = await resolveCompletionBody(completion(result));
-    expect(body).toEqual({ kind: 'spilled', path: SPILL_PATH });
+    const body = await resolveCompletionBody(completion(result), spillDir);
+    expect(body).toEqual({ kind: 'spilled', path: spillPath });
     if (body.kind !== 'spilled') throw new Error('expected spilled');
 
     // Full result on disk — not truncated.
     expect(await readFile(body.path, 'utf8')).toBe(result);
-    // Owner-only permissions.
-    const info = await stat(body.path);
-    expect(info.mode & 0o777).toBe(0o600);
+    // Owner-only file in an owner-only spill dir.
+    expect((await stat(body.path)).mode & 0o777).toBe(0o600);
+    expect((await stat(spillDir)).mode & 0o777).toBe(0o700);
   });
 
   it('honors a TASK_MAX_OUTPUT_LENGTH override that forces a small budget', async () => {
     process.env['TASK_MAX_OUTPUT_LENGTH'] = '8';
     expect(completionInlineBudget()).toBe(8);
-    const body = await resolveCompletionBody(completion('this is longer than eight'));
+    const body = await resolveCompletionBody(
+      completion('this is longer than eight'),
+      spillDir,
+    );
     expect(body.kind).toBe('spilled');
   });
 });
 
 describe('teamMateCompletionOutputPath', () => {
   it('sanitizes unsafe characters in source and id for filename safety', () => {
-    expect(teamMateCompletionOutputPath('a/b', 'c:d')).toBe(
-      '/tmp/teammate-a_b-c_d.output',
+    const dir = '/cache/flow/spill';
+    expect(teamMateCompletionOutputPath(dir, 'a/b', 'c:d')).toBe(
+      '/cache/flow/spill/teammate-a_b-c_d.output',
     );
     // The real id shape is `name:turnId` — the colon must be sanitized.
-    expect(teamMateCompletionOutputPath('reviewer', 'reviewer:turn-7')).toBe(
-      '/tmp/teammate-reviewer-reviewer_turn-7.output',
+    expect(teamMateCompletionOutputPath(dir, 'reviewer', 'reviewer:turn-7')).toBe(
+      '/cache/flow/spill/teammate-reviewer-reviewer_turn-7.output',
     );
   });
 });

--- a/packages/dreamux/tests/runtime-paths.test.ts
+++ b/packages/dreamux/tests/runtime-paths.test.ts
@@ -7,7 +7,9 @@ import {
   DREAMUX_UNIX_SOCKET_PATH_MAX_BYTES,
   BUNDLED_SKILL_NAMES,
   adminSocketPath,
+  cacheRoot,
   dispatcherAccessPath,
+  dispatcherCompletionSpillDir,
   dispatcherDir,
   dispatcherFeishuAttachmentCacheDir,
   dispatcherTeamMateDir,
@@ -89,8 +91,12 @@ describe('runtime paths', () => {
     expect(dispatcherAccessPath('dispatcher-a')).toBe(
       join(stateRoot(), 'dispatcher-a', 'access.json'),
     );
+    // Cache, not durable state (issue #182 PR-2).
     expect(dispatcherFeishuAttachmentCacheDir('dispatcher-a')).toBe(
-      join(stateRoot(), 'dispatcher-a', 'feishu-attachments'),
+      join(cacheRoot(), 'dispatcher-a', 'feishu-attachments'),
+    );
+    expect(dispatcherCompletionSpillDir('dispatcher-a')).toBe(
+      join(cacheRoot(), 'dispatcher-a', 'spill'),
     );
     expect(dispatcherTeamMateDir('dispatcher-a')).toBe(
       join(stateRoot(), 'dispatcher-a', 'teammate'),
@@ -149,6 +155,17 @@ describe('runtime paths', () => {
         join(workspace, '.codex', 'skills', skillName),
       ),
     );
+  });
+
+  it('keeps cache artifacts under cache/, never under durable state (issue #182 PR-2)', () => {
+    expect(cacheRoot()).toBe(join(dreamuxRoot(), 'cache'));
+    for (const cachePath of [
+      dispatcherCompletionSpillDir('dispatcher-a'),
+      dispatcherFeishuAttachmentCacheDir('dispatcher-a'),
+    ]) {
+      expect(cachePath.startsWith(cacheRoot())).toBe(true);
+      expect(cachePath.startsWith(stateRoot())).toBe(false);
+    }
   });
 
   it('places logs under component log directories', () => {

--- a/packages/dreamux/tests/teammate-agent-service.test.ts
+++ b/packages/dreamux/tests/teammate-agent-service.test.ts
@@ -22,7 +22,10 @@ import type { TurnSettledSignal } from '../src/agent-runtime/turn.js';
 import type { InboundTurnInput } from '../src/agent-runtime/turn.js';
 import { TeamMateAgentService } from '../src/dispatcher-service/teammate/service.js';
 import { DispatcherStore } from '../src/state/dispatcher-store.js';
-import { resetRuntimeConfig } from '../src/platform/paths.js';
+import {
+  dispatcherCompletionSpillDir,
+  resetRuntimeConfig,
+} from '../src/platform/paths.js';
 import { createBuiltinProviderRegistry } from '../src/registry/index.js';
 import { testDispatcherConfig, testDreamuxConfig } from './helpers/config.js';
 
@@ -257,6 +260,24 @@ describe('TeamMateAgentService', () => {
     expect(codexProvider.contexts[0]?.dispatcher?.runtime.provider).toBe(
       'builtin:codex',
     );
+
+    // Issue #182 PR-2: a teammate runtime spills under its OPERATOR dispatcher
+    // id ('flow'), NOT its composite runtime id — for both runtime kinds. The
+    // launcher resolves completionSpillDir to the operator cache regardless of
+    // the id argument, and the spill dir must not carry the teammate-name
+    // segment that the runtime dir (dispatcherDir) does.
+    const operatorSpill = dispatcherCompletionSpillDir('flow');
+    for (const { captured, name } of [
+      { captured: claudeProvider.contexts[0], name: 'claude-mate' },
+      { captured: codexProvider.contexts[0], name: 'codex-mate' },
+    ]) {
+      const paths = captured?.paths;
+      expect(paths).toBeDefined();
+      expect(paths!.completionSpillDir('ignored-arg')).toBe(operatorSpill);
+      // The runtime dir is keyed by the teammate name; the spill dir is not.
+      expect(paths!.dispatcherDir('ignored-arg')).toContain(name);
+      expect(paths!.completionSpillDir('ignored-arg')).not.toContain(name);
+    }
   });
 
   it('dispatcher and teammate referencing the same agent id get the same resolved runtime (#148)', async () => {

--- a/packages/dreamux/tests/uninstall.test.ts
+++ b/packages/dreamux/tests/uninstall.test.ts
@@ -14,6 +14,7 @@ import { runUninstall } from '../src/onboard/uninstall.js';
 import type { CommandRunner } from '../src/onboard/types.js';
 import {
   logsRoot,
+  cacheRoot,
   runRoot,
   resetRuntimeConfig,
   stateRoot,
@@ -66,6 +67,7 @@ describe('dreamux uninstall', () => {
     mkdirSync(configDir, { recursive: true });
     mkdirSync(stateRoot(), { recursive: true });
     mkdirSync(join(runRoot(), 'sockets'), { recursive: true });
+    mkdirSync(join(cacheRoot(), 'flow', 'spill'), { recursive: true });
     mkdirSync(logsRoot(), { recursive: true });
     mkdirSync(dirname(servicePath), { recursive: true });
     for (const skillDir of workspaceSkillDirs) {
@@ -105,6 +107,7 @@ describe('dreamux uninstall', () => {
     expect(existsSync(configDir)).toBe(false);
     expect(existsSync(stateRoot())).toBe(false);
     expect(existsSync(runRoot())).toBe(false);
+    expect(existsSync(cacheRoot())).toBe(false);
     expect(existsSync(logsRoot())).toBe(false);
     expect(existsSync(servicePath)).toBe(false);
     for (const skillDir of workspaceSkillDirs) {
@@ -116,6 +119,7 @@ describe('dreamux uninstall', () => {
         { status: 'removed', path: servicePath, reason: 'systemd unit' },
         { status: 'removed', path: stateRoot(), reason: 'dreamux state directory' },
         { status: 'removed', path: runRoot(), reason: 'dreamux run directory' },
+        { status: 'removed', path: cacheRoot(), reason: 'dreamux cache directory' },
         { status: 'removed', path: logsRoot(), reason: 'dreamux logs directory' },
         ...workspaceSkillDirs.map((skillDir) => ({
           status: 'skipped' as const,


### PR DESCRIPTION
## 这是什么

Epic #182 的 **PR-2**，目标分支 `feature/state-layout-epic`（基于已合入的 PR-1 `003fbe9`）。

把可重建的 cache 产物迁出 `state/`（与共享 `/tmp`），进入新的 `~/.dreamux/cache/<dispatcher-id>/` 树。

## 范围（仅限 PR-2）

- **Completion spill**：原 `/tmp/teammate-<source>-<id>.output` → `cache/<id>/spill/teammate-<source>-<id>.output`。中立的 `completion-body.ts` 保持 runtime-agnostic——`resolveCompletionBody(completion, spillDir)` 接收 spillDir、不再出现 dispatcher id；spillDir 经新增的 `AgentRuntimePathContext.completionSpillDir(id)` 注入。teammate launcher 把它解析为**操作者** dispatcher 的 cache（而非 teammate 的 composite runtime id），使同一操作者的 spill 归并到一个 `cache/<id>/spill`。spill 文件无人回读——仅其路径被内联进 dispatcher 回合。
- **Feishu 附件缓存**：`state/<id>/feishu-attachments` → `cache/<id>/feishu-attachments`（可重取、可删）。
- `dreamux uninstall` 连带删除 `cache/`。

## 安全加固（沿用 PR #183 review 模式）

spill 目录与附件缓存目录均经 `ensureOwnerOnlyDir` 创建：预存的宽松权限目录会被收紧到 0700，符号链接 / 外部 uid 目录会 fail-loud——与 run/socket 树同一不变量。spill/附件文件保持 0600 + 显式 chmod。

## 升级影响（changelog 已声明 BREAKING）

无自动迁移。旧 `/tmp/teammate-*.output` 与 `state/<id>/feishu-attachments/` 在升级后不再使用，changelog 注明可手工删除。

## 测试

`rush build` + `eslint` + KB `check.sh` 全过；完整套件 **615 passed**（`DREAMUX_SKIP_LIVE_CODEX=1`）。新增/更新覆盖：cache 路径 builder + 「cache, never state」不变量、spill 文件名新签名、`resolveCompletionBody` 落 spillDir（0700 目录 + 0600 文件）、codex/claude spill 指针解析到 cache、**teammate launcher 的操作者 id（非 composite）spill 解析**、uninstall 删 cache。

## 评审说明

本 PR 已过一轮 5-lens 对抗式自审 + 逐条验证，2 个 confirmed major 已修复：(1) spill/附件目录改用 `ensureOwnerOnlyDir`（补预存目录收紧 + 符号链接/外部 uid 拒绝，与 PR-1 一致）；(2) 补 teammate 操作者-id spill 解析的直接测试（防 composite-id 变异）。另顺手修正 3 处 KB uninstall 枚举（补 run+cache）。

Refs #182