### PR TITLE
fix(state): teammate.history 走 streaming fold，不再无界读取整份 ledger (#182 final gate)

### DIFF
--- a/common/changes/@excitedjs/dreamux/epic182-history-streaming-fold_2026-06-11-23-00.json
+++ b/common/changes/@excitedjs/dreamux/epic182-history-streaming-fold_2026-06-11-23-00.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Internal: fold the per-dispatcher session ledger via a streaming reader so `teammate.history` (materializeSessions) no longer buffers the whole append-only sessions.jsonl into an events array (issue #182 final gate). No user-visible behavior, API, schema, or path change; history output is identical.",
+      "type": "none",
+      "packageName": "@excitedjs/dreamux"
+    }
+  ],
+  "packageName": "@excitedjs/dreamux",
+  "email": "053700@gmail.com"
+}

--- a/packages/dreamux/src/dispatcher-service/teammate/session-ledger.ts
+++ b/packages/dreamux/src/dispatcher-service/teammate/session-ledger.ts
@@ -198,6 +198,21 @@ export class TeamMateSessionLedger {
     dispatcherId: string,
     sessionId: string,
   ): AsyncGenerator<TeamMateSessionLedgerEvent> {
+    for await (const event of this.streamEvents(dispatcherId)) {
+      if (event.session_id === sessionId) yield event;
+    }
+  }
+
+  /**
+   * Stream every ledger event for one dispatcher in append order, yielding line
+   * by line so callers fold with bounded memory rather than buffering the whole
+   * file (a settled event can carry up to 160k chars of assistant text, so the
+   * long-lived append-only ledger must never be materialized whole — issue #182
+   * final gate). A missing ledger yields nothing; a torn/partial line is skipped.
+   */
+  private async *streamEvents(
+    dispatcherId: string,
+  ): AsyncGenerator<TeamMateSessionLedgerEvent> {
     const path = dispatcherTeamMateSessionLedgerPath(dispatcherId);
     const stream = createReadStream(path, { encoding: 'utf8' });
     const lines = createInterface({ input: stream, crlfDelay: Infinity });
@@ -210,7 +225,7 @@ export class TeamMateSessionLedger {
         } catch {
           continue; // skip a torn/partial line rather than fail the read
         }
-        if (parsed.session_id === sessionId) yield parsed;
+        yield parsed;
       }
     } catch (err) {
       if (!isNotFound(err)) {
@@ -226,13 +241,16 @@ export class TeamMateSessionLedger {
 
   /**
    * Fold the ledger into one {@link TeamMateSessionRow} per `session_id` — the
-   * recovery view a session can be reconstructed from. PR-6 builds the public,
-   * filterable/cursored query on top of this.
+   * recovery view a session can be reconstructed from, and the source the public
+   * `history` surface filters/paginates over. Folds over a STREAMING reader so it
+   * never buffers the whole append-only ledger: only one event is live at a time
+   * and the rows hold bounded aggregates/previews (never the full assistant
+   * text), so memory scales with the session count, not the ledger length or the
+   * captured-output size (issue #182 final gate).
    */
   async materializeSessions(dispatcherId: string): Promise<TeamMateSessionRow[]> {
-    const events = await this.read(dispatcherId);
     const rows = new Map<string, TeamMateSessionRow>();
-    for (const event of events) {
+    for await (const event of this.streamEvents(dispatcherId)) {
       const existing = rows.get(event.session_id);
       const row = existing ?? newSessionRow(event);
       row.last_seen_at = Math.max(row.last_seen_at, event.timestamp);

--- a/packages/dreamux/tests/session-ledger.test.ts
+++ b/packages/dreamux/tests/session-ledger.test.ts
@@ -4,7 +4,7 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { execa } from 'execa';
 
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import {
   AgentRuntimeProviderCatalog,
@@ -210,6 +210,35 @@ describe('TeamMateSessionLedger (unit)', () => {
     const ledger = new TeamMateSessionLedger(noopLog());
     await ledger.append({ identity: identity({ session_id: null }), type: 'spawn', prompt: 'x' });
     expect(await ledger.read('flow')).toEqual([]);
+  });
+
+  it('materializeSessions folds via a streaming reader, not an unbounded read() (#182 final gate)', async () => {
+    const ledger = new TeamMateSessionLedger(noopLog());
+    // Two sessions; one carries a huge settled assistant body to model the
+    // long-ledger memory risk the streaming fold must avoid.
+    await ledger.append({ identity: identity({ session_id: 'sess-a', name: 'a' }), type: 'spawn', prompt: 'a1', turnId: 't1' });
+    await ledger.append({
+      identity: identity({ session_id: 'sess-a', name: 'a' }),
+      type: 'settled',
+      turnId: 't1',
+      assistant: 'x'.repeat(170_000),
+      settleStatus: 'completed',
+    });
+    await ledger.append({ identity: identity({ session_id: 'sess-b', name: 'b' }), type: 'spawn', prompt: 'b1', turnId: 't1' });
+
+    // The public `history` source must not buffer the whole append-only ledger
+    // into an events array via the unbounded `read()`.
+    const readSpy = vi.spyOn(ledger, 'read');
+    const rows = await ledger.materializeSessions('flow');
+    expect(readSpy).not.toHaveBeenCalled();
+    readSpy.mockRestore();
+
+    expect(rows.map((r) => r.session_id).sort()).toEqual(['sess-a', 'sess-b']);
+    // Folded rows keep only bounded previews — never the full assistant text.
+    const a = rows.find((r) => r.session_id === 'sess-a')!;
+    expect(a.last_assistant_preview).not.toBeNull();
+    expect(a.last_assistant_preview!.length).toBeLessThanOrEqual(500);
+    expect(JSON.stringify(rows)).not.toContain('x'.repeat(1000));
   });
 });
 


### PR DESCRIPTION
修复 #195 最终 feature→main 集成 review 的 Codex P1。基于 `feature/state-layout-epic` 最新 head。目标分支 `feature/state-layout-epic`，**不要合并**；合入后 #195 会随 feature 更新。

## P1（属实）

公开 `teammate.history` 路径 `historyScoped → sessionLedger.materializeSessions()` 之前调用 `read(dispatcherId)`（无 `limit`），先把整份 `state/<id>/teammate/sessions.jsonl` materialize 成事件数组（含每条 settled 行最多 160k 的 assistant 文本），再折叠/过滤/分页。这条 read path 的内存随 append-only ledger 总事件数增长，违反了「单个 append-only per-dispatcher ledger 必须 streaming/bounded 读取」的 final gate（`last(turns)` 早已 streaming，问题只在 `history`）。

## 改动

- 抽出私有 `streamEvents(dispatcherId)` async generator（逐行、append 顺序）；`streamSession` 改为带 session 过滤地委托它。
- `materializeSessions` 改为 fold over `streamEvents`，不再 `read()`：同一时刻只有一个 event 存活，session row 只保留有界聚合 + preview（≤500 字符），**绝不保留 assistant 全文**——内存随 session 数增长，而非 ledger 长度或捕获输出大小。输出/行为不变。
- `read()`（支持 `limit`）保留给测试/调试，已不在任何生产读路径上（src 内唯一调用方是 history，现已 streaming；channel-binding store 的 `read()` 是另一个无关类）。

## 验证

- 新增回归测试：`materializeSessions` **不调用** `read()`（`vi.spyOn` 断言），并把两个 session（其一带 170k assistant body）折叠成只含 ≤500 字符 preview 的 row，`JSON.stringify(rows)` 不含全文。
- `tsc` 通过；`eslint .` 通过；`vitest`（DREAMUX_SKIP_LIVE_CODEX=1）**692 passed / 2 skipped**；`.agents` KB 未受影响。
- 已用 `workflow_dispatch` 在本 head 触发完整 CI（含 macOS rush）；结果见 PR 评论。

> 注：本 PR base（feature）当前仍是 main-only 触发（#194 尚未合入），故本 PR 不会自动跑 CI，用 dispatch 验证。

## P0/P1

无其它。单点 streaming 修复 + 回归测试。