### PR TITLE
feat(state): relocate managed worktrees + require dispatcher cwd (#182 PR-4)

### DIFF
--- a/.agents/decisions/top-level-design.md
+++ b/.agents/decisions/top-level-design.md
@@ -113,6 +113,15 @@ state that the dispatcher shares one Codex context across those chats.
 It holds dispatcher declarations, local Feishu credentials, and the dispatcher
 cwd used for the workspace-local skill install.
 
+Each dispatcher MUST declare an explicit `cwd` (issue #182 PR-4). `dreamux serve`
+fails loud at startup if any enabled dispatcher has no `cwd` — there is no
+fallback to a Dreamux state directory (`~/.dreamux/state/<id>/cwd`). A
+configured-but-missing `cwd` is created with mkdir -p; a `cwd` that is not a
+usable directory fails startup. `dreamux doctor` diagnoses the same contract per
+dispatcher. The workspace is also the root under which managed worktrees live
+(see State And Logs), so it must be a real operator project dir, never inside
+`~/.dreamux`.
+
 Issue #110 supersedes the earlier Feishu/Codex-specific dispatcher keys with a
 providerized config v2 envelope. Issue #135 refines the runtime boundary: this
 phase wires one built-in `builtin:feishu` bidirectional channel and one
@@ -243,8 +252,6 @@ State and logs are server-owned. They are not operator-editable config.
           <name>.jsonl         forward-only TeamMate lifecycle history
         runtime/
           <name>/              runtime-private socket/config state
-        worktrees/
-          <slug>/              Dreamux-managed TeamMate/Team worktrees
       team/
         records/
           <team-id>.json        Team lifecycle record and TeamLeader pointer
@@ -268,6 +275,25 @@ State and logs are server-owned. They are not operator-editable config.
           <name>.log           TeamMate Codex runtime stdout
           <name>.stderr.log    TeamMate Codex runtime stderr
 ```
+
+Dreamux-managed TeamMate/Team Git worktrees are NOT under `~/.dreamux` (issue
+#182 PR-4, relocated out of `state/<id>/teammate/worktrees/`). They live in the
+dispatcher's own workspace:
+
+```text
+<dispatcher cwd>/
+  .workspace/
+    .gitignore                 self-ignores the whole subtree (`*`)
+    worktree/
+      <repo-slug>/             <sanitized-basename>-<sha256(repo-root):12>
+        <slug>/                one managed TeamMate/Team worktree
+```
+
+`.workspace/` self-ignores so managed worktrees never become repo content;
+`<repo-slug>` disambiguates same-named repos across Team/TeamMate usage. Managed
+worktree creation fails loud if the workspace resolves under `~/.dreamux`. Legacy
+identity records still pointing at the old under-state path are read verbatim (no
+rewrite, no deletion); only newly created managed worktrees use the new location.
 
 Host logging (issue #70): `dreamux serve`, the Feishu channel (gate
 deliver/drop, inbound submit, outbound, `/introduce`), and dispatcher lifecycle

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -92,7 +92,20 @@ That record wins over older runtime-dir / SQLite decisions.
 - `~/.dreamux/config.json` — the only dreamux operator-editable config
   source. It holds dispatcher declarations and local Feishu credentials.
   `dreamux serve` must fail loudly when it is missing and tell the operator
-  to run `dreamux onboard`.
+  to run `dreamux onboard`. Each dispatcher MUST declare an explicit `cwd`
+  (issue #182 PR-4): `dreamux serve` fails loud at startup if any enabled
+  dispatcher has no `cwd` — there is no fallback to a state directory. A
+  missing `cwd` directory is created (mkdir -p); an unusable one fails loud.
+  `dreamux doctor` diagnoses the same per-dispatcher contract.
+- `<dispatcher cwd>/.workspace/worktree/<repo-slug>/<slug>/` — Dreamux-managed
+  TeamMate/Team Git worktrees (issue #182 PR-4), relocated out of
+  `~/.dreamux/state/<id>/teammate/worktrees/`. They live in the dispatcher's
+  own workspace, never under `~/.dreamux`; `.workspace/` self-ignores (a `*`
+  .gitignore) so they never become repo content. `<repo-slug>` is
+  `<sanitized-basename>-<sha256(repo-root):12>`, disambiguating same-named repos
+  across Team/TeamMate usage. Managed worktree creation fails loud if the
+  workspace resolves under `~/.dreamux`. Legacy identity records pointing at the
+  old under-state path are read verbatim (no rewrite, no deletion).
 - `~/.dreamux/state/` — durable server-owned state: per-dispatcher
   `status.json`, `access.json`, and `teammate/` task ledgers. Safe to remove
   when the operator intentionally wants to discard server state.

--- a/common/changes/@excitedjs/dreamux/epic182-pr4-managed-worktree-relocation_2026-06-11-12-00.json
+++ b/common/changes/@excitedjs/dreamux/epic182-pr4-managed-worktree-relocation_2026-06-11-12-00.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "BREAKING (dispatcher workspace + managed worktree layout): every configured dispatcher must now declare an explicit `cwd` (issue #182 PR-4). `dreamux serve` fails loud at startup if any enabled dispatcher has no `cwd` — there is no longer a fallback to a Dreamux state directory (`~/.dreamux/state/<id>/cwd`). A configured-but-missing `cwd` is created with mkdir -p; a `cwd` that is not a usable directory fails startup. `dreamux doctor` diagnoses the same contract per dispatcher (`dispatcher <id> workspace`). Rebuild: add `\"cwd\": \"/abs/path/to/workspace\"` to each dispatcher in ~/.dreamux/config.json (a real, operator-owned project directory, NOT inside ~/.dreamux) and `daemon restart`. Dreamux-managed TeamMate/Team Git worktrees were relocated OUT of `~/.dreamux/state/<id>/teammate/worktrees/` into the dispatcher workspace at `<cwd>/.workspace/worktree/<repo-disambiguated-slug>/<teammate-or-team-slug>/`. `.workspace/` is self-ignored (a `*` .gitignore) so managed worktrees never become repo content. The repo-disambiguated slug (`<sanitized-basename>-<sha256(repo-root):12>`) keeps same-named repos and Team/TeamMate worktrees distinct across repos. Managed worktree creation fails loud if the workspace resolves under `~/.dreamux`. Legacy teammate/Team identity records that still point at the old under-state worktree path are read verbatim (no rewrite, no deletion); only newly created managed worktrees use the new location, so a teammate with a since-deleted old managed worktree is re-prepared at the new path on reopen. reuse-cwd teammates are unchanged and do not require the dispatcher cwd contract. No persisted file FORMAT change. Not included: PR-5 session ledger, PR-6 list/status/history read surface, PR-7 Team MCP cleanup, logs/retention.",
+      "type": "minor",
+      "packageName": "@excitedjs/dreamux"
+    }
+  ],
+  "packageName": "@excitedjs/dreamux",
+  "email": "053700@gmail.com"
+}

--- a/packages/dreamux/src/cli/doctor.ts
+++ b/packages/dreamux/src/cli/doctor.ts
@@ -37,6 +37,7 @@ import {
   setRuntimeConfig,
   stateRoot,
 } from '../platform/paths.js';
+import { diagnoseDispatcherWorkspace } from '../dispatcher-service/dispatcher-workspace.js';
 import { ExecaCommandRunner } from '../onboard/commands.js';
 import {
   defaultServiceNodeProbe,
@@ -128,6 +129,17 @@ export async function runDreamuxDoctor(
       name: check.name,
       ok: await runner.check(check.bin, check.args),
       detail: check.bin,
+    });
+  }
+
+  // Dispatcher workspace cwd contract (issue #182 PR-4): each configured
+  // dispatcher must declare an explicit, usable `cwd` — no state-dir fallback.
+  for (const dispatcher of config.dispatchers) {
+    const diagnosis = await diagnoseDispatcherWorkspace(config, dispatcher.id);
+    checks.push({
+      name: `dispatcher ${dispatcher.id} workspace`,
+      ok: diagnosis.ok,
+      detail: diagnosis.detail,
     });
   }
 

--- a/packages/dreamux/src/cli/doctor.ts
+++ b/packages/dreamux/src/cli/doctor.ts
@@ -132,9 +132,21 @@ export async function runDreamuxDoctor(
     });
   }
 
