### PR TITLE
feat(logs): #182 logs 阶段 + macOS runtime-socket 路径预算最终门禁

### DIFF
--- a/.agents/decisions/runtime-run-root.md
+++ b/.agents/decisions/runtime-run-root.md
@@ -65,10 +65,20 @@ feishu-attachments/` dirs — the changelog notes them as manually deletable.
   `codex app-server --listen unix://<path>` and connect with
   `ws+unix://<path>`; resume/checkpoint never depends on the path. Each
   runtime start allocates a fresh short random name
-  (`allocateRuntimeSocketPath`) under, in preference order:
+  (`allocateRuntimeSocketPath`), picking the first of these that fits the
+  `sun_path` budget, in preference order:
   1. `$XDG_RUNTIME_DIR/dreamux/sockets/` (operator input — shared-tmp values
      like `/tmp` are rejected);
-  2. `~/.dreamux/run/sockets/`.
+  2. `~/.dreamux/run/sockets/`;
+  3. `<os-private-temp>/dreamux/sockets/` — the per-user OS temp dir **only when
+     it is private, not world-shared `/tmp`** (issue #182 final gate). On macOS
+     `os.tmpdir()` is the per-user `$TMPDIR` (`/var/folders/<…>/T`, owner-only)
+     and is far shorter than a long per-run durable `$HOME`, so it keeps Codex
+     sockets within budget when there is no `$XDG_RUNTIME_DIR` and
+     `~/.dreamux/run/sockets/` is over budget (the macOS CI failure mode). On
+     Linux `os.tmpdir()` is `/tmp` (shared) and is rejected, so this candidate
+     never reintroduces a world-shared tmp socket. The temp dir is resolved from
+     `TMPDIR`/`TMP`/`TEMP` then `os.tmpdir()`.
   Shared `/tmp` / `/var/tmp` are never used; if no candidate fits the budget,
   allocation fails loudly. The old descriptive `state/<id>/codex.sock` path
   and its digest-named fallback are deleted.

--- a/.agents/decisions/top-level-design.md
+++ b/.agents/decisions/top-level-design.md
@@ -234,28 +234,39 @@ Rules:
 
 State and logs are server-owned. They are not operator-editable config.
 
+The tree splits volatile run files (`run/`) and rebuildable cache (`cache/`)
+from durable state (`state/`); see
+[runtime-run-root](runtime-run-root.md) for the run/cache decision.
+
 ```text
 ~/.dreamux/
-  config.json
-  state/
-    server.json
-    admin.sock
+  config.json                  operator-edited config + Feishu credentials
+  run/                         volatile; safe to clear while no server runs
+    admin.sock                 stable admin/control IPC endpoint
+    admin.sock.lock
+    restart-intent.json        one-shot daemon restart marker
+    sockets/                   fallback root for fresh random runtime sockets
+  cache/
+    dispatcher-a/              rebuildable; safe to clear while no server runs
+      spill/                   over-budget teammate completion spill files
+      feishu-attachments/      inbound attachment downloads
+  state/                       durable server-owned state
     dispatcher-a/
       status.json
       access.json
       chat-bots.json
-      codex.sock
       teammate/
         identities/
           <name>.json          one TeamMate identity/checkpoint per file
         sessions.jsonl         per-dispatcher session ledger (issue #182 PR-5)
         runtime/
-          <name>/              runtime-private socket/config state
+          <name>/              runtime-private config/control state (no sockets)
       team/
         records/
           <team-id>.json        Team lifecycle record and TeamLeader pointer
         ledger/
           <team-id>.jsonl       append-only Team lifecycle ledger
+        channel-bindings.json   Team ↔ Feishu group bindings
   logs/
     dreamux-server.log
     daemon.stdout.log          when run as a daemon (onboard service redirect)
@@ -273,7 +284,15 @@ State and logs are server-owned. They are not operator-editable config.
         dispatcher-a/
           <name>.log           TeamMate Codex runtime stdout
           <name>.stderr.log    TeamMate Codex runtime stderr
+    claude-code/
+      dispatcher-a.stderr.log  Claude Code resident child stderr
+      teammate/
+        dispatcher-a/
+          <name>.stderr.log    TeamMate Claude Code runtime stderr
 ```
+
+Empty runtime child stdout/stderr logs are removed on clean shutdown (see the
+logging note below), so a normal run leaves only files that captured output.
 
 Dreamux-managed TeamMate/Team Git worktrees are NOT under `~/.dreamux` (issue
 #182 PR-4, relocated out of `state/<id>/teammate/worktrees/`). They live in the
@@ -297,10 +316,12 @@ rewrite, no deletion); only newly created managed worktrees use the new location
 Host logging (issue #70): `dreamux serve`, the Feishu channel (gate
 deliver/drop, inbound submit, outbound, `/introduce`), and dispatcher lifecycle
 write structured `pino` JSON to these files (and mirror to stderr so a
-foreground `serve` stays visible). Path builders live in `src/runtime/paths.ts`;
-logger construction lives in `src/runtime/logger.ts`. Message bodies are never
-logged; `app_secret` is redacted. See
-[the logging decision](logging.md).
+foreground `serve` stays visible). Neutral path builders live in
+`src/platform/paths.ts` (with volatile runtime-socket allocation in
+`src/platform/runtime-sockets.ts` and per-runtime log/socket paths in each
+builtin's `src/agent-runtime/builtin/<name>/paths.ts`); logger construction
+lives in `src/platform/logger.ts`. Message bodies are never logged; `app_secret`
+is redacted. See [the logging decision](logging.md).
 
 Logs (issue #182 logs stage): logs are diagnostics, never durable state — the
 whole `logs/` tree is rebuildable and safe to clear while no server runs.
@@ -315,9 +336,6 @@ removes its child's stdout/stderr log on clean shutdown if it stayed zero-byte
 (`platform/logs.ts removeEmptyLogFile`), keeping only files that captured real
 startup/crash output. This is per-child self-cleanup of files this process
 created, distinct from the operator's manual age-based pruning.
-
-`server.json` stores process-level status only: pid, status, version, started
-time, admin socket path, and last error.
 
 `status.json` stores dispatcher process status, last-known Codex thread id,
 child process status, and diagnostic timestamps. It must not contain Feishu
@@ -385,22 +403,28 @@ grants trust. It also records bot-added baseline bookkeeping (`needsBaseline`,
 `seenEventIds` for idempotent `im.chat.member.bot.added_v1` handling). It is
 server-owned discovery state, safe to delete; it holds no credentials.
 
-`codex.sock` is the Codex app-server WebSocket-over-Unix-socket endpoint for the
-dispatcher. It is not the Feishu MCP transport. The Feishu MCP default transport
-is stdio.
+A Codex app-server runtime listens on a WebSocket-over-Unix-socket endpoint
+(`codex app-server --listen unix://<path>`, connected via `ws+unix://<path>`).
+It is not the Feishu MCP transport (the Feishu MCP default transport is stdio).
+The socket is an ephemeral rendezvous endpoint: resume/checkpoint never depends
+on the path, so each runtime start allocates a **fresh random** name and the
+path is never persisted to durable state (identity/history/ledger/checkpoint/
+status) — it lives only in supervisor/runtime memory.
 
 Socket path builders must live in `src/platform/paths.ts` (neutral) and each
-builtin's own `paths.ts` (runtime-specific, per the issue #143 de-leak). They
-must enforce a short Unix socket path budget before spawning child processes.
-Dispatcher ids are validated as stable path segments and length-checked so
-derived `admin.sock` and `codex.sock` paths stay within Linux and macOS
-`sun_path` limits. When a Codex socket's descriptive in-state path exceeds the
-budget (deep `$HOME`, long teammate runtime roots such as
-`state/<dispatcher>/teammate/runtime/<name>/`), the builtin falls back to a
-short deterministic digest-named socket under a private per-user runtime root —
-`XDG_RUNTIME_DIR`, or a non-shared os tmpdir such as macOS's per-user
-`$TMPDIR`. The shared `/tmp` is never used for sockets (see the global-bin
-decision record); with no private root available the start still fails loudly.
+builtin's own `paths.ts` (runtime-specific, per the issue #143 de-leak); the
+volatile rendezvous-socket allocation is `src/platform/runtime-sockets.ts`. They
+enforce a short Unix socket path budget before spawning child processes.
+Dispatcher ids are validated, stable, length-checked path segments so the
+derived `run/admin.sock` stays within Linux and macOS `sun_path` limits.
+`allocateRuntimeSocketPath` picks the first candidate that fits the budget, in
+order: `$XDG_RUNTIME_DIR/dreamux/sockets/`, then `~/.dreamux/run/sockets/`, then
+a private per-user OS temp dir (`<os-private-temp>/dreamux/sockets/`, e.g. macOS
+`$TMPDIR` = `/var/folders/<…>/T`, far shorter than a long durable `$HOME`). The
+shared `/tmp` / `/var/tmp` is never used for sockets (see the global-bin and
+[runtime-run-root](runtime-run-root.md) decisions); with no in-budget candidate
+the start fails loudly. The old descriptive in-state `codex.sock` and its
+deterministic digest-named fallback are gone.
 
 There is no `runtime_dir`, no SQLite database, no persisted inbound message
 queue, and no persisted reaction ledger. `stateRoot()` is the single state root;

--- a/.agents/decisions/top-level-design.md
+++ b/.agents/decisions/top-level-design.md
@@ -302,6 +302,20 @@ logger construction lives in `src/runtime/logger.ts`. Message bodies are never
 logged; `app_secret` is redacted. See
 [the logging decision](logging.md).
 
+Logs (issue #182 logs stage): logs are diagnostics, never durable state — the
+whole `logs/` tree is rebuildable and safe to clear while no server runs.
+Retention is **manual**, not automatic: Dreamux does not age-prune logs in 0.x;
+a 7-day retention is the documented guidance and zero-byte files are always safe
+to delete (see the `dreamux-maintenance` skill's Log Maintenance section). Runtime
+child stdout/stderr logs are opened eagerly as inherited fds (they cannot be
+lazily created — the child needs a valid fd at spawn), and normal Codex/Claude
+traffic flows over the socket/stream rather than stdout/stderr, so they are
+usually empty. To stop one-empty-file-per-start accumulation, each supervisor
+removes its child's stdout/stderr log on clean shutdown if it stayed zero-byte
+(`platform/logs.ts removeEmptyLogFile`), keeping only files that captured real
+startup/crash output. This is per-child self-cleanup of files this process
+created, distinct from the operator's manual age-based pruning.
+
 `server.json` stores process-level status only: pid, status, version, started
 time, admin socket path, and last error.
 

--- a/common/changes/@excitedjs/dreamux/epic182-logs-and-socket-budget_2026-06-11-22-00.json
+++ b/common/changes/@excitedjs/dreamux/epic182-logs-and-socket-budget_2026-06-11-22-00.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Logs stage + runtime socket path-budget fix (issue #182). Logs: runtime child stdout/stderr log files are opened eagerly as inherited fds and normal Codex/Claude traffic flows over the socket/stream, so they are usually empty; each supervisor now removes its child's stdout/stderr log on clean shutdown when it stayed zero-byte, so empty logs no longer accumulate one-per-start (files that captured startup/crash output are kept). Log retention stays MANUAL in 0.x — Dreamux does not age-prune logs; a 7-day retention is the documented guidance and zero-byte files are always safe to delete (see the dreamux-maintenance skill's Log Maintenance section). The whole ~/.dreamux/logs/ tree is rebuildable and safe to clear while no server runs. Runtime sockets: the volatile rendezvous-socket allocator now also considers a private per-user OS temp dir (resolved from TMPDIR/TMP/TEMP then os.tmpdir()) after $XDG_RUNTIME_DIR and ~/.dreamux/run/sockets/, but only when it is NOT a world-shared root like /tmp (Linux /tmp is still rejected). On macOS, os.tmpdir() is the per-user $TMPDIR (/var/folders/.../T, owner-only) and is far shorter than a long per-run $HOME, so Codex/Claude sockets stay within the Unix sun_path budget when there is no $XDG_RUNTIME_DIR and the run root would be over budget — fixing the macOS path-budget failure without using shared /tmp and without persisting socket paths. Rebuild: none. No config/state schema change; old empty log files left by a previous version may be deleted manually.",
+      "type": "minor",
+      "packageName": "@excitedjs/dreamux"
+    }
+  ],
+  "packageName": "@excitedjs/dreamux",
+  "email": "053700@gmail.com"
+}

--- a/packages/dreamux/skills/dreamux-maintenance/SKILL.md
+++ b/packages/dreamux/skills/dreamux-maintenance/SKILL.md
@@ -71,6 +71,27 @@ dreamux config show
 | Skill path is a real file or directory | Dreamux leaves it untouched. If this is an intentional override, keep it; otherwise rename or remove it and restart the dispatcher. |
 | Skill symlink is broken after an upgrade | Restart the dispatcher or rerun `dreamux onboard`; startup recreates stale or broken bundled skill symlinks. |
 
+## Log Maintenance
+
+Dreamux does not auto-prune logs (no automatic retention in 0.x). Pruning is a
+deliberate operator action:
+
+- A **7-day retention** is acceptable; delete logs older than that when disk
+  matters. Logs hold only diagnostics, never durable state.
+- **Zero-byte log files are always safe to delete.** Empty runtime child
+  stdout/stderr logs are now removed automatically when the child shuts down
+  cleanly, so they no longer accumulate one-per-start; what remains under
+  `~/.dreamux/logs/` are files that actually captured startup/crash output.
+- The whole `~/.dreamux/logs/` tree is rebuildable: it is safe to clear while no
+  `dreamux serve` is running; it is recreated on the next start.
+
+Prune manually, e.g. (run only while the server is stopped):
+
+```bash
+find ~/.dreamux/logs -type f -mtime +7 -delete   # drop logs older than 7 days
+find ~/.dreamux/logs -type f -empty -delete       # drop any leftover empties
+```
+
 ## Turn Mechanics
 
 For questions about active turns, steering, background commands, and repeated

--- a/packages/dreamux/src/agent-runtime/builtin/claude-code/supervisor.ts
+++ b/packages/dreamux/src/agent-runtime/builtin/claude-code/supervisor.ts
@@ -15,6 +15,7 @@ import {
   isProcessAlive,
   killProcessGroup,
 } from '../../../platform/process.js';
+import { removeEmptyLogFile } from '../../../platform/logs.js';
 import { ClaudeCodeStreamRpc } from './rpc.js';
 import type {
   ClaudeCodeSession,
@@ -160,6 +161,10 @@ class LiveClaudeCodeSession implements ClaudeCodeSession {
     this.exited = true;
     this.rpc = null;
     this.child = null;
+    // The child is gone, so its inherited stderr fd is released. Drop the stderr
+    // log if it stayed empty — claude traffic flows over the resident stream, so
+    // it usually captures nothing (issue #182 logs stage).
+    await removeEmptyLogFile(this.spec.stderrLogPath);
   }
 
   private onChildExit(): void {

--- a/packages/dreamux/src/agent-runtime/builtin/codex/supervisor.ts
+++ b/packages/dreamux/src/agent-runtime/builtin/codex/supervisor.ts
@@ -22,6 +22,7 @@ import { mkdir, open, rm, stat } from 'node:fs/promises';
 import { dirname } from 'node:path';
 import { isProcessAlive, killProcessGroup } from '../../../platform/process.js';
 import { ensureOwnerOnlyDir } from '../../../platform/owner-only-dir.js';
+import { removeEmptyLogFile } from '../../../platform/logs.js';
 
 export interface CodexProcessOptions {
   /** Unix socket path the daemon should listen on. */
@@ -190,6 +191,11 @@ export class CodexProcess {
     } catch {
       /* best effort */
     }
+    // The child has exited, so its inherited stdout/stderr fds are released.
+    // Drop the log files if the child produced no output — normal Codex traffic
+    // flows over the socket, so they are usually empty (issue #182 logs stage).
+    await removeEmptyLogFile(this.opts.stdoutLogPath);
+    await removeEmptyLogFile(this.opts.stderrLogPath);
     this.child = null;
   }
 }

--- a/packages/dreamux/src/platform/logs.ts
+++ b/packages/dreamux/src/platform/logs.ts
@@ -1,0 +1,31 @@
+/**
+ * Log-file hygiene helpers (issue #182 logs stage).
+ *
+ * Runtime child stdout/stderr logs are opened eagerly as inherited fds before
+ * the child produces any output (the supervisor must hand the child a valid fd
+ * at spawn time, so they cannot be created lazily). Normal Codex traffic flows
+ * over the Unix socket and normal Claude Code traffic over the resident stream,
+ * so these files mostly stay empty and would otherwise accumulate one zero-byte
+ * file per runtime start. After a clean child shutdown the owning supervisor
+ * calls {@link removeEmptyLogFile} on each child log path to drop the empties
+ * while keeping any file that actually captured startup/crash output.
+ *
+ * This is per-child self-cleanup of files this process created — NOT age-based
+ * pruning of the operator's accumulated logs, which #182 keeps manual.
+ */
+
+import { stat, unlink } from 'node:fs/promises';
+
+/**
+ * Remove `path` only if it exists and is zero bytes. Best-effort: a missing
+ * file, a non-empty file, or any IO error leaves things untouched and never
+ * throws, so teardown is never blocked by log hygiene.
+ */
+export async function removeEmptyLogFile(path: string): Promise<void> {
+  try {
+    const info = await stat(path);
+    if (info.size === 0) await unlink(path);
+  } catch {
+    /* best effort — missing/busy/non-empty files are left as-is */
+  }
+}

--- a/packages/dreamux/src/platform/runtime-sockets.ts
+++ b/packages/dreamux/src/platform/runtime-sockets.ts
@@ -8,11 +8,20 @@
  * path must never be persisted into durable state (identity, history, ledger,
  * checkpoint, or status surfaces) — it lives only in supervisor/runtime memory.
  *
- * Placement preference:
+ * Placement preference (the allocator picks the first that fits the `sun_path`
+ * budget):
  *   1. `$XDG_RUNTIME_DIR/dreamux/sockets/` — the canonical private per-user
  *      runtime dir on Linux. It is operator input, so a shared-tmp value is
  *      rejected rather than trusted.
  *   2. `~/.dreamux/run/sockets/` — the dreamux-owned volatile run root.
+ *   3. `<os-private-temp>/dreamux/sockets/` — the per-user OS temp dir **only
+ *      when it is a private root, not world-shared `/tmp`** (issue #182 final
+ *      gate). On macOS `os.tmpdir()` is the per-user `$TMPDIR`
+ *      (`/var/folders/<…>/T`, owner-only) and is far shorter than a long
+ *      per-run durable `$HOME`, so it keeps Codex sockets within budget when
+ *      there is no `$XDG_RUNTIME_DIR` and `~/.dreamux/run/sockets/` is over
+ *      budget. On Linux `os.tmpdir()` is `/tmp` (shared) and is rejected, so
+ *      this candidate never reintroduces a world-shared tmp socket.
  * Shared world-writable tmp roots (`/tmp`, `/var/tmp`) are never used for
  * sockets (global-bin decision record). When no candidate fits the `sun_path`
  * budget, allocation fails loudly.
@@ -25,6 +34,7 @@
 
 import { randomBytes } from 'node:crypto';
 import { rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
 import { join, normalize, sep } from 'node:path';
 
 import {
@@ -61,7 +71,30 @@ export function runtimeSocketDirCandidates(
     candidates.push(join(xdg, 'dreamux', 'sockets'));
   }
   candidates.push(join(runRoot(), 'sockets'));
+  // Per-user OS temp dir, but only when it is a PRIVATE root (macOS `$TMPDIR`
+  // = `/var/folders/<…>/T`, owner-only) — never world-shared `/tmp` (Linux),
+  // which `isSharedTmpPath` rejects. This is the short, private fallback that
+  // keeps sockets within the `sun_path` budget on macOS with no
+  // `$XDG_RUNTIME_DIR` and a long per-run `$HOME` (issue #182 final gate). It
+  // is consulted after the dreamux-owned run root, so short-`$HOME` placement
+  // is unchanged; the supervisor still enforces owner-only on the dir.
+  const tmp = osTempDir(env);
+  if (tmp !== '' && !isSharedTmpPath(tmp)) {
+    candidates.push(join(tmp, 'dreamux', 'sockets'));
+  }
   return candidates;
+}
+
+/**
+ * The per-user OS temp directory, resolved from the passed env so tests are
+ * deterministic, mirroring Node's `os.tmpdir()` precedence
+ * (`TMPDIR` → `TMP` → `TEMP` → platform default).
+ */
+function osTempDir(env: NodeJS.ProcessEnv): string {
+  const fromEnv = env['TMPDIR'] ?? env['TMP'] ?? env['TEMP'];
+  const raw = fromEnv !== undefined && fromEnv.trim() !== '' ? fromEnv : tmpdir();
+  // Strip a single trailing separator so joined paths stay canonical.
+  return raw.endsWith(sep) && raw.length > 1 ? raw.slice(0, -1) : raw;
 }
 
 /**
@@ -81,9 +114,9 @@ export function allocateRuntimeSocketPath(
     const path = join(dir, name);
     if (unixSocketPathFitsBudget(path)) return path;
   }
-  // No candidate fits the budget. `runtimeSocketDirCandidates` always ends with
-  // the dreamux-owned run/sockets dir, so re-asserting on the last candidate
-  // (still a sweepable dir, not the bare run root) yields the fail-loud message.
+  // No candidate fits the budget. Every candidate is a dreamux-owned, sweepable
+  // sockets dir (never the bare run root), so re-asserting on the last one
+  // yields the fail-loud message naming the longest-shot placement we tried.
   const fallback = candidates[candidates.length - 1] as string;
   return assertUnixSocketPathBudget(join(fallback, name), label);
 }

--- a/packages/dreamux/tests/dispatcher-codex-home.test.ts
+++ b/packages/dreamux/tests/dispatcher-codex-home.test.ts
@@ -16,6 +16,7 @@ import {
   runRoot,
   setRuntimeConfig,
   stateRoot,
+  unixSocketPathFitsBudget,
 } from '../src/platform/paths.js';
 import {
   allocateCodexSocketPath,
@@ -110,10 +111,15 @@ describe('global Codex home doctor', () => {
 
   it('rejects too-long app-server socket paths when no private root fits the budget', async () => {
     const previousXdg = process.env['XDG_RUNTIME_DIR'];
-    // A pathological $HOME blows the budget for the dreamux-owned fallback,
-    // and with no XDG root there is no other candidate: fail loudly.
+    const previousTmpdir = process.env['TMPDIR'];
+    // A pathological $HOME blows the budget for the dreamux-owned fallback. To
+    // assert the fail-loud path deterministically across platforms, also remove
+    // the other private candidates: no XDG root, and a shared-tmp TMPDIR so the
+    // private-OS-temp candidate is rejected too (on macOS the real $TMPDIR is a
+    // short private root that would otherwise fit; issue #182 final gate).
     process.env['HOME'] = join(runtimeDir, 'h'.repeat(120));
     delete process.env['XDG_RUNTIME_DIR'];
+    process.env['TMPDIR'] = '/tmp';
 
     try {
       await expect(
@@ -122,6 +128,29 @@ describe('global Codex home doctor', () => {
     } finally {
       if (previousXdg === undefined) delete process.env['XDG_RUNTIME_DIR'];
       else process.env['XDG_RUNTIME_DIR'] = previousXdg;
+      if (previousTmpdir === undefined) delete process.env['TMPDIR'];
+      else process.env['TMPDIR'] = previousTmpdir;
+    }
+  });
+
+  it('uses the private OS temp dir for deep home dirs when XDG is absent (#182 macOS gate)', async () => {
+    const previousXdg = process.env['XDG_RUNTIME_DIR'];
+    const previousTmpdir = process.env['TMPDIR'];
+    // The macOS CI shape: long $HOME, no $XDG_RUNTIME_DIR, but a short PRIVATE
+    // $TMPDIR keeps the Codex socket within budget instead of failing loudly.
+    process.env['HOME'] = join(runtimeDir, 'h'.repeat(120));
+    delete process.env['XDG_RUNTIME_DIR'];
+    process.env['TMPDIR'] = join(runtimeDir, 't');
+
+    try {
+      const socket = allocateCodexSocketPath('dispatcher-with-long-id');
+      expect(socket.startsWith(join(runtimeDir, 't', 'dreamux', 'sockets'))).toBe(true);
+      expect(unixSocketPathFitsBudget(socket)).toBe(true);
+    } finally {
+      if (previousXdg === undefined) delete process.env['XDG_RUNTIME_DIR'];
+      else process.env['XDG_RUNTIME_DIR'] = previousXdg;
+      if (previousTmpdir === undefined) delete process.env['TMPDIR'];
+      else process.env['TMPDIR'] = previousTmpdir;
     }
   });
 

--- a/packages/dreamux/tests/log-hygiene.test.ts
+++ b/packages/dreamux/tests/log-hygiene.test.ts
@@ -1,0 +1,46 @@
+import { mkdtempSync, rmSync } from 'node:fs';
+import { readFile, stat, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { removeEmptyLogFile } from '../src/platform/logs.js';
+
+/**
+ * Empty child-log cleanup (issue #182 logs stage): supervisors call
+ * `removeEmptyLogFile` on a child's stdout/stderr log after the child exits, so
+ * a clean run that produced no output leaves no zero-byte file behind, while any
+ * file that captured output is kept.
+ */
+describe('removeEmptyLogFile', () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'dreamux-log-hygiene-'));
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('removes a zero-byte log file', async () => {
+    const path = join(dir, 'child.stderr.log');
+    await writeFile(path, '');
+    await removeEmptyLogFile(path);
+    await expect(stat(path)).rejects.toMatchObject({ code: 'ENOENT' });
+  });
+
+  it('keeps a log file that captured output', async () => {
+    const path = join(dir, 'child.stderr.log');
+    await writeFile(path, 'panic: something went wrong\n');
+    await removeEmptyLogFile(path);
+    expect(await readFile(path, 'utf8')).toBe('panic: something went wrong\n');
+  });
+
+  it('is a no-op (never throws) when the file does not exist', async () => {
+    await expect(
+      removeEmptyLogFile(join(dir, 'never-created.log')),
+    ).resolves.toBeUndefined();
+  });
+});

--- a/packages/dreamux/tests/runtime-sockets.test.ts
+++ b/packages/dreamux/tests/runtime-sockets.test.ts
@@ -21,6 +21,7 @@ describe('runtime socket allocation', () => {
   let root: string;
   let previousHome: string | undefined;
   let previousXdg: string | undefined;
+  let previousTmpdir: string | undefined;
 
   beforeEach(() => {
     // The fixture root must NOT live under /tmp: the shared-tmp guard would
@@ -29,8 +30,14 @@ describe('runtime socket allocation', () => {
     root = mkdtempSync(join(homedir(), '.dreamux-sockets-test-'));
     previousHome = process.env['HOME'];
     previousXdg = process.env['XDG_RUNTIME_DIR'];
+    previousTmpdir = process.env['TMPDIR'];
     process.env['HOME'] = join(root, 'home');
     delete process.env['XDG_RUNTIME_DIR'];
+    // Pin TMPDIR to a shared-tmp value so the private-OS-temp candidate is
+    // excluded by default; tests that exercise it set TMPDIR explicitly. This
+    // keeps allocation deterministic across Linux (`/tmp`) and macOS
+    // (`$TMPDIR` = `/var/folders/…`, which would otherwise be a valid candidate).
+    process.env['TMPDIR'] = '/tmp';
     resetRuntimeConfig();
   });
 
@@ -39,6 +46,8 @@ describe('runtime socket allocation', () => {
     else process.env['HOME'] = previousHome;
     if (previousXdg === undefined) delete process.env['XDG_RUNTIME_DIR'];
     else process.env['XDG_RUNTIME_DIR'] = previousXdg;
+    if (previousTmpdir === undefined) delete process.env['TMPDIR'];
+    else process.env['TMPDIR'] = previousTmpdir;
     resetRuntimeConfig();
     rmSync(root, { recursive: true, force: true });
   });
@@ -86,8 +95,40 @@ describe('runtime socket allocation', () => {
     }
   });
 
+  it('uses a private OS temp dir when XDG is absent and the run root is over budget (#182 macOS gate)', () => {
+    // Reproduce the macOS CI failure: no XDG_RUNTIME_DIR and a long per-run HOME
+    // push ~/.dreamux/run/sockets over the sun_path budget. A short, PRIVATE
+    // TMPDIR (the macOS $TMPDIR analog) must keep the socket within budget
+    // without touching shared /tmp or depending on the long durable HOME.
+    process.env['HOME'] = join(root, 'h'.repeat(120));
+    resetRuntimeConfig();
+    const privateTmp = join(root, 't'); // short, under the real (short) home
+    const path = allocateRuntimeSocketPath('test socket', { TMPDIR: privateTmp });
+    expect(path.startsWith(join(privateTmp, 'dreamux', 'sockets'))).toBe(true);
+    expect(path.endsWith('.sock')).toBe(true);
+    expect(unixSocketPathFitsBudget(path)).toBe(true);
+    expect(isSharedTmpPath(path)).toBe(false);
+  });
+
+  it('never uses a shared-tmp TMPDIR for sockets', () => {
+    // On Linux os.tmpdir() is /tmp (shared); the private-temp candidate must be
+    // excluded so we never reintroduce a world-shared tmp socket.
+    for (const sharedTmp of ['/tmp', '/var/tmp', '/private/tmp']) {
+      expect(runtimeSocketDirCandidates({ TMPDIR: sharedTmp })).toEqual([
+        join(runRoot(), 'sockets'),
+      ]);
+    }
+    // A private TMPDIR is appended after the dreamux run root, never before it.
+    expect(runtimeSocketDirCandidates({ TMPDIR: join(root, 't') })).toEqual([
+      join(runRoot(), 'sockets'),
+      join(root, 't', 'dreamux', 'sockets'),
+    ]);
+  });
+
   it('fails loudly when even the dreamux-owned fallback is over budget', () => {
     process.env['HOME'] = join(root, 'h'.repeat(120));
+    // TMPDIR pinned to shared /tmp (beforeEach) is excluded, so no private-temp
+    // candidate rescues an over-budget run root here.
     expect(() => allocateRuntimeSocketPath('test socket', {})).toThrow(
       /test socket is too long for Unix sockets/,
     );


### PR DESCRIPTION
基于 `feature/state-layout-epic` 最新 head（含 PR-8 `b3e3a86`）。本 PR 收掉 #182 的 **logs 阶段**，并一并关闭从已关闭的 #192 预览评审遗留的 **macOS runtime-socket 路径预算 final-integration blocker**（见 issue #182 最新 blocker 评论）。目标分支 `feature/state-layout-epic`，**不要合并**。

## Logs 阶段（#182 第 8 步）

按 issue 决策（决策表第 8 行「lazy creation / fewer empty files / retained diagnosability」；operator：7 天保留可接受、零字节日志可直接删、**清理不做自动代码**、保留分离 stderr 文件不转 JSONL）：

- 新增 `platform/logs.ts removeEmptyLogFile(path)`：对零字节文件 stat+unlink，best-effort。运行时子进程 stdout/stderr 日志是以**继承 fd** 方式在 spawn 前就打开的（子进程在 spawn 时必须拿到有效 fd，无法真正惰性创建），而正常 Codex/Claude 流量走 socket/stream，所以这些文件通常为空。codex 与 claude-code supervisor 现在在子进程干净退出（reap/stop）后，对其 stdout/stderr 日志调用它——空日志不再「每次启动攒一个」，有真实启动/崩溃输出的文件保留。这是对**本进程自己创建**的空文件做自清理，与「按时间批量删历史日志」无关。
- **保留策略仍是手动**（0.x 不做自动 age-pruning）：在 `dreamux-maintenance` skill 新增 Log Maintenance 段（7 天保留指引、零字节随时可删、`logs/` 整树可重建、给出仅在停服时运行的 `find` 示例）；KB top-level-design 同步。

## Runtime socket 路径预算（final gate blocker）

`allocateRuntimeSocketPath` 现在在 `$XDG_RUNTIME_DIR/dreamux/sockets/` 与 `~/.dreamux/run/sockets/` 之后，**再**考虑 `<os-private-temp>/dreamux/sockets/`，但仅当该 OS temp 根是**私有**目录、而非世界共享的 `/tmp`：

- macOS 上 `os.tmpdir()` 即每用户私有的 `$TMPDIR`（`/var/folders/<…>/T`，owner-only），远短于较长的 per-run `$HOME`——因此在**无 `$XDG_RUNTIME_DIR` 且 run root 超预算**（正是 macOS CI 失败场景）时，Codex/Claude socket 仍在 `sun_path` 103 字节预算内。
- Linux 的 `/tmp` 仍被 `isSharedTmpPath` 拒绝，绝不重新引入共享 /tmp socket；socket 路径不持久化、不入 durable state；候选目录均为 dreamux-owned、可被 sweep；supervisor 仍 `ensureOwnerOnlyDir` 强制 owner-only。
- 注：`top-level-design.md` 本就把「macOS 私有 `$TMPDIR`」写为既定设计；此前**实现漏了该候选**，本 PR 让代码与设计对齐。`runtime-run-root.md` 决策文档补上第 3 候选。

## 验证

- `tsc` 通过；`eslint .` 通过；`.agents` KB OK；`vitest`（DREAMUX_SKIP_LIVE_CODEX=1）**690 passed / 2 skipped**。
- 新增测试：log-hygiene 单测（删空/留非空/缺失即 no-op）；runtime-socket macOS 门禁（私有 TMPDIR 让超预算 run-root 场景回到预算内）+ 共享 /tmp 拒绝；既有 socket 测试用 `TMPDIR` 固定以跨平台确定性。
- Rush change note 已加（无 rebuild）。

> 无法在本机跑 macOS CI；该修复同时覆盖真实 macOS 使用与 CI（私有 $TMPDIR 候选），并有针对超预算 + 私有 TMPDIR 的单测护栏。

## logs 阶段是否还有不能留到后面的项

据我盘点：**没有**。row-8 三项（lazy/fewer-empty/diagnosability）已落地；7 天保留按 operator 决策做成**文档化手动**（非自动代码）；macOS socket 预算 blocker 已修。日志目录的**结构性 per-dispatcher 重排**（提案树里的 `logs/<id>/{channel,mcp,runtimes}`）是「方向性 consider」、非 row-8 交付项，且空文件清理已实质消解「空/分散」问题——我未做该大改，作为可选结构性后续项交由 operator 决定；如要也可在本 epic 内追加。