### PR TITLE
ci: 让门禁覆盖 feature 集成分支，而非仅 main (#182)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,11 +23,17 @@
 
 name: ci
 
+# Trigger scope: these gates must cover the epic integration branches too, not
+# only `main`. Implementation PRs target a `feature/**` integration branch first
+# (issue #182), so a `main`-only filter left those PRs unchecked and forced
+# manual `workflow_dispatch` runs. Run on PRs into `main` or any `feature/**`
+# branch, on pushes to those branches (validating the integrated state after a
+# merge), and on manual dispatch.
 on:
   push:
-    branches: [main]
+    branches: [main, 'feature/**']
   pull_request:
-    branches: [main]
+    branches: [main, 'feature/**']
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
插队小 PR（#182 评论 line 514/519 的 operator 指示）：收敛 CI 触发范围，让必要的 build/typecheck/lint/test 等门禁覆盖所有相关分支/PR，而不是只在 `main` 相关 PR 上跑。基于 `feature/state-layout-epic` 最新 head。目标分支 `feature/state-layout-epic`，**不要合并**。

## 背景

本 epic 的实现 PR 先打到 `feature/state-layout-epic`（再到 `main`）。原 `ci.yml` 只在 `push`/`pull_request` 到 `main` 触发，导致面向 feature 分支的 PR（如 #190/#191/#193）**完全不跑** build/typecheck/lint/test/shellcheck/gitleaks/KB 门禁——尤其 macOS `rush test`，此前只能靠手动 `workflow_dispatch` 才验证到（#193 的 macOS gate 就是这么发现并修的）。

## 改动（单文件，`.github/workflows/ci.yml`）

```yaml
on:
  push:
    branches: [main, 'feature/**']
  pull_request:
    branches: [main, 'feature/**']
  workflow_dispatch:
```

- `pull_request`：base 为 `main` **或** `feature/**` 的 PR 都跑全部 gate。
- `push`：推到 `main`/`feature/**` 时跑（合并后验证集成态）。
- `workflow_dispatch` 保留。
- PR-only job（`rush change` 声明检查）与 diff-base 逻辑本就 key on `github.base_ref` / event name，feature-base 下无需改动即可正确工作。

## 验证

- `python3 -c yaml.safe_load` 解析通过；`on` 为 `{push:{branches:[main,feature/**]}, pull_request:{branches:[main,feature/**]}, workflow_dispatch}`。
- `workflow_dispatch` 在本分支 head 手动跑了一次完整 CI 以确认 workflow 仍可执行且全绿：见 Actions（run 链接见 PR 评论/Actions 页）。
- 纯 CI workflow 改动，无源码/测试变更，故未跑 vitest/tsc（不受影响）。
- gitleaks 干净；提交带 Claude co-author trailer；`.codex/` 未提交。

## 注意（行为何时生效）

`pull_request` 事件使用 **base 分支**上的 workflow 定义。本 PR 的 base（`feature/state-layout-epic`）当前仍是旧的 main-only 触发，所以**本 PR 自身不会自动触发** CI（这也是我用 `workflow_dispatch` 验证的原因）。一旦本 PR 合入 feature，之后所有面向 `feature/**` 的 PR 都会自动跑门禁，无需再手动 dispatch。

## P0/P1

无。单文件触发范围调整，最小完整。