### PR TITLE
chore(mcp): #182 收尾清理 — 退场 create_group + 移除只写的 per-name history 索引 (PR-8)

### DIFF
--- a/.agents/components/dispatcher-skill.md
+++ b/.agents/components/dispatcher-skill.md
@@ -19,10 +19,14 @@ ships in the npm package:
   ([provider architecture realignment](../decisions/provider-architecture-realignment.md)).
 - `team-dev-workflow` covers multi-teammate review, design, merge, and unblock
   coordination.
-- `team` MCP is injected for dispatcher-only Team Mode lifecycle: create a
-  TeamLeader, create and bind a Feishu group from a P2P control request, read
-  Team status/ledger, bind or transfer back Feishu group channels, and dissolve
-  a Team. TeamLeader member work still uses the caller-scoped TeamMate MCP.
+- `team` MCP is injected for dispatcher-only Team Mode lifecycle, addressed by
+  Team name (issue #182 PR-7/PR-8): `create` a TeamLeader (optionally binding an
+  EXISTING Feishu group via `bind_group: { chat_id }`), inspect with `list`
+  (compact rows) / `status` (one Team's detail incl. active bound group) /
+  `history` (filterable recovery search), `bind_group` an existing group or
+  `transfer_channel_back`, and `dissolve` a Team. The `create_group`
+  (create-a-new-group) and raw `ledger` verbs were retired. TeamLeader member
+  work still uses the caller-scoped TeamMate MCP.
 - `dreamux-maintenance` covers installed Dreamux diagnosis and safe operation.
 
 They are not installed through Codex plugin marketplaces. `dreamux onboard` and

--- a/.agents/decisions/provider-architecture-realignment.md
+++ b/.agents/decisions/provider-architecture-realignment.md
@@ -120,9 +120,11 @@ see its `verbs/` (spawn/resume/history), `persistence/history-index.ts` and
 - **Identity and state location.** A teammate is a flat name plus a base record
   (agent runtime id, dispatcher owner, source/runtime cwd, optional managed
   worktree metadata, checkpoint, status, close metadata). State is server-owned
-  under `~/.dreamux/state/<dispatcher>/teammate/` with `identities/`,
-  `history/`, `runtime/`, and managed `worktrees/` subtrees; paths go through
-  `/packages/dreamux/src/platform/paths.ts`.
+  under `~/.dreamux/state/<dispatcher>/teammate/` with `identities/`, `runtime/`,
+  and managed `worktrees/` subtrees plus the per-dispatcher `sessions.jsonl`
+  recovery ledger; paths go through `/packages/dreamux/src/platform/paths.ts`.
+  (The per-name `history/<name>.jsonl` index was removed in issue #182 PR-8 — the
+  session ledger is the single durable recovery record; see top-level-design.)
 - **Ownership.** The Dispatcher Service owns TeamMate identity and history
   through focused modules under
   `/packages/dreamux/src/dispatcher-service/teammate/`.

--- a/.agents/decisions/top-level-design.md
+++ b/.agents/decisions/top-level-design.md
@@ -248,8 +248,6 @@ State and logs are server-owned. They are not operator-editable config.
       teammate/
         identities/
           <name>.json          one TeamMate identity/checkpoint per file
-        history/
-          <name>.jsonl         forward-only TeamMate lifecycle history
         sessions.jsonl         per-dispatcher session ledger (issue #182 PR-5)
         runtime/
           <name>/              runtime-private socket/config state
@@ -709,11 +707,10 @@ the TeamMate name a concrete, never-reused address:
 ## Team Mode Core
 
 Issue #171 starts Team Mode. Dispatcher runtimes receive a `team` MCP server for
-dispatcher-only team lifecycle: `create`, `create_group`, `list`, `status`,
-`history`, `bind_group`, `transfer_channel_back`, and `dissolve`. `create`
-requires `repo_cwd`, `leader_agent_runtime`, and `intent` (issue #182 PR-3 — the
-same `intent` requirement applies to `create_group`); `dissolve` requires
-`note`. Dreamux does not infer a default TeamLeader runtime.
+dispatcher-only team lifecycle: `create`, `list`, `status`, `history`,
+`bind_group`, `transfer_channel_back`, and `dissolve`. `create` requires
+`repo_cwd`, `leader_agent_runtime`, and `intent` (issue #182 PR-3); `dissolve`
+requires `note`. Dreamux does not infer a default TeamLeader runtime.
 
 Issue #182 PR-7 aligned the Team read/binding surface with the TeamMate
 read-surface model: the public surface is addressed by **Team name** (the
@@ -726,9 +723,19 @@ mirroring the TeamMate `history`, while the raw lifecycle event timeline stays
 an internal/debug ledger; and `bind_channel` is simplified to `bind_group`
 (Team name + `chat_id`, group-only — the redundant `chat_type` is gone from the
 public surface, since the binding store rejects non-group anyway).
-`transfer_channel_back` likewise drops `chat_type`. (`create_group` — create a
-brand-new Feishu group from a P2P control channel — is retained for now; its
-retirement is tracked as a follow-up.)
+`transfer_channel_back` likewise drops `chat_type`.
+
+Issue #182 PR-8 (the epic's final cleanup) retired `create_group` — the
+create-a-brand-new-Feishu-group-and-invite-users tool — from the public Team MCP
+surface, capabilities, and docs. Its binding role is replaced by an optional
+`create.bind_group: { chat_id }` that binds an EXISTING group at create time
+through the same `ChannelBindingStore` path; the generic Feishu
+`bot.createGroup` transport primitive and the dispatcher's group-create wiring
+were removed with it. The same PR removed the write-only per-name TeamMate
+history index (`state/<id>/teammate/history/<name>.jsonl` plus
+`appendHistory`/`TeamMateIdentityStore.history()`): after PR-6 the durable
+session ledger (`sessions.jsonl`) is the single recovery record, so the per-name
+index had no readers and only added files.
 
 A TeamLeader is a TeamMate identity with `role:
 "team_leader"` and dispatcher owner. Team-owned members are normal TeamMate
@@ -749,13 +756,14 @@ active bindings back before closing the team. TeamLeader Feishu MCP calls carry
 their server-derived team principal and can reply/react only in bound team
 channels; the dispatcher keeps the global Feishu management surface.
 
-From a P2P control channel, `team.create_group` can create a Team, ask the
-shared dispatcher Feishu bot to create a new group and invite the requester /
-specified peers, then bind that new group to the TeamLeader through the same
-ChannelBindingStore path. The source P2P channel is never bound or transferred:
-it remains the dispatcher control plane. TeamLeaders do not get independent
-Feishu identities or credentials; they are internal AgentRuntime roles behind
-the dispatcher-owned shared bot.
+A Team binds to an EXISTING Feishu group chat — at create time via
+`create.bind_group: { chat_id }`, or later via `team.bind_group` — through the
+`ChannelBindingStore` path; bindings are group-only. (Issue #182 PR-8 retired the
+older `create_group` flow that created a brand-new group and invited users.)
+A dispatcher's P2P control channel is never bound or transferred: it remains the
+dispatcher control plane. TeamLeaders do not get independent Feishu identities or
+credentials; they are internal AgentRuntime roles behind the dispatcher-owned
+shared bot.
 
 ## Reaction Ownership
 

--- a/common/changes/@excitedjs/dreamux/epic182-pr8-final-cleanup_2026-06-11-21-00.json
+++ b/common/changes/@excitedjs/dreamux/epic182-pr8-final-cleanup_2026-06-11-21-00.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "BREAKING: Final #182 cleanup — retire the public `team.create_group` tool and remove the write-only per-name TeamMate history index (issue #182 PR-8). (1) `team.create_group` (create a brand-new Feishu group and invite users) is removed from the Team MCP tool list, capabilities, admin methods, and docs. Its binding role is replaced by an optional `team.create` argument `bind_group: { chat_id }` that binds an EXISTING Feishu group chat to the new Team at create time; a standalone `team.bind_group` still binds an existing group later. The dreamux-side group-creation plumbing (TeamService.createGroup, the dispatcher's createFeishuGroup wiring, and the channel bot's createGroup method) was removed with it. (2) The per-name TeamMate history index `~/.dreamux/state/<dispatcher-id>/teammate/history/<name>.jsonl` is no longer written or read: since PR-6 the durable session ledger `sessions.jsonl` is the single recovery record (list/status/history/last all read it), so the per-name index had no readers and only added files. `appendHistory`, `TeamMateIdentityStore.history()`, the per-name path builder, and the `TeamMateHistoryEvent` types were removed. Rebuild: none required for stored state — Team records, channel bindings, and the session ledger load unchanged. Existing `teammate/history/<name>.jsonl` files become unused and may be deleted manually. Any saved automation or prompt that called `team.create_group` must switch to `team.create` with `bind_group` (binding an existing group); creating a brand-new Feishu group from the Team MCP is no longer supported.",
+      "type": "minor",
+      "packageName": "@excitedjs/dreamux"
+    }
+  ],
+  "packageName": "@excitedjs/dreamux",
+  "email": "053700@gmail.com"
+}

--- a/packages/dreamux/skills/dispatcher/SKILL.md
+++ b/packages/dreamux/skills/dispatcher/SKILL.md
@@ -72,11 +72,10 @@ do not inspect the target repo directly from the dispatcher.
 
 - `create` — create a Team and TeamLeader. Requires `repo_cwd`,
   `leader_agent_runtime`, and `intent` (the Team's recovery subject); no default
-  leader runtime is inferred.
-- `create_group` — from a P2P control channel, create a Team, create a Feishu
-  group, invite the requester/peers when Feishu permissions allow it, and bind
-  the new group to the TeamLeader. Requires `intent`, same as `create`. The
-  source P2P remains with the dispatcher.
+  leader runtime is inferred. Optionally pass `bind_group: { chat_id }` to bind
+  an EXISTING Feishu group chat to the new Team at create time. (The former
+  `create_group` tool — create a brand-new Feishu group and invite users — was
+  retired; bind an existing group instead.)
 - `list` — compact scan rows for current Teams (name, status, intent, repo
   signal, leader name/state, member count, bound group marker, timestamps). Keep
   it cheap and scannable; reach for `status` for detail.

--- a/packages/dreamux/src/admin/methods.ts
+++ b/packages/dreamux/src/admin/methods.ts
@@ -263,6 +263,7 @@ export const adminMethods: Record<string, AdminHandler> = {
     // Required recovery subject (issue #182 PR-3).
     const intent = mustNonEmptyString(params, 'intent');
     const prompt = optionalString(params, 'prompt');
+    const bindGroup = optionalBindGroup(params, 'bind_group');
     try {
       return await server.dispatcherService.createTeam({
         dispatcherId: id,
@@ -272,6 +273,7 @@ export const adminMethods: Record<string, AdminHandler> = {
         intent,
         ...(worktree !== null ? { worktree } : {}),
         ...(prompt !== null ? { prompt } : {}),
+        ...(bindGroup !== null ? { bindGroup } : {}),
       });
     } catch (err) {
       throw new AdminError('TEAM_CREATE_FAILED', parseMessage(err));
@@ -329,25 +331,6 @@ export const adminMethods: Record<string, AdminHandler> = {
       provider: 'builtin:feishu',
       chatId: mustString(params, 'chat_id'),
       chatType: 'group',
-    });
-  },
-
-  'mcp.team.create_group': async (server, params) => {
-    const id = mustDispatcherId(params);
-    mustExistingDispatcher(server, id);
-    return server.dispatcherService.createTeamGroup({
-      dispatcherId: id,
-      name: mustString(params, 'name'),
-      repoCwd: mustString(params, 'repo_cwd'),
-      leaderAgentRuntime: mustString(params, 'leader_agent_runtime'),
-      sourceChatId: mustString(params, 'source_chat_id'),
-      sourceChatType: mustString(params, 'source_chat_type') === 'p2p' ? 'p2p' : 'group',
-      requesterOpenId: mustString(params, 'requester_open_id'),
-      // Required recovery subject — same contract as team.create (issue #182 PR-3).
-      intent: mustNonEmptyString(params, 'intent'),
-      ...optionalMappedStringProp(params ?? {}, 'group_name', 'groupName'),
-      ...optionalStringProp(params ?? {}, 'prompt'),
-      inviteOpenIds: optionalStringArray(params, 'invite_open_ids') ?? [],
     });
   },
 
@@ -589,6 +572,23 @@ function optionalCloseStatus(
   throw new AdminError('BAD_REQUEST', `param '${key}' must be open or closed`);
 }
 
+function optionalBindGroup(
+  params: Record<string, unknown> | undefined,
+  key: string,
+): { chatId: string } | null {
+  if (params === undefined) return null;
+  const value = params[key];
+  if (value === undefined || value === null) return null;
+  if (typeof value !== 'object' || Array.isArray(value)) {
+    throw new AdminError('BAD_REQUEST', `param '${key}' must be an object`);
+  }
+  const chatId = (value as Record<string, unknown>)['chat_id'];
+  if (typeof chatId !== 'string' || chatId === '') {
+    throw new AdminError('BAD_REQUEST', `param '${key}.chat_id' must be a non-empty string`);
+  }
+  return { chatId };
+}
+
 function optionalTeamStatus(
   params: Record<string, unknown> | undefined,
   key: string,
@@ -615,34 +615,12 @@ function optionalInteger(
   return value as number;
 }
 
-function optionalStringArray(
-  params: Record<string, unknown> | undefined,
-  key: string,
-): string[] | null {
-  if (params === undefined) return null;
-  const value = params[key];
-  if (value === undefined || value === null) return null;
-  if (!Array.isArray(value) || value.some((item) => typeof item !== 'string')) {
-    throw new AdminError('BAD_REQUEST', `param '${key}' must be an array of strings`);
-  }
-  return value as string[];
-}
-
 function optionalStringProp(
   params: Record<string, unknown>,
   key: string,
 ): Record<string, string> {
   const value = optionalString(params, key);
   return value === null ? {} : { [key]: value };
-}
-
-function optionalMappedStringProp(
-  params: Record<string, unknown>,
-  key: string,
-  targetKey: string,
-): Record<string, string> {
-  const value = optionalString(params, key);
-  return value === null ? {} : { [targetKey]: value };
 }
 
 function mustExistingDispatcher(server: Server, id: string): void {

--- a/packages/dreamux/src/channel/feishu/bot.ts
+++ b/packages/dreamux/src/channel/feishu/bot.ts
@@ -38,14 +38,10 @@ import {
   type TransportLogger,
 } from '@excitedjs/feishu-transport';
 import type {
-  FeishuCreateGroupInput,
-  FeishuCreateGroupResult,
   FeishuInviteMembersInput,
   FeishuInviteMembersResult,
 } from '@excitedjs/feishu-transport';
 export type {
-  FeishuCreateGroupInput,
-  FeishuCreateGroupResult,
   FeishuInviteMembersInput,
   FeishuInviteMembersResult,
 } from '@excitedjs/feishu-transport';
@@ -117,7 +113,6 @@ export interface FeishuBot extends FeishuMessageResourceFetcher {
   readonly botOpenId: string | undefined;
   start(routes: FeishuInboundRoutes): Promise<void>;
   send(target: OutboundTarget, text: string): Promise<FeishuSendResult>;
-  createGroup(input: FeishuCreateGroupInput): Promise<FeishuCreateGroupResult>;
   inviteMembers(input: FeishuInviteMembersInput): Promise<FeishuInviteMembersResult>;
   addReaction(messageId: string, emoji: string): Promise<string>;
   removeReaction(messageId: string, reactionId: string): Promise<void>;
@@ -207,10 +202,6 @@ export function createFeishuBot(
     async send(target: OutboundTarget, text: string): Promise<FeishuSendResult> {
       const { messageIds } = await transport.send(target, text);
       return { messageIds };
-    },
-
-    createGroup(input: FeishuCreateGroupInput): Promise<FeishuCreateGroupResult> {
-      return transport.createGroup(input);
     },
 
     inviteMembers(input: FeishuInviteMembersInput): Promise<FeishuInviteMembersResult> {
@@ -336,7 +327,6 @@ function asRecord(value: unknown): Record<string, unknown> | undefined {
 // -------------------------------------------------------------- fake (tests)
 
 export interface FakeFeishuBot extends FeishuBot {
-  readonly createdGroups: Array<{ name: string; userOpenIds: string[]; chatId: string }>;
   readonly sentMessages: Array<{
     chatId: string;
     target: OutboundTarget;
@@ -358,7 +348,6 @@ export interface FakeFeishuBot extends FeishuBot {
     | { op: 'remove'; messageId: string; reactionId: string }
   >;
   inject(event: FeishuInboundEvent): Promise<void>;
-  setCreateGroupError(err: Error | null): void;
   injectBotMemberAdded(event: FeishuBotMemberAddedEvent): Promise<void>;
   setSendError(err: Error | null): void;
   setReactionError(err: Error | null): void;
@@ -380,7 +369,6 @@ export function createFakeFeishuBot(appId: string = 'fake-bot'): FakeFeishuBot {
   let nextMessageId = 1;
   let nextReactionId = 1;
   let sendError: Error | null = null;
-  let createGroupError: Error | null = null;
   let reactionError: Error | null = null;
   let removeReactionError: Error | null = null;
   const messageResources = new Map<string, FeishuMessageResourceResponse | Error>();
@@ -395,7 +383,6 @@ export function createFakeFeishuBot(appId: string = 'fake-bot'): FakeFeishuBot {
     reactionId: string;
   }> = [];
   const reactionOps: FakeFeishuBot['reactionOps'] = [];
-  const createdGroups: Array<{ name: string; userOpenIds: string[]; chatId: string }> = [];
 
   return {
     appId,
@@ -412,12 +399,6 @@ export function createFakeFeishuBot(appId: string = 'fake-bot'): FakeFeishuBot {
       const id = `message-fake-${nextMessageId++}`;
       sent.push({ chatId: target.chatId, target, text, messageIds: [id] });
       return { messageIds: [id] };
-    },
-    async createGroup(input: FeishuCreateGroupInput): Promise<FeishuCreateGroupResult> {
-      if (createGroupError !== null) throw createGroupError;
-      const chatId = `oc_fake_group_${createdGroups.length + 1}`;
-      createdGroups.push({ name: input.name, userOpenIds: input.userOpenIds, chatId });
-      return { chatId };
     },
     async inviteMembers(input: FeishuInviteMembersInput): Promise<FeishuInviteMembersResult> {
       return { addedOpenIds: input.userOpenIds };
@@ -454,9 +435,6 @@ export function createFakeFeishuBot(appId: string = 'fake-bot'): FakeFeishuBot {
     get sentMessages() {
       return sent;
     },
-    get createdGroups() {
-      return createdGroups;
-    },
     get reactions() {
       return reactions;
     },
@@ -469,9 +447,6 @@ export function createFakeFeishuBot(appId: string = 'fake-bot'): FakeFeishuBot {
     async inject(event: FeishuInboundEvent): Promise<void> {
       if (routes === null) throw new Error('fake bot not started');
       await routes.onMessage(event);
-    },
-    setCreateGroupError(err: Error | null): void {
-      createGroupError = err;
     },
     async injectBotMemberAdded(event: FeishuBotMemberAddedEvent): Promise<void> {
       if (routes === null) throw new Error('fake bot not started');

--- a/packages/dreamux/src/dispatcher-service/dispatcher/service.ts
+++ b/packages/dreamux/src/dispatcher-service/dispatcher/service.ts
@@ -4,11 +4,7 @@ import type {
   AgentRuntimeProviderCatalog,
   CompletionEnvelope,
 } from '../../agent-runtime/index.js';
-import type {
-  FeishuBot,
-  FeishuCreateGroupInput,
-  FeishuCreateGroupResult,
-} from '../../channel/feishu/bot.js';
+import type { FeishuBot } from '../../channel/feishu/bot.js';
 import {
   FeishuChannelSession,
   type FeishuInboundEnvelope,
@@ -255,17 +251,6 @@ export class DispatcherAgentService {
   ): boolean {
     const slot = this.slots.get(dispatcherId);
     return slot?.channel.messageBelongsToChat(messageId, chatId) ?? false;
-  }
-
-  async createFeishuGroup(
-    input: FeishuCreateGroupInput & { dispatcherId: string },
-  ): Promise<FeishuCreateGroupResult> {
-    const slot = this.mustRunningSlot(input.dispatcherId);
-    const created = await slot.channel.bot.createGroup({
-      name: input.name,
-      userOpenIds: input.userOpenIds,
-    });
-    return created;
   }
 
   async shutdown(): Promise<void> {

--- a/packages/dreamux/src/dispatcher-service/service.ts
+++ b/packages/dreamux/src/dispatcher-service/service.ts
@@ -32,9 +32,7 @@ import type {
 } from './teammate/types.js';
 import type {
   TeamBindChannelInput,
-  TeamCreateGroupInput,
   TeamCreateInput,
-  TeamCreateGroupResult,
   TeamDissolveInput,
   TeamHistoryQuery,
   TeamTransferChannelBackInput,
@@ -112,7 +110,6 @@ export class DispatcherService {
     });
     this.teams = new TeamService({
       teammates: this.teammates,
-      createFeishuGroup: (input) => this.dispatchers.createFeishuGroup(input),
     });
   }
 
@@ -241,10 +238,6 @@ export class DispatcherService {
 
   createTeam(input: TeamCreateInput) {
     return this.teams.create(input);
-  }
-
-  createTeamGroup(input: TeamCreateGroupInput): Promise<TeamCreateGroupResult> {
-    return this.teams.createGroup(input);
   }
 
   listTeams(dispatcherId: string) {

--- a/packages/dreamux/src/dispatcher-service/team/service.ts
+++ b/packages/dreamux/src/dispatcher-service/team/service.ts
@@ -123,17 +123,30 @@ export class TeamService {
       summary: `created team ${teamId} with leader ${leaderName}`,
     });
     // Optionally bind an existing Feishu group at create time (issue #182 PR-8,
-    // the settled replacement for the retired create_group flow).
+    // the settled replacement for the retired create_group flow). Bind is the
+    // last step; if it fails the Team is already persisted, so roll back by
+    // dissolving the just-created Team rather than leaving a half-created one a
+    // retry would then collide with as "already exists" (mirrors the rollback
+    // the old create_group flow did on Feishu setup failure).
     let binding: TeamChannelBindingSummary | null = null;
     if (input.bindGroup !== undefined) {
-      const bound = await this.bindChannel({
-        dispatcherId: input.dispatcherId,
-        teamId,
-        provider: 'builtin:feishu',
-        chatId: input.bindGroup.chatId,
-        chatType: 'group',
-      });
-      binding = { provider: bound.provider, chat_id: bound.chat_id };
+      try {
+        const bound = await this.bindChannel({
+          dispatcherId: input.dispatcherId,
+          teamId,
+          provider: 'builtin:feishu',
+          chatId: input.bindGroup.chatId,
+          chatType: 'group',
+        });
+        binding = { provider: bound.provider, chat_id: bound.chat_id };
+      } catch (err) {
+        await this.dissolve({
+          dispatcherId: input.dispatcherId,
+          teamId,
+          note: 'Team group binding failed at create time',
+        });
+        throw err;
+      }
     }
     return {
       team,

--- a/packages/dreamux/src/dispatcher-service/team/service.ts
+++ b/packages/dreamux/src/dispatcher-service/team/service.ts
@@ -9,13 +9,10 @@ import {
 } from '../teammate/types.js';
 import { ChannelBindingStore } from '../channel-binding/store.js';
 import type { ChannelBinding } from '../channel-binding/store.js';
-import type { FeishuCreateGroupInput, FeishuCreateGroupResult } from '../../channel/feishu/bot.js';
 import { TeamStore } from './store.js';
 import type {
   TeamBindChannelInput,
   TeamChannelBindingSummary,
-  TeamCreateGroupInput,
-  TeamCreateGroupResult,
   TeamCreateInput,
   TeamCreateResult,
   TeamDissolveInput,
@@ -33,9 +30,6 @@ import type { TeamMateIdentityStatus } from '../teammate/types.js';
 
 export interface TeamServiceOptions {
   teammates: TeamMateAgentService;
-  createFeishuGroup?: (
-    input: FeishuCreateGroupInput & { dispatcherId: string },
-  ) => Promise<FeishuCreateGroupResult>;
 }
 
 export class TeamService {
@@ -46,8 +40,8 @@ export class TeamService {
   constructor(private readonly opts: TeamServiceOptions) {}
 
   async create(input: TeamCreateInput): Promise<TeamCreateResult> {
-    // Required recovery subject — enforced for in-process callers (and the
-    // create_group path that delegates here) too (issue #182 PR-3).
+    // Required recovery subject — enforced for in-process callers too
+    // (issue #182 PR-3).
     requireLifecycleText(input.intent, 'Team create intent');
     const teamId = validateTeamId(input.name);
     const existing = await this.store.get(input.dispatcherId, teamId);
@@ -128,12 +122,24 @@ export class TeamService {
       type: 'create',
       summary: `created team ${teamId} with leader ${leaderName}`,
     });
+    // Optionally bind an existing Feishu group at create time (issue #182 PR-8,
+    // the settled replacement for the retired create_group flow).
+    let binding: TeamChannelBindingSummary | null = null;
+    if (input.bindGroup !== undefined) {
+      const bound = await this.bindChannel({
+        dispatcherId: input.dispatcherId,
+        teamId,
+        provider: 'builtin:feishu',
+        chatId: input.bindGroup.chatId,
+        chatType: 'group',
+      });
+      binding = { provider: bound.provider, chat_id: bound.chat_id };
+    }
     return {
       team,
       leader: leader.teammate,
       member_count: await this.memberCount(team),
-      // No group is bound at create time; `create_group`/`bind_group` set it.
-      binding: null,
+      binding,
       turn: leader.turn,
     };
   }
@@ -211,8 +217,8 @@ export class TeamService {
     );
     // dissolve note is required (issue #182 PR-3), so the member/leader close
     // calls and the ledger carry the operator's real reason — no synthetic
-    // 'team dissolved' fallback. Internal/system dissolves (e.g. the
-    // create_group rollback) pass an explicit system-authored note instead.
+    // 'team dissolved' fallback. Internal/system dissolves pass an explicit
+    // system-authored note instead.
     for (const member of members) {
       await this.opts.teammates.closeScoped({
         principal: teamLeaderPrincipal({
@@ -280,60 +286,6 @@ export class TeamService {
       }
     }
     return binding;
-  }
-
-  async createGroup(input: TeamCreateGroupInput): Promise<TeamCreateGroupResult> {
-    if (input.sourceChatType !== 'p2p') {
-      throw new Error('create_team_group must be requested from a P2P control channel');
-    }
-    if (this.opts.createFeishuGroup === undefined) {
-      throw new Error('Feishu group creation is not available for this dispatcher');
-    }
-    const created = await this.create(input);
-    let group: FeishuCreateGroupResult;
-    let binding: ChannelBinding | null = null;
-    try {
-      group = await this.opts.createFeishuGroup({
-        dispatcherId: input.dispatcherId,
-        name: input.groupName ?? input.name,
-        userOpenIds: uniqueOpenIds([
-          input.requesterOpenId,
-          ...(input.inviteOpenIds ?? []),
-        ]),
-      });
-      binding = await this.bindChannel({
-        dispatcherId: input.dispatcherId,
-        teamId: created.team.team_id,
-        provider: 'builtin:feishu',
-        chatId: group.chatId,
-        chatType: 'group',
-      });
-      await this.store.appendLedger(created.team, {
-        type: 'create_group',
-        summary: `created Feishu group ${group.chatId} for team ${created.team.team_id}`,
-      });
-    } catch (err) {
-      await this.dissolve({
-        dispatcherId: input.dispatcherId,
-        teamId: created.team.team_id,
-        note: 'Feishu group setup failed',
-      });
-      throw err;
-    }
-    return {
-      ...created,
-      binding: {
-        provider: binding.provider,
-        chat_id: binding.chat_id,
-        chat_type: binding.chat_type,
-        team_id: binding.team_id,
-        leader_name: binding.leader_name,
-      },
-      invited_open_ids: uniqueOpenIds([
-        input.requesterOpenId,
-        ...(input.inviteOpenIds ?? []),
-      ]),
-    };
   }
 
   async resolveChannel(input: {
@@ -518,10 +470,6 @@ function teamLeaderPrompt(team: TeamRecord): string {
     `Repository cwd: ${team.repo_cwd}`,
     team.intent !== null ? `Intent: ${team.intent}` : '',
   ].filter((line) => line !== '').join('\n');
-}
-
-function uniqueOpenIds(ids: string[]): string[] {
-  return [...new Set(ids.filter((id) => id !== ''))];
 }
 
 function matchesTeamHistoryQuery(

--- a/packages/dreamux/src/dispatcher-service/team/types.ts
+++ b/packages/dreamux/src/dispatcher-service/team/types.ts
@@ -38,6 +38,12 @@ export interface TeamCreateInput {
   /** Required recovery subject for the Team (issue #182 PR-3). */
   intent: string;
   prompt?: string;
+  /**
+   * Optional: bind an EXISTING Feishu group chat to the new Team at create time
+   * (issue #182 PR-7/PR-8). This is the settled replacement for the retired
+   * `create_group` flow — it binds an existing group, it does not create one.
+   */
+  bindGroup?: { chatId: string };
 }
 
 export interface TeamDissolveInput {
@@ -60,32 +66,6 @@ export interface TeamTransferChannelBackInput {
   provider: 'builtin:feishu';
   chatId: string;
   chatType: 'group' | 'p2p';
-}
-
-export interface TeamCreateGroupInput {
-  dispatcherId: string;
-  name: string;
-  repoCwd: string;
-  leaderAgentRuntime: string;
-  sourceChatId: string;
-  sourceChatType: 'p2p' | 'group';
-  requesterOpenId: string;
-  groupName?: string;
-  inviteOpenIds?: string[];
-  /** Required recovery subject — same contract as TeamCreateInput (issue #182 PR-3). */
-  intent: string;
-  prompt?: string;
-}
-
-export interface TeamCreateGroupResult extends TeamCreateResult {
-  binding: {
-    provider: 'builtin:feishu';
-    chat_id: string;
-    chat_type: 'group';
-    team_id: string;
-    leader_name: string;
-  };
-  invited_open_ids: string[];
 }
 
 export type TeamLedgerEventType =

--- a/packages/dreamux/src/dispatcher-service/teammate/identity-store.ts
+++ b/packages/dreamux/src/dispatcher-service/teammate/identity-store.ts
@@ -1,15 +1,12 @@
-import { appendFile, mkdir, readFile, readdir, writeFile } from 'node:fs/promises';
+import { mkdir, readFile, readdir, writeFile } from 'node:fs/promises';
 import { dirname } from 'node:path';
 
 import {
-  dispatcherTeamMateHistoryPath,
   dispatcherTeamMateIdentitiesDir,
   dispatcherTeamMateIdentityPath,
 } from '../../platform/paths.js';
 import {
   validateTeamMateName,
-  type TeamMateHistoryEvent,
-  type TeamMateHistoryEventType,
   type TeamMateIdentity,
   type TeamMateIdentityStatus,
   type TeamMateOwner,
@@ -56,13 +53,6 @@ export interface TeamMateIdentityUpdateInput {
   lastError?: string | null;
   closedAt?: number | null;
   closeNote?: string | null;
-}
-
-export interface TeamMateHistoryAppendInput {
-  type: TeamMateHistoryEventType;
-  prompt?: string | null;
-  turnId?: string | null;
-  note?: string | null;
 }
 
 export class TeamMateIdentityStore {
@@ -165,71 +155,6 @@ export class TeamMateIdentityStore {
     };
     await this.write(updated);
     return updated;
-  }
-
-  async appendHistory(
-    identity: TeamMateIdentity,
-    input: TeamMateHistoryAppendInput,
-  ): Promise<void> {
-    try {
-      const event: TeamMateHistoryEvent = {
-        version: 1,
-        event_id: Date.now(),
-        timestamp: Date.now(),
-        dispatcher_id: identity.dispatcher_id,
-        name: identity.name,
-        owner: identity.owner,
-        role: identity.role,
-        team_id: identity.team_id,
-        type: input.type,
-        agent_runtime: identity.agent_runtime,
-        source_cwd: identity.source_cwd,
-        source_repo: identity.source_repo,
-        cwd: identity.cwd,
-        runtime_cwd: identity.runtime_cwd,
-        worktree: identity.worktree,
-        checkpoint: identity.checkpoint,
-        prompt_preview:
-          input.prompt !== undefined && input.prompt !== null
-            ? preview(input.prompt)
-            : null,
-        turn_id: input.turnId ?? null,
-        status: identity.status,
-        note: input.note ?? null,
-      };
-      const path = dispatcherTeamMateHistoryPath(
-        identity.dispatcher_id,
-        identity.name,
-      );
-      await mkdir(dirname(path), { recursive: true });
-      await appendFile(path, `${JSON.stringify(event)}\n`, { mode: 0o600 });
-    } catch (err) {
-      this.log.warn('TeamMate history append failed', {
-        dispatcher_id: identity.dispatcher_id,
-        name: identity.name,
-        error: err instanceof Error ? err.message : String(err),
-      });
-    }
-  }
-
-  async history(
-    dispatcherId: string,
-    name: string,
-  ): Promise<TeamMateHistoryEvent[]> {
-    validateTeamMateName(name);
-    let raw: string;
-    try {
-      raw = await readFile(dispatcherTeamMateHistoryPath(dispatcherId, name), 'utf8');
-    } catch (err) {
-      if (isNotFound(err)) return [];
-      throw err;
-    }
-    const events: TeamMateHistoryEvent[] = [];
-    for (const line of raw.split('\n')) {
-      if (line.trim() === '') continue;
-      events.push(readHistoryEvent(dispatcherId, name, JSON.parse(line) as unknown));
-    }
-    return events.sort((a, b) => a.timestamp - b.timestamp || a.event_id - b.event_id);
   }
 
   private async write(identity: TeamMateIdentity): Promise<void> {
@@ -378,32 +303,6 @@ function readWorktreeIdentity(
         ? record['cleanup_error']
         : null,
   };
-}
-
-function readHistoryEvent(
-  dispatcherId: string,
-  name: string,
-  value: unknown,
-): TeamMateHistoryEvent {
-  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
-    throw new Error('invalid TeamMate history event');
-  }
-  const record = value as Record<string, unknown>;
-  if (
-    record['version'] !== 1 ||
-    record['dispatcher_id'] !== dispatcherId ||
-    record['name'] !== name ||
-    typeof record['timestamp'] !== 'number' ||
-    typeof record['event_id'] !== 'number'
-  ) {
-    throw new Error(`invalid TeamMate history event for ${JSON.stringify(name)}`);
-  }
-  return record as unknown as TeamMateHistoryEvent;
-}
-
-function preview(text: string): string {
-  const collapsed = text.replace(/\s+/g, ' ').trim();
-  return collapsed.length <= 500 ? collapsed : `${collapsed.slice(0, 497)}...`;
 }
 
 function isNotFound(err: unknown): boolean {

--- a/packages/dreamux/src/dispatcher-service/teammate/runtime-state.ts
+++ b/packages/dreamux/src/dispatcher-service/teammate/runtime-state.ts
@@ -63,10 +63,6 @@ export class TeamMateRuntimeStateStore implements AgentRuntimeStateStore {
         ? { lastError: extras.last_error }
         : {}),
     });
-    await this.store.appendHistory(this.identity, {
-      type: 'state',
-      note: status,
-    });
   }
 
   async setThreadId(_id: string, threadId: string): Promise<void> {
@@ -88,10 +84,6 @@ export class TeamMateRuntimeStateStore implements AgentRuntimeStateStore {
     this.identity = await this.store.update(this.identity, {
       status: 'degraded',
       lastError: error,
-    });
-    await this.store.appendHistory(this.identity, {
-      type: 'state',
-      note: error,
     });
   }
 }

--- a/packages/dreamux/src/dispatcher-service/teammate/service.ts
+++ b/packages/dreamux/src/dispatcher-service/teammate/service.ts
@@ -297,11 +297,6 @@ export class TeamMateAgentService {
     const turn = await this.submitPrompt(dispatcherId, name, input.prompt, {
       principal: input.principal,
     });
-    await this.identities.appendHistory(live.state.current(), {
-      type: 'spawn',
-      prompt: input.prompt,
-      turnId: turn.turn_id ?? null,
-    });
     await this.sessionLedger.append({
       identity: live.state.current(),
       type: 'spawn',
@@ -340,11 +335,6 @@ export class TeamMateAgentService {
     }
     const turn = await this.submitPrompt(dispatcherId, input.name, input.prompt, {
       principal: input.principal,
-    });
-    await this.identities.appendHistory(live.state.current(), {
-      type: 'send',
-      prompt: input.prompt,
-      turnId: turn.turn_id ?? null,
     });
     // The send may have reopened a closed teammate from its checkpoint, so the
     // session ledger continues the SAME session id carried on the identity
@@ -393,10 +383,6 @@ export class TeamMateAgentService {
       // same close write so the close event is captured rather than skipped
       // (PR #187 review P3). Never re-keyed to the runtime thread id.
       ...(identity.session_id === null ? { sessionId: randomUUID() } : {}),
-    });
-    await this.identities.appendHistory(closed, {
-      type: 'close',
-      note: input.note,
     });
     await this.sessionLedger.append({
       identity: closed,
@@ -715,11 +701,6 @@ export class TeamMateAgentService {
     const live = await this.startRuntime(input.dispatcherId, identity, provider, agent);
     identity = live.state.current();
     const turn = await this.submitPrompt(input.dispatcherId, name, input.prompt);
-    await this.identities.appendHistory(live.state.current(), {
-      type: 'spawn',
-      prompt: input.prompt,
-      turnId: turn.turn_id ?? null,
-    });
     await this.sessionLedger.append({
       identity: live.state.current(),
       type: 'spawn',

--- a/packages/dreamux/src/dispatcher-service/teammate/types.ts
+++ b/packages/dreamux/src/dispatcher-service/teammate/types.ts
@@ -69,38 +69,6 @@ export interface TeamMateIdentity {
   close_note: string | null;
 }
 
-export type TeamMateHistoryEventType =
-  | 'spawn'
-  | 'send'
-  // Legacy event, no longer written (the `resume` verb was removed in #155;
-  // send now subsumes it). Retained so pre-#155 history files still parse.
-  | 'resume'
-  | 'close'
-  | 'state';
-
-export interface TeamMateHistoryEvent {
-  version: 1;
-  event_id: number;
-  timestamp: number;
-  dispatcher_id: string;
-  name: string;
-  owner: TeamMateOwner;
-  role: TeamMateRole;
-  team_id: string | null;
-  type: TeamMateHistoryEventType;
-  agent_runtime: string;
-  source_cwd: string;
-  source_repo: string | null;
-  cwd: string;
-  runtime_cwd: string;
-  worktree: TeamMateWorktreeIdentity;
-  checkpoint: AgentRuntimeResumeCheckpoint | null;
-  prompt_preview: string | null;
-  turn_id: string | null;
-  status: TeamMateIdentityStatus;
-  note: string | null;
-}
-
 /**
  * One durable session-ledger event (issue #182 PR-5). Append-only, one line per
  * lifecycle fact in the per-dispatcher `sessions.jsonl`. Every event denormalizes

--- a/packages/dreamux/src/mcp/team-mcp.ts
+++ b/packages/dreamux/src/mcp/team-mcp.ts
@@ -99,25 +99,19 @@ async function handleRequest(
 
 function teamTools(): Array<Record<string, unknown>> {
   return [
-    tool('create', 'Create a Team and start its TeamLeader. intent is required: it is the durable recovery subject for the Team.', {
+    tool('create', 'Create a Team and start its TeamLeader. intent is required: it is the durable recovery subject for the Team. Optionally bind an existing Feishu group chat at create time via bind_group.', {
       name: { type: 'string', minLength: 1, maxLength: 64 },
       repo_cwd: { type: 'string', minLength: 1, maxLength: 4096 },
       leader_agent_runtime: { type: 'string', minLength: 1, maxLength: 128 },
       intent: { type: 'string', minLength: 1, maxLength: 2000 },
       prompt: { type: 'string', maxLength: 20000 },
+      bind_group: {
+        type: 'object',
+        additionalProperties: false,
+        properties: { chat_id: { type: 'string', minLength: 1 } },
+        required: ['chat_id'],
+      },
     }, ['name', 'repo_cwd', 'leader_agent_runtime', 'intent']),
-    tool('create_group', 'Create a Team, create a Feishu group, and bind that group to the TeamLeader. intent is required (same contract as create).', {
-      name: { type: 'string', minLength: 1, maxLength: 64 },
-      repo_cwd: { type: 'string', minLength: 1, maxLength: 4096 },
-      leader_agent_runtime: { type: 'string', minLength: 1, maxLength: 128 },
-      source_chat_id: { type: 'string', minLength: 1 },
-      source_chat_type: { type: 'string', enum: ['p2p', 'group'] },
-      requester_open_id: { type: 'string', minLength: 1 },
-      invite_open_ids: { type: 'array', items: { type: 'string' } },
-      group_name: { type: 'string', minLength: 1 },
-      intent: { type: 'string', minLength: 1, maxLength: 2000 },
-      prompt: { type: 'string', maxLength: 20000 },
-    }, ['name', 'repo_cwd', 'leader_agent_runtime', 'source_chat_id', 'source_chat_type', 'requester_open_id', 'intent']),
     tool('list', 'List Teams owned by this dispatcher (compact scan rows: name, status, intent, repo, leader, member count, bound group).', {}, []),
     tool('status', 'Read one Team\'s detailed current status by its name (record, TeamLeader status/session, member count, active bound group).', {
       name: { type: 'string', minLength: 1, maxLength: 64 },
@@ -186,8 +180,6 @@ function mapToolCall(call: ToolCall): { method: string; params: Record<string, u
   switch (call.name) {
     case 'create':
       return { method: 'mcp.team.create', params: createArgs(call.arguments) };
-    case 'create_group':
-      return { method: 'mcp.team.create_group', params: createGroupArgs(call.arguments) };
     case 'list':
       return { method: 'mcp.team.list', params: {} };
     case 'status':
@@ -208,26 +200,21 @@ function mapToolCall(call: ToolCall): { method: string; params: Record<string, u
 function createArgs(value: unknown): Record<string, unknown> {
   const obj = asRecord(value, 'create arguments');
   const prompt = optionalString(obj, 'prompt');
+  // Optional: bind an existing Feishu group at create time (issue #182 PR-8).
+  const bindGroupRaw = obj['bind_group'];
+  let bindGroup: { chat_id: string } | null = null;
+  if (bindGroupRaw !== undefined && bindGroupRaw !== null) {
+    const bindObj = asRecord(bindGroupRaw, 'bind_group');
+    bindGroup = { chat_id: requireString(bindObj, 'chat_id') };
+  }
   return {
     name: requireString(obj, 'name'),
     repo_cwd: requireString(obj, 'repo_cwd'),
     leader_agent_runtime: requireString(obj, 'leader_agent_runtime'),
-    // Required recovery subject (issue #182 PR-3); create_group reuses this.
+    // Required recovery subject (issue #182 PR-3).
     intent: requireString(obj, 'intent'),
     ...(prompt !== null ? { prompt } : {}),
-  };
-}
-
-function createGroupArgs(value: unknown): Record<string, unknown> {
-  const obj = asRecord(value, 'create_group arguments');
-  const inviteOpenIds = optionalStringArray(obj, 'invite_open_ids');
-  return {
-    ...createArgs(value),
-    source_chat_id: requireString(obj, 'source_chat_id'),
-    source_chat_type: requireString(obj, 'source_chat_type'),
-    requester_open_id: requireString(obj, 'requester_open_id'),
-    ...optionalStringProp(obj, 'group_name'),
-    ...(inviteOpenIds !== null ? { invite_open_ids: inviteOpenIds } : {}),
+    ...(bindGroup !== null ? { bind_group: bindGroup } : {}),
   };
 }
 
@@ -316,23 +303,6 @@ function optionalInteger(obj: Record<string, unknown>, key: string): number | nu
   if (value === undefined || value === null) return null;
   if (!Number.isInteger(value)) throw new Error(`${key} must be an integer`);
   return value as number;
-}
-
-function optionalStringArray(obj: Record<string, unknown>, key: string): string[] | null {
-  const value = obj[key];
-  if (value === undefined || value === null) return null;
-  if (!Array.isArray(value) || value.some((item) => typeof item !== 'string')) {
-    throw new Error(`${key} must be an array of strings`);
-  }
-  return value as string[];
-}
-
-function optionalStringProp(
-  obj: Record<string, unknown>,
-  key: string,
-): Record<string, string> {
-  const value = optionalString(obj, key);
-  return value === null ? {} : { [key]: value };
 }
 
 function okResponse(id: JsonRpcRequest['id'], result: unknown): string {

--- a/packages/dreamux/src/platform/paths.ts
+++ b/packages/dreamux/src/platform/paths.ts
@@ -284,18 +284,6 @@ export function dispatcherTeamMateIdentityPath(
   );
 }
 
-/** Forward-only JSONL history for one TeamMate identity. */
-export function dispatcherTeamMateHistoryPath(
-  id: string,
-  teammateName: string,
-): string {
-  return join(
-    dispatcherTeamMateDir(id),
-    'history',
-    `${teamMateNameSegment(teammateName)}.jsonl`,
-  );
-}
-
 /**
  * Per-dispatcher append-only TeamMate/Team session ledger (issue #182 PR-5).
  * One file per dispatcher — NOT one file per transient runtime session — so the

--- a/packages/dreamux/tests/admin-methods-intent-note.test.ts
+++ b/packages/dreamux/tests/admin-methods-intent-note.test.ts
@@ -16,12 +16,11 @@ import type { Server } from '../src/server.js';
  */
 const stubServer = {
   repos: { dispatchers: { get: () => ({ dispatcher_id: 'flow' }) } },
-  // create_group reads intent while building the call args, so member access on
-  // createTeamGroup happens before validation throws — the stub just needs the
-  // property to exist; the validation rejects before it is ever invoked.
+  // Lifecycle calls reject on the intent/note guard before the service is ever
+  // reached; the stub service methods just assert they are not invoked.
   dispatcherService: {
-    createTeamGroup: () => {
-      throw new Error('createTeamGroup must not be reached on a rejected request');
+    createTeam: () => {
+      throw new Error('createTeam must not be reached on a rejected request');
     },
   },
 } as unknown as Server;
@@ -65,22 +64,9 @@ describe('admin layer enforces required non-empty intent/note (#182 PR-3)', () =
     await expectBadRequest('mcp.team.create', { ...base, intent: '' });
   });
 
-  it('rejects team.create_group with missing or empty intent', async () => {
-    const base = {
-      dispatcher_id: 'flow',
-      name: 'alpha',
-      repo_cwd: '/repo',
-      leader_agent_runtime: 'codex',
-      source_chat_id: 'chat-1',
-      source_chat_type: 'p2p',
-      requester_open_id: 'user-1',
-    };
-    await expectBadRequest('mcp.team.create_group', base);
-    await expectBadRequest('mcp.team.create_group', { ...base, intent: '' });
-  });
-
   it('rejects team.dissolve with missing or empty note', async () => {
-    const base = { dispatcher_id: 'flow', team_id: 'alpha' };
+    // #182 PR-7: Team lifecycle is addressed by `name`.
+    const base = { dispatcher_id: 'flow', name: 'alpha' };
     await expectBadRequest('mcp.team.dissolve', base);
     await expectBadRequest('mcp.team.dissolve', { ...base, note: '' });
   });

--- a/packages/dreamux/tests/runtime-paths.test.ts
+++ b/packages/dreamux/tests/runtime-paths.test.ts
@@ -13,7 +13,6 @@ import {
   dispatcherDir,
   dispatcherFeishuAttachmentCacheDir,
   dispatcherTeamMateDir,
-  dispatcherTeamMateHistoryPath,
   dispatcherTeamMateIdentitiesDir,
   dispatcherTeamMateIdentityPath,
   dispatcherTeamMateRuntimeDir,
@@ -111,15 +110,6 @@ describe('runtime paths', () => {
         'teammate',
         'identities',
         'reviewer-1.json',
-      ),
-    );
-    expect(dispatcherTeamMateHistoryPath('dispatcher-a', 'reviewer-1')).toBe(
-      join(
-        stateRoot(),
-        'dispatcher-a',
-        'teammate',
-        'history',
-        'reviewer-1.jsonl',
       ),
     );
     expect(dispatcherTeamMateRuntimeDir('dispatcher-a', 'reviewer-1')).toBe(

--- a/packages/dreamux/tests/team-mcp.test.ts
+++ b/packages/dreamux/tests/team-mcp.test.ts
@@ -121,12 +121,60 @@ function schemaOf(
 }
 
 describe('team-mcp stdio shim', () => {
-  it('marks create.intent, create_group.intent, and dissolve.note required (#182 PR-3)', async () => {
+  it('marks create.intent and dissolve.note required; create_group is retired (#182 PR-3/PR-8)', async () => {
     const tools = await toolSchemas();
     expect(schemaOf(tools, 'create').required).toContain('intent');
-    expect(schemaOf(tools, 'create_group').required).toContain('intent');
+    // #182 PR-8: create_group is retired from the public Team MCP surface; an
+    // existing group is bound via the optional `bind_group` on `create` instead.
+    expect(tools.map((t) => t['name'])).not.toContain('create_group');
+    expect(schemaOf(tools, 'create').properties).toHaveProperty('bind_group');
     // #182 PR-7: public addressing is by `name`.
     expect(schemaOf(tools, 'dissolve').required).toEqual(['name', 'note']);
+  });
+
+  it('forwards create.bind_group to the admin create method (#182 PR-8)', async () => {
+    const admin = await startFakeAdminServer((request) => ({
+      id: request.id,
+      ok: true,
+      result: { ok: true },
+    }));
+    try {
+      const input = new PassThrough();
+      const output = new PassThrough();
+      const reader = new JsonLineReader(output);
+      const run = runTeamMcp({
+        dispatcherId: 'dispatcher-a',
+        adminSocketPath: admin.socketPath,
+        input,
+        output,
+        log: () => {},
+      });
+      writeJson(input, {
+        jsonrpc: '2.0',
+        id: 1,
+        method: 'tools/call',
+        params: {
+          name: 'create',
+          arguments: {
+            name: 'alpha',
+            repo_cwd: '/repo',
+            leader_agent_runtime: 'codex',
+            intent: 'ship it',
+            bind_group: { chat_id: 'chat-1' },
+          },
+        },
+      });
+      await reader.next();
+      expect(admin.requests[0]?.method).toBe('mcp.team.create');
+      expect(admin.requests[0]?.params).toMatchObject({
+        name: 'alpha',
+        bind_group: { chat_id: 'chat-1' },
+      });
+      input.end();
+      await run;
+    } finally {
+      await admin.close();
+    }
   });
 
   it('aligns the Team read surface with the TeamMate model and addresses by name (#182 PR-7)', async () => {

--- a/packages/dreamux/tests/team-service.test.ts
+++ b/packages/dreamux/tests/team-service.test.ts
@@ -475,6 +475,38 @@ describe('TeamService', () => {
     });
   });
 
+  it('history paginates by cursor and rejects an invalid cursor (#182 PR-7 P2)', async () => {
+    const repo = await initGitRepo(join(root, 'history-page-repo'));
+    const { teams } = buildServices();
+    for (const name of ['t-one', 't-two', 't-three']) {
+      await teams.create({
+        dispatcherId: 'flow',
+        name,
+        repoCwd: repo,
+        leaderAgentRuntime: 'flow',
+        intent: 'work',
+      });
+    }
+
+    const page1 = await teams.history({ dispatcherId: 'flow', limit: 2 });
+    expect(page1.items).toHaveLength(2);
+    expect(page1.next_cursor).not.toBeNull();
+    const page2 = await teams.history({
+      dispatcherId: 'flow',
+      limit: 2,
+      cursor: page1.next_cursor!,
+    });
+    expect(page2.items).toHaveLength(1);
+    expect(page2.next_cursor).toBeNull();
+    // The two pages together cover all three Teams with no overlap.
+    const seen = [...page1.items, ...page2.items].map((row) => row.name).sort();
+    expect(seen).toEqual(['t-one', 't-three', 't-two']);
+    // An invalid cursor fails loud rather than silently resetting to page 0.
+    await expect(
+      teams.history({ dispatcherId: 'flow', cursor: 'not-a-cursor' }),
+    ).rejects.toThrow(/invalid history cursor/);
+  });
+
   it('history is a filterable recovery search; list/status surface the bound group (#182 PR-7)', async () => {
     const repo = await initGitRepo(join(root, 'history-repo'));
     const { teams } = buildServices();

--- a/packages/dreamux/tests/team-service.test.ts
+++ b/packages/dreamux/tests/team-service.test.ts
@@ -120,8 +120,6 @@ function buildServices(): {
   teams: TeamService;
   teammates: TeamMateAgentService;
   provider: FakeProvider;
-  createdGroups: Array<{ name: string; userOpenIds: string[]; chatId: string }>;
-  setCreateGroupError(err: Error | null): void;
 } {
   const config = testDreamuxConfig([testDispatcherConfig({ cwd: dispatcherCwd })]);
   const registry = createBuiltinProviderRegistry();
@@ -134,26 +132,8 @@ function buildServices(): {
     agentRuntimeProviders: new AgentRuntimeProviderCatalog({ registry }),
     log: noopLog(),
   });
-  const createdGroups: Array<{ name: string; userOpenIds: string[]; chatId: string }> = [];
-  let createGroupError: Error | null = null;
-  const teams = new TeamService({
-    teammates,
-    createFeishuGroup: async (input) => {
-      if (createGroupError !== null) throw createGroupError;
-      const chatId = `fake_group_${createdGroups.length + 1}`;
-      createdGroups.push({ name: input.name, userOpenIds: input.userOpenIds, chatId });
-      return { chatId };
-    },
-  });
-  return {
-    teams,
-    teammates,
-    provider,
-    createdGroups,
-    setCreateGroupError(err): void {
-      createGroupError = err;
-    },
-  };
+  const teams = new TeamService({ teammates });
+  return { teams, teammates, provider };
 }
 
 describe('TeamService', () => {
@@ -462,103 +442,37 @@ describe('TeamService', () => {
     ).rejects.toThrow(/does not exist/);
   });
 
-  it('creates a team group from P2P and binds the new group', async () => {
-    const repo = await initGitRepo(join(root, 'group-repo'));
-    const { teams, createdGroups } = buildServices();
+  it('create binds an existing Feishu group via bind_group (#182 PR-8)', async () => {
+    const repo = await initGitRepo(join(root, 'bindgroup-repo'));
+    const { teams } = buildServices();
 
-    const result = await teams.createGroup({
+    // #182 PR-8: the retired create_group is replaced by binding an EXISTING
+    // group at create time — no new Feishu group is created.
+    const result = await teams.create({
       dispatcherId: 'flow',
       name: 'gamma',
       intent: 'work',
       repoCwd: repo,
       leaderAgentRuntime: 'flow',
-      sourceChatId: 'p2p_control',
-      sourceChatType: 'p2p',
-      requesterOpenId: 'ou_requester',
-      inviteOpenIds: ['ou_peer', 'ou_requester'],
-      groupName: 'Gamma Team',
+      bindGroup: { chatId: 'oc_existing_group' },
     });
-
-    expect(createdGroups).toEqual([
-      {
-        name: 'Gamma Team',
-        userOpenIds: ['ou_requester', 'ou_peer'],
-        chatId: 'fake_group_1',
-      },
-    ]);
-    expect(result.team.leader_name).toMatch(/^tl-gamma-[a-z0-9]{8}$/);
-    expect(result.binding).toMatchObject({
+    expect(result.binding).toEqual({
       provider: 'builtin:feishu',
-      chat_id: 'fake_group_1',
-      chat_type: 'group',
-      team_id: 'gamma',
-      leader_name: result.team.leader_name,
+      chat_id: 'oc_existing_group',
     });
+    // The bound group resolves to the Team, and status/list surface it.
     await expect(
       teams.resolveChannel({
         dispatcherId: 'flow',
         provider: 'builtin:feishu',
-        chatId: 'p2p_control',
-        chatType: 'p2p',
-      }),
-    ).resolves.toBeNull();
-    await expect(
-      teams.resolveChannel({
-        dispatcherId: 'flow',
-        provider: 'builtin:feishu',
-        chatId: 'fake_group_1',
+        chatId: 'oc_existing_group',
         chatType: 'group',
       }),
     ).resolves.toMatchObject({ team_id: 'gamma' });
-    expect((await teams.ledger('flow', 'gamma')).events.map((event) => event.type))
-      .toEqual(['create', 'bind_channel', 'create_group']);
-  });
-
-  it('dissolves the team when Feishu group creation fails', async () => {
-    const repo = await initGitRepo(join(root, 'failure-repo'));
-    const { teams, setCreateGroupError } = buildServices();
-    setCreateGroupError(new Error('missing Feishu chat permission'));
-
-    await expect(
-      teams.createGroup({
-        dispatcherId: 'flow',
-        name: 'delta',
-        intent: 'work',
-        repoCwd: repo,
-        leaderAgentRuntime: 'flow',
-        sourceChatId: 'p2p_control',
-        sourceChatType: 'p2p',
-        requesterOpenId: 'ou_requester',
-      }),
-    ).rejects.toThrow(/missing Feishu chat permission/);
-
-    const status = await teams.status('flow', 'delta');
-    expect(status.team.status).toBe('closed');
-    expect(
-      await teams.resolveChannel({
-        dispatcherId: 'flow',
-        provider: 'builtin:feishu',
-        chatId: 'fake_group_1',
-        chatType: 'group',
-      }),
-    ).toBeNull();
-  });
-
-  it('rejects create_group from a non-P2P source channel', async () => {
-    const repo = await initGitRepo(join(root, 'non-p2p-repo'));
-    const { teams } = buildServices();
-    await expect(
-      teams.createGroup({
-        dispatcherId: 'flow',
-        name: 'epsilon',
-        intent: 'work',
-        repoCwd: repo,
-        leaderAgentRuntime: 'flow',
-        sourceChatId: 'group_source',
-        sourceChatType: 'group',
-        requesterOpenId: 'ou_requester',
-      }),
-    ).rejects.toThrow(/P2P control channel/);
+    expect((await teams.status('flow', 'gamma')).binding).toEqual({
+      provider: 'builtin:feishu',
+      chat_id: 'oc_existing_group',
+    });
   });
 
   it('history is a filterable recovery search; list/status surface the bound group (#182 PR-7)', async () => {

--- a/packages/dreamux/tests/teammate-agent-service.test.ts
+++ b/packages/dreamux/tests/teammate-agent-service.test.ts
@@ -441,24 +441,14 @@ describe('TeamMateAgentService', () => {
     expect(provider.runtimes).toHaveLength(1);
     expect(provider.runtimes[0]?.submitted).toHaveLength(3);
 
-    // The forward-only per-name history index is still written (the raw
-    // history_events read surface was removed in #188; the file remains).
-    const historyFile = await readFile(
-      join(root, 'home', '.dreamux', 'state', 'flow', 'teammate', 'history', `${reviewer}.jsonl`),
-      'utf8',
+    // #182 PR-8: the write-only per-name history index was removed; the durable
+    // session ledger is the single recovery record. It captures the spawn + each
+    // send (no synthetic 'state' rows), in append order, with prompt previews.
+    const events = (await service.sessions().read('flow')).filter(
+      (event) => event.name === reviewer,
     );
-    const events = historyFile
-      .split('\n')
-      .filter((line) => line.trim() !== '')
-      .map((line) => JSON.parse(line) as { type: string; prompt_preview: string | null });
-    expect(events.map((event) => event.type)).toEqual([
-      'state',
-      'spawn',
-      'send',
-      'send',
-    ]);
+    expect(events.map((event) => event.type)).toEqual(['spawn', 'send', 'send']);
     expect(events.map((event) => event.prompt_preview)).toEqual([
-      null,
       'Review the change.',
       'Check tests too.',
       'Continue from prior context.',
@@ -641,12 +631,12 @@ describe('TeamMateAgentService', () => {
     expect((await service.status('flow', closer)).status).toBe('closed');
     expect(provider.runtimes).toHaveLength(1); // no new runtime started
 
-    const historyFile = await readFile(
-      join(root, 'home', '.dreamux', 'state', 'flow', 'teammate', 'history', `${closer}.jsonl`),
-      'utf8',
+    // #182 PR-8: closing retains the durable session ledger (spawn + close),
+    // the single recovery record now that the per-name history index is gone.
+    const events = (await service.sessions().read('flow')).filter(
+      (event) => event.name === closer,
     );
-    expect(historyFile).toContain('"type":"spawn"');
-    expect(historyFile).toContain('"type":"close"');
+    expect(events.map((event) => event.type)).toEqual(['spawn', 'close']);
   });
 
   it('send reopens a closed teammate from its checkpoint (issue #155)', async () => {

--- a/packages/dreamux/tests/teammate-agent-service.test.ts
+++ b/packages/dreamux/tests/teammate-agent-service.test.ts
@@ -1692,6 +1692,54 @@ describe('TeamMateAgentService', () => {
     });
   });
 
+  it('last(turns) evicts older turns beyond the window, keeping the most recent by start order (#188 bounded fold)', async () => {
+    const { catalog, provider } = providerCatalog();
+    const config = testDreamuxConfig([testDispatcherConfig({ cwd: dispatcherCwd })]);
+    const service = new TeamMateAgentService({
+      config,
+      dispatchers: new DispatcherStore(config),
+      agentRuntimeProviders: catalog,
+      onTeamMateCompletion: () => undefined,
+      log: noopLog(),
+    });
+
+    const name = (
+      await service.spawn({
+        dispatcherId: 'flow',
+        name: 'evict',
+        intent: 'work',
+        prompt: 'first',
+        cwd: root,
+      })
+    ).teammate.name;
+    const runtime = provider.runtimes[0]!;
+    // Settle FOUR turns in one session so last(turns=2) must drive the bounded
+    // fold's eviction path (recent.size > requestedTurns) more than once.
+    runtime.lastText = 'a1';
+    runtime.settle('completed', 'turn-1');
+    await waitForSettled(service, 1);
+    for (const [turnId, text, prompt] of [
+      ['turn-2', 'a2', 'second'],
+      ['turn-3', 'a3', 'third'],
+      ['turn-4', 'a4', 'fourth'],
+    ] as const) {
+      await service.send({ dispatcherId: 'flow', name, prompt });
+      runtime.lastText = text;
+      runtime.settle('completed', turnId);
+      await waitForSettled(service, Number(turnId.slice('turn-'.length)));
+    }
+
+    // Only the two most-recent-by-start turns survive, in append order.
+    const last = await service.last('flow', name, 2);
+    expect(last.requested_turns).toBe(2);
+    expect(last.returned_turns).toBe(2);
+    expect(last.turns.map((turn) => turn.turn_id)).toEqual(['turn-3', 'turn-4']);
+    expect(last.turns.map((turn) => turn.assistant)).toEqual(['a3', 'a4']);
+    // Default (turns=1) keeps only the newest.
+    const latest = await service.last('flow', name);
+    expect(latest.turns.map((turn) => turn.turn_id)).toEqual(['turn-4']);
+  });
+
   it('last works on a closed teammate without starting a runtime (#188)', async () => {
     const { catalog, provider } = providerCatalog();
     const config = testDreamuxConfig([testDispatcherConfig({ cwd: dispatcherCwd })]);


### PR DESCRIPTION
#182 的收尾清理 PR，目标是让该 epic 在并入前**不留任何 deferred item 到下一个 epic**（依据 issue #182 评论 line 489 的 hard gate 与 line 490/492「所有 deferred/P2/follow-up 必须在 #182 内解决，可合并到一个最终清理 PR」）。基于 feature 最新 head（已含 PR-6/PR-7）。目标分支 `feature/state-layout-epic`，**不要合并**。

## 关闭的 deferred 项

1. **退场 `team.create_group`（hard gate，line 489）**
   - 从公共 Team MCP tool list、capabilities、admin 方法、docs 中移除 `create_group`（建新 Feishu 群 + 拉人）。
   - 其「绑定」职责由 `team.create` 的可选参数 `bind_group: { chat_id }` 取代——在 create 时绑定一个**已存在**的群（走同一 `ChannelBindingStore`）；独立的 `team.bind_group` 仍可后续绑定已存在的群。
   - 一并移除 dreamux 侧建群管道：`TeamService.createGroup`、dispatcher 的 `createFeishuGroup` 接线、channel bot 的 `createGroup` 方法。`@excitedjs/feishu-transport` 里的通用 Lark 原语保持不动（不属于 Team surface，跨包改动超出范围）。

2. **移除只写的 per-name TeamMate history 索引**（PR-6 复审遗留 P2）
   - PR-6 之后 `sessions.jsonl` 会话账本已是唯一恢复记录（list/status/history/last 都读它），`history/<name>.jsonl` 自此**只写不读**、纯属文件膨胀源（正是 #182 要消灭的）。
   - 删除 `appendHistory`、`TeamMateIdentityStore.history()`、对应 path builder、`TeamMateHistoryEvent` 类型；保留 `TeamLedgerEventType` 里的 `create_group` 成员仅用于旧账本解析兼容。

3. **补 `team.history` 分页回归**（PR-7 复审遗留 P2）：cursor 翻页覆盖全量无重叠 + 非法 cursor fail-loud。

## 经判断「已决议、无需实现」的项（不算 unresolved scope）

- Richer `close_status`：#182 决策表为「Defer，保持 open/closed 直到有真实消费者」——这是已决议的「保持简单」，非待办。
- `team.history` 全量读后内存过滤的流式/派生索引：决策为「Team 量级增长后再做」的条件性 future。
- status/history 更深字段（issue 措辞为 Suggested）：可选项，未承诺。

## 兼容性 / Rebuild

- 存量状态无需 rebuild：Team 记录、channel 绑定、会话账本照常加载。遗留的 `teammate/history/<name>.jsonl` 文件变为未使用，可手动删除（changelog 已说明）。
- 调用过 `team.create_group` 的自动化需改用 `team.create` + `bind_group`（绑定已存在的群）；从 Team MCP 新建 Feishu 群的能力不再提供。

## 验证

- `tsc` 通过；`vitest`（DREAMUX_SKIP_LIVE_CODEX=1）**683 passed / 2 skipped**（连续两次稳定绿）；`eslint .` 通过；`.agents` KB OK。
- BREAKING rush change note 已加（英文、公开安全）。

## 是否还有不能留到下个 epic 的剩余项

据我对 #182 评论 + PR-6/PR-7 复审的盘点：**没有**。create_group 退场（hard gate）、其 bind_group 替代、per-name history 移除、Team history 分页测试均已在本 PR 关闭；其余 follow-up 要么本段已做，要么是「保持现状」的已决议项。剩下的只是 epic 并入前各 PR 走完 Codex + Claude 复审。