### PR TITLE
feat(visibility): scoped teammate.* chokepoint + team_name bindings (#199 slice 4)

### DIFF
--- a/.agents/decisions/provider-architecture-realignment.md
+++ b/.agents/decisions/provider-architecture-realignment.md
@@ -100,10 +100,11 @@ see its `verbs/` (spawn/resume/history), `persistence/history-index.ts` and
   teammate layer only knows teammate identities.
 - **Dispatcher-facing verbs, no unified suffix:** `spawn`, `send`, `close` for
   lifecycle; `history`, `list`, `status`, `last`, `get_capabilities` for
-  read/recovery. `history` is the durable session-ledger recovery search
-  surface; `last` reads a teammate's most recent settled turn(s) from that
-  ledger by concrete name (issue #188 reworked both and removed the obsolete
-  `ctx` and raw `history_events` verbs). `spawn`/`send` return after submitting
+  read/recovery. `history` is the recovery search surface, served from the
+  per-name records; `last` reads a teammate's most recent settled turn(s) by
+  concrete name from the per-name turns archive (issue #188 reworked both and
+  removed the obsolete `ctx` and raw `history_events` verbs; issue #199 Slice 3
+  moved both off the session ledger — see top-level-design). `spawn`/`send` return after submitting
   the runtime turn; the dispatcher recovers through history/last instead of a
   task result ledger. (Issue #155 dropped the original standalone `resume`
   verb — see below.)
@@ -119,12 +120,12 @@ see its `verbs/` (spawn/resume/history), `persistence/history-index.ts` and
   implementation behind one `resume()` runtime surface.
 - **Identity and state location.** A teammate is a flat name plus a base record
   (agent runtime id, dispatcher owner, source/runtime cwd, optional managed
-  worktree metadata, checkpoint, status, close metadata). State is server-owned
-  under `~/.dreamux/state/<dispatcher>/teammate/` with `identities/`, `runtime/`,
-  and managed `worktrees/` subtrees plus the per-dispatcher `sessions.jsonl`
-  recovery ledger; paths go through `/packages/dreamux/src/platform/paths.ts`.
-  (The per-name `history/<name>.jsonl` index was removed in issue #182 PR-8 — the
-  session ledger is the single durable recovery record; see top-level-design.)
+  worktree metadata, runtime-native `session_id`, status, close metadata). State
+  is server-owned under `~/.dreamux/state/<dispatcher>/teammate/`; paths go
+  through `/packages/dreamux/src/platform/paths.ts`. (Issue #199 Slice 3 settled
+  the layout on the per-name `records/<name>.json` recovery record plus the
+  per-name `turns/<name>.jsonl` archive, retiring the `sessions.jsonl` session
+  ledger and the persisted `checkpoint` object — see top-level-design.)
 - **Ownership.** The Dispatcher Service owns TeamMate identity and history
   through focused modules under
   `/packages/dreamux/src/dispatcher-service/teammate/`.

--- a/.agents/decisions/top-level-design.md
+++ b/.agents/decisions/top-level-design.md
@@ -798,13 +798,23 @@ A TeamLeader is a TeamMate identity with `role:
 identities with `role: "team_member"` and `owner.kind: "team"`.
 
 The same `teammate` MCP surface is caller-scoped by server-derived principal,
-not by tool arguments. Dispatcher callers see dispatcher-owned TeamMates and
-TeamLeaders. TeamLeader callers see only members owned by their own team and
-spawn members into the shared Team managed worktree. Ordinary TeamMate callers
-still do not receive lifecycle tools.
+not by tool arguments, through a SINGLE visibility predicate (`principalCanAccess`)
+enforced at exactly two chokepoints — a scoped list read and a scoped single read
+— so no read site can widen visibility independently (issue #199 Slice 4). The
+rules: a dispatcher caller sees ONLY the ordinary TeamMates it directly spawned
+(`role: "teammate"`) — NOT the TeamLeaders (which are dispatcher-owned but
+`role: "team_leader"`) and NOT Team members; a TeamLeader caller sees only the
+members of its own Team; an ordinary TeamMate caller sees no peers (and gets no
+lifecycle tools). A dispatcher inspects its Teams — including the compact leader
+and member-count summary — through the `team.*` surface, never through
+`teammate.*`. The Team service controls its own TeamLeader and members through an
+INTERNAL `team_service` authority (constructed only by the Team service, never
+derived from a public caller), since a TeamLeader is reachable by no public
+principal. TeamLeader members spawn into the shared Team managed worktree.
 
-Channel binding is persisted under `state/<dispatcher-id>/team/` and is scoped
-to group chats only. Bound Feishu group inbound is gated and formatted by the
+Channel binding is persisted as JSON under
+`state/<dispatcher-id>/team/channel-bindings.json`, keyed by the concrete
+`team_name` (issue #199 Slice 4), and is scoped to group chats only. Bound Feishu group inbound is gated and formatted by the
 Feishu channel exactly as before, then routed by Dispatcher Service to the
 owning TeamLeader runtime. Unbound and P2P inbound still route to the
 dispatcher. `transfer_channel_back` deactivates a binding; `dissolve` transfers

--- a/common/changes/@excitedjs/dreamux/i199-slice4-team-visibility_2026-06-12-03-00.json
+++ b/common/changes/@excitedjs/dreamux/i199-slice4-team-visibility_2026-06-12-03-00.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "BREAKING: Team visibility closeout (issue #199 Slice 4). The `teammate.*` surface no longer leaks TeamLeaders or Team members to the dispatcher: visibility is enforced by one predicate at two scoped read chokepoints, so a dispatcher sees only the ordinary TeamMates it spawned, a TeamLeader sees only its own members, and an ordinary TeamMate sees no peers. A dispatcher inspects Teams through `team.*` compact summaries. The persisted channel binding key is renamed from `team_id` to `team_name` in `state/<dispatcher>/team/channel-bindings.json`. 0.x is fail-loud + rebuild (no automatic migration). Rebuild: delete `~/.dreamux/state/<dispatcher>/team/channel-bindings.json` after upgrading and re-bind any Team Feishu groups via `team.bind_group`.",
+      "type": "minor",
+      "packageName": "@excitedjs/dreamux"
+    }
+  ],
+  "packageName": "@excitedjs/dreamux",
+  "email": "053700@gmail.com"
+}

--- a/packages/dreamux/src/dispatcher-service/CLAUDE.md
+++ b/packages/dreamux/src/dispatcher-service/CLAUDE.md
@@ -37,6 +37,16 @@ is wiring only — all per-dispatcher orchestration lives here.
   teammate/team-leader agent is simply not injected the "spawn teammate" tool;
   role differentiation is done by the MCP tool set + system prompt this service
   injects at launch.
+- **`teammate.*` visibility is one predicate at two chokepoints (issue #199
+  Slice 4).** `principalCanAccess` is the sole rule and is applied ONLY in
+  `scopedList` (list reads) and `mustIdentity` (single reads), so no read site
+  can widen visibility. A dispatcher principal sees only the ordinary TeamMates
+  it spawned (`role: 'teammate'`) — never a TeamLeader (dispatcher-owned but
+  `role: 'team_leader'`) or a Team member; a `team_leader` principal sees only
+  its own members; a `teammate` principal sees nothing. The Team service reaches
+  its own leader + members through the INTERNAL `team_service` principal (built
+  only by the Team service, never from a public caller); a dispatcher inspects
+  Teams via `team.*` compact summaries, never `teammate.*`.
 - **Teammate storage is the per-name record + the per-name turns archive
   (issue #199 Slice 3).** `teammate/records/<name>.json` is the primary record —
   identity plus a rolling recovery summary (turn_count / last_seen_at / last

--- a/packages/dreamux/src/dispatcher-service/channel-binding/store.ts
+++ b/packages/dreamux/src/dispatcher-service/channel-binding/store.ts
@@ -1,6 +1,6 @@
-import { mkdir, readFile, writeFile } from 'node:fs/promises';
-import { dirname } from 'node:path';
+import { readFile } from 'node:fs/promises';
 
+import { writeFileAtomic } from '../../platform/atomic-write.js';
 import { dispatcherChannelBindingsPath } from '../../platform/paths.js';
 
 export type ChannelProvider = 'builtin:feishu';
@@ -124,8 +124,7 @@ export class ChannelBindingStore {
     file: ChannelBindingFile,
   ): Promise<void> {
     const path = dispatcherChannelBindingsPath(dispatcherId);
-    await mkdir(dirname(path), { recursive: true });
-    await writeFile(path, `${JSON.stringify(file, null, 2)}\n`, { mode: 0o600 });
+    await writeFileAtomic(path, `${JSON.stringify(file, null, 2)}\n`);
   }
 }
 

--- a/packages/dreamux/src/dispatcher-service/channel-binding/store.ts
+++ b/packages/dreamux/src/dispatcher-service/channel-binding/store.ts
@@ -10,7 +10,8 @@ export interface ChannelBinding {
   provider: ChannelProvider;
   chat_id: string;
   chat_type: 'group';
-  team_id: string;
+  /** The concrete Team key the chat is bound to (issue #199 Slice 4). */
+  team_name: string;
   leader_name: string;
   active: boolean;
   created_at: number;
@@ -28,7 +29,7 @@ export interface BindChannelInput {
   provider: ChannelProvider;
   chatId: string;
   chatType: ChannelChatType;
-  teamId: string;
+  teamName: string;
   leaderName: string;
 }
 
@@ -50,7 +51,7 @@ export class ChannelBindingStore {
       provider: input.provider,
       chat_id: input.chatId,
       chat_type: input.chatType,
-      team_id: input.teamId,
+      team_name: input.teamName,
       leader_name: input.leaderName,
       active: true,
       created_at: now,

--- a/packages/dreamux/src/dispatcher-service/service.ts
+++ b/packages/dreamux/src/dispatcher-service/service.ts
@@ -160,7 +160,7 @@ export class DispatcherService {
     if (binding !== null) {
       const result = await this.teams.deliverToLeader({
         dispatcherId,
-        teamId: binding.team_id,
+        teamId: binding.team_name,
         turn: input,
       });
       if (result.status === 'submitted') await hooks?.onAccepted?.(input);

--- a/packages/dreamux/src/dispatcher-service/team/service.ts
+++ b/packages/dreamux/src/dispatcher-service/team/service.ts
@@ -3,9 +3,8 @@ import { Buffer } from 'node:buffer';
 import { WorktreeManager } from '../teammate/worktree-manager.js';
 import type { TeamMateAgentService, TeamMateSharedWorkspace } from '../teammate/service.js';
 import {
-  dispatcherPrincipal,
   requireLifecycleText,
-  teamLeaderPrincipal,
+  teamServicePrincipal,
 } from '../teammate/types.js';
 import { ChannelBindingStore } from '../channel-binding/store.js';
 import type { ChannelBinding } from '../channel-binding/store.js';
@@ -26,7 +25,10 @@ import type {
   TeamView,
 } from './types.js';
 import { validateTeamId } from './types.js';
-import type { TeamMateIdentityStatus } from '../teammate/types.js';
+import type {
+  TeamMateIdentityStatus,
+  TeamMateRuntimeStatus,
+} from '../teammate/types.js';
 
 export interface TeamServiceOptions {
   teammates: TeamMateAgentService;
@@ -165,9 +167,10 @@ export class TeamService {
 
   /**
    * Filterable Team recovery search (issue #182 PR-7) — the Team-side mirror of
-   * the TeamMate `history` surface. Finds Teams (closed included) by
-   * team_name/status/repo/intent/time, sorted most-recent first, with a cursor.
-   * The raw per-team lifecycle event timeline stays internal (`ledger`), not here.
+   * the TeamMate `history` surface. Reads the compact recovery rows straight
+   * from the `team/records/<team_name>.json` JSON records (closed included),
+   * sorted most-recent first, with a cursor. There is no team event/audit
+   * archive to fold (issue #199 Slice 3 removed it).
    */
   async history(input: TeamHistoryQuery): Promise<TeamHistoryResult> {
     const teams = await this.store.list(input.dispatcherId);
@@ -194,11 +197,11 @@ export class TeamService {
 
   async dissolve(input: TeamDissolveInput): Promise<TeamSummary> {
     // Required dissolve reason — enforced for in-process callers too (issue
-    // #182 PR-3); it also feeds the member/leader closes and the ledger.
+    // #182 PR-3); it also feeds the member/leader closes.
     requireLifecycleText(input.note, 'Team dissolve note');
     const team = await this.mustTeam(input.dispatcherId, input.teamId);
     for (const binding of await this.bindings.list(input.dispatcherId)) {
-      if (binding.active && binding.team_id === team.team_id) {
+      if (binding.active && binding.team_name === team.team_id) {
         await this.bindings.transferBack({
           dispatcherId: input.dispatcherId,
           provider: binding.provider,
@@ -207,30 +210,20 @@ export class TeamService {
         });
       }
     }
-    const members = await this.opts.teammates.listScoped(
-      teamLeaderPrincipal({
-        dispatcherId: input.dispatcherId,
-        teamId: team.team_id,
-        leaderName: team.leader_name,
-      }),
-    );
+    const principal = this.teamPrincipal(team);
+    const members = await this.members(team);
     // dissolve note is required (issue #182 PR-3), so the member/leader close
-    // calls and the ledger carry the operator's real reason — no synthetic
-    // 'team dissolved' fallback. Internal/system dissolves pass an explicit
-    // system-authored note instead.
+    // calls carry the operator's real reason — no synthetic 'team dissolved'
+    // fallback. Internal/system dissolves pass an explicit system-authored note.
     for (const member of members) {
       await this.opts.teammates.closeScoped({
-        principal: teamLeaderPrincipal({
-          dispatcherId: input.dispatcherId,
-          teamId: team.team_id,
-          leaderName: team.leader_name,
-        }),
+        principal,
         name: member.name,
         note: input.note,
       });
     }
-    await this.opts.teammates.close({
-      dispatcherId: input.dispatcherId,
+    await this.opts.teammates.closeScoped({
+      principal,
       name: team.leader_name,
       note: input.note,
     });
@@ -257,7 +250,7 @@ export class TeamService {
       provider: input.provider,
       chatId: input.chatId,
       chatType: input.chatType,
-      teamId: team.team_id,
+      teamName: team.team_id,
       leaderName: team.leader_name,
     });
     return binding;
@@ -277,7 +270,7 @@ export class TeamService {
   }): Promise<ChannelBinding | null> {
     const binding = await this.bindings.resolve(input);
     if (binding === null) return null;
-    const team = await this.store.get(input.dispatcherId, binding.team_id);
+    const team = await this.store.get(input.dispatcherId, binding.team_name);
     if (team === null || team.status === 'closed') return null;
     return binding;
   }
@@ -297,7 +290,7 @@ export class TeamService {
     });
     return (
       binding !== null &&
-      binding.team_id === input.teamId &&
+      binding.team_name === input.teamId &&
       binding.leader_name === input.leaderName
     );
   }
@@ -310,7 +303,7 @@ export class TeamService {
     const team = await this.mustTeam(input.dispatcherId, input.teamId);
     if (team.status === 'closed') return { status: 'stopped' };
     return this.opts.teammates.channelInputScoped(
-      dispatcherPrincipal(input.dispatcherId),
+      this.teamPrincipal(team),
       team.leader_name,
       input.turn,
     );
@@ -330,12 +323,11 @@ export class TeamService {
   }
 
   private async summary(team: TeamRecord): Promise<TeamSummary> {
-    let leader = null;
-    try {
-      leader = await this.opts.teammates.status(team.dispatcher_id, team.leader_name);
-    } catch {
-      leader = null;
-    }
+    // #199 Slice 4: the leader is read with the internal Team-service authority —
+    // a TeamLeader is not visible on the dispatcher `teammate.*` surface.
+    const leader = await this.opts.teammates
+      .statusScoped(this.teamPrincipal(team), team.leader_name)
+      .catch(() => null);
     return {
       team: teamView(team),
       leader,
@@ -384,12 +376,19 @@ export class TeamService {
   private async leaderState(
     team: TeamRecord,
   ): Promise<TeamMateIdentityStatus | null> {
-    try {
-      return (await this.opts.teammates.status(team.dispatcher_id, team.leader_name))
-        .status;
-    } catch {
-      return null;
-    }
+    const leader = await this.opts.teammates
+      .statusScoped(this.teamPrincipal(team), team.leader_name)
+      .catch(() => null);
+    return leader?.status ?? null;
+  }
+
+  /** The internal Team-service authority over this Team (issue #199 Slice 4). */
+  private teamPrincipal(team: TeamRecord) {
+    return teamServicePrincipal({
+      dispatcherId: team.dispatcher_id,
+      teamId: team.team_id,
+      leaderName: team.leader_name,
+    });
   }
 
   /** The active bound Feishu group for a Team, or null when none is bound. */
@@ -398,7 +397,7 @@ export class TeamService {
   ): Promise<TeamChannelBindingSummary | null> {
     const bindings = await this.bindings.list(team.dispatcher_id);
     const active = bindings.find(
-      (binding) => binding.active && binding.team_id === team.team_id,
+      (binding) => binding.active && binding.team_name === team.team_id,
     );
     return active === undefined
       ? null
@@ -406,13 +405,18 @@ export class TeamService {
   }
 
   private async memberCount(team: TeamRecord): Promise<number> {
-    return (await this.opts.teammates.listScoped(
-      teamLeaderPrincipal({
-        dispatcherId: team.dispatcher_id,
-        teamId: team.team_id,
-        leaderName: team.leader_name,
-      }),
-    )).length;
+    return (await this.members(team)).length;
+  }
+
+  /**
+   * The Team's members only (issue #199 Slice 4): the internal Team-service
+   * authority can see both the leader and the members, so the leader (known by
+   * its concrete name) is filtered out of member listings.
+   */
+  private async members(team: TeamRecord): Promise<TeamMateRuntimeStatus[]> {
+    return (await this.opts.teammates.listScoped(this.teamPrincipal(team))).filter(
+      (member) => member.name !== team.leader_name,
+    );
   }
 
   private async mustTeam(dispatcherId: string, teamId: string): Promise<TeamRecord> {

--- a/packages/dreamux/src/dispatcher-service/team/store.ts
+++ b/packages/dreamux/src/dispatcher-service/team/store.ts
@@ -1,6 +1,6 @@
-import { mkdir, readFile, readdir, writeFile } from 'node:fs/promises';
-import { dirname } from 'node:path';
+import { readFile, readdir } from 'node:fs/promises';
 
+import { writeFileAtomic } from '../../platform/atomic-write.js';
 import {
   dispatcherTeamRecordPath,
   dispatcherTeamRecordsDir,
@@ -83,8 +83,7 @@ export class TeamStore {
 
   private async write(team: TeamRecord): Promise<void> {
     const path = dispatcherTeamRecordPath(team.dispatcher_id, team.team_id);
-    await mkdir(dirname(path), { recursive: true });
-    await writeFile(path, `${JSON.stringify(team, null, 2)}\n`, { mode: 0o600 });
+    await writeFileAtomic(path, `${JSON.stringify(team, null, 2)}\n`);
   }
 }
 

--- a/packages/dreamux/src/dispatcher-service/teammate/identity-store.ts
+++ b/packages/dreamux/src/dispatcher-service/teammate/identity-store.ts
@@ -1,6 +1,6 @@
-import { mkdir, readFile, readdir, writeFile } from 'node:fs/promises';
-import { dirname } from 'node:path';
+import { readFile, readdir } from 'node:fs/promises';
 
+import { writeFileAtomic } from '../../platform/atomic-write.js';
 import {
   dispatcherTeamMateRecordsDir,
   dispatcherTeamMateRecordPath,
@@ -171,10 +171,9 @@ export class TeamMateIdentityStore {
       identity.dispatcher_id,
       identity.name,
     );
-    await mkdir(dirname(path), { recursive: true });
-    await writeFile(path, `${JSON.stringify(identity, null, 2)}\n`, {
-      mode: 0o600,
-    });
+    // Atomic write (issue #199 Slice 4): a concurrent `last`/`get` reader (e.g.
+    // a parallel settle capture) must never observe a truncated record.
+    await writeFileAtomic(path, `${JSON.stringify(identity, null, 2)}\n`);
   }
 }
 

--- a/packages/dreamux/src/dispatcher-service/teammate/service.ts
+++ b/packages/dreamux/src/dispatcher-service/teammate/service.ts
@@ -63,6 +63,7 @@ import {
   type TeamMateWorktreeRequest,
   dispatcherPrincipal,
   principalDispatcherId,
+  teamServicePrincipal,
 } from './types.js';
 
 interface LiveTeamMate {
@@ -421,12 +422,22 @@ export class TeamMateAgentService {
 
   async listScoped(principal: TeamMateCallerPrincipal): Promise<TeamMateRuntimeStatus[]> {
     const dispatcherId = principalDispatcherId(principal);
-    const identities = await this.identities.list(dispatcherId);
-    return identities
-      .filter((identity) => principalCanAccess(principal, identity))
-      .map((identity) =>
-        this.toStatus(identity, this.live.get(liveKey(dispatcherId, identity.name))?.runtime ?? null),
-      );
+    return (await this.scopedList(principal)).map((identity) =>
+      this.toStatus(identity, this.live.get(liveKey(dispatcherId, identity.name))?.runtime ?? null),
+    );
+  }
+
+  /**
+   * The scoped LIST chokepoint (issue #199 Slice 4): the only place a list of
+   * records is read for the `teammate.*` surface. Reads every record for the
+   * principal's dispatcher and keeps just the ones {@link principalCanAccess}
+   * admits, so list/history can never widen visibility independently.
+   */
+  private async scopedList(
+    principal: TeamMateCallerPrincipal,
+  ): Promise<TeamMateIdentity[]> {
+    const identities = await this.identities.list(principalDispatcherId(principal));
+    return identities.filter((identity) => principalCanAccess(principal, identity));
   }
 
   async status(
@@ -464,19 +475,16 @@ export class TeamMateAgentService {
       principal: TeamMateCallerPrincipal;
     },
   ): Promise<TeamMateHistoryResult> {
-    const dispatcherId = principalDispatcherId(input.principal);
     // #199 Slice 3: `history` reads the per-name RECORDS only — each record
     // carries the rolling recovery summary (turn count, last-seen, previews), so
     // there is no turn/event fold here. Closed teammates keep their record and
     // stay searchable; live-only facts (runtime status) come from the live map.
-    const identities = await this.identities.list(dispatcherId);
+    // #199 Slice 4: visibility is enforced by the same scoped-list chokepoint as
+    // `list`, so `history` can never surface a record `list` would hide.
     const rows: TeamMateRecordRow[] = [];
-    for (const identity of identities) {
+    for (const identity of await this.scopedList(input.principal)) {
       const row = this.toRecordRow(identity);
-      if (
-        principalCanAccess(input.principal, identity) &&
-        this.matchesRecordQuery(row, input)
-      ) {
+      if (this.matchesRecordQuery(row, input)) {
         rows.push(row);
       }
     }
@@ -685,7 +693,16 @@ export class TeamMateAgentService {
     });
     const live = await this.startRuntime(input.dispatcherId, identity, provider, agent);
     identity = live.state.current();
-    const turn = await this.submitPrompt(input.dispatcherId, name, input.prompt);
+    // The TeamLeader is not reachable through the public dispatcher principal
+    // (issue #199 Slice 4); the bootstrap turn submits under the internal
+    // Team-service authority over this leader.
+    const turn = await this.submitPrompt(input.dispatcherId, name, input.prompt, {
+      principal: teamServicePrincipal({
+        dispatcherId: input.dispatcherId,
+        teamId: input.teamId,
+        leaderName: name,
+      }),
+    });
     await this.recordSubmittedTurn(input.dispatcherId, live, {
       turnId: turn.turn_id ?? null,
       turnOrigin: 'dispatcher',
@@ -1007,6 +1024,13 @@ export class TeamMateAgentService {
     }
   }
 
+  /**
+   * The scoped single-read chokepoint (issue #199 Slice 4): the only place a
+   * record is read by name for the `teammate.*` surface (status / last / send /
+   * close all resolve their target here). An out-of-scope record reports the
+   * same "does not exist" as a missing one, so visibility never leaks through an
+   * existence oracle.
+   */
   private async mustIdentity(
     dispatcherId: string,
     name: string,
@@ -1370,6 +1394,21 @@ function ownerForPrincipal(principal: TeamMateCallerPrincipal): TeamMateIdentity
   return { kind: 'dispatcher', dispatcher_id: principal.dispatcherId };
 }
 
+/**
+ * The single visibility predicate for the `teammate.*` surface (issue #199
+ * Slice 4). Every scoped read enforces it through exactly one of two
+ * chokepoints — {@link TeamMateAgentService.scopedList} for list reads and
+ * {@link TeamMateAgentService.mustIdentity} for single reads — so the rules
+ * below are applied consistently and cannot be bypassed by a new read site.
+ *
+ * - A dispatcher sees only the ordinary TeamMates it directly spawned: a
+ *   dispatcher-owned record with `role === 'teammate'`. A TeamLeader is also
+ *   dispatcher-owned (its `owner.kind` is `dispatcher`), so `role` is what
+ *   keeps a leader — and every Team member — out of the dispatcher's view; the
+ *   dispatcher inspects Teams through the `team.*` surface instead.
+ * - A TeamLeader sees only the members of its own Team.
+ * - An ordinary TeamMate sees nothing (it cannot read peers).
+ */
 function principalCanAccess(
   principal: TeamMateCallerPrincipal,
   identity: TeamMateIdentity,
@@ -1377,12 +1416,24 @@ function principalCanAccess(
   if (principal.kind === 'dispatcher') {
     return (
       identity.dispatcher_id === principal.dispatcherId &&
-      identity.owner.kind === 'dispatcher'
+      identity.owner.kind === 'dispatcher' &&
+      identity.role === 'teammate'
     );
   }
   if (principal.kind === 'team_leader') {
     return (
       identity.dispatcher_id === principal.dispatcherId &&
+      identity.owner.kind === 'team' &&
+      identity.owner.team_id === principal.teamId &&
+      identity.role === 'team_member'
+    );
+  }
+  if (principal.kind === 'team_service') {
+    // Internal Team-service authority: its own TeamLeader (by concrete name) plus
+    // the members of its Team. Never derived from a public caller.
+    if (identity.dispatcher_id !== principal.dispatcherId) return false;
+    if (identity.role === 'team_leader') return identity.name === principal.leaderName;
+    return (
       identity.owner.kind === 'team' &&
       identity.owner.team_id === principal.teamId &&
       identity.role === 'team_member'

--- a/packages/dreamux/src/dispatcher-service/teammate/types.ts
+++ b/packages/dreamux/src/dispatcher-service/teammate/types.ts
@@ -182,6 +182,20 @@ export type TeamMateCallerPrincipal =
   | {
       kind: 'teammate';
       dispatcherId: string;
+    }
+  | {
+      /**
+       * Internal Team-service authority (issue #199 Slice 4): grants the Team
+       * service control over its OWN Team — the TeamLeader record plus the
+       * members of `teamId`. It is constructed ONLY by the Team service (the
+       * public admin/MCP layer never derives it from a caller), so it can never
+       * widen the dispatcher/team_leader/teammate visibility of the public
+       * `teammate.*` surface.
+       */
+      kind: 'team_service';
+      dispatcherId: string;
+      teamId: string;
+      leaderName: string;
     };
 
 export interface TeamMateDispatcherOwner {
@@ -440,6 +454,23 @@ export function teamLeaderPrincipal(input: {
 
 export function teammatePrincipal(dispatcherId: string): TeamMateCallerPrincipal {
   return { kind: 'teammate', dispatcherId };
+}
+
+/**
+ * The internal Team-service authority over one Team (issue #199 Slice 4): the
+ * TeamLeader record plus the members of `teamId`. Built ONLY by the Team service.
+ */
+export function teamServicePrincipal(input: {
+  dispatcherId: string;
+  teamId: string;
+  leaderName: string;
+}): TeamMateCallerPrincipal {
+  return {
+    kind: 'team_service',
+    dispatcherId: input.dispatcherId,
+    teamId: input.teamId,
+    leaderName: input.leaderName,
+  };
 }
 
 export function principalDispatcherId(principal: TeamMateCallerPrincipal): string {

--- a/packages/dreamux/src/mcp/teammate-mcp.ts
+++ b/packages/dreamux/src/mcp/teammate-mcp.ts
@@ -159,7 +159,7 @@ function teammateTools(
     tool('status', 'Read one TeamMate identity and live runtime status by its concrete name.', {
       name: { type: 'string', minLength: 1, maxLength: 64 },
     }, ['name']),
-    tool('last', 'Read a TeamMate\'s most recent settled turn(s) from the durable session ledger by concrete name. Works for a closed/stopped TeamMate without starting a runtime; this is the fallback when a completion was not delivered. turns defaults to 1 (range 1..5); the newest turn is last.', {
+    tool('last', 'Read a TeamMate\'s most recent settled turn(s) by concrete name. Reads the TeamMate record first (existence / scope / common fields), then folds the recent settled turns from its per-name turns archive; it never starts or resumes a runtime, so it works for a closed/stopped TeamMate. This is the fallback when a completion was not delivered. turns defaults to 1 (range 1..5); the newest turn is last.', {
       name: { type: 'string', minLength: 1, maxLength: 64 },
       turns: { type: 'integer', minimum: 1, maximum: 5 },
     }, ['name']),

--- a/packages/dreamux/src/platform/atomic-write.ts
+++ b/packages/dreamux/src/platform/atomic-write.ts
@@ -1,0 +1,29 @@
+import { randomUUID } from 'node:crypto';
+import { mkdir, rename, rm, writeFile } from 'node:fs/promises';
+import { dirname } from 'node:path';
+
+/**
+ * Atomically write a file (issue #199 Slice 4). A plain `writeFile` truncates
+ * the target before writing, so a concurrent reader can observe an empty or
+ * partial file — exactly the `JSON.parse('')` race the per-name record store hit
+ * under parallel settles. Writing the full contents to a sibling temp file and
+ * `rename`-ing it into place makes the swap atomic: a reader always sees either
+ * the complete old file or the complete new one, never a torn write. The temp is
+ * created in the SAME directory so the rename stays on one filesystem.
+ */
+export async function writeFileAtomic(
+  path: string,
+  data: string,
+  options: { mode?: number } = {},
+): Promise<void> {
+  const dir = dirname(path);
+  await mkdir(dir, { recursive: true });
+  const tmp = `${path}.${randomUUID()}.tmp`;
+  try {
+    await writeFile(tmp, data, { mode: options.mode ?? 0o600 });
+    await rename(tmp, path);
+  } catch (err) {
+    await rm(tmp, { force: true }).catch(() => undefined);
+    throw err;
+  }
+}

--- a/packages/dreamux/tests/team-service.test.ts
+++ b/packages/dreamux/tests/team-service.test.ts
@@ -9,7 +9,11 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { AgentRuntimeProviderCatalog } from '../src/agent-runtime/index.js';
 import { TeamService } from '../src/dispatcher-service/team/service.js';
 import { TeamMateAgentService } from '../src/dispatcher-service/teammate/service.js';
-import { teamLeaderPrincipal } from '../src/dispatcher-service/teammate/types.js';
+import {
+  teamLeaderPrincipal,
+  teammatePrincipal,
+  teamServicePrincipal,
+} from '../src/dispatcher-service/teammate/types.js';
 import { DispatcherStore } from '../src/state/dispatcher-store.js';
 import { resetRuntimeConfig } from '../src/platform/paths.js';
 import { createBuiltinProviderRegistry } from '../src/registry/index.js';
@@ -339,8 +343,12 @@ describe('TeamService', () => {
     expect(status.leader?.name).toBe(secondLeader);
 
     // Both leader identities persist; the old closed one is still addressable by
-    // its own concrete name (not reused, not deleted).
-    const oldLeader = await teammates.status('flow', firstLeader);
+    // its own concrete name (not reused, not deleted) through the Team-service
+    // authority — a TeamLeader is never on the dispatcher `teammate.*` surface.
+    const oldLeader = await teammates.statusScoped(
+      teamServicePrincipal({ dispatcherId: 'flow', teamId: 'alpha', leaderName: firstLeader }),
+      firstLeader,
+    );
     expect(oldLeader.status).toBe('closed');
     expect(oldLeader.name).toBe(firstLeader);
   });
@@ -436,12 +444,24 @@ describe('TeamService', () => {
     expect(member.teammate).not.toHaveProperty('role');
     expect(member.teammate).not.toHaveProperty('display_name');
     expect(provider.contexts.at(-1)?.cwd).toBe(workspace.runtimeCwd);
-    // Dispatcher-scoped list sees the two leaders + the ungrouped teammate.
-    // display_name is gone, so identify by the concrete-name base (the random
-    // 8-char suffix stripped).
+    // #199 Slice 4 leak prevention: the dispatcher's teammate.* sees ONLY the
+    // ordinary teammate it spawned — never a TeamLeader and never a Team member.
+    // (concrete names carry a random 8-char suffix; identify by the base.)
     const base = (name: string): string => name.replace(/-[a-z0-9]{8}$/, '');
     expect((await teammates.list('flow')).map((entry) => base(entry.name)).sort())
-      .toEqual(['solo', 'tl-alpha', 'tl-beta']);
+      .toEqual(['solo']);
+    // A TeamLeader is invisible to the dispatcher through status / last / history.
+    for (const leaderName of [alphaTeam.team.leader_name, betaTeam.team.leader_name]) {
+      await expect(teammates.status('flow', leaderName)).rejects.toThrow(/does not exist/);
+      await expect(teammates.last('flow', leaderName)).rejects.toThrow(/does not exist/);
+    }
+    // A Team member is invisible to the dispatcher too.
+    await expect(teammates.status('flow', builderName)).rejects.toThrow(/does not exist/);
+    expect(
+      (await teammates.history({ dispatcherId: 'flow' })).items.map((row) => base(row.name)),
+    ).toEqual(['solo']);
+    // A TeamLeader sees only the members of its OWN team — not the leaders, not
+    // the dispatcher's ordinary teammates, not another team's members.
     expect((await teammates.listScoped(alpha)).map((entry) => base(entry.name))).toEqual([
       'tm-builder',
     ]);
@@ -449,6 +469,11 @@ describe('TeamService', () => {
     await expect(teammates.statusScoped(beta, builderName)).rejects.toThrow(/does not exist/);
     await expect(
       teammates.sendScoped({ principal: beta, name: builderName, prompt: 'nope' }),
+    ).rejects.toThrow(/does not exist/);
+    // An ordinary TeamMate principal can read no peers at all.
+    expect(await teammates.listScoped(teammatePrincipal('flow'))).toEqual([]);
+    await expect(
+      teammates.statusScoped(teammatePrincipal('flow'), builderName),
     ).rejects.toThrow(/does not exist/);
     await expect(
       teammates.closeScoped({ principal: beta, name: builderName, note: 'nope' }),
@@ -481,7 +506,7 @@ describe('TeamService', () => {
         chatId: 'oc_existing_group',
         chatType: 'group',
       }),
-    ).resolves.toMatchObject({ team_id: 'gamma' });
+    ).resolves.toMatchObject({ team_name: 'gamma' });
     expect((await teams.status('flow', 'gamma')).binding).toEqual({
       provider: 'builtin:feishu',
       chat_id: 'oc_existing_group',

--- a/packages/dreamux/tests/teammate-agent-service.test.ts
+++ b/packages/dreamux/tests/teammate-agent-service.test.ts
@@ -21,6 +21,7 @@ import {
 import type { TurnSettledSignal } from '../src/agent-runtime/turn.js';
 import type { InboundTurnInput } from '../src/agent-runtime/turn.js';
 import { TeamMateAgentService } from '../src/dispatcher-service/teammate/service.js';
+import { teamServicePrincipal } from '../src/dispatcher-service/teammate/types.js';
 import { DispatcherStore } from '../src/state/dispatcher-store.js';
 import {
   dispatcherCompletionSpillDir,
@@ -578,7 +579,7 @@ describe('TeamMateAgentService', () => {
     expect(provider.runtimes).toHaveLength(2);
     expect(provider.runtimes[1]?.wasThreadResumed()).toBe(true);
 
-    // #188: last is a durable ledger read keyed by the concrete name. Resolved
+    // #188/#199: last is a pure record+turns read keyed by the concrete name. Resolved
     // to the identity's session, it returns a well-formed result; with no
     // completion sink wired here, no settled turn was captured.
     const last = await second.last('flow', builder);
@@ -589,7 +590,7 @@ describe('TeamMateAgentService', () => {
     expect(last.turns).toEqual([]);
   });
 
-  it('returns a bounded session ledger with worktree metadata and filters', async () => {
+  it('returns bounded history rows with worktree metadata and filters (#199)', async () => {
     const repo = await initGitRepo(join(root, 'ledger-repo'));
     const { catalog } = providerCatalog();
     const config = testDreamuxConfig([testDispatcherConfig({ cwd: dispatcherCwd })]);
@@ -1740,7 +1741,7 @@ describe('TeamMateAgentService', () => {
     await expect(service.last('flow', name, 1.5)).rejects.toThrow(/1\.\.5/);
   });
 
-  it('last reads settled turns from the durable ledger, filtered by session, with truncation metadata (#188)', async () => {
+  it('last reads settled turns from the per-name turns archive with truncation metadata (#188/#199)', async () => {
     const { catalog, provider } = providerCatalog();
     const config = testDreamuxConfig([testDispatcherConfig({ cwd: dispatcherCwd })]);
     const service = new TeamMateAgentService({
@@ -1960,15 +1961,25 @@ describe('TeamMateAgentService', () => {
     await service.createTeamLeader(leaderInput);
     // The public service seam must not rebind a concrete name to a new session —
     // not even for a CLOSED leader. #188: concrete names are never reused, and
-    // the duplicate check includes closed identities.
-    await service.close({ dispatcherId: 'flow', name: 'tl-alpha-fixedaaa', note: 'done' });
+    // the duplicate check includes closed identities. #199 Slice 4: a TeamLeader
+    // is closed through the internal Team-service authority — it is not visible
+    // on the dispatcher `teammate.*` surface.
+    await service.closeScoped({
+      principal: teamServicePrincipal({
+        dispatcherId: 'flow',
+        teamId: 'alpha',
+        leaderName: 'tl-alpha-fixedaaa',
+      }),
+      name: 'tl-alpha-fixedaaa',
+      note: 'done',
+    });
     await expect(service.createTeamLeader(leaderInput)).rejects.toThrow(
       /already exists/,
     );
   });
 });
 
-/** Poll the durable ledger until it has captured `count` settled turns. */
+/** Poll the per-name turns archive until it has captured `count` settled turns. */
 async function waitForSettled(
   service: TeamMateAgentService,
   name: string,

--- a/packages/dreamux/tests/teammate-completion-e2e.test.ts
+++ b/packages/dreamux/tests/teammate-completion-e2e.test.ts
@@ -468,8 +468,9 @@ describe('reverse delivery end-to-end (Seam ①→②→③ through the facade)'
     teammateRuntime.settle('completed', turnId);
     await flush();
 
-    // #188: last reads the settled turn from the durable ledger by concrete
-    // name. The settled-turn append trails reverse delivery, so wait for it.
+    // #188/#199: last reads the settled turn from the per-name turns archive by
+    // concrete name. The settled-turn capture trails reverse delivery, so wait
+    // for it (the record write is atomic, so this concurrent read is safe).
     await waitFor(
       async () => (await facade.getTeamMateLast('flow', reviewer)).returned_turns === 1,
     );

--- a/packages/dreamux/tests/teammate-completion-e2e.test.ts
+++ b/packages/dreamux/tests/teammate-completion-e2e.test.ts
@@ -353,7 +353,7 @@ describe('reverse delivery end-to-end (Seam ①→②→③ through the facade)'
     await facade.shutdown();
   });
 
-  it('pushes a dispatcher-initiated TeamLeader turn back to the dispatcher (not pull-only)', async () => {
+  it('pushes the dispatcher-initiated bootstrap TeamLeader completion to the dispatcher; the dispatcher cannot send to the leader directly (#199 Slice 4)', async () => {
     await initGitRepo(workspace(root));
     const descriptor = createBuiltinProviderRegistry().resolve('builtin:codex');
     const provider = new FakeProvider(descriptor);
@@ -370,27 +370,26 @@ describe('reverse delivery end-to-end (Seam ①→②→③ through the facade)'
 
     const dispatcherRuntime = provider.runtimes[0]!;
     const leaderRuntime = provider.runtimes[1]!;
+    const leaderName = created.team.leader_name;
+    // The create bootstrap turn is dispatcher-initiated (origin 'dispatcher'), so
+    // settling it pushes the completion back to the dispatcher — not pull-only.
     const bootstrapTurnId =
       created.turn.status === 'submitted' ? created.turn.turn_id : 'unreachable';
     leaderRuntime.settle('completed', bootstrapTurnId);
     await flush();
-
-    const leaderName = created.team.leader_name;
-    const sent = await facade.sendTeamMate({
-      dispatcherId: 'flow',
-      name: leaderName,
-      prompt: 'Status check from the dispatcher.',
-    });
-    const turnId =
-      sent.turn.status === 'submitted' ? sent.turn.turn_id : 'unreachable';
-    leaderRuntime.settle('completed', turnId);
-    await flush();
-
-    // A dispatcher-initiated turn to the leader returns to the dispatcher like
-    // any teammate (it is not pull-only).
     expect(dispatcherRuntime.delivered.map((env) => env.id)).toContain(
-      `${leaderName}:${turnId}`,
+      `${leaderName}:${bootstrapTurnId}`,
     );
+
+    // #199 Slice 4: the dispatcher cannot reach the TeamLeader through
+    // teammate.send — a TeamLeader is not on the dispatcher `teammate.*` surface.
+    await expect(
+      facade.sendTeamMate({
+        dispatcherId: 'flow',
+        name: leaderName,
+        prompt: 'Status check from the dispatcher.',
+      }),
+    ).rejects.toThrow(/does not exist/);
 
     await facade.shutdown();
   });


### PR DESCRIPTION
## Summary

Epic #199 Slice 4 — Team visibility. Closes the `teammate.*` leak that let a
dispatcher see TeamLeaders, consolidates all `teammate.*` reads behind one
scoped visibility chokepoint, and renames the channel-binding key to
`team_name`.

## Visibility (the leak fix + chokepoint)

- **The leak:** a TeamLeader is dispatcher-owned (`owner.kind: 'dispatcher'`)
  but `role: 'team_leader'`. The old dispatcher predicate only checked
  `owner.kind`, so a dispatcher could see its TeamLeaders through `teammate.*`.
  `principalCanAccess` (the single visibility predicate) now also requires
  `role === 'teammate'` for the dispatcher, so leaders **and** members are
  hidden.
- **One chokepoint, two readers:** every `teammate.*` read now goes through
  `scopedList` (list / history) or `mustIdentity` (status / last / send /
  close). `history` reuses the same scoped list as `list`, so it can never
  surface a record `list` would hide.
- **Rules enforced:** dispatcher sees only the ordinary TeamMates it spawned;
  TeamLeader sees only the members of its own Team; ordinary TeamMate sees no
  peers. A dispatcher inspects Teams through `team.*` compact summaries.

## Internal `team_service` authority

A TeamLeader is reachable by **no** public principal, but the Team service must
read/close/channel its leader and list/dissolve its members. A new internal
`team_service` principal grants control over one Team's leader + members. It is
constructed **only** by the Team service (never derived from a public caller via
the admin/MCP layer), so it cannot widen the public surface. Member listings
exclude the leader by its concrete name; the create bootstrap turn submits under
this authority.

## Channel bindings

The persisted channel binding key is renamed `team_id` → `team_name`
(`channel-bindings.json` stays JSON-only). A rush change carries `BREAKING:` +
`Rebuild:` for the field rename.

## Other

- `team.history` already reads the compact `team/records/<team_name>.json` JSON
  rows — there is no team audit/history JSONL to fold (Slice 3 removed it);
  confirmed and documented.
- Cleaned the remaining stale team/teammate "ledger" comments flagged in the
  Slice 3 reviews.

## Tests

- Rewrote the Team visibility test into explicit **leak-prevention** checks:
  the dispatcher cannot see a leader or member via `list` / `status` / `last` /
  `history`; a TeamLeader sees only its own members; cross-team and
  ordinary-teammate reads are denied.
- Updated the leader close / read tests to the `team_service` authority.
- Rewrote the e2e leader-routing test: the only dispatcher-origin leader path is
  now the create bootstrap turn (its completion pushes to the dispatcher), and
  the dispatcher cannot `send` to a leader.
- Updated the `.agents/` KB visibility contract + the dispatcher-service
  invariant.

## Checklist mapping

1. **team.history reads compact records** — already records-backed from
   `team/records/<team_name>.json`; confirmed + comment cleaned. No new code.
2. **No new raw team JSONL** — none added; team audit JSONL stays removed.
3. **Channel bindings use `team_name`** — renamed across the store + the team /
   dispatcher consumers; rush change for the storage field rename.
4. **One scoped read chokepoint** — `principalCanAccess` at `scopedList` +
   `mustIdentity`; dispatcher hides leaders/members; TeamLeader sees only its
   members; ordinary TeamMate sees nothing. The internal `team_service`
   authority keeps Team orchestration working without widening the public view.
5. **Leak-prevention tests** — the rewritten visibility test asserts every rule;
   Team info is exposed only through `team.*`.

## Validation

- `rush build` — clean (all 4 packages).
- `eslint .` (dreamux) — clean.
- `vitest run` (dreamux) — 688 passed, 2 skipped (live-codex skipped via
  `DREAMUX_SKIP_LIVE_CODEX=1`).
- `.agents/scripts/check.sh` — KB OK.
- `git diff --check` — clean.

## Notes / residual

- **Net direction:** `src/**` is net-additive (+97) this slice — it adds the
  `team_service` authority, the two scoped-read chokepoints, and the
  leak-prevention plumbing. Tightening visibility + adding an internal authority
  is inherently additive; the Epic still closes net-subtractive overall.
- **Deferred to Slice 5:** fail-loud DETECTION of the old `team_id`-keyed
  bindings and the rest of the old-state detection + the final Epic changelog
  closeout. This slice ships only the necessary BREAKING/Rebuild change note.

Targets `feature/i199-team-mcp-history-storage`. Do not merge — TeamLeader
coordinates review + merge.

---

## Review fixes — `70eacec`

Addressing the PR #204 review (P1 blockers + P2 cleanup):

- **P1.1 — atomic record writes.** The macOS CI flake was a `JSON.parse('')`
  race: a plain `writeFile` truncates the target before writing, so a
  `last`/status read polling concurrently with a settle write could observe an
  empty file. New `platform/atomic-write.ts` writes a sibling temp file then
  `rename`s it into place; the teammate record, team record, and channel-binding
  stores all route through it. A reader now always sees the complete old or new
  file — the corruption is fixed at the source, not swallowed. The e2e test
  already `waitFor`s the settled write before reading `last`; the race was the
  concurrent torn write, now eliminated.
- **P1.2 — `last` MCP description.** Rewritten to the Slice 3/4 contract: reads
  the record first (existence/scope), then folds recent settled turns from the
  per-name turns archive, and never starts/resumes a runtime.
- **P2 — KB wording.** Cleaned stale `sessions.jsonl` / session-ledger /
  checkpoint references in `provider-architecture-realignment.md`.
- **P2 — channel-binding legacy `team_id` detection** stays deferred to Slice 5
  (see "Deferred to Slice 5" above); this slice only ships the BREAKING/Rebuild
  note, no scope-expanding guard.

Re-validated: `rush build` / `rush lint` / `rush test` / `.agents/scripts/check.sh`
/ `git diff --check` all clean.