-  // Dispatcher workspace cwd contract (issue #182 PR-4): each configured
-  // dispatcher must declare an explicit, usable `cwd` — no state-dir fallback.
+  // Dispatcher workspace cwd contract (issue #182 PR-4): each ENABLED dispatcher
+  // must declare an explicit, usable `cwd` — no state-dir fallback. This mirrors
+  // `Server.assertDispatcherWorkspaces`, which enforces the contract only for
+  // enabled dispatchers (PR #186 review P3): a disabled dispatcher is never
+  // started, so its cwd is reported as a non-blocking diagnostic instead of a
+  // failure, keeping doctor and `dreamux serve` on the same contract.
   for (const dispatcher of config.dispatchers) {
+    if (dispatcher.enabled === false) {
+      checks.push({
+        name: `dispatcher ${dispatcher.id} workspace`,
+        ok: true,
+        detail: 'disabled; workspace cwd contract not enforced',
+      });
+      continue;
+    }
     const diagnosis = await diagnoseDispatcherWorkspace(config, dispatcher.id);
     checks.push({
       name: `dispatcher ${dispatcher.id} workspace`,

--- a/packages/dreamux/src/dispatcher-service/CLAUDE.md
+++ b/packages/dreamux/src/dispatcher-service/CLAUDE.md
@@ -25,10 +25,14 @@ is wiring only — all per-dispatcher orchestration lives here.
 - **Same creation path for dispatcher and teammate agents.** Both go through
   `AgentRuntimeProviderCatalog.resolve(ref).createRuntime(...)`. No parallel
   worker/runtime tree.
-- **cwd is supplied by the launcher.** The dispatcher agent's cwd is computed
-  here (`config.cwd ?? defaultDispatcherCwd(id)`); a teammate's cwd is its
+- **cwd is supplied by the launcher.** The dispatcher agent's cwd is its
+  validated workspace (`ensureDispatcherWorkspace(config, id)` in
+  `dispatcher-workspace.ts`): every dispatcher MUST declare an explicit `cwd`,
+  there is no state-dir fallback (issue #182 PR-4). A teammate's cwd is its
   resolved target (`identity.cwd`). Passed as the required `cwd` create-context
-  field — never derived inside the runtime.
+  field — never derived inside the runtime. Managed TeamMate/Team worktrees live
+  under that workspace at `<cwd>/.workspace/worktree/<repo-slug>/<slug>/`, never
+  under `~/.dreamux`.
 - **Nested dispatch is prevented by MCP injection, not a runtime check.** A
   teammate/team-leader agent is simply not injected the "spawn teammate" tool;
   role differentiation is done by the MCP tool set + system prompt this service

--- a/packages/dreamux/src/dispatcher-service/dispatcher-workspace.ts
+++ b/packages/dreamux/src/dispatcher-service/dispatcher-workspace.ts
@@ -1,0 +1,132 @@
+import { constants } from 'node:fs';
+import { access, mkdir, stat } from 'node:fs/promises';
+import { resolve } from 'node:path';
+
+import type { DreamuxConfig } from '../config/config.js';
+
+/**
+ * Dispatcher workspace cwd policy (issue #182 PR-4).
+ *
+ * Every configured dispatcher MUST declare an explicit `cwd`: there is no
+ * fallback to a Dreamux state directory (`~/.dreamux/state/<id>/cwd`). The
+ * workspace is the dispatcher agent's working directory AND the root under
+ * which Dreamux-managed TeamMate/Team worktrees live
+ * (`<workspace>/.workspace/worktree/...`), so it must be a real, operator-owned
+ * project directory — never inside Dreamux's own state tree.
+ *
+ * The policy is enforced loud at server startup and the dispatcher launch path,
+ * and diagnosed (non-throwing) by `dreamux doctor`.
+ */
+
+/**
+ * The configured, absolute dispatcher workspace cwd, or `null` when the
+ * dispatcher declares no `cwd`. Pure: it resolves the configured value to an
+ * absolute path but touches no filesystem.
+ */
+export function configuredDispatcherCwd(
+  config: DreamuxConfig,
+  dispatcherId: string,
+): string | null {
+  const entry = config.dispatchers.find((dispatcher) => dispatcher.id === dispatcherId);
+  const cwd = entry?.cwd ?? null;
+  if (cwd === null || cwd.trim() === '') return null;
+  return resolve(cwd);
+}
+
+/**
+ * Resolve and validate a dispatcher's workspace cwd, failing loud when the
+ * contract is broken (issue #182 PR-4):
+ *
+ *  - no explicit `cwd` configured → throw (no state-dir fallback);
+ *  - cwd configured but missing → created with `mkdir -p` semantics;
+ *  - cwd not a directory, or not read/write/exec accessible → throw.
+ *
+ * Returns the absolute, validated workspace path. Idempotent: safe to call at
+ * startup pre-flight and again per dispatcher launch / teammate spawn.
+ */
+export async function ensureDispatcherWorkspace(
+  config: DreamuxConfig,
+  dispatcherId: string,
+): Promise<string> {
+  const cwd = configuredDispatcherCwd(config, dispatcherId);
+  if (cwd === null) {
+    throw new Error(
+      `dispatcher ${JSON.stringify(dispatcherId)} has no configured \`cwd\`; ` +
+        'set an explicit workspace directory in ~/.dreamux/config.json — dreamux ' +
+        'no longer falls back to a state directory (issue #182)',
+    );
+  }
+  try {
+    await mkdir(cwd, { recursive: true });
+  } catch (err) {
+    throw new Error(
+      `dispatcher ${JSON.stringify(dispatcherId)} workspace cwd could not be ` +
+        `created: ${cwd}: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+  let info;
+  try {
+    info = await stat(cwd);
+  } catch (err) {
+    throw new Error(
+      `dispatcher ${JSON.stringify(dispatcherId)} workspace cwd is not ` +
+        `accessible: ${cwd}: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+  if (!info.isDirectory()) {
+    throw new Error(
+      `dispatcher ${JSON.stringify(dispatcherId)} workspace cwd is not a ` +
+        `directory: ${cwd}`,
+    );
+  }
+  try {
+    await access(cwd, constants.R_OK | constants.W_OK | constants.X_OK);
+  } catch (err) {
+    throw new Error(
+      `dispatcher ${JSON.stringify(dispatcherId)} workspace cwd is not ` +
+        `read/write accessible: ${cwd}: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+  return cwd;
+}
+
+export interface DispatcherWorkspaceDiagnosis {
+  ok: boolean;
+  detail: string;
+}
+
+/**
+ * Non-throwing variant for `dreamux doctor`: reports the cwd contract state
+ * without creating or mutating anything. A configured-but-missing directory is
+ * not an error — server startup creates it — but a missing/empty `cwd`, a
+ * non-directory, or an inaccessible directory is.
+ */
+export async function diagnoseDispatcherWorkspace(
+  config: DreamuxConfig,
+  dispatcherId: string,
+): Promise<DispatcherWorkspaceDiagnosis> {
+  const cwd = configuredDispatcherCwd(config, dispatcherId);
+  if (cwd === null) {
+    return {
+      ok: false,
+      detail:
+        'no configured `cwd`; set an explicit workspace directory in config.json ' +
+        '(dreamux no longer falls back to a state directory)',
+    };
+  }
+  let info;
+  try {
+    info = await stat(cwd);
+  } catch {
+    return { ok: true, detail: `${cwd} (missing; created at server startup)` };
+  }
+  if (!info.isDirectory()) {
+    return { ok: false, detail: `${cwd} exists but is not a directory` };
+  }
+  try {
+    await access(cwd, constants.R_OK | constants.W_OK | constants.X_OK);
+  } catch {
+    return { ok: false, detail: `${cwd} is not read/write accessible` };
+  }
+  return { ok: true, detail: cwd };
+}

--- a/packages/dreamux/src/dispatcher-service/dispatcher/service.ts
+++ b/packages/dreamux/src/dispatcher-service/dispatcher/service.ts
@@ -26,10 +26,8 @@ import {
   type DispatcherRow,
   type DispatcherStatus,
 } from '../../state/dispatcher-store.js';
-import {
-  adminSocketPath as defaultAdminSocketPath,
-  defaultDispatcherCwd,
-} from '../../platform/paths.js';
+import { adminSocketPath as defaultAdminSocketPath } from '../../platform/paths.js';
+import { ensureDispatcherWorkspace } from '../dispatcher-workspace.js';
 import {
   loggerToLevelFn,
   type DreamuxLogger,
@@ -295,7 +293,11 @@ export class DispatcherAgentService {
     const runtimeProvider = this.opts.agentRuntimeProviders.resolve(
       dispatcherConfig?.runtime.provider ?? BUILTIN_CODEX_PROVIDER_REF,
     );
-    const cwd = dispatcherConfig?.cwd ?? defaultDispatcherCwd(id);
+    // The dispatcher agent runs in its validated workspace (issue #182 PR-4):
+    // no fallback to a Dreamux state dir. Server startup pre-flights this, so a
+    // misconfigured dispatcher never reaches launch; the call here is idempotent
+    // and keeps the launch path self-validating.
+    const cwd = await ensureDispatcherWorkspace(this.opts.config, id);
     const channelLog = this.opts.channelLoggerFactory(id);
     const channel = new FeishuChannelSession({
       dispatcherId: id,

--- a/packages/dreamux/src/dispatcher-service/team/service.ts
+++ b/packages/dreamux/src/dispatcher-service/team/service.ts
@@ -50,6 +50,9 @@ export class TeamService {
       dispatcherId: input.dispatcherId,
       teammateName: `team-${teamId}`,
       cwd: input.repoCwd,
+      dispatcherWorkspace: await this.opts.teammates.dispatcherWorkspace(
+        input.dispatcherId,
+      ),
       request: input.worktree ?? {
         mode: 'managed',
         slug: `team-${teamId}`,

--- a/packages/dreamux/src/dispatcher-service/teammate/service.ts
+++ b/packages/dreamux/src/dispatcher-service/teammate/service.ts
@@ -30,6 +30,7 @@ import {
   dispatcherTeamMateRuntimeDir,
 } from '../../platform/paths.js';
 import { validateDispatcherId } from '../../state/dispatcher-id.js';
+import { ensureDispatcherWorkspace } from '../dispatcher-workspace.js';
 import { TeamMateIdentityStore } from './identity-store.js';
 import { TeamMateRuntimeStateStore } from './runtime-state.js';
 import { WorktreeManager } from './worktree-manager.js';
@@ -189,12 +190,19 @@ export class TeamMateAgentService {
       input.agentRuntime ?? this.defaultAgentRuntime(dispatcherId);
     const agent = this.resolveAgent(dispatcherId, agentRuntimeId);
     const provider = this.opts.agentRuntimeProviders.resolve(agent.provider);
+    // Only a managed worktree is placed under the dispatcher workspace, so only
+    // managed mode resolves (and thus enforces) the dispatcher cwd contract;
+    // reuse-cwd never forces it (issue #182 PR-4).
+    const managedMode = (input.worktree?.mode ?? 'reuse-cwd') === 'managed';
     const workspace =
       input.sharedWorkspace ??
       (await this.worktrees.prepare({
         dispatcherId,
         teammateName: name,
         cwd,
+        ...(managedMode
+          ? { dispatcherWorkspace: await this.dispatcherWorkspace(dispatcherId) }
+          : {}),
         request: input.worktree,
       }));
     if (input.sharedWorkspace === undefined) {
@@ -619,6 +627,7 @@ export class TeamMateAgentService {
       dispatcherId: identity.dispatcher_id,
       teammateName: identity.name,
       cwd: identity.source_cwd,
+      dispatcherWorkspace: await this.dispatcherWorkspace(identity.dispatcher_id),
       request: {
         mode: 'managed',
         ...(identity.worktree.slug !== null ? { slug: identity.worktree.slug } : {}),
@@ -957,6 +966,17 @@ export class TeamMateAgentService {
       this.opts.config.dispatchers.find((entry) => entry.id === dispatcherId) ??
       null
     );
+  }
+
+  /**
+   * Resolve and validate the dispatcher workspace cwd (issue #182 PR-4): the
+   * root under which managed worktrees are placed. Fails loud when the
+   * dispatcher declares no explicit `cwd` — there is no state-dir fallback.
+   * Exposed so the Team service (which owns its own WorktreeManager) resolves
+   * the same workspace.
+   */
+  async dispatcherWorkspace(dispatcherId: string): Promise<string> {
+    return ensureDispatcherWorkspace(this.opts.config, dispatcherId);
   }
 
   private toStatus(

--- a/packages/dreamux/src/dispatcher-service/teammate/worktree-manager.ts
+++ b/packages/dreamux/src/dispatcher-service/teammate/worktree-manager.ts
@@ -1,10 +1,14 @@
-import { access, mkdir, realpath, stat } from 'node:fs/promises';
+import { access, mkdir, realpath, stat, writeFile } from 'node:fs/promises';
 import { dirname, resolve } from 'node:path';
 
 import { execa } from 'execa';
 
-import { dispatcherTeamMateWorktreePath } from '../../platform/paths.js';
-import { teamMateNameSegment } from '../../platform/paths.js';
+import { isUnderDreamuxRoot, teamMateNameSegment } from '../../platform/paths.js';
+import {
+  managedWorkspaceDir,
+  managedWorkspaceGitignorePath,
+  managedWorktreePath,
+} from './worktree-paths.js';
 import type {
   TeamMateWorktreeCleanupState,
   TeamMateWorktreeIdentity,
@@ -23,6 +27,13 @@ export class WorktreeManager {
     dispatcherId: string;
     teammateName: string;
     cwd: string;
+    /**
+     * The validated dispatcher workspace (issue #182 PR-4): managed worktrees
+     * are placed under `<dispatcherWorkspace>/.workspace/worktree/...`. Required
+     * for managed mode; reuse-cwd ignores it (and callers omit it there, so a
+     * reuse-cwd spawn never forces the dispatcher cwd contract).
+     */
+    dispatcherWorkspace?: string;
     request?: TeamMateWorktreeRequest;
   }): Promise<PreparedTeamMateWorkspace> {
     const sourceCwd = resolve(input.cwd);
@@ -46,11 +57,34 @@ export class WorktreeManager {
       };
     }
 
+    if (input.dispatcherWorkspace === undefined) {
+      throw new Error(
+        'managed worktree creation requires a dispatcher workspace; the ' +
+          'dispatcher must declare an explicit `cwd` (issue #182 PR-4)',
+      );
+    }
+    const dispatcherWorkspace = resolve(input.dispatcherWorkspace);
+    // A managed worktree must never land inside Dreamux's own home tree —
+    // including the retired state-dir fallback. The cwd contract makes a
+    // missing workspace fail at startup; this guard additionally rejects a
+    // workspace an operator explicitly pointed at `~/.dreamux` (issue #182 PR-4).
+    if (isUnderDreamuxRoot(dispatcherWorkspace)) {
+      throw new Error(
+        'managed worktrees must not be created under the Dreamux home ' +
+          `(~/.dreamux); dispatcher workspace resolves there: ${dispatcherWorkspace}`,
+      );
+    }
     const sourceRepo = await this.repoRoot(sourceCwd);
+    const canonicalRepoRoot = await realpath(sourceRepo);
     const slug = validateWorktreeSlug(input.request?.slug ?? input.teammateName);
     const branch = input.request?.branch ?? `dreamux/${teamMateNameSegment(slug)}`;
     const baseRef = input.request?.base_ref ?? 'HEAD';
-    const path = dispatcherTeamMateWorktreePath(input.dispatcherId, slug);
+    const path = managedWorktreePath({
+      dispatcherWorkspace,
+      canonicalRepoRoot,
+      slug,
+    });
+    await this.ensureWorkspaceBoundary(dispatcherWorkspace);
     await mkdir(dirname(path), { recursive: true });
     const exists = await pathExists(path);
     if (!exists) {
@@ -120,6 +154,24 @@ export class WorktreeManager {
         cleanup_state: 'retained-error',
         cleanup_error: err instanceof Error ? err.message : String(err),
       };
+    }
+  }
+
+  /**
+   * Ensure `<workspace>/.workspace/` exists and self-ignores its whole subtree,
+   * so Dreamux-managed worktrees never surface as content of the dispatcher's
+   * own repo (issue #182 PR-4). The `*` gitignore is written once; an existing
+   * file is left untouched.
+   */
+  private async ensureWorkspaceBoundary(dispatcherWorkspace: string): Promise<void> {
+    await mkdir(managedWorkspaceDir(dispatcherWorkspace), { recursive: true });
+    const gitignore = managedWorkspaceGitignorePath(dispatcherWorkspace);
+    if (!(await pathExists(gitignore))) {
+      await writeFile(
+        gitignore,
+        '# Dreamux-managed worktrees — never repo content.\n*\n',
+        'utf8',
+      );
     }
   }
 

--- a/packages/dreamux/src/dispatcher-service/teammate/worktree-manager.ts
+++ b/packages/dreamux/src/dispatcher-service/teammate/worktree-manager.ts
@@ -1,9 +1,12 @@
-import { access, mkdir, realpath, stat, writeFile } from 'node:fs/promises';
+import { access, mkdir, readFile, realpath, stat, writeFile } from 'node:fs/promises';
 import { dirname, resolve } from 'node:path';
 
 import { execa } from 'execa';
 
-import { isUnderDreamuxRoot, teamMateNameSegment } from '../../platform/paths.js';
+import {
+  isRealPathUnderDreamuxRoot,
+  teamMateNameSegment,
+} from '../../platform/paths.js';
 import {
   managedWorkspaceDir,
   managedWorkspaceGitignorePath,
@@ -63,12 +66,18 @@ export class WorktreeManager {
           'dispatcher must declare an explicit `cwd` (issue #182 PR-4)',
       );
     }
-    const dispatcherWorkspace = resolve(input.dispatcherWorkspace);
+    // Canonicalize the workspace with realpath BEFORE the Dreamux-home guard and
+    // before building the worktree path (issue #182 PR-4, PR #186 review P1): a
+    // workspace that is outside `~/.dreamux` lexically but symlinks into it would
+    // otherwise place managed worktrees physically under Dreamux home. The
+    // workspace exists here — `ensureDispatcherWorkspace` mkdir'd it — so the
+    // real path is well-defined.
+    const dispatcherWorkspace = await realpath(input.dispatcherWorkspace);
     // A managed worktree must never land inside Dreamux's own home tree —
-    // including the retired state-dir fallback. The cwd contract makes a
-    // missing workspace fail at startup; this guard additionally rejects a
-    // workspace an operator explicitly pointed at `~/.dreamux` (issue #182 PR-4).
-    if (isUnderDreamuxRoot(dispatcherWorkspace)) {
+    // including the retired state-dir fallback and any symlink into it. The cwd
+    // contract makes a missing workspace fail at startup; this guard additionally
+    // rejects a workspace that (really) resolves under `~/.dreamux`.
+    if (await isRealPathUnderDreamuxRoot(dispatcherWorkspace)) {
       throw new Error(
         'managed worktrees must not be created under the Dreamux home ' +
           `(~/.dreamux); dispatcher workspace resolves there: ${dispatcherWorkspace}`,
@@ -160,19 +169,17 @@ export class WorktreeManager {
   /**
    * Ensure `<workspace>/.workspace/` exists and self-ignores its whole subtree,
    * so Dreamux-managed worktrees never surface as content of the dispatcher's
-   * own repo (issue #182 PR-4). The `*` gitignore is written once; an existing
-   * file is left untouched.
+   * own repo (issue #182 PR-4). The boundary is Dreamux-owned, so an existing
+   * `.gitignore` that does NOT safely ignore everything is repaired to the
+   * canonical content rather than trusted (PR #186 review P2): a stale or
+   * tampered boundary file would otherwise let worktree contents leak into the
+   * dispatcher repo view.
    */
   private async ensureWorkspaceBoundary(dispatcherWorkspace: string): Promise<void> {
     await mkdir(managedWorkspaceDir(dispatcherWorkspace), { recursive: true });
     const gitignore = managedWorkspaceGitignorePath(dispatcherWorkspace);
-    if (!(await pathExists(gitignore))) {
-      await writeFile(
-        gitignore,
-        '# Dreamux-managed worktrees — never repo content.\n*\n',
-        'utf8',
-      );
-    }
+    if (await boundaryGitignoreIsSafe(gitignore)) return;
+    await writeFile(gitignore, BOUNDARY_GITIGNORE_CONTENT, 'utf8');
   }
 
   private async repoRoot(cwd: string): Promise<string> {
@@ -187,6 +194,33 @@ export class WorktreeManager {
       return null;
     }
   }
+}
+
+const BOUNDARY_GITIGNORE_CONTENT =
+  '# Dreamux-managed worktrees — never repo content.\n*\n';
+
+/**
+ * A `.workspace/.gitignore` is "safe" only when it ignores everything in the
+ * boundary: it must contain a bare `*` ignore-all line and NO `!`-negation that
+ * could un-ignore worktree content (PR #186 review P2). A missing file is
+ * unsafe (nothing is ignored yet). Comments and blank lines are ignored.
+ */
+async function boundaryGitignoreIsSafe(gitignorePath: string): Promise<boolean> {
+  let content: string;
+  try {
+    content = await readFile(gitignorePath, 'utf8');
+  } catch (err) {
+    if (isNotFound(err)) return false;
+    throw err;
+  }
+  let ignoresAll = false;
+  for (const rawLine of content.split('\n')) {
+    const line = rawLine.trim();
+    if (line === '' || line.startsWith('#')) continue;
+    if (line.startsWith('!')) return false;
+    if (line === '*') ignoresAll = true;
+  }
+  return ignoresAll;
 }
 
 async function retainedState(

--- a/packages/dreamux/src/dispatcher-service/teammate/worktree-paths.ts
+++ b/packages/dreamux/src/dispatcher-service/teammate/worktree-paths.ts
@@ -1,0 +1,68 @@
+import { createHash } from 'node:crypto';
+import { basename, join } from 'node:path';
+
+import { teamMateNameSegment } from '../../platform/paths.js';
+
+/**
+ * Placement of Dreamux-managed Git worktrees (issue #182 PR-4).
+ *
+ * Managed TeamMate/Team worktrees no longer live under `~/.dreamux`. They are
+ * created under the dispatcher's own workspace:
+ *
+ *   <dispatcher-workspace>/.workspace/worktree/<repo-slug>/<teammate-or-team-slug>/
+ *
+ * `.workspace/` is a Dreamux-owned, self-ignored boundary inside the workspace
+ * (see WorktreeManager.prepare, which drops a `*` .gitignore). `<repo-slug>`
+ * disambiguates worktrees of different source repos that happen to share a
+ * basename; the inner slug is the teammate name or `team-<id>`.
+ */
+
+/** Dreamux-owned boundary directory inside a dispatcher workspace. */
+export const MANAGED_WORKSPACE_DIRNAME = '.workspace';
+const WORKTREE_SUBDIR = 'worktree';
+
+/** `<workspace>/.workspace` — the Dreamux-owned boundary, self-ignored. */
+export function managedWorkspaceDir(dispatcherWorkspace: string): string {
+  return join(dispatcherWorkspace, MANAGED_WORKSPACE_DIRNAME);
+}
+
+/** The `.gitignore` Dreamux writes into `.workspace` so it never becomes repo content. */
+export function managedWorkspaceGitignorePath(dispatcherWorkspace: string): string {
+  return join(managedWorkspaceDir(dispatcherWorkspace), '.gitignore');
+}
+
+/** `<workspace>/.workspace/worktree` — root of all managed worktrees. */
+export function managedWorktreeRoot(dispatcherWorkspace: string): string {
+  return join(managedWorkspaceDir(dispatcherWorkspace), WORKTREE_SUBDIR);
+}
+
+/**
+ * Repo-disambiguated slug: a sanitized basename joined to a short, stable hash
+ * of the canonical source-repo root. Two distinct repos that share a basename
+ * map to distinct directories; the same repo always maps to the same directory
+ * across every Team and TeamMate worktree, so collisions inside a repo are
+ * carried entirely by the inner slug (and caught by the existing
+ * managed-worktree-availability check).
+ */
+export function repoDisambiguatedSlug(canonicalRepoRoot: string): string {
+  const base = teamMateNameSegment(basename(canonicalRepoRoot)) || 'repo';
+  const hash = createHash('sha256').update(canonicalRepoRoot).digest('hex').slice(0, 12);
+  return `${base}-${hash}`;
+}
+
+/**
+ * Absolute path of a managed worktree for a (source repo, slug) pair under a
+ * dispatcher workspace. The inner slug segment is sanitized the same way every
+ * neutral teammate path segment is.
+ */
+export function managedWorktreePath(input: {
+  dispatcherWorkspace: string;
+  canonicalRepoRoot: string;
+  slug: string;
+}): string {
+  return join(
+    managedWorktreeRoot(input.dispatcherWorkspace),
+    repoDisambiguatedSlug(input.canonicalRepoRoot),
+    teamMateNameSegment(input.slug),
+  );
+}

--- a/packages/dreamux/src/platform/paths.ts
+++ b/packages/dreamux/src/platform/paths.ts
@@ -26,6 +26,7 @@
  * `runtime_dir` concept (and its `runtimeRoot()` alias) was retired in issue #98.
  */
 
+import { realpath } from 'node:fs/promises';
 import { homedir } from 'node:os';
 import { dirname, isAbsolute, join, relative, resolve, sep } from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -72,16 +73,48 @@ export function dreamuxRoot(): string {
   return join(homedir(), '.dreamux');
 }
 
+/** Lexical containment: is `candidate` at or under `root` (both resolved)? */
+function pathIsAtOrUnder(root: string, candidate: string): boolean {
+  const rel = relative(resolve(root), resolve(candidate));
+  return rel === '' || (!rel.startsWith(`..${sep}`) && rel !== '..' && !isAbsolute(rel));
+}
+
 /**
  * True when `path` resolves to, or inside, the dreamux home root
- * (`~/.dreamux`). Managed worktree creation uses this to fail loud rather than
- * place a worktree under Dreamux's own state/run/cache tree (issue #182 PR-4):
- * a dispatcher workspace must be a real operator project directory, never the
- * retired state-dir fallback or any other path inside `~/.dreamux`.
+ * (`~/.dreamux`). Lexical only — a path that *symlinks* into `~/.dreamux` is not
+ * caught here; use {@link isRealPathUnderDreamuxRoot} for the placement guard.
+ * Managed worktree creation must fail loud rather than place a worktree under
+ * Dreamux's own state/run/cache tree (issue #182 PR-4): a dispatcher workspace
+ * must be a real operator project directory, never the retired state-dir
+ * fallback or any other path inside `~/.dreamux`.
  */
 export function isUnderDreamuxRoot(path: string): boolean {
-  const rel = relative(dreamuxRoot(), resolve(path));
-  return rel === '' || (!rel.startsWith(`..${sep}`) && rel !== '..' && !isAbsolute(rel));
+  return pathIsAtOrUnder(dreamuxRoot(), path);
+}
+
+/** realpath, falling back to a lexical resolve when the path does not exist. */
+async function canonicalPath(path: string): Promise<string> {
+  try {
+    return await realpath(path);
+  } catch {
+    return resolve(path);
+  }
+}
+
+/**
+ * Symlink-safe variant of {@link isUnderDreamuxRoot} (issue #182 PR-4, PR #186
+ * review P1): canonicalizes BOTH the dreamux root and `path` with `realpath`
+ * before the containment check, so a workspace path that lives outside
+ * `~/.dreamux` lexically but symlinks into it is still rejected. This is the
+ * authoritative guard for managed-worktree placement, where a bypass would put
+ * worktrees physically under Dreamux home.
+ */
+export async function isRealPathUnderDreamuxRoot(path: string): Promise<boolean> {
+  const [realRoot, realPath] = await Promise.all([
+    canonicalPath(dreamuxRoot()),
+    canonicalPath(path),
+  ]);
+  return pathIsAtOrUnder(realRoot, realPath);
 }
 
 export function stateRoot(): string {

--- a/packages/dreamux/src/platform/paths.ts
+++ b/packages/dreamux/src/platform/paths.ts
@@ -27,7 +27,7 @@
  */
 
 import { homedir } from 'node:os';
-import { dirname, join } from 'node:path';
+import { dirname, isAbsolute, join, relative, resolve, sep } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 import {
@@ -70,6 +70,18 @@ export function getRuntimeConfig(): DreamuxConfig {
 
 export function dreamuxRoot(): string {
   return join(homedir(), '.dreamux');
+}
+
+/**
+ * True when `path` resolves to, or inside, the dreamux home root
+ * (`~/.dreamux`). Managed worktree creation uses this to fail loud rather than
+ * place a worktree under Dreamux's own state/run/cache tree (issue #182 PR-4):
+ * a dispatcher workspace must be a real operator project directory, never the
+ * retired state-dir fallback or any other path inside `~/.dreamux`.
+ */
+export function isUnderDreamuxRoot(path: string): boolean {
+  const rel = relative(dreamuxRoot(), resolve(path));
+  return rel === '' || (!rel.startsWith(`..${sep}`) && rel !== '..' && !isAbsolute(rel));
 }
 
 export function stateRoot(): string {
@@ -256,16 +268,6 @@ export function dispatcherTeamMateRuntimeDir(
   teammateName: string,
 ): string {
   return join(dispatcherTeamMateDir(id), 'runtime', teamMateNameSegment(teammateName));
-}
-
-/** Dreamux-managed Git worktrees for one dispatcher. */
-export function dispatcherTeamMateWorktreesDir(id: string): string {
-  return join(dispatcherTeamMateDir(id), 'worktrees');
-}
-
-/** One Dreamux-managed Git worktree path for a teammate slug. */
-export function dispatcherTeamMateWorktreePath(id: string, slug: string): string {
-  return join(dispatcherTeamMateWorktreesDir(id), teamMateNameSegment(slug));
 }
 
 /** Per-dispatcher Team Mode state root. */

--- a/packages/dreamux/src/server.ts
+++ b/packages/dreamux/src/server.ts
@@ -44,6 +44,7 @@ import {
 import { RestartIntentConsumer } from './daemon/restart-intent.js';
 import type { ClaudeCodeSessionFactory } from './agent-runtime/builtin/claude-code/supervisor.js';
 import { DispatcherService } from './dispatcher-service/service.js';
+import { ensureDispatcherWorkspace } from './dispatcher-service/dispatcher-workspace.js';
 export {
   IN_PROGRESS_REACTION_EMOJI,
   RECEIVED_REACTION_EMOJI,
@@ -195,6 +196,13 @@ export class Server {
       }),
     );
 
+    // Dispatcher workspace cwd contract (issue #182 PR-4): every enabled
+    // dispatcher must declare an explicit, usable `cwd` — there is no fallback
+    // to a Dreamux state dir. Pre-flight all of them before taking the admin
+    // lock or launching anything, and fail the whole start loud (aggregated) so
+    // a misconfigured deployment never comes up half-broken.
+    await this.assertDispatcherWorkspaces();
+
     // Before taking the new run/ admin lock, fail loud if an OLD-version
     // server still holds the pre-#182 state/ admin lock — the two locks are at
     // different paths and would not otherwise see each other (issue #182 P1).
@@ -236,6 +244,30 @@ export class Server {
           'dispatcher failed to start',
         );
       }
+    }
+  }
+
+  /**
+   * Validate the workspace cwd of every enabled dispatcher (issue #182 PR-4).
+   * Aggregates all failures into one loud error so the operator sees every
+   * misconfigured dispatcher at once, rather than fixing them one boot at a
+   * time. A throw here aborts `start()` before any socket or dispatcher.
+   */
+  private async assertDispatcherWorkspaces(): Promise<void> {
+    const config = this.opts.config ?? BUILT_IN_DEFAULTS;
+    const failures: string[] = [];
+    for (const row of this.repos.dispatchers.listEnabled()) {
+      try {
+        await ensureDispatcherWorkspace(config, row.dispatcher_id);
+      } catch (err) {
+        failures.push(err instanceof Error ? err.message : String(err));
+      }
+    }
+    if (failures.length > 0) {
+      throw new Error(
+        `dreamux serve cannot start — dispatcher workspace cwd contract failed:\n` +
+          failures.map((message) => `  - ${message}`).join('\n'),
+      );
     }
   }
 

--- a/packages/dreamux/tests/dispatcher-workspace.test.ts
+++ b/packages/dreamux/tests/dispatcher-workspace.test.ts
@@ -1,0 +1,249 @@
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { mkdir, stat } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import {
+  configuredDispatcherCwd,
+  diagnoseDispatcherWorkspace,
+  ensureDispatcherWorkspace,
+} from '../src/dispatcher-service/dispatcher-workspace.js';
+import {
+  managedWorkspaceGitignorePath,
+  managedWorktreePath,
+  managedWorktreeRoot,
+  repoDisambiguatedSlug,
+} from '../src/dispatcher-service/teammate/worktree-paths.js';
+import {
+  dreamuxRoot,
+  isUnderDreamuxRoot,
+  resetRuntimeConfig,
+} from '../src/platform/paths.js';
+import { Server } from '../src/server.js';
+import type { DreamuxLogger } from '../src/platform/logger.js';
+import { testDispatcherConfig, testDreamuxConfig } from './helpers/config.js';
+
+const NO_CWD_MESSAGE = /no configured `cwd`/;
+
+function noopLog(): DreamuxLogger {
+  const log = {
+    info: () => undefined,
+    warn: () => undefined,
+    error: () => undefined,
+    debug: () => undefined,
+    child: () => log,
+  };
+  return log as unknown as DreamuxLogger;
+}
+
+describe('dispatcher workspace cwd contract (issue #182 PR-4)', () => {
+  let root: string;
+  let previousHome: string | undefined;
+
+  beforeEach(() => {
+    root = mkdtempSync(join(tmpdir(), 'dreamux-workspace-'));
+    previousHome = process.env['HOME'];
+    process.env['HOME'] = join(root, 'home');
+    resetRuntimeConfig();
+  });
+
+  afterEach(() => {
+    if (previousHome === undefined) delete process.env['HOME'];
+    else process.env['HOME'] = previousHome;
+    resetRuntimeConfig();
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  it('resolves a configured cwd to an absolute path and null when unset', () => {
+    const configured = testDreamuxConfig([
+      testDispatcherConfig({ id: 'flow', cwd: join(root, 'ws') }),
+    ]);
+    expect(configuredDispatcherCwd(configured, 'flow')).toBe(join(root, 'ws'));
+
+    const unset = testDreamuxConfig([testDispatcherConfig({ id: 'flow', cwd: null })]);
+    expect(configuredDispatcherCwd(unset, 'flow')).toBeNull();
+
+    const blank = testDreamuxConfig([testDispatcherConfig({ id: 'flow', cwd: '   ' })]);
+    expect(configuredDispatcherCwd(blank, 'flow')).toBeNull();
+  });
+
+  it('fails loud when a dispatcher declares no cwd — no state-dir fallback', async () => {
+    const config = testDreamuxConfig([testDispatcherConfig({ id: 'flow', cwd: null })]);
+    await expect(ensureDispatcherWorkspace(config, 'flow')).rejects.toThrow(
+      NO_CWD_MESSAGE,
+    );
+  });
+
+  it('creates a missing configured cwd with mkdir -p semantics', async () => {
+    const cwd = join(root, 'nested', 'workspace');
+    const config = testDreamuxConfig([testDispatcherConfig({ id: 'flow', cwd })]);
+    const resolved = await ensureDispatcherWorkspace(config, 'flow');
+    expect(resolved).toBe(cwd);
+    expect((await stat(cwd)).isDirectory()).toBe(true);
+  });
+
+  it('rejects a configured cwd that is not a directory', async () => {
+    const cwd = join(root, 'a-file');
+    writeFileSync(cwd, 'not a dir');
+    const config = testDreamuxConfig([testDispatcherConfig({ id: 'flow', cwd })]);
+    await expect(ensureDispatcherWorkspace(config, 'flow')).rejects.toThrow(
+      /could not be created|not a directory/,
+    );
+  });
+
+  it('rejects a configured cwd whose parent is unusable (mkdir fails)', async () => {
+    const parentFile = join(root, 'blocker');
+    writeFileSync(parentFile, 'i am a file, not a parent dir');
+    const cwd = join(parentFile, 'workspace');
+    const config = testDreamuxConfig([testDispatcherConfig({ id: 'flow', cwd })]);
+    await expect(ensureDispatcherWorkspace(config, 'flow')).rejects.toThrow(
+      /could not be created|not (a )?directory|accessible/,
+    );
+  });
+
+  describe('diagnoseDispatcherWorkspace (doctor, non-throwing)', () => {
+    it('reports a missing cwd as a failure', async () => {
+      const config = testDreamuxConfig([testDispatcherConfig({ id: 'flow', cwd: null })]);
+      const diagnosis = await diagnoseDispatcherWorkspace(config, 'flow');
+      expect(diagnosis.ok).toBe(false);
+      expect(diagnosis.detail).toMatch(/no configured `cwd`/);
+    });
+
+    it('reports an existing directory as ok', async () => {
+      const cwd = join(root, 'ws');
+      await mkdir(cwd, { recursive: true });
+      const config = testDreamuxConfig([testDispatcherConfig({ id: 'flow', cwd })]);
+      const diagnosis = await diagnoseDispatcherWorkspace(config, 'flow');
+      expect(diagnosis.ok).toBe(true);
+      expect(diagnosis.detail).toBe(cwd);
+    });
+
+    it('reports a missing-but-configured dir as ok (created at startup)', async () => {
+      const cwd = join(root, 'not-yet');
+      const config = testDreamuxConfig([testDispatcherConfig({ id: 'flow', cwd })]);
+      const diagnosis = await diagnoseDispatcherWorkspace(config, 'flow');
+      expect(diagnosis.ok).toBe(true);
+      expect(diagnosis.detail).toMatch(/created at server startup/);
+    });
+
+    it('reports a non-directory cwd as a failure', async () => {
+      const cwd = join(root, 'a-file');
+      writeFileSync(cwd, 'file');
+      const config = testDreamuxConfig([testDispatcherConfig({ id: 'flow', cwd })]);
+      const diagnosis = await diagnoseDispatcherWorkspace(config, 'flow');
+      expect(diagnosis.ok).toBe(false);
+      expect(diagnosis.detail).toMatch(/not a directory/);
+    });
+  });
+
+  describe('Server.start() pre-flight', () => {
+    it('fails loud when an enabled dispatcher lacks an explicit cwd', async () => {
+      const config = testDreamuxConfig([
+        testDispatcherConfig({ id: 'flow', cwd: null, enabled: true }),
+      ]);
+      const server = new Server({
+        config,
+        adminSocketPath: join(root, 'admin.sock'),
+        logger: noopLog(),
+        channelLoggerFactory: () => noopLog(),
+      });
+      await expect(server.start()).rejects.toThrow(
+        /dispatcher workspace cwd contract failed[\s\S]*flow[\s\S]*no configured `cwd`/,
+      );
+      await server.shutdown();
+    });
+
+    it('aggregates failures across multiple misconfigured dispatchers', async () => {
+      const config = testDreamuxConfig([
+        testDispatcherConfig({ id: 'flow', cwd: null, enabled: true }),
+        testDispatcherConfig({
+          id: 'docs',
+          cwd: null,
+          enabled: true,
+          channelId: 'docs-primary',
+          feishu: { app_id: 'app-docs', app_secret: 'secret-docs' },
+        }),
+      ]);
+      const server = new Server({
+        config,
+        adminSocketPath: join(root, 'admin.sock'),
+        logger: noopLog(),
+        channelLoggerFactory: () => noopLog(),
+      });
+      const error = await server.start().then(
+        () => null,
+        (err: unknown) => (err instanceof Error ? err.message : String(err)),
+      );
+      expect(error).not.toBeNull();
+      expect(error).toMatch(/flow/);
+      expect(error).toMatch(/docs/);
+      await server.shutdown();
+    });
+  });
+
+  describe('isUnderDreamuxRoot', () => {
+    it('is true for the dreamux root itself and paths inside it', () => {
+      expect(isUnderDreamuxRoot(dreamuxRoot())).toBe(true);
+      expect(isUnderDreamuxRoot(join(dreamuxRoot(), 'state', 'flow', 'cwd'))).toBe(
+        true,
+      );
+    });
+
+    it('is false for sibling paths, including prefix-similar siblings', () => {
+      expect(isUnderDreamuxRoot(join(root, 'home', 'projects'))).toBe(false);
+      // `~/.dreamux-foo` shares a textual prefix but is NOT under `~/.dreamux`.
+      expect(isUnderDreamuxRoot(`${dreamuxRoot()}-foo`)).toBe(false);
+    });
+  });
+});
+
+describe('managed worktree path builders (issue #182 PR-4)', () => {
+  const workspace = '/work/space';
+
+  it('roots managed worktrees under <workspace>/.workspace/worktree', () => {
+    expect(managedWorktreeRoot(workspace)).toBe('/work/space/.workspace/worktree');
+    expect(managedWorkspaceGitignorePath(workspace)).toBe(
+      '/work/space/.workspace/.gitignore',
+    );
+  });
+
+  it('maps the same repo to a stable repo-disambiguated slug', () => {
+    const repo = '/home/dev/project';
+    expect(repoDisambiguatedSlug(repo)).toBe(repoDisambiguatedSlug(repo));
+    expect(repoDisambiguatedSlug(repo)).toMatch(/^project-[0-9a-f]{12}$/);
+  });
+
+  it('disambiguates different repos that share a basename', () => {
+    const a = repoDisambiguatedSlug('/home/dev/project');
+    const b = repoDisambiguatedSlug('/srv/other/project');
+    expect(a).not.toBe(b);
+    // Same human-readable prefix, different hash suffix.
+    expect(a.startsWith('project-')).toBe(true);
+    expect(b.startsWith('project-')).toBe(true);
+  });
+
+  it('sanitizes unsafe basenames into the slug', () => {
+    const slug = repoDisambiguatedSlug('/home/dev/weird name@v2');
+    expect(slug).toMatch(/^weird_name_v2-[0-9a-f]{12}$/);
+  });
+
+  it('places a worktree at <root>/<repo-slug>/<inner-slug> and sanitizes the inner slug', () => {
+    const path = managedWorktreePath({
+      dispatcherWorkspace: workspace,
+      canonicalRepoRoot: '/home/dev/project',
+      slug: 'team-alpha',
+    });
+    expect(path).toBe(
+      `${managedWorktreeRoot(workspace)}/${repoDisambiguatedSlug('/home/dev/project')}/team-alpha`,
+    );
+
+    const sanitized = managedWorktreePath({
+      dispatcherWorkspace: workspace,
+      canonicalRepoRoot: '/home/dev/project',
+      slug: 'has spaces/and@symbols',
+    });
+    expect(sanitized.endsWith('/has_spaces_and_symbols')).toBe(true);
+  });
+});

--- a/packages/dreamux/tests/dispatcher-workspace.test.ts
+++ b/packages/dreamux/tests/dispatcher-workspace.test.ts
@@ -1,5 +1,5 @@
 import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
-import { mkdir, stat } from 'node:fs/promises';
+import { mkdir, stat, symlink } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
@@ -18,6 +18,7 @@ import {
 } from '../src/dispatcher-service/teammate/worktree-paths.js';
 import {
   dreamuxRoot,
+  isRealPathUnderDreamuxRoot,
   isUnderDreamuxRoot,
   resetRuntimeConfig,
 } from '../src/platform/paths.js';
@@ -195,6 +196,26 @@ describe('dispatcher workspace cwd contract (issue #182 PR-4)', () => {
       expect(isUnderDreamuxRoot(join(root, 'home', 'projects'))).toBe(false);
       // `~/.dreamux-foo` shares a textual prefix but is NOT under `~/.dreamux`.
       expect(isUnderDreamuxRoot(`${dreamuxRoot()}-foo`)).toBe(false);
+    });
+  });
+
+  describe('isRealPathUnderDreamuxRoot (symlink-safe)', () => {
+    it('catches a path outside ~/.dreamux that symlinks into it', async () => {
+      const target = join(dreamuxRoot(), 'state', 'sneaky');
+      await mkdir(target, { recursive: true });
+      const outsideLink = join(root, 'outside-link');
+      await symlink(target, outsideLink);
+
+      // Lexically outside (the pure check misses it)...
+      expect(isUnderDreamuxRoot(outsideLink)).toBe(false);
+      // ...but the symlink-safe check follows the link and rejects it.
+      expect(await isRealPathUnderDreamuxRoot(outsideLink)).toBe(true);
+    });
+
+    it('is false for a genuine project dir outside ~/.dreamux', async () => {
+      const project = join(root, 'home', 'projects', 'app');
+      await mkdir(project, { recursive: true });
+      expect(await isRealPathUnderDreamuxRoot(project)).toBe(false);
     });
   });
 });

--- a/packages/dreamux/tests/doctor.test.ts
+++ b/packages/dreamux/tests/doctor.test.ts
@@ -129,6 +129,11 @@ describe('dreamux doctor command', () => {
       env: {},
     });
 
+    // The dispatcher workspace cwd contract (issue #182 PR-4) is diagnosed
+    // per dispatcher; a configured cwd reports ok.
+    expect(
+      result.checks.find((check) => check.name === 'dispatcher flow workspace'),
+    ).toMatchObject({ ok: true });
     expect(result.ok, JSON.stringify(result, null, 2)).toBe(true);
     expect(result.checks.find((check) => check.name === 'config')).toMatchObject({
       ok: true,
@@ -158,6 +163,46 @@ describe('dreamux doctor command', () => {
     expect(result.dispatchers[0]?.foreground.errors.join('\n')).toContain(
       'requires codex >= 0.137.0',
     );
+  });
+
+  it('fails loud when a dispatcher declares no workspace cwd (#182 PR-4)', async () => {
+    const runner = new FakeRunner();
+    runner.nodeVersions.set('codex', 'codex-cli 0.137.0');
+    // Config file with the dispatcher's `cwd` omitted entirely.
+    const configPath = join(root, 'config', 'config.json');
+    mkdirSync(dirname(configPath), { recursive: true });
+    writeFileSync(
+      configPath,
+      JSON.stringify(
+        testSingleDispatcherFileObject({
+          id: 'flow',
+          enabled: true,
+          feishu: { app_id: 'app-test', app_secret: 'secret-test' },
+          codex: {
+            approval_policy: 'never',
+            sandbox_mode: 'workspace-write',
+            extra_args: [],
+            extra_env: {},
+          },
+        }),
+      ),
+      { mode: 0o600 },
+    );
+    writeDispatcherHome({ auth: true });
+
+    const result = await runDreamuxDoctor({
+      runner,
+      platform: 'linux',
+      homeDir: join(root, 'home'),
+      env: {},
+    });
+
+    const workspaceCheck = result.checks.find(
+      (check) => check.name === 'dispatcher flow workspace',
+    );
+    expect(workspaceCheck?.ok).toBe(false);
+    expect(workspaceCheck?.detail).toMatch(/no configured `cwd`/);
+    expect(result.ok).toBe(false);
   });
 
   it('does not expose Feishu app secrets in doctor results', async () => {

--- a/packages/dreamux/tests/doctor.test.ts
+++ b/packages/dreamux/tests/doctor.test.ts
@@ -205,6 +205,47 @@ describe('dreamux doctor command', () => {
     expect(result.ok).toBe(false);
   });
 
+  it('does not fail the workspace check for a disabled dispatcher with no cwd (#182 PR-4, PR#186 P3)', async () => {
+    const runner = new FakeRunner();
+    runner.nodeVersions.set('codex', 'codex-cli 0.137.0');
+    // A DISABLED dispatcher with `cwd` omitted: server startup never enforces
+    // the cwd contract for it, so doctor must report it as a non-blocking
+    // diagnostic rather than a failure (alignment with serve semantics).
+    const configPath = join(root, 'config', 'config.json');
+    mkdirSync(dirname(configPath), { recursive: true });
+    writeFileSync(
+      configPath,
+      JSON.stringify(
+        testSingleDispatcherFileObject({
+          id: 'flow',
+          enabled: false,
+          feishu: { app_id: 'app-test', app_secret: 'secret-test' },
+          codex: {
+            approval_policy: 'never',
+            sandbox_mode: 'workspace-write',
+            extra_args: [],
+            extra_env: {},
+          },
+        }),
+      ),
+      { mode: 0o600 },
+    );
+    writeDispatcherHome({ auth: true });
+
+    const result = await runDreamuxDoctor({
+      runner,
+      platform: 'linux',
+      homeDir: join(root, 'home'),
+      env: {},
+    });
+
+    const workspaceCheck = result.checks.find(
+      (check) => check.name === 'dispatcher flow workspace',
+    );
+    expect(workspaceCheck?.ok).toBe(true);
+    expect(workspaceCheck?.detail).toMatch(/disabled/);
+  });
+
   it('does not expose Feishu app secrets in doctor results', async () => {
     const runner = new FakeRunner();
     writeConfig();

--- a/packages/dreamux/tests/e2e.test.ts
+++ b/packages/dreamux/tests/e2e.test.ts
@@ -93,7 +93,9 @@ function configWithDispatcher(): DreamuxConfig {
     dispatchers: [
       testDispatcherConfig({
         id: 'flow',
-        cwd: null,
+        // Explicit workspace cwd (issue #182 PR-4): no state-dir fallback. The
+        // e2e flow runs no managed worktree, so the per-dispatcher dir works.
+        cwd: defaultDispatcherCwd('flow'),
         enabled: true,
         feishu: {
           app_id: 'app-e2e',

--- a/packages/dreamux/tests/smoke.test.ts
+++ b/packages/dreamux/tests/smoke.test.ts
@@ -147,7 +147,11 @@ function buildServer(opts: {
   runtimeSocketSweep?: () => Promise<string[]>;
 }): Server {
   return new Server({
-    config: opts.config ?? BUILT_IN_DEFAULTS,
+    // The dispatcher workspace cwd contract (issue #182 PR-4) resolves cwd from
+    // config, so the default smoke config declares `flow` with an explicit cwd.
+    // Tests that register the row via the store use `upsert` to stay idempotent
+    // against this seed.
+    config: opts.config ?? configWithDispatcher(),
     providerRegistry: opts.providerRegistry,
     adminSocketPath: join(opts.runtimeDir, 'admin.sock'),
     skipBotSecret: opts.skipBotSecret ?? true,
@@ -382,7 +386,10 @@ function configWithDispatcher(overrides: ConfigDispatcherOverrides = {}): Dreamu
   return testDreamuxConfig([
     testDispatcherConfig({
       id: overrides.id ?? 'flow',
-      cwd: overrides.cwd ?? null,
+      // The dispatcher workspace cwd contract (issue #182 PR-4) requires an
+      // explicit cwd. The smoke flow runs no managed worktree, so the legacy
+      // per-dispatcher dir is a fine, already-provisioned workspace here.
+      cwd: overrides.cwd ?? defaultDispatcherCwd(overrides.id ?? 'flow'),
       enabled: overrides.enabled ?? true,
       feishu: overrides.feishu ?? {
         app_id: 'app-smoke',
@@ -447,7 +454,7 @@ describe('dreamux MVP smoke', () => {
 
   it('happy path: inbound reaches Codex, and assistant text is not auto-sent', async () => {
     server = buildServer({ runtimeDir, fake, bot });
-    server.repos.dispatchers.create({
+    server.repos.dispatchers.upsert({
       dispatcher_id: 'flow',
       bot_app_id: 'app-smoke',
       bot_secret_ref: 'env:UNUSED',
@@ -493,7 +500,7 @@ describe('dreamux MVP smoke', () => {
     const self = 'fake-open-id-app-smoke'; // the fake bot's own open_id
     const atUs = [{ key: '@_bot', id: { open_id: self }, name: 'Dispatcher' }];
     server = buildServer({ runtimeDir, fake, bot });
-    server.repos.dispatchers.create({
+    server.repos.dispatchers.upsert({
       dispatcher_id: 'flow',
       bot_app_id: 'app-smoke',
       bot_secret_ref: 'env:UNUSED',
@@ -563,7 +570,7 @@ describe('dreamux MVP smoke', () => {
   it('starts the dispatcher app-server with global default Codex home and tm on PATH', async () => {
     const capturedCodexOptions: CodexProcessOptions[] = [];
     server = buildServer({ runtimeDir, fake, bot, capturedCodexOptions });
-    server.repos.dispatchers.create({
+    server.repos.dispatchers.upsert({
       dispatcher_id: 'flow',
       bot_app_id: 'app-smoke',
       bot_secret_ref: 'env:UNUSED',
@@ -650,6 +657,7 @@ describe('dreamux MVP smoke', () => {
         dispatchers: [
           testDispatcherConfig({
             id: 'flow',
+            cwd: defaultDispatcherCwd('flow'),
             runtime: {
               provider: providerRef,
               config: {
@@ -696,7 +704,7 @@ describe('dreamux MVP smoke', () => {
 
   it('starts fresh Codex threads with Dreamux dispatcher base instructions', async () => {
     server = buildServer({ runtimeDir, fake, bot });
-    server.repos.dispatchers.create({
+    server.repos.dispatchers.upsert({
       dispatcher_id: 'flow',
       bot_app_id: 'app-smoke',
       bot_secret_ref: 'env:UNUSED',
@@ -752,7 +760,7 @@ describe('dreamux MVP smoke', () => {
 
   it('resumes Codex threads with Dreamux dispatcher base instructions', async () => {
     server = buildServer({ runtimeDir, fake, bot });
-    server.repos.dispatchers.create({
+    server.repos.dispatchers.upsert({
       dispatcher_id: 'flow',
       bot_app_id: 'app-smoke',
       bot_secret_ref: 'env:UNUSED',
@@ -877,7 +885,14 @@ describe('dreamux MVP smoke', () => {
 
   it('routes bound Feishu group inbound to the TeamLeader and transfers back', async () => {
     const repo = initGitRepoSync(join(runtimeDir, 'team-repo'));
-    server = buildServer({ runtimeDir, fake, bot, config: configWithDispatcher() });
+    // Team creation builds a managed worktree, which must live under a real
+    // workspace, never `~/.dreamux` (issue #182 PR-4).
+    server = buildServer({
+      runtimeDir,
+      fake,
+      bot,
+      config: configWithDispatcher({ cwd: join(runtimeDir, 'workspace') }),
+    });
     await server.start();
 
     await server.dispatcherService.createTeam({
@@ -1010,7 +1025,7 @@ describe('dreamux MVP smoke', () => {
       replyFor: captureAndEchoCodexInput(codexInputs),
     });
     server = buildServer({ runtimeDir, fake, bot });
-    server.repos.dispatchers.create({
+    server.repos.dispatchers.upsert({
       dispatcher_id: 'flow',
       bot_app_id: 'app-smoke',
       bot_secret_ref: 'env:UNUSED',
@@ -1081,7 +1096,7 @@ describe('dreamux MVP smoke', () => {
     };
 
     server = buildServer({ runtimeDir, fake, bot });
-    server.repos.dispatchers.create({
+    server.repos.dispatchers.upsert({
       dispatcher_id: 'flow',
       bot_app_id: 'app-smoke',
       bot_secret_ref: 'env:UNUSED',
@@ -1127,7 +1142,7 @@ describe('dreamux MVP smoke', () => {
 
   it('adds the in-progress reaction before cancelling the received one (add-then-cancel)', async () => {
     server = buildServer({ runtimeDir, fake, bot });
-    server.repos.dispatchers.create({
+    server.repos.dispatchers.upsert({
       dispatcher_id: 'flow',
       bot_app_id: 'app-smoke',
       bot_secret_ref: 'env:UNUSED',
@@ -1177,7 +1192,7 @@ describe('dreamux MVP smoke', () => {
     };
 
     server = buildServer({ runtimeDir, fake, bot });
-    server.repos.dispatchers.create({
+    server.repos.dispatchers.upsert({
       dispatcher_id: 'flow',
       bot_app_id: 'app-smoke',
       bot_secret_ref: 'env:UNUSED',
@@ -1231,7 +1246,7 @@ describe('dreamux MVP smoke', () => {
 
   it('mcp.react adds a model-owned reaction without clearing received reactions', async () => {
     server = buildServer({ runtimeDir, fake, bot });
-    server.repos.dispatchers.create({
+    server.repos.dispatchers.upsert({
       dispatcher_id: 'flow',
       bot_app_id: 'app-smoke',
       bot_secret_ref: 'env:UNUSED',
@@ -1286,7 +1301,7 @@ describe('dreamux MVP smoke', () => {
 
   it('access gate drops bot-loop messages before queue or reaction', async () => {
     server = buildServer({ runtimeDir, fake, bot });
-    server.repos.dispatchers.create({
+    server.repos.dispatchers.upsert({
       dispatcher_id: 'flow',
       bot_app_id: 'app-smoke',
       bot_secret_ref: 'env:UNUSED',
@@ -1306,7 +1321,7 @@ describe('dreamux MVP smoke', () => {
 
   it('access gate drops Feishu bot/app sender types before queue or reaction', async () => {
     server = buildServer({ runtimeDir, fake, bot });
-    server.repos.dispatchers.create({
+    server.repos.dispatchers.upsert({
       dispatcher_id: 'flow',
       bot_app_id: 'app-smoke',
       bot_secret_ref: 'env:UNUSED',
@@ -1327,7 +1342,7 @@ describe('dreamux MVP smoke', () => {
 
   it('access gate drops unmentioned group messages before queue or reaction', async () => {
     server = buildServer({ runtimeDir, fake, bot });
-    server.repos.dispatchers.create({
+    server.repos.dispatchers.upsert({
       dispatcher_id: 'flow',
       bot_app_id: 'app-smoke',
       bot_secret_ref: 'env:UNUSED',
@@ -1359,7 +1374,7 @@ describe('dreamux MVP smoke', () => {
       last_gate: null,
     });
     server = buildServer({ runtimeDir, fake, bot });
-    server.repos.dispatchers.create({
+    server.repos.dispatchers.upsert({
       dispatcher_id: 'flow',
       bot_app_id: 'app-smoke',
       bot_secret_ref: 'env:UNUSED',
@@ -1402,7 +1417,7 @@ describe('dreamux MVP smoke', () => {
       last_gate: null,
     });
     server = buildServer({ runtimeDir, fake, bot });
-    server.repos.dispatchers.create({
+    server.repos.dispatchers.upsert({
       dispatcher_id: 'flow',
       bot_app_id: 'app-smoke',
       bot_secret_ref: 'env:UNUSED',
@@ -1454,7 +1469,7 @@ describe('dreamux MVP smoke', () => {
       last_gate: null,
     });
     server = buildServer({ runtimeDir, fake, bot });
-    server.repos.dispatchers.create({
+    server.repos.dispatchers.upsert({
       dispatcher_id: 'flow',
       bot_app_id: 'app-smoke',
       bot_secret_ref: 'env:UNUSED',
@@ -1501,7 +1516,7 @@ describe('dreamux MVP smoke', () => {
       last_gate: null,
     });
     server = buildServer({ runtimeDir, fake, bot });
-    server.repos.dispatchers.create({
+    server.repos.dispatchers.upsert({
       dispatcher_id: 'flow',
       bot_app_id: 'app-smoke',
       bot_secret_ref: 'env:UNUSED',
@@ -1559,7 +1574,7 @@ describe('dreamux MVP smoke', () => {
       bot,
       channelLoggerFactory: () => channel.logger,
     });
-    server.repos.dispatchers.create({
+    server.repos.dispatchers.upsert({
       dispatcher_id: 'flow',
       bot_app_id: 'app-smoke',
       bot_secret_ref: 'env:UNUSED',
@@ -1611,7 +1626,7 @@ describe('dreamux MVP smoke', () => {
       last_gate: null,
     });
     server = buildServer({ runtimeDir, fake, bot });
-    server.repos.dispatchers.create({
+    server.repos.dispatchers.upsert({
       dispatcher_id: 'flow',
       bot_app_id: 'app-smoke',
       bot_secret_ref: 'env:UNUSED',
@@ -1658,7 +1673,7 @@ describe('dreamux MVP smoke', () => {
       bot,
       channelLoggerFactory: () => channel.logger,
     });
-    server.repos.dispatchers.create({
+    server.repos.dispatchers.upsert({
       dispatcher_id: 'flow',
       bot_app_id: 'app-smoke',
       bot_secret_ref: 'env:UNUSED',
@@ -1704,7 +1719,7 @@ describe('dreamux MVP smoke', () => {
       last_gate: null,
     });
     server = buildServer({ runtimeDir, fake, bot });
-    server.repos.dispatchers.create({
+    server.repos.dispatchers.upsert({
       dispatcher_id: 'flow',
       bot_app_id: 'app-smoke',
       bot_secret_ref: 'env:UNUSED',
@@ -1743,7 +1758,7 @@ describe('dreamux MVP smoke', () => {
       last_gate: null,
     });
     server = buildServer({ runtimeDir, fake, bot });
-    server.repos.dispatchers.create({
+    server.repos.dispatchers.upsert({
       dispatcher_id: 'flow',
       bot_app_id: 'app-smoke',
       bot_secret_ref: 'env:UNUSED',
@@ -1787,7 +1802,7 @@ describe('dreamux MVP smoke', () => {
       last_gate: null,
     });
     server = buildServer({ runtimeDir, fake, bot });
-    server.repos.dispatchers.create({
+    server.repos.dispatchers.upsert({
       dispatcher_id: 'flow',
       bot_app_id: 'app-smoke',
       bot_secret_ref: 'env:UNUSED',
@@ -1849,7 +1864,7 @@ describe('dreamux MVP smoke', () => {
       bot,
       channelLoggerFactory: () => channel.logger,
     });
-    server.repos.dispatchers.create({
+    server.repos.dispatchers.upsert({
       dispatcher_id: 'flow',
       bot_app_id: 'app-smoke',
       bot_secret_ref: 'env:UNUSED',
@@ -1925,7 +1940,7 @@ describe('dreamux MVP smoke', () => {
       bot,
       channelLoggerFactory: () => channel.logger,
     });
-    server.repos.dispatchers.create({
+    server.repos.dispatchers.upsert({
       dispatcher_id: 'flow',
       bot_app_id: 'app-smoke',
       bot_secret_ref: 'env:UNUSED',
@@ -1979,7 +1994,7 @@ describe('dreamux MVP smoke', () => {
       bot,
       channelLoggerFactory: () => channel.logger,
     });
-    server.repos.dispatchers.create({
+    server.repos.dispatchers.upsert({
       dispatcher_id: 'flow',
       bot_app_id: 'app-smoke',
       bot_secret_ref: 'env:UNUSED',
@@ -2027,7 +2042,7 @@ describe('dreamux MVP smoke', () => {
       bot,
       channelLoggerFactory: () => channel.logger,
     });
-    server.repos.dispatchers.create({
+    server.repos.dispatchers.upsert({
       dispatcher_id: 'flow',
       bot_app_id: 'app-smoke',
       bot_secret_ref: 'env:UNUSED',
@@ -2075,7 +2090,7 @@ describe('dreamux MVP smoke', () => {
       bot,
       channelLoggerFactory: () => channel.logger,
     });
-    server.repos.dispatchers.create({
+    server.repos.dispatchers.upsert({
       dispatcher_id: 'flow',
       bot_app_id: 'app-smoke',
       bot_secret_ref: 'env:UNUSED',
@@ -2100,7 +2115,7 @@ describe('dreamux MVP smoke', () => {
 
   it('records a trust-domain warning when one dispatcher receives multiple chats', async () => {
     server = buildServer({ runtimeDir, fake, bot });
-    server.repos.dispatchers.create({
+    server.repos.dispatchers.upsert({
       dispatcher_id: 'flow',
       bot_app_id: 'app-smoke',
       bot_secret_ref: 'env:UNUSED',
@@ -2134,7 +2149,7 @@ describe('dreamux MVP smoke', () => {
       bot,
       channelLoggerFactory: () => capture.logger,
     });
-    server.repos.dispatchers.create({
+    server.repos.dispatchers.upsert({
       dispatcher_id: 'flow',
       bot_app_id: 'app-smoke',
       bot_secret_ref: 'env:UNUSED',
@@ -2171,7 +2186,7 @@ describe('dreamux MVP smoke', () => {
       bot,
       channelLoggerFactory: () => capture.logger,
     });
-    server.repos.dispatchers.create({
+    server.repos.dispatchers.upsert({
       dispatcher_id: 'flow',
       bot_app_id: 'app-smoke',
       bot_secret_ref: 'env:UNUSED',
@@ -2203,7 +2218,7 @@ describe('dreamux MVP smoke', () => {
       bot,
       channelLoggerFactory: () => capture.logger,
     });
-    server.repos.dispatchers.create({
+    server.repos.dispatchers.upsert({
       dispatcher_id: 'flow',
       bot_app_id: 'app-smoke',
       bot_secret_ref: 'env:UNUSED',
@@ -2243,7 +2258,7 @@ describe('dreamux MVP smoke', () => {
       bot,
       channelLoggerFactory: () => capture.logger,
     });
-    server.repos.dispatchers.create({
+    server.repos.dispatchers.upsert({
       dispatcher_id: 'flow',
       bot_app_id: 'app-smoke',
       bot_secret_ref: 'env:UNUSED',
@@ -2284,7 +2299,7 @@ describe('dreamux MVP smoke', () => {
       bot,
       channelLoggerFactory: () => capture.logger,
     });
-    server.repos.dispatchers.create({
+    server.repos.dispatchers.upsert({
       dispatcher_id: 'flow',
       bot_app_id: 'app-smoke',
       bot_secret_ref: 'env:UNUSED',
@@ -2345,7 +2360,7 @@ describe('dreamux MVP smoke', () => {
     });
 
     server = buildServer({ runtimeDir, fake, bot });
-    server.repos.dispatchers.create({
+    server.repos.dispatchers.upsert({
       dispatcher_id: 'flow',
       bot_app_id: 'app-smoke',
       bot_secret_ref: 'env:UNUSED',
@@ -2371,7 +2386,7 @@ describe('dreamux MVP smoke', () => {
 
   it('process-local dedupe drops Feishu redelivery before turn and reaction', async () => {
     server = buildServer({ runtimeDir, fake, bot });
-    server.repos.dispatchers.create({
+    server.repos.dispatchers.upsert({
       dispatcher_id: 'flow',
       bot_app_id: 'app-smoke',
       bot_secret_ref: 'env:UNUSED',
@@ -2469,7 +2484,7 @@ describe('dreamux MVP smoke', () => {
     });
 
     server = buildServer({ runtimeDir, fake, bot });
-    server.repos.dispatchers.create({
+    server.repos.dispatchers.upsert({
       dispatcher_id: 'flow',
       bot_app_id: 'app-smoke',
       bot_secret_ref: 'env:UNUSED',
@@ -2492,7 +2507,7 @@ describe('dreamux MVP smoke', () => {
     });
 
     server = buildServer({ runtimeDir, fake, bot });
-    server.repos.dispatchers.create({
+    server.repos.dispatchers.upsert({
       dispatcher_id: 'flow',
       bot_app_id: 'app-smoke',
       bot_secret_ref: 'env:UNUSED',
@@ -2517,7 +2532,7 @@ describe('dreamux MVP smoke', () => {
   // before any business RPC; without it, every call comes back "Not initialized".
   it('init handshake runs before thread/start', async () => {
     server = buildServer({ runtimeDir, fake, bot });
-    server.repos.dispatchers.create({
+    server.repos.dispatchers.upsert({
       dispatcher_id: 'flow',
       bot_app_id: 'app-smoke',
       bot_secret_ref: 'env:UNUSED',
@@ -2569,7 +2584,7 @@ describe('dreamux MVP smoke', () => {
   it('concurrent startDispatcher calls coalesce — only one Codex spawn', async () => {
     const counter = { count: 0 };
     server = buildServer({ runtimeDir, fake, bot, spawnCounter: counter });
-    server.repos.dispatchers.create({
+    server.repos.dispatchers.upsert({
       dispatcher_id: 'flow',
       bot_app_id: 'app-smoke',
       bot_secret_ref: 'env:UNUSED',
@@ -2599,7 +2614,7 @@ describe('dreamux MVP smoke', () => {
       codexRestartBackoffBaseMs: 5,
       codexRestartBackoffMaxMs: 5,
     });
-    server.repos.dispatchers.create({
+    server.repos.dispatchers.upsert({
       dispatcher_id: 'flow',
       bot_app_id: 'app-smoke',
       bot_secret_ref: 'env:UNUSED',
@@ -2635,7 +2650,7 @@ describe('dreamux MVP smoke', () => {
       codexRestartBackoffBaseMs: 100,
       codexRestartBackoffMaxMs: 100,
     });
-    server.repos.dispatchers.create({
+    server.repos.dispatchers.upsert({
       dispatcher_id: 'flow',
       bot_app_id: 'app-smoke',
       bot_secret_ref: 'env:UNUSED',
@@ -2673,7 +2688,7 @@ describe('dreamux MVP smoke', () => {
       codexRestartBackoffBaseMs: 5,
       codexRestartBackoffMaxMs: 5,
     });
-    server.repos.dispatchers.create({
+    server.repos.dispatchers.upsert({
       dispatcher_id: 'flow',
       bot_app_id: 'app-smoke',
       bot_secret_ref: 'env:UNUSED',
@@ -2717,7 +2732,7 @@ describe('dreamux MVP smoke', () => {
       codexRestartBackoffBaseMs: 5,
       codexRestartBackoffMaxMs: 5,
     });
-    server.repos.dispatchers.create({
+    server.repos.dispatchers.upsert({
       dispatcher_id: 'flow',
       bot_app_id: 'app-smoke',
       bot_secret_ref: 'env:UNUSED',

--- a/packages/dreamux/tests/team-service.test.ts
+++ b/packages/dreamux/tests/team-service.test.ts
@@ -13,7 +13,7 @@ import { teamLeaderPrincipal } from '../src/dispatcher-service/teammate/types.js
 import { DispatcherStore } from '../src/state/dispatcher-store.js';
 import { resetRuntimeConfig } from '../src/platform/paths.js';
 import { createBuiltinProviderRegistry } from '../src/registry/index.js';
-import { testDreamuxConfig } from './helpers/config.js';
+import { testDispatcherConfig, testDreamuxConfig } from './helpers/config.js';
 import type {
   AgentRuntime,
   AgentRuntimeCapabilities,
@@ -113,6 +113,9 @@ class FakeProvider implements AgentRuntimeProvider {
   }
 }
 
+/** The dispatcher workspace cwd for the current test; set in beforeEach. */
+let dispatcherCwd: string;
+
 function buildServices(): {
   teams: TeamService;
   teammates: TeamMateAgentService;
@@ -120,7 +123,7 @@ function buildServices(): {
   createdGroups: Array<{ name: string; userOpenIds: string[]; chatId: string }>;
   setCreateGroupError(err: Error | null): void;
 } {
-  const config = testDreamuxConfig();
+  const config = testDreamuxConfig([testDispatcherConfig({ cwd: dispatcherCwd })]);
   const registry = createBuiltinProviderRegistry();
   const descriptor = registry.resolve('builtin:codex');
   const provider = new FakeProvider(descriptor);
@@ -164,6 +167,10 @@ describe('TeamService', () => {
     root = realpathSync(mkdtempSync(join(tmpdir(), 'dreamux-team-')));
     previousHome = process.env['HOME'];
     process.env['HOME'] = join(root, 'home');
+    // The dispatcher workspace cwd contract (issue #182 PR-4) requires an
+    // explicit, non-`~/.dreamux` workspace; managed team worktrees land under
+    // `<workspace>/.workspace/worktree/...`.
+    dispatcherCwd = join(root, 'workspace');
     resetRuntimeConfig();
   });
 

--- a/packages/dreamux/tests/teammate-agent-service.test.ts
+++ b/packages/dreamux/tests/teammate-agent-service.test.ts
@@ -1156,6 +1156,88 @@ describe('TeamMateAgentService', () => {
     expect((await readFile(gitignore, 'utf8')).split('\n')).toContain('*');
   });
 
+  it('repairs an existing unsafe .workspace/.gitignore (#182 PR-4, PR#186 P2)', async () => {
+    const repo = await initGitRepo(join(root, 'unsafe-boundary-repo'));
+    const { catalog } = providerCatalog();
+    const config = testDreamuxConfig([testDispatcherConfig({ cwd: dispatcherCwd })]);
+    const service = new TeamMateAgentService({
+      config,
+      dispatchers: new DispatcherStore(config),
+      agentRuntimeProviders: catalog,
+      log: noopLog(),
+    });
+
+    // Seed an existing boundary file that does NOT safely ignore everything: it
+    // un-ignores worktree content via a negation and has no bare `*`.
+    const boundaryDir = join(dispatcherCwd, '.workspace');
+    await mkdir(boundaryDir, { recursive: true });
+    const gitignore = join(boundaryDir, '.gitignore');
+    await writeFile(gitignore, '# keep some stuff\n!leaked\n', 'utf8');
+
+    await service.spawn({
+      dispatcherId: 'flow',
+      name: 'unsafe-boundary',
+      intent: 'work',
+      prompt: 'go',
+      cwd: repo,
+      worktree: {
+        mode: 'managed',
+        slug: 'unsafe-boundary',
+        branch: 'dreamux/unsafe-boundary',
+        cleanup: 'keep',
+      },
+    });
+
+    // The unsafe file must have been repaired to the canonical ignore-all form.
+    const lines = (await readFile(gitignore, 'utf8'))
+      .split('\n')
+      .map((line) => line.trim());
+    expect(lines).toContain('*');
+    expect(lines.some((line) => line.startsWith('!'))).toBe(false);
+  });
+
+  it('rejects a managed worktree under a workspace that symlinks into Dreamux home (#182 PR-4, PR#186 P1)', async () => {
+    const repo = await initGitRepo(join(root, 'symlink-repo'));
+    // A directory physically inside Dreamux home, reached via a workspace path
+    // that is OUTSIDE Dreamux home lexically but symlinks into it.
+    const targetUnderDreamux = join(root, 'home', '.dreamux', 'state', 'sneaky');
+    await mkdir(targetUnderDreamux, { recursive: true });
+    const symlinkedWorkspace = join(root, 'outside-link');
+    await symlink(targetUnderDreamux, symlinkedWorkspace);
+
+    const config = testDreamuxConfig([
+      testDispatcherConfig({ cwd: symlinkedWorkspace }),
+    ]);
+    const { catalog } = providerCatalog();
+    const service = new TeamMateAgentService({
+      config,
+      dispatchers: new DispatcherStore(config),
+      agentRuntimeProviders: catalog,
+      log: noopLog(),
+    });
+
+    await expect(
+      service.spawn({
+        dispatcherId: 'flow',
+        name: 'sneaky',
+        intent: 'work',
+        prompt: 'go',
+        cwd: repo,
+        worktree: {
+          mode: 'managed',
+          slug: 'sneaky',
+          branch: 'dreamux/sneaky',
+          cleanup: 'keep',
+        },
+      }),
+    ).rejects.toThrow(/must not be created under the Dreamux home/);
+
+    // And no managed worktree was physically created under Dreamux home.
+    expect(existsSync(join(targetUnderDreamux, '.workspace', 'worktree'))).toBe(
+      false,
+    );
+  });
+
   it('rejects two teammate identities using the same explicit managed slug', async () => {
     const repo = await initGitRepo(join(root, 'same-slug-repo'));
     const { catalog } = providerCatalog();

--- a/packages/dreamux/tests/teammate-agent-service.test.ts
+++ b/packages/dreamux/tests/teammate-agent-service.test.ts
@@ -24,6 +24,8 @@ import { TeamMateAgentService } from '../src/dispatcher-service/teammate/service
 import { DispatcherStore } from '../src/state/dispatcher-store.js';
 import {
   dispatcherCompletionSpillDir,
+  dispatcherTeamMateIdentitiesDir,
+  dispatcherTeamMateIdentityPath,
   resetRuntimeConfig,
 } from '../src/platform/paths.js';
 import { createBuiltinProviderRegistry } from '../src/registry/index.js';
@@ -155,8 +157,15 @@ function providerCatalog(): {
   };
 }
 
+/**
+ * The dispatcher workspace cwd for the current test (issue #182 PR-4); set in
+ * beforeEach to a non-`~/.dreamux` directory so managed worktrees land under
+ * `<workspace>/.workspace/worktree/...`. reuse-cwd tests ignore it.
+ */
+let dispatcherCwd: string;
+
 function buildService(provider: AgentRuntimeProvider): TeamMateAgentService {
-  const config = testDreamuxConfig();
+  const config = testDreamuxConfig([testDispatcherConfig({ cwd: dispatcherCwd })]);
   const dispatchers = new DispatcherStore(config);
   const registry = createBuiltinProviderRegistry();
   const descriptor = registry.resolve('builtin:codex');
@@ -184,6 +193,7 @@ describe('TeamMateAgentService', () => {
     root = realpathSync(mkdtempSync(join(tmpdir(), 'dreamux-teammate-agent-')));
     previousHome = process.env['HOME'];
     process.env['HOME'] = join(root, 'home');
+    dispatcherCwd = join(root, 'workspace');
     resetRuntimeConfig();
   });
 
@@ -376,7 +386,7 @@ describe('TeamMateAgentService', () => {
 
   it('spawns a named resumable teammate and records raw history events', async () => {
     const { catalog, provider } = providerCatalog();
-    const config = testDreamuxConfig();
+    const config = testDreamuxConfig([testDispatcherConfig({ cwd: dispatcherCwd })]);
     const service = new TeamMateAgentService({
       config,
       dispatchers: new DispatcherStore(config),
@@ -471,7 +481,7 @@ describe('TeamMateAgentService', () => {
   it('returns a bounded session ledger with worktree metadata and filters', async () => {
     const repo = await initGitRepo(join(root, 'ledger-repo'));
     const { catalog } = providerCatalog();
-    const config = testDreamuxConfig();
+    const config = testDreamuxConfig([testDispatcherConfig({ cwd: dispatcherCwd })]);
     const service = new TeamMateAgentService({
       config,
       dispatchers: new DispatcherStore(config),
@@ -557,7 +567,7 @@ describe('TeamMateAgentService', () => {
 
   it('closes a live teammate without deleting its history', async () => {
     const { catalog } = providerCatalog();
-    const config = testDreamuxConfig();
+    const config = testDreamuxConfig([testDispatcherConfig({ cwd: dispatcherCwd })]);
     const service = new TeamMateAgentService({
       config,
       dispatchers: new DispatcherStore(config),
@@ -604,7 +614,7 @@ describe('TeamMateAgentService', () => {
 
   it('send reopens a closed teammate from its checkpoint (issue #155)', async () => {
     const { catalog, provider } = providerCatalog();
-    const config = testDreamuxConfig();
+    const config = testDreamuxConfig([testDispatcherConfig({ cwd: dispatcherCwd })]);
     const service = new TeamMateAgentService({
       config,
       dispatchers: new DispatcherStore(config),
@@ -648,7 +658,7 @@ describe('TeamMateAgentService', () => {
 
   it('send updates the recorded intent when supplied, and leaves it unchanged otherwise (#182 PR-3)', async () => {
     const { catalog } = providerCatalog();
-    const config = testDreamuxConfig();
+    const config = testDreamuxConfig([testDispatcherConfig({ cwd: dispatcherCwd })]);
     const service = new TeamMateAgentService({
       config,
       dispatchers: new DispatcherStore(config),
@@ -695,7 +705,7 @@ describe('TeamMateAgentService', () => {
 
   it('rejects direct service spawn/close with missing or empty intent/note (#182 PR-3 P1)', async () => {
     const { catalog } = providerCatalog();
-    const config = testDreamuxConfig();
+    const config = testDreamuxConfig([testDispatcherConfig({ cwd: dispatcherCwd })]);
     const service = new TeamMateAgentService({
       config,
       dispatchers: new DispatcherStore(config),
@@ -733,7 +743,7 @@ describe('TeamMateAgentService', () => {
 
   it('fails loud when spawned with an agentRuntime that matches no agent', async () => {
     const { catalog } = providerCatalog();
-    const config = testDreamuxConfig();
+    const config = testDreamuxConfig([testDispatcherConfig({ cwd: dispatcherCwd })]);
     const service = new TeamMateAgentService({
       config,
       dispatchers: new DispatcherStore(config),
@@ -754,7 +764,7 @@ describe('TeamMateAgentService', () => {
 
   it('requires cwd for native teammate spawn', async () => {
     const { catalog } = providerCatalog();
-    const config = testDreamuxConfig();
+    const config = testDreamuxConfig([testDispatcherConfig({ cwd: dispatcherCwd })]);
     const service = new TeamMateAgentService({
       config,
       dispatchers: new DispatcherStore(config),
@@ -773,7 +783,7 @@ describe('TeamMateAgentService', () => {
 
   it('reads old identities without owner as dispatcher-owned until mutated', async () => {
     const { catalog } = providerCatalog();
-    const config = testDreamuxConfig();
+    const config = testDreamuxConfig([testDispatcherConfig({ cwd: dispatcherCwd })]);
     const service = new TeamMateAgentService({
       config,
       dispatchers: new DispatcherStore(config),
@@ -828,7 +838,7 @@ describe('TeamMateAgentService', () => {
   it('prepares managed worktrees, persists metadata, and deletes clean worktrees on close', async () => {
     const repo = await initGitRepo(join(root, 'repo'));
     const { catalog, provider } = providerCatalog();
-    const config = testDreamuxConfig();
+    const config = testDreamuxConfig([testDispatcherConfig({ cwd: dispatcherCwd })]);
     const service = new TeamMateAgentService({
       config,
       dispatchers: new DispatcherStore(config),
@@ -882,7 +892,7 @@ describe('TeamMateAgentService', () => {
     const linked = join(root, 'linked-repo');
     await symlink(repo, linked);
     const { catalog } = providerCatalog();
-    const config = testDreamuxConfig();
+    const config = testDreamuxConfig([testDispatcherConfig({ cwd: dispatcherCwd })]);
     const service = new TeamMateAgentService({
       config,
       dispatchers: new DispatcherStore(config),
@@ -905,7 +915,7 @@ describe('TeamMateAgentService', () => {
   it('recreates a deleted managed worktree when send reopens a closed teammate', async () => {
     const repo = await initGitRepo(join(root, 'reopen-repo'));
     const { catalog, provider } = providerCatalog();
-    const config = testDreamuxConfig();
+    const config = testDreamuxConfig([testDispatcherConfig({ cwd: dispatcherCwd })]);
     const service = new TeamMateAgentService({
       config,
       dispatchers: new DispatcherStore(config),
@@ -954,7 +964,7 @@ describe('TeamMateAgentService', () => {
   it('marks intentionally retained managed worktrees as kept on close', async () => {
     const repo = await initGitRepo(join(root, 'kept-repo'));
     const { catalog } = providerCatalog();
-    const config = testDreamuxConfig();
+    const config = testDreamuxConfig([testDispatcherConfig({ cwd: dispatcherCwd })]);
     const service = new TeamMateAgentService({
       config,
       dispatchers: new DispatcherStore(config),
@@ -988,7 +998,7 @@ describe('TeamMateAgentService', () => {
   it('retains dirty managed worktrees on close', async () => {
     const repo = await initGitRepo(join(root, 'dirty-repo'));
     const { catalog } = providerCatalog();
-    const config = testDreamuxConfig();
+    const config = testDreamuxConfig([testDispatcherConfig({ cwd: dispatcherCwd })]);
     const service = new TeamMateAgentService({
       config,
       dispatchers: new DispatcherStore(config),
@@ -1023,7 +1033,7 @@ describe('TeamMateAgentService', () => {
   it('retains clean detached managed worktrees with unique commits', async () => {
     const repo = await initGitRepo(join(root, 'detached-repo'));
     const { catalog } = providerCatalog();
-    const config = testDreamuxConfig();
+    const config = testDreamuxConfig([testDispatcherConfig({ cwd: dispatcherCwd })]);
     const service = new TeamMateAgentService({
       config,
       dispatchers: new DispatcherStore(config),
@@ -1061,11 +1071,14 @@ describe('TeamMateAgentService', () => {
     expect(existsSync(worktreePath)).toBe(true);
   });
 
-  it('rejects a managed path that exists for a different source repository', async () => {
+  it('disambiguates the same managed slug across different source repos (#182 PR-4)', async () => {
+    // Repo-disambiguation: two different source repos that share an inner slug
+    // must map to DISTINCT managed worktrees (under distinct repo-slug dirs),
+    // not collide at one path. This is the cross-repo uniqueness contract.
     const firstRepo = await initGitRepo(join(root, 'slug-a'));
     const secondRepo = await initGitRepo(join(root, 'slug-b'));
     const { catalog } = providerCatalog();
-    const config = testDreamuxConfig();
+    const config = testDreamuxConfig([testDispatcherConfig({ cwd: dispatcherCwd })]);
     const service = new TeamMateAgentService({
       config,
       dispatchers: new DispatcherStore(config),
@@ -1073,7 +1086,7 @@ describe('TeamMateAgentService', () => {
       log: noopLog(),
     });
 
-    await service.spawn({
+    const first = await service.spawn({
       dispatcherId: 'flow',
       name: 'first-slug',
       intent: 'work',
@@ -1086,27 +1099,67 @@ describe('TeamMateAgentService', () => {
         cleanup: 'keep',
       },
     });
-    await expect(
-      service.spawn({
-        dispatcherId: 'flow',
-        name: 'second-slug',
-        intent: 'work',
-        prompt: 'go',
-        cwd: secondRepo,
-        worktree: {
-          mode: 'managed',
-          slug: 'shared-slug',
-          branch: 'dreamux/shared-slug',
-          cleanup: 'keep',
-        },
-      }),
-    ).rejects.toThrow(/not registered for source repo|already owned/);
+    const second = await service.spawn({
+      dispatcherId: 'flow',
+      name: 'second-slug',
+      intent: 'work',
+      prompt: 'go',
+      cwd: secondRepo,
+      worktree: {
+        mode: 'managed',
+        slug: 'shared-slug',
+        branch: 'dreamux/shared-slug',
+        cleanup: 'keep',
+      },
+    });
+
+    const firstPath = first.teammate.worktree.path;
+    const secondPath = second.teammate.worktree.path;
+    expect(firstPath).not.toBe(secondPath);
+    // Both live under the dispatcher workspace boundary, never under ~/.dreamux.
+    const boundary = join(dispatcherCwd, '.workspace', 'worktree');
+    expect(firstPath.startsWith(boundary)).toBe(true);
+    expect(secondPath.startsWith(boundary)).toBe(true);
+    // Same inner slug, different repo-disambiguated parent dir.
+    expect(join(firstPath, '..')).not.toBe(join(secondPath, '..'));
+    expect(existsSync(firstPath)).toBe(true);
+    expect(existsSync(secondPath)).toBe(true);
+  });
+
+  it('self-ignores the .workspace boundary so managed worktrees are not repo content (#182 PR-4)', async () => {
+    const repo = await initGitRepo(join(root, 'boundary-repo'));
+    const { catalog } = providerCatalog();
+    const config = testDreamuxConfig([testDispatcherConfig({ cwd: dispatcherCwd })]);
+    const service = new TeamMateAgentService({
+      config,
+      dispatchers: new DispatcherStore(config),
+      agentRuntimeProviders: catalog,
+      log: noopLog(),
+    });
+
+    await service.spawn({
+      dispatcherId: 'flow',
+      name: 'boundary',
+      intent: 'work',
+      prompt: 'go',
+      cwd: repo,
+      worktree: {
+        mode: 'managed',
+        slug: 'boundary',
+        branch: 'dreamux/boundary',
+        cleanup: 'keep',
+      },
+    });
+
+    const gitignore = join(dispatcherCwd, '.workspace', '.gitignore');
+    expect(existsSync(gitignore)).toBe(true);
+    expect((await readFile(gitignore, 'utf8')).split('\n')).toContain('*');
   });
 
   it('rejects two teammate identities using the same explicit managed slug', async () => {
     const repo = await initGitRepo(join(root, 'same-slug-repo'));
     const { catalog } = providerCatalog();
-    const config = testDreamuxConfig();
+    const config = testDreamuxConfig([testDispatcherConfig({ cwd: dispatcherCwd })]);
     const service = new TeamMateAgentService({
       config,
       dispatchers: new DispatcherStore(config),
@@ -1146,7 +1199,7 @@ describe('TeamMateAgentService', () => {
 
   it('fails loud on a legacy provider_ref teammate identity (pre-#148)', async () => {
     const { catalog } = providerCatalog();
-    const config = testDreamuxConfig();
+    const config = testDreamuxConfig([testDispatcherConfig({ cwd: dispatcherCwd })]);
     const service = new TeamMateAgentService({
       config,
       dispatchers: new DispatcherStore(config),
@@ -1189,9 +1242,75 @@ describe('TeamMateAgentService', () => {
     ).rejects.toThrow(/legacy provider_ref format/);
   });
 
+  it('reads a legacy under-state managed worktree path verbatim (#182 PR-4)', async () => {
+    // A teammate identity persisted before the worktree relocation carries a
+    // managed worktree.path under `~/.dreamux/state/.../worktrees/`. The reader
+    // must surface that legacy path UNCHANGED — never rewrite it to the new
+    // `.workspace/worktree/...` layout and never delete the old location.
+    const { catalog } = providerCatalog();
+    const config = testDreamuxConfig([testDispatcherConfig({ cwd: dispatcherCwd })]);
+    const service = new TeamMateAgentService({
+      config,
+      dispatchers: new DispatcherStore(config),
+      agentRuntimeProviders: catalog,
+      log: noopLog(),
+    });
+    const legacyWorktreePath = join(
+      root,
+      'home',
+      '.dreamux',
+      'state',
+      'flow',
+      'teammate',
+      'worktrees',
+      'legacy-mate',
+    );
+    await mkdir(dispatcherTeamMateIdentitiesDir('flow'), { recursive: true });
+    await writeFile(
+      dispatcherTeamMateIdentityPath('flow', 'legacy-mate'),
+      JSON.stringify({
+        version: 1,
+        dispatcher_id: 'flow',
+        name: 'legacy-mate',
+        owner: { kind: 'dispatcher', dispatcher_id: 'flow' },
+        role: 'teammate',
+        team_id: null,
+        agent_runtime: 'flow',
+        source_cwd: root,
+        source_repo: root,
+        cwd: legacyWorktreePath,
+        runtime_cwd: legacyWorktreePath,
+        worktree: {
+          mode: 'managed',
+          slug: 'legacy-mate',
+          path: legacyWorktreePath,
+          branch: 'dreamux/legacy-mate',
+          base_ref: 'HEAD',
+          cleanup: 'keep',
+          cleanup_state: 'managed-active',
+          cleanup_error: null,
+        },
+        intent: 'legacy work',
+        created_at: 1,
+        updated_at: 1,
+        status: 'closed',
+        checkpoint: null,
+        last_error: null,
+        closed_at: 2,
+        close_note: 'archived',
+      }),
+      { mode: 0o600 },
+    );
+
+    const status = await service.status('flow', 'legacy-mate');
+    expect(status.worktree.mode).toBe('managed');
+    expect(status.worktree.path).toBe(legacyWorktreePath);
+    expect(status.runtime_cwd).toBe(legacyWorktreePath);
+  });
+
   it('does not wire the settle hook when no completion sink is configured', async () => {
     const { catalog, provider } = providerCatalog();
-    const config = testDreamuxConfig();
+    const config = testDreamuxConfig([testDispatcherConfig({ cwd: dispatcherCwd })]);
     const service = new TeamMateAgentService({
       config,
       dispatchers: new DispatcherStore(config),
@@ -1210,7 +1329,7 @@ describe('TeamMateAgentService', () => {
 
   it('delivers a settled teammate turn upward as a completion envelope', async () => {
     const { catalog, provider } = providerCatalog();
-    const config = testDreamuxConfig();
+    const config = testDreamuxConfig([testDispatcherConfig({ cwd: dispatcherCwd })]);
     const received: Array<{ id: string; name: string; env: CompletionEnvelope }> = [];
     const service = new TeamMateAgentService({
       config,
@@ -1250,7 +1369,7 @@ describe('TeamMateAgentService', () => {
 
   it('delivers terminal failure/stop settlements with their own status', async () => {
     const { catalog, provider } = providerCatalog();
-    const config = testDreamuxConfig();
+    const config = testDreamuxConfig([testDispatcherConfig({ cwd: dispatcherCwd })]);
     const received: CompletionEnvelope[] = [];
     const service = new TeamMateAgentService({
       config,
@@ -1292,7 +1411,7 @@ describe('TeamMateAgentService', () => {
 
   it('drops null-turn settlements rather than fabricating a completion id', async () => {
     const { catalog, provider } = providerCatalog();
-    const config = testDreamuxConfig();
+    const config = testDreamuxConfig([testDispatcherConfig({ cwd: dispatcherCwd })]);
     const received: CompletionEnvelope[] = [];
     const service = new TeamMateAgentService({
       config,
@@ -1320,7 +1439,7 @@ describe('TeamMateAgentService', () => {
 
   it('delivers concurrent teammate completions without dropping any', async () => {
     const { catalog, provider } = providerCatalog();
-    const config = testDreamuxConfig();
+    const config = testDreamuxConfig([testDispatcherConfig({ cwd: dispatcherCwd })]);
     const received: CompletionEnvelope[] = [];
     const service = new TeamMateAgentService({
       config,

--- a/packages/dreamux/tests/teammate-completion-delivery.test.ts
+++ b/packages/dreamux/tests/teammate-completion-delivery.test.ts
@@ -15,10 +15,10 @@ import {
 } from '../src/agent-runtime/index.js';
 import { createFakeFeishuBot } from '../src/channel/feishu/bot.js';
 import { DispatcherAgentService } from '../src/dispatcher-service/dispatcher/service.js';
-import { resetRuntimeConfig } from '../src/platform/paths.js';
+import { defaultDispatcherCwd, resetRuntimeConfig } from '../src/platform/paths.js';
 import { createBuiltinProviderRegistry } from '../src/registry/index.js';
 import { DispatcherStore } from '../src/state/dispatcher-store.js';
-import { testDreamuxConfig } from './helpers/config.js';
+import { testDispatcherConfig, testDreamuxConfig } from './helpers/config.js';
 
 const CAPABILITIES: AgentRuntimeCapabilities = {
   resume: { supported: true, checkpoint: 'codexThread' },
@@ -102,7 +102,7 @@ function buildService(
   behavior: DeliveryBehavior,
   adminSocketPath: string,
 ): DispatcherAgentService {
-  const config = testDreamuxConfig();
+  const config = testDreamuxConfig([testDispatcherConfig({ cwd: defaultDispatcherCwd('flow') })]);
   const registry = createBuiltinProviderRegistry();
   const descriptor = registry.resolve('builtin:codex');
   registry.registerImplementation(

--- a/packages/dreamux/tests/teammate-completion-e2e.test.ts
+++ b/packages/dreamux/tests/teammate-completion-e2e.test.ts
@@ -26,7 +26,7 @@ import { teamLeaderPrincipal } from '../src/dispatcher-service/teammate/types.js
 import { resetRuntimeConfig } from '../src/platform/paths.js';
 import { createBuiltinProviderRegistry } from '../src/registry/index.js';
 import { DispatcherStore } from '../src/state/dispatcher-store.js';
-import { testDreamuxConfig } from './helpers/config.js';
+import { testDispatcherConfig, testDreamuxConfig } from './helpers/config.js';
 
 const FAKE_CAPABILITIES: AgentRuntimeCapabilities = {
   resume: { supported: true, checkpoint: 'codexThread' },
@@ -155,11 +155,18 @@ class FakeProvider implements AgentRuntimeProvider {
   }
 }
 
+/**
+ * Dispatcher workspace cwd for the current test (issue #182 PR-4); set in
+ * beforeEach to the per-test `workspace/` dir (a real, non-`~/.dreamux` repo)
+ * so managed team worktrees land under `<workspace>/.workspace/worktree/...`.
+ */
+let dispatcherCwd: string;
+
 function buildFacade(
   provider: FakeProvider,
   adminSocketPath: string,
 ): DispatcherService {
-  const config = testDreamuxConfig();
+  const config = testDreamuxConfig([testDispatcherConfig({ cwd: dispatcherCwd })]);
   const registry = createBuiltinProviderRegistry();
   const descriptor = registry.resolve('builtin:codex');
   registry.registerImplementation(descriptor.id, provider);
@@ -183,6 +190,7 @@ describe('reverse delivery end-to-end (Seam ①→②→③ through the facade)'
   beforeEach(async () => {
     root = mkdtempSync(join(tmpdir(), 'dx-reverse-e2e-'));
     await mkdir(join(root, 'workspace'));
+    dispatcherCwd = join(root, 'workspace');
     adminSocketPath = join(root, 'a.sock');
     previousHome = process.env['HOME'];
     process.env['HOME'] = join(root, 'home');


### PR DESCRIPTION
## 目标（#182 PR-4）

将 Dreamux 托管的 TeamMate/Team worktree 迁出 `~/.dreamux`，并把 dispatcher 工作目录（cwd）契约提升到服务启动与 doctor 层。

Reviewer gate（issue 更新）：https://github.com/excitedjs/dreamux/issues/182#issuecomment-4677089342

## 改动

**托管 worktree 重新落位**
- 新位置：`<dispatcher-cwd>/.workspace/worktree/<repo-slug>/<slug>/`，不再位于 `~/.dreamux/state/<id>/teammate/worktrees/`。
- `repo-slug = <sanitized-basename>-<sha256(repo-root):12>`，保证同名仓库在跨仓库 / Team / TeamMate 使用下互不冲突；同仓库同 slug 的冲突仍由 `assertManagedWorktreeAvailable` 捕获。
- `.workspace/` 写入 `*` 的 `.gitignore` 自忽略，托管 worktree 永不成为仓库内容。
- 若 workspace 解析到 `~/.dreamux` 下，托管 worktree 创建直接 fail loud。

**dispatcher 工作目录 cwd 契约**
- 每个 dispatcher 必须显式声明 `cwd`；`dreamux serve` 启动时对所有 enabled dispatcher 做预检，缺失即 fail loud（聚合所有失败）——不再回退到 state 目录。
- 配置了但目录不存在 → mkdir -p 创建；不是目录 / 不可读写 → fail loud。
- `dreamux doctor` 增加 `dispatcher <id> workspace` 诊断（非抛错）。
- dispatcher agent 启动 cwd 由 `ensureDispatcherWorkspace` 提供（移除 `config.cwd ?? defaultDispatcherCwd(id)` 回退）。

**兼容与边界**
- reuse-cwd teammate 行为不变，且不触发 cwd 契约。
- 旧身份记录中指向旧 under-state worktree 路径的，按原样读取——不重写、不删除。
- cleanup/dissolve 仍是 git 边界内的 `git worktree remove`，不越界删除。

## 新增/改动文件

- 新增 `dispatcher-service/dispatcher-workspace.ts`（configured/ensure/diagnose cwd）
- 新增 `dispatcher-service/teammate/worktree-paths.ts`（repo 消歧的托管 worktree 路径构造器）
- `platform/paths.ts`：新增 `isUnderDreamuxRoot`；移除失效的 worktree 路径构造器
- `server.ts` 启动预检 + `cli/doctor.ts` 诊断 + dispatcher/teammate/team 服务接线

## 测试

- 新增 `tests/dispatcher-workspace.test.ts`：cwd 契约（缺失拒绝 / mkdir-p / 非目录 / 不可用拒绝）、doctor 诊断、`Server.start()` fail-loud（含多 dispatcher 聚合）、`isUnderDreamuxRoot`、路径构造器（跨仓库消歧 / 长名与非法字符净化）
- `teammate-agent-service.test.ts`：跨仓库同 slug 消歧落位、`.workspace/.gitignore` 自忽略、旧 under-state worktree 路径原样读取
- 更新 team-service / smoke / e2e / completion-delivery / completion-e2e / doctor 的配置以提供显式 cwd
- 全量：`652 passed | 2 skipped`（2 个为 live-codex 跳过），`tsc` build OK，`eslint` clean

## Changelog / 文档

- rush change note（`BREAKING:` + `Rebuild:` 指南）
- `.agents/decisions/top-level-design.md`、根 `CLAUDE.md`、`dispatcher-service/CLAUDE.md` 同步更新；`.agents` check 通过

## 明确不在本 PR 范围

PR-5 session ledger、PR-6 list/status/history 读面、PR-7 Team MCP 清理、logs/retention。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
