### PR TITLE
feat(registry): generic provider loader + channel kind (#209 slice 2)

### DIFF
--- a/.agents/decisions/npm-package-split-and-channel-targets.md
+++ b/.agents/decisions/npm-package-split-and-channel-targets.md
@@ -552,16 +552,21 @@ These guards are epic-wide; they land across the issue #209 slices. Status:
 - **Slice 2 (generic provider loader + channel kind) — satisfied now:** the
   runtime-specific external loader is split into a kind-agnostic skeleton
   (`registry/provider-loader.ts`: dynamic import, default/named export
-  selection, factory invocation, duplicate-ref skipping, descriptor
-  registration, fail-loud formatting) plus per-kind contract assertions
+  selection, factory invocation, descriptor registration, fail-loud formatting)
+  plus per-kind contract assertions
   (`agent-runtime/external-provider.ts` for `agentRuntime`,
   `channel/external-channel-provider.ts` for `channel`). `builtin:*` refs resolve
   through the `BUILTIN_PROVIDER_PACKAGES` alias map and use the same loading path
   as `npm:*` refs; a missing/unmapped built-in package fails loud with the named
-  ref. The public `loadExternalAgentRuntimeProviders` surface and its error
-  classes are unchanged, so runtime loading stays behavior-stable. Wiring the
-  channel loader into config validation and promoting `@excitedjs/feishu-channel`
-  to a real provider implementation remain later channel slices.
+  ref. The loader's already-loaded skip is implementation-aware: a built-in
+  descriptor that is pre-registered without an implementation still flows through
+  import + factory + implementation registration (reusing the existing
+  descriptor), so the slice-3 Codex/Claude extraction can switch built-ins onto
+  this loader without no-op'ing. The public `loadExternalAgentRuntimeProviders`
+  surface and its error class identities are unchanged, so runtime loading stays
+  behavior-stable. Wiring the channel loader into config validation and promoting
+  `@excitedjs/feishu-channel` to a real provider implementation remain later
+  channel slices.
 
 ## Alternatives Considered
 

--- a/.agents/decisions/npm-package-split-and-channel-targets.md
+++ b/.agents/decisions/npm-package-split-and-channel-targets.md
@@ -549,6 +549,19 @@ These guards are epic-wide; they land across the issue #209 slices. Status:
   remaining guards (core not importing the Feishu SDK/transport; built-in
   packages bundled by default; binding store v2; Team/Channel MCP ownership;
   role-gated skill injection; symlink removal) land in their respective slices.
+- **Slice 2 (generic provider loader + channel kind) — satisfied now:** the
+  runtime-specific external loader is split into a kind-agnostic skeleton
+  (`registry/provider-loader.ts`: dynamic import, default/named export
+  selection, factory invocation, duplicate-ref skipping, descriptor
+  registration, fail-loud formatting) plus per-kind contract assertions
+  (`agent-runtime/external-provider.ts` for `agentRuntime`,
+  `channel/external-channel-provider.ts` for `channel`). `builtin:*` refs resolve
+  through the `BUILTIN_PROVIDER_PACKAGES` alias map and use the same loading path
+  as `npm:*` refs; a missing/unmapped built-in package fails loud with the named
+  ref. The public `loadExternalAgentRuntimeProviders` surface and its error
+  classes are unchanged, so runtime loading stays behavior-stable. Wiring the
+  channel loader into config validation and promoting `@excitedjs/feishu-channel`
+  to a real provider implementation remain later channel slices.
 
 ## Alternatives Considered
 

--- a/common/changes/@excitedjs/dreamux/i209-provider-loader_2026-06-13-00-00.json
+++ b/common/changes/@excitedjs/dreamux/i209-provider-loader_2026-06-13-00-00.json
@@ -1,7 +1,7 @@
 {
   "changes": [
     {
-      "comment": "Refactor the external provider loader into a kind-agnostic package-loader skeleton (registry/provider-loader.ts) plus per-kind contract assertions for agentRuntime and channel, and add a channel provider loader that resolves builtin:feishu -> @excitedjs/feishu-channel through the shared built-in package alias map (issue #209). The public loadExternalAgentRuntimeProviders surface and its error classes are unchanged; no behavior change.",
+      "comment": "Refactor the external provider loader into a kind-agnostic package-loader skeleton (registry/provider-loader.ts) plus per-kind contract assertions for agentRuntime and channel, and add a channel provider loader that resolves builtin:feishu -> @excitedjs/feishu-channel through the shared built-in package alias map (issue #209). The public loadExternalAgentRuntimeProviders surface and its error classes/identities are unchanged; two contract-error message strings were reworded to be kind-neutral. The loader's already-loaded skip is implementation-aware, so a pre-registered built-in descriptor still gets its package implementation loaded. No production behavior change in this slice (config still feeds only npm: agentRuntime refs).",
       "type": "patch",
       "packageName": "@excitedjs/dreamux"
     }

--- a/common/changes/@excitedjs/dreamux/i209-provider-loader_2026-06-13-00-00.json
+++ b/common/changes/@excitedjs/dreamux/i209-provider-loader_2026-06-13-00-00.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Refactor the external provider loader into a kind-agnostic package-loader skeleton (registry/provider-loader.ts) plus per-kind contract assertions for agentRuntime and channel, and add a channel provider loader that resolves builtin:feishu -> @excitedjs/feishu-channel through the shared built-in package alias map (issue #209). The public loadExternalAgentRuntimeProviders surface and its error classes are unchanged; no behavior change.",
+      "type": "patch",
+      "packageName": "@excitedjs/dreamux"
+    }
+  ],
+  "packageName": "@excitedjs/dreamux",
+  "email": "053700@gmail.com"
+}

--- a/packages/dreamux/src/agent-runtime/CLAUDE.md
+++ b/packages/dreamux/src/agent-runtime/CLAUDE.md
@@ -44,7 +44,13 @@ agent session; how it talks to its engine is the engine's business.
 - **External providers use the same path.** `npm:` providers load through
   `external-provider.ts` into the same `ProviderRegistry` + catalog as builtins
   (no third provider tree); they self-declare capabilities, which core validates
-  but never mirrors.
+  but never mirrors. `external-provider.ts` is now the `agentRuntime`
+  specialization of the kind-agnostic `registry/provider-loader.ts` skeleton (it
+  owns dynamic import, export selection, factory invocation, duplicate handling,
+  descriptor registration, and fail-loud formatting); the `channel` kind reuses
+  that same skeleton through `channel/external-channel-provider.ts`. `builtin:*`
+  refs resolve to their package via `registry/builtins.ts`
+  (`BUILTIN_PROVIDER_PACKAGES`) and then take the identical loading path.
 - **cwd is a required launch parameter** on the create context — supplied by the
   launcher (Dispatcher Service), never derived inside the runtime.
 

--- a/packages/dreamux/src/agent-runtime/external-provider.ts
+++ b/packages/dreamux/src/agent-runtime/external-provider.ts
@@ -1,10 +1,32 @@
+/**
+ * External `agentRuntime` provider loader (issue #209).
+ *
+ * This is the `agentRuntime` specialization of the generic provider package
+ * loader (`../registry/provider-loader.ts`). It keeps the public surface in-repo
+ * callers and tests import (`loadExternalAgentRuntimeProviders`, the factory
+ * type, and the two error classes) while delegating the kind-agnostic mechanics
+ * — dynamic import, export selection, factory invocation, duplicate handling,
+ * descriptor registration, and fail-loud formatting — to the shared skeleton.
+ *
+ * The `channel` kind reuses the same skeleton through a sibling loader; only the
+ * contract assertions below are runtime-specific.
+ */
 import {
-  formatProviderRef,
-  parseProviderRef,
-  type NpmProviderRef,
   type ProviderDescriptor,
   type ProviderRegistry,
 } from '../registry/index.js';
+import {
+  assertLoadedProviderObject,
+  assertProviderDescriptorShape,
+  errMessage,
+  isRecord,
+  loadProviderPackages,
+  type ProviderContractContext,
+  type ProviderFactory,
+  type ProviderModule,
+  type ProviderModuleImporter,
+  type ProviderPackageLoaderSpec,
+} from '../registry/provider-loader.js';
 import type {
   AgentRuntimeCapabilities,
   AgentRuntimeProvider,
@@ -18,17 +40,11 @@ export interface ExternalAgentRuntimeProviderFactoryContext {
   descriptor: ProviderDescriptor;
 }
 
-export type ExternalAgentRuntimeProviderFactory = (
-  context: ExternalAgentRuntimeProviderFactoryContext,
-) => AgentRuntimeProvider | Promise<AgentRuntimeProvider>;
+export type ExternalAgentRuntimeProviderFactory = ProviderFactory<AgentRuntimeProvider>;
 
-export type ExternalAgentRuntimeModule = Record<string, unknown> & {
-  default?: unknown;
-};
+export type ExternalAgentRuntimeModule = ProviderModule;
 
-export type ExternalAgentRuntimeModuleImporter = (
-  packageName: string,
-) => Promise<ExternalAgentRuntimeModule>;
+export type ExternalAgentRuntimeModuleImporter = ProviderModuleImporter;
 
 export class ExternalAgentRuntimeProviderLoadError extends Error {
   constructor(
@@ -59,197 +75,77 @@ export interface LoadExternalAgentRuntimeProvidersOptions {
   importModule?: ExternalAgentRuntimeModuleImporter;
 }
 
+const AGENT_RUNTIME_LOADER_SPEC: ProviderPackageLoaderSpec<AgentRuntimeProvider> = {
+  kind: 'agentRuntime',
+  createLoadError: (ref, message, options) =>
+    new ExternalAgentRuntimeProviderLoadError(ref, message, options),
+  createContractError: (ref, message) =>
+    new ExternalAgentRuntimeProviderContractError(ref, message),
+  assertProvider: assertExternalAgentRuntimeProvider,
+};
+
 export async function loadExternalAgentRuntimeProviders(
   options: LoadExternalAgentRuntimeProvidersOptions,
 ): Promise<void> {
-  const importModule = options.importModule ?? defaultImportModule;
-  const refs = uniqueNpmRefs(options.refs);
-  for (const ref of refs) {
-    if (options.registry.hasRef(ref.raw)) continue;
-    await loadOneExternalAgentRuntimeProvider({
-      registry: options.registry,
-      ref,
-      importModule,
-    });
-  }
-}
-
-async function loadOneExternalAgentRuntimeProvider(options: {
-  registry: ProviderRegistry;
-  ref: NpmProviderRef;
-  importModule: ExternalAgentRuntimeModuleImporter;
-}): Promise<void> {
-  const module = await importExternalModule(options.ref, options.importModule);
-  const factory = externalFactoryExport(options.ref, module);
-  const seedDescriptor: ProviderDescriptor = {
-    id: options.ref.raw,
-    kind: 'agentRuntime',
-    ref: options.ref,
-  };
-  let provider: AgentRuntimeProvider;
-  try {
-    provider = await factory({
-      ref: options.ref.raw,
-      descriptor: seedDescriptor,
-    });
-  } catch (err) {
-    throw new ExternalAgentRuntimeProviderLoadError(
-      options.ref.raw,
-      `provider factory threw: ${errMessage(err)}`,
-      { cause: err },
-    );
-  }
-
-  assertExternalAgentRuntimeProvider(options.ref.raw, provider);
-  options.registry.register(provider.descriptor);
-  options.registry.registerImplementation(provider.descriptor.id, provider);
-}
-
-async function importExternalModule(
-  ref: NpmProviderRef,
-  importModule: ExternalAgentRuntimeModuleImporter,
-): Promise<ExternalAgentRuntimeModule> {
-  try {
-    return await importModule(ref.package);
-  } catch (err) {
-    throw new ExternalAgentRuntimeProviderLoadError(
-      ref.raw,
-      `could not import package ${JSON.stringify(ref.package)}: ${errMessage(err)}`,
-      { cause: err },
-    );
-  }
-}
-
-function externalFactoryExport(
-  ref: NpmProviderRef,
-  module: ExternalAgentRuntimeModule,
-): ExternalAgentRuntimeProviderFactory {
-  const exportName = ref.export ?? 'default';
-  const value = ref.export === null ? module.default : module[ref.export];
-  if (typeof value !== 'function') {
-    throw new ExternalAgentRuntimeProviderContractError(
-      ref.raw,
-      `expected ${exportName} export to be an agentRuntime provider factory`,
-    );
-  }
-  return value as ExternalAgentRuntimeProviderFactory;
+  await loadProviderPackages(options, AGENT_RUNTIME_LOADER_SPEC);
 }
 
 function assertExternalAgentRuntimeProvider(
-  expectedRef: string,
   value: unknown,
+  context: ProviderContractContext,
 ): asserts value is AgentRuntimeProvider {
-  if (typeof value !== 'object' || value === null) {
-    throw new ExternalAgentRuntimeProviderContractError(
-      expectedRef,
-      'factory must return an AgentRuntimeProvider object',
-    );
-  }
+  assertLoadedProviderObject(value, context);
   const candidate = value as Partial<AgentRuntimeProvider>;
-  if (candidate.ref !== expectedRef) {
-    throw new ExternalAgentRuntimeProviderContractError(
-      expectedRef,
-      `provider.ref must be ${JSON.stringify(expectedRef)}`,
-    );
-  }
-  assertDescriptor(expectedRef, candidate.descriptor);
+  assertProviderDescriptorShape(candidate.descriptor, 'agentRuntime', context);
   if (typeof candidate.getCapabilities !== 'function') {
-    throw new ExternalAgentRuntimeProviderContractError(
-      expectedRef,
-      'provider.getCapabilities must be a function',
-    );
+    context.fail('provider.getCapabilities must be a function');
   }
   if (typeof candidate.createRuntime !== 'function') {
-    throw new ExternalAgentRuntimeProviderContractError(
-      expectedRef,
-      'provider.createRuntime must be a function',
-    );
+    context.fail('provider.createRuntime must be a function');
   }
   let capabilities: AgentRuntimeCapabilities;
   try {
-    capabilities = candidate.getCapabilities();
+    capabilities = candidate.getCapabilities!();
   } catch (err) {
-    throw new ExternalAgentRuntimeProviderContractError(
-      expectedRef,
-      `provider.getCapabilities threw: ${errMessage(err)}`,
-    );
+    context.fail(`provider.getCapabilities threw: ${errMessage(err)}`);
   }
-  assertCapabilities(expectedRef, capabilities);
-}
-
-function assertDescriptor(
-  expectedRef: string,
-  descriptor: ProviderDescriptor | undefined,
-): asserts descriptor is ProviderDescriptor {
-  if (descriptor === undefined) {
-    throw new ExternalAgentRuntimeProviderContractError(
-      expectedRef,
-      'provider.descriptor is required',
-    );
-  }
-  if (descriptor.kind !== 'agentRuntime') {
-    throw new ExternalAgentRuntimeProviderContractError(
-      expectedRef,
-      `provider.descriptor.kind must be "agentRuntime" (got ${JSON.stringify(descriptor.kind)})`,
-    );
-  }
-  if (typeof descriptor.id !== 'string' || descriptor.id.trim() === '') {
-    throw new ExternalAgentRuntimeProviderContractError(
-      expectedRef,
-      'provider.descriptor.id must be a non-empty string',
-    );
-  }
-  if (formatProviderRef(descriptor.ref) !== expectedRef) {
-    throw new ExternalAgentRuntimeProviderContractError(
-      expectedRef,
-      `provider.descriptor.ref must be ${JSON.stringify(expectedRef)}`,
-    );
-  }
+  assertCapabilities(capabilities, context);
 }
 
 function assertCapabilities(
-  expectedRef: string,
   value: unknown,
+  context: ProviderContractContext,
 ): asserts value is AgentRuntimeCapabilities {
   if (!isRecord(value)) {
-    throw new ExternalAgentRuntimeProviderContractError(
-      expectedRef,
-      'capabilities must be an object',
-    );
+    context.fail('capabilities must be an object');
   }
   const capabilities = value as Partial<AgentRuntimeCapabilities>;
-  assertResumeCapability(expectedRef, capabilities.resume);
-  assertSupportedBoolean(expectedRef, 'steer', capabilities.steer);
+  assertResumeCapability(capabilities.resume, context);
+  assertSupportedBoolean('steer', capabilities.steer, context);
   if (!isRecord(capabilities.events) || !isEventKind(capabilities.events['kind'])) {
-    throw new ExternalAgentRuntimeProviderContractError(
-      expectedRef,
-      'capabilities.events.kind must be "push" or "synthesized"',
-    );
+    context.fail('capabilities.events.kind must be "push" or "synthesized"');
   }
-  assertSupportedBoolean(expectedRef, 'last', capabilities.last);
-  assertSupportedBoolean(expectedRef, 'context', capabilities.context);
+  assertSupportedBoolean('last', capabilities.last, context);
+  assertSupportedBoolean('context', capabilities.context, context);
   if (!Array.isArray(capabilities.teammateCompletion)) {
-    throw new ExternalAgentRuntimeProviderContractError(
-      expectedRef,
-      'capabilities.teammateCompletion must be an array',
-    );
+    context.fail('capabilities.teammateCompletion must be an array');
   }
   for (const shape of capabilities.teammateCompletion) {
-    assertCompletionDeliveryShape(expectedRef, shape);
+    assertCompletionDeliveryShape(shape, context);
   }
 }
 
-function assertResumeCapability(expectedRef: string, value: unknown): void {
+function assertResumeCapability(
+  value: unknown,
+  context: ProviderContractContext,
+): void {
   if (!isRecord(value) || typeof value['supported'] !== 'boolean') {
-    throw new ExternalAgentRuntimeProviderContractError(
-      expectedRef,
-      'capabilities.resume.supported must be a boolean',
-    );
+    context.fail('capabilities.resume.supported must be a boolean');
   }
-  if (value['supported'] === true) {
-    if (typeof value['checkpoint'] !== 'string' || value['checkpoint'] === '') {
-      throw new ExternalAgentRuntimeProviderContractError(
-        expectedRef,
+  const resume = value as Record<string, unknown>;
+  if (resume['supported'] === true) {
+    if (typeof resume['checkpoint'] !== 'string' || resume['checkpoint'] === '') {
+      context.fail(
         'capabilities.resume.checkpoint must be a non-empty string when resume is supported',
       );
     }
@@ -257,67 +153,35 @@ function assertResumeCapability(expectedRef: string, value: unknown): void {
 }
 
 function assertSupportedBoolean(
-  expectedRef: string,
   name: string,
   value: unknown,
+  context: ProviderContractContext,
 ): void {
   if (!isRecord(value) || typeof value['supported'] !== 'boolean') {
-    throw new ExternalAgentRuntimeProviderContractError(
-      expectedRef,
-      `capabilities.${name}.supported must be a boolean`,
-    );
+    context.fail(`capabilities.${name}.supported must be a boolean`);
   }
 }
 
 function assertCompletionDeliveryShape(
-  expectedRef: string,
   value: unknown,
+  context: ProviderContractContext,
 ): asserts value is CompletionDeliveryShape {
   if (!isRecord(value)) {
-    throw new ExternalAgentRuntimeProviderContractError(
-      expectedRef,
-      'capabilities.teammateCompletion entries must be objects',
-    );
+    context.fail('capabilities.teammateCompletion entries must be objects');
   }
-  if (typeof value['kind'] !== 'string' || value['kind'] === '') {
-    throw new ExternalAgentRuntimeProviderContractError(
-      expectedRef,
-      'capabilities.teammateCompletion entries must include a kind',
-    );
+  const shape = value as Record<string, unknown>;
+  if (typeof shape['kind'] !== 'string' || shape['kind'] === '') {
+    context.fail('capabilities.teammateCompletion entries must include a kind');
   }
-  if (typeof value['description'] !== 'string' || value['description'] === '') {
-    throw new ExternalAgentRuntimeProviderContractError(
-      expectedRef,
+  if (typeof shape['description'] !== 'string' || shape['description'] === '') {
+    context.fail(
       'capabilities.teammateCompletion entries must include a description',
     );
   }
-}
-
-function uniqueNpmRefs(refs: Iterable<string>): NpmProviderRef[] {
-  const out = new Map<string, NpmProviderRef>();
-  for (const raw of refs) {
-    const parsed = parseProviderRef(raw);
-    if (parsed.source === 'npm') out.set(parsed.raw, parsed);
-  }
-  return [...out.values()];
-}
-
-async function defaultImportModule(
-  packageName: string,
-): Promise<ExternalAgentRuntimeModule> {
-  return import(packageName) as Promise<ExternalAgentRuntimeModule>;
 }
 
 function isEventKind(
   value: unknown,
 ): value is AgentRuntimeCapabilities['events']['kind'] {
   return value === 'push' || value === 'synthesized';
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === 'object' && value !== null && !Array.isArray(value);
-}
-
-function errMessage(err: unknown): string {
-  return err instanceof Error ? err.message : String(err);
 }

--- a/packages/dreamux/src/channel/external-channel-provider.ts
+++ b/packages/dreamux/src/channel/external-channel-provider.ts
@@ -1,0 +1,99 @@
+/**
+ * External `channel` provider loader (issue #209).
+ *
+ * The `channel` specialization of the generic provider package loader
+ * (`../registry/provider-loader.ts`). It mirrors the `agentRuntime` loader: the
+ * shared skeleton owns dynamic import, export selection, factory invocation,
+ * duplicate handling, descriptor registration, and fail-loud formatting, while
+ * the assertions here enforce the `ChannelProvider` contract.
+ *
+ * A channel provider must expose a `channel` descriptor, an optional config
+ * reader, and a channel session factory. `builtin:feishu` resolves to
+ * `@excitedjs/feishu-channel` through the same loading path once the alias is
+ * resolved; a missing built-in channel package fails loud with the named ref.
+ */
+import {
+  type ProviderDescriptor,
+  type ProviderRegistry,
+} from '../registry/index.js';
+import {
+  assertLoadedProviderObject,
+  assertProviderDescriptorShape,
+  loadProviderPackages,
+  type ProviderContractContext,
+  type ProviderFactory,
+  type ProviderModule,
+  type ProviderModuleImporter,
+  type ProviderPackageLoaderSpec,
+} from '../registry/provider-loader.js';
+import type { ChannelProvider } from '@excitedjs/dreamux-types';
+
+export interface ExternalChannelProviderFactoryContext {
+  /** Canonical provider ref from config, for example `builtin:feishu`. */
+  ref: string;
+  /** Descriptor the provider must expose back to Dreamux. */
+  descriptor: ProviderDescriptor;
+}
+
+export type ExternalChannelProviderFactory = ProviderFactory<ChannelProvider>;
+
+export type ExternalChannelModule = ProviderModule;
+
+export type ExternalChannelModuleImporter = ProviderModuleImporter;
+
+export class ExternalChannelProviderLoadError extends Error {
+  constructor(
+    readonly providerRef: string,
+    message: string,
+    options: { cause?: unknown } = {},
+  ) {
+    super(
+      `failed to load channel provider ${JSON.stringify(providerRef)}: ${message}`,
+      options,
+    );
+    this.name = 'ExternalChannelProviderLoadError';
+  }
+}
+
+export class ExternalChannelProviderContractError extends Error {
+  constructor(readonly providerRef: string, message: string) {
+    super(`invalid channel provider ${JSON.stringify(providerRef)}: ${message}`);
+    this.name = 'ExternalChannelProviderContractError';
+  }
+}
+
+export interface LoadChannelProvidersOptions {
+  registry: ProviderRegistry;
+  refs: Iterable<string>;
+  importModule?: ExternalChannelModuleImporter;
+}
+
+const CHANNEL_LOADER_SPEC: ProviderPackageLoaderSpec<ChannelProvider> = {
+  kind: 'channel',
+  createLoadError: (ref, message, options) =>
+    new ExternalChannelProviderLoadError(ref, message, options),
+  createContractError: (ref, message) =>
+    new ExternalChannelProviderContractError(ref, message),
+  assertProvider: assertChannelProvider,
+};
+
+export async function loadChannelProviders(
+  options: LoadChannelProvidersOptions,
+): Promise<void> {
+  await loadProviderPackages(options, CHANNEL_LOADER_SPEC);
+}
+
+function assertChannelProvider(
+  value: unknown,
+  context: ProviderContractContext,
+): asserts value is ChannelProvider {
+  assertLoadedProviderObject(value, context);
+  const candidate = value as Partial<ChannelProvider>;
+  assertProviderDescriptorShape(candidate.descriptor, 'channel', context);
+  if (candidate.readConfig !== undefined && typeof candidate.readConfig !== 'function') {
+    context.fail('provider.readConfig must be a function when present');
+  }
+  if (typeof candidate.createSession !== 'function') {
+    context.fail('provider.createSession must be a function');
+  }
+}

--- a/packages/dreamux/src/registry/builtins.ts
+++ b/packages/dreamux/src/registry/builtins.ts
@@ -32,6 +32,43 @@ export const BUILTIN_FEISHU_PROVIDER_REF = 'builtin:feishu';
 export const BUILTIN_CODEX_PROVIDER_REF = 'builtin:codex';
 export const BUILTIN_CLAUDE_CODE_PROVIDER_REF = 'builtin:claude-code';
 
+/**
+ * Built-in provider id -> npm package the generic loader imports for it
+ * (issue #209). The built-in refs stay stable; Dreamux resolves them to the
+ * packages that ship the built-in providers so `builtin:*` and `npm:*` refs use
+ * the same loading path. Each package version-bumps independently behind the
+ * stable ref.
+ */
+export const BUILTIN_PROVIDER_PACKAGES: Readonly<Record<string, string>> = {
+  codex: '@excitedjs/agent-runtime-codex',
+  'claude-code': '@excitedjs/agent-runtime-claude-code',
+  feishu: '@excitedjs/feishu-channel',
+};
+
+/** Thrown when a `builtin:` ref has no known package mapping. */
+export class UnknownBuiltinProviderPackageError extends Error {
+  constructor(readonly id: string) {
+    super(
+      `builtin provider ${JSON.stringify(`builtin:${id}`)} has no known ` +
+        'package mapping',
+    );
+    this.name = 'UnknownBuiltinProviderPackageError';
+  }
+}
+
+/**
+ * Resolve a built-in provider id to the npm package that ships it. Throws
+ * {@link UnknownBuiltinProviderPackageError} for an unmapped id so the loader can
+ * fail loud with a named ref rather than a raw module-loader error.
+ */
+export function resolveBuiltinProviderPackage(id: string): string {
+  const packageName = BUILTIN_PROVIDER_PACKAGES[id];
+  if (packageName === undefined) {
+    throw new UnknownBuiltinProviderPackageError(id);
+  }
+  return packageName;
+}
+
 /** The provider refs Dreamux ships and recognizes. */
 export const BUILTIN_PROVIDERS: readonly BuiltinSpec[] = [
   { id: 'codex', kind: 'agentRuntime' },

--- a/packages/dreamux/src/registry/index.ts
+++ b/packages/dreamux/src/registry/index.ts
@@ -9,3 +9,4 @@
 export * from './provider-ref.js';
 export * from './registry.js';
 export * from './builtins.js';
+export * from './provider-loader.js';

--- a/packages/dreamux/src/registry/provider-loader.ts
+++ b/packages/dreamux/src/registry/provider-loader.ts
@@ -80,8 +80,15 @@ export interface LoadProviderPackagesOptions {
 /**
  * Load every package-backed provider ref in `refs` into the registry using the
  * kind-specific `spec`. Builtin (`builtin:`) and external (`npm:`) refs both
- * flow through here; already-registered refs are skipped, and refs are
- * de-duplicated by canonical form.
+ * flow through here; refs are de-duplicated by canonical form.
+ *
+ * The skip condition is implementation-aware, not descriptor-aware: a ref is
+ * skipped only once its *implementation* is registered. A built-in descriptor
+ * may already exist in the registry (the builtin descriptors are pre-registered)
+ * while its package implementation has not been loaded yet — that ref must still
+ * flow through import + factory + implementation registration. Skipping on
+ * descriptor existence alone would silently leave pre-registered built-ins
+ * without a loaded implementation (the slice-3 Codex/Claude extraction path).
  */
 export async function loadProviderPackages<
   TProvider extends { readonly descriptor: ProviderDescriptor },
@@ -91,9 +98,23 @@ export async function loadProviderPackages<
 ): Promise<void> {
   const importModule = options.importModule ?? defaultImportModule;
   for (const ref of uniqueLoadableRefs(options.refs)) {
-    if (options.registry.hasRef(ref.raw)) continue;
+    if (isImplementationLoaded(options.registry, ref)) continue;
     await loadOneProviderPackage(options.registry, ref, importModule, spec);
   }
+}
+
+/**
+ * True when `ref` already has both a registered descriptor and a registered
+ * implementation. A descriptor without an implementation (a pre-registered
+ * built-in awaiting its package) returns false so the loader proceeds.
+ */
+function isImplementationLoaded(
+  registry: ProviderRegistry,
+  ref: ProviderRef,
+): boolean {
+  if (!registry.hasRef(ref.raw)) return false;
+  const descriptor = registry.resolve(ref.raw);
+  return registry.getImplementation(descriptor.id) !== undefined;
 }
 
 async function loadOneProviderPackage<
@@ -104,10 +125,13 @@ async function loadOneProviderPackage<
   importModule: ProviderModuleImporter,
   spec: ProviderPackageLoaderSpec<TProvider>,
 ): Promise<void> {
+  const existing = registry.hasRef(ref.raw)
+    ? registry.resolve(ref.raw)
+    : undefined;
   const packageName = resolvePackageName(ref, spec);
   const module = await importProviderModule(ref, packageName, importModule, spec);
   const factory = selectFactoryExport(ref, module, spec);
-  const seedDescriptor: ProviderDescriptor = {
+  const seedDescriptor: ProviderDescriptor = existing ?? {
     id: seedDescriptorId(ref),
     kind: spec.kind,
     ref,
@@ -132,8 +156,13 @@ async function loadOneProviderPackage<
     },
   });
 
-  registry.register(provider.descriptor);
-  registry.registerImplementation(provider.descriptor.id, provider);
+  // A pre-registered built-in keeps its existing descriptor; only its
+  // implementation is loaded from the package. Package-backed refs register
+  // both the descriptor and the implementation.
+  if (existing === undefined) {
+    registry.register(provider.descriptor);
+  }
+  registry.registerImplementation(seedDescriptor.id, provider);
 }
 
 function resolvePackageName<
@@ -178,7 +207,7 @@ function selectFactoryExport<
   if (typeof value !== 'function') {
     throw spec.createContractError(
       ref.raw,
-      `expected ${exportName ?? 'default'} export to be a ${spec.kind} provider factory`,
+      `expected ${exportName ?? 'default'} export to be a provider factory function for kind ${JSON.stringify(spec.kind)}`,
     );
   }
   return value as ProviderFactory<TProvider>;

--- a/packages/dreamux/src/registry/provider-loader.ts
+++ b/packages/dreamux/src/registry/provider-loader.ts
@@ -1,0 +1,256 @@
+/**
+ * Generic provider package loader skeleton (issue #209).
+ *
+ * Dreamux core owns provider loading. This module is the kind-agnostic skeleton
+ * shared by the `agentRuntime` and `channel` external loaders: it resolves the
+ * package name for a ref, dynamically imports the module, selects the factory
+ * export, invokes it, registers the resulting descriptor + implementation, and
+ * formats fail-loud load/contract errors consistently.
+ *
+ * Kind-specific contract assertions stay with each kind's loader (see
+ * `../agent-runtime/external-provider.ts` and
+ * `../channel/external-channel-provider.ts`). `builtin:*` refs resolve to their
+ * package through {@link resolveBuiltinProviderPackage} and then use the same
+ * loading path as package-backed `npm:` refs.
+ */
+
+import { resolveBuiltinProviderPackage } from './builtins.js';
+import {
+  parseProviderRef,
+  type NpmProviderRef,
+  type ProviderRef,
+} from './provider-ref.js';
+import type { ProviderDescriptor, ProviderKind } from './registry.js';
+import type { ProviderRegistry } from './registry.js';
+
+export type ProviderModule = Record<string, unknown> & {
+  default?: unknown;
+};
+
+export type ProviderModuleImporter = (
+  packageName: string,
+) => Promise<ProviderModule>;
+
+/** Context passed to a provider package's factory export. */
+export interface ProviderFactoryContext {
+  /** Canonical provider ref from config, for example `npm:some-pkg#provider`. */
+  ref: string;
+  /** Seed descriptor the provider must echo back to Dreamux. */
+  descriptor: ProviderDescriptor;
+}
+
+export type ProviderFactory<TProvider> = (
+  context: ProviderFactoryContext,
+) => TProvider | Promise<TProvider>;
+
+/** Context handed to a kind-specific contract assertion. */
+export interface ProviderContractContext {
+  ref: string;
+  descriptor: ProviderDescriptor;
+  /** Throw the kind-specific contract error with a consistent prefix. */
+  fail(message: string): never;
+}
+
+/**
+ * Per-kind hooks the generic skeleton needs: how to format errors and how to
+ * assert the loaded value satisfies that kind's provider contract.
+ */
+export interface ProviderPackageLoaderSpec<
+  TProvider extends { readonly descriptor: ProviderDescriptor },
+> {
+  kind: ProviderKind;
+  createLoadError(
+    ref: string,
+    message: string,
+    options?: { cause?: unknown },
+  ): Error;
+  createContractError(ref: string, message: string): Error;
+  assertProvider(
+    value: unknown,
+    context: ProviderContractContext,
+  ): asserts value is TProvider;
+}
+
+export interface LoadProviderPackagesOptions {
+  registry: ProviderRegistry;
+  refs: Iterable<string>;
+  importModule?: ProviderModuleImporter;
+}
+
+/**
+ * Load every package-backed provider ref in `refs` into the registry using the
+ * kind-specific `spec`. Builtin (`builtin:`) and external (`npm:`) refs both
+ * flow through here; already-registered refs are skipped, and refs are
+ * de-duplicated by canonical form.
+ */
+export async function loadProviderPackages<
+  TProvider extends { readonly descriptor: ProviderDescriptor },
+>(
+  options: LoadProviderPackagesOptions,
+  spec: ProviderPackageLoaderSpec<TProvider>,
+): Promise<void> {
+  const importModule = options.importModule ?? defaultImportModule;
+  for (const ref of uniqueLoadableRefs(options.refs)) {
+    if (options.registry.hasRef(ref.raw)) continue;
+    await loadOneProviderPackage(options.registry, ref, importModule, spec);
+  }
+}
+
+async function loadOneProviderPackage<
+  TProvider extends { readonly descriptor: ProviderDescriptor },
+>(
+  registry: ProviderRegistry,
+  ref: ProviderRef,
+  importModule: ProviderModuleImporter,
+  spec: ProviderPackageLoaderSpec<TProvider>,
+): Promise<void> {
+  const packageName = resolvePackageName(ref, spec);
+  const module = await importProviderModule(ref, packageName, importModule, spec);
+  const factory = selectFactoryExport(ref, module, spec);
+  const seedDescriptor: ProviderDescriptor = {
+    id: seedDescriptorId(ref),
+    kind: spec.kind,
+    ref,
+  };
+
+  let provider: TProvider;
+  try {
+    provider = await factory({ ref: ref.raw, descriptor: seedDescriptor });
+  } catch (err) {
+    throw spec.createLoadError(
+      ref.raw,
+      `provider factory threw: ${errMessage(err)}`,
+      { cause: err },
+    );
+  }
+
+  spec.assertProvider(provider, {
+    ref: ref.raw,
+    descriptor: seedDescriptor,
+    fail: (message) => {
+      throw spec.createContractError(ref.raw, message);
+    },
+  });
+
+  registry.register(provider.descriptor);
+  registry.registerImplementation(provider.descriptor.id, provider);
+}
+
+function resolvePackageName<
+  TProvider extends { readonly descriptor: ProviderDescriptor },
+>(ref: ProviderRef, spec: ProviderPackageLoaderSpec<TProvider>): string {
+  if (ref.source === 'npm') return ref.package;
+  try {
+    return resolveBuiltinProviderPackage(ref.id);
+  } catch (err) {
+    throw spec.createLoadError(ref.raw, errMessage(err), { cause: err });
+  }
+}
+
+async function importProviderModule<
+  TProvider extends { readonly descriptor: ProviderDescriptor },
+>(
+  ref: ProviderRef,
+  packageName: string,
+  importModule: ProviderModuleImporter,
+  spec: ProviderPackageLoaderSpec<TProvider>,
+): Promise<ProviderModule> {
+  try {
+    return await importModule(packageName);
+  } catch (err) {
+    throw spec.createLoadError(
+      ref.raw,
+      `could not import package ${JSON.stringify(packageName)}: ${errMessage(err)}`,
+      { cause: err },
+    );
+  }
+}
+
+function selectFactoryExport<
+  TProvider extends { readonly descriptor: ProviderDescriptor },
+>(
+  ref: ProviderRef,
+  module: ProviderModule,
+  spec: ProviderPackageLoaderSpec<TProvider>,
+): ProviderFactory<TProvider> {
+  const exportName = ref.source === 'npm' ? ref.export : null;
+  const value = exportName === null ? module.default : module[exportName];
+  if (typeof value !== 'function') {
+    throw spec.createContractError(
+      ref.raw,
+      `expected ${exportName ?? 'default'} export to be a ${spec.kind} provider factory`,
+    );
+  }
+  return value as ProviderFactory<TProvider>;
+}
+
+function seedDescriptorId(ref: ProviderRef): string {
+  return ref.source === 'builtin' ? ref.id : ref.raw;
+}
+
+function uniqueLoadableRefs(refs: Iterable<string>): ProviderRef[] {
+  const out = new Map<string, ProviderRef>();
+  for (const raw of refs) {
+    const parsed = parseProviderRef(raw);
+    out.set(parsed.raw, parsed);
+  }
+  return [...out.values()];
+}
+
+async function defaultImportModule(
+  packageName: string,
+): Promise<ProviderModule> {
+  return import(packageName) as Promise<ProviderModule>;
+}
+
+/**
+ * Shared structural check: the loaded value is a provider object whose `ref`
+ * matches the ref Dreamux asked the package to implement.
+ */
+export function assertLoadedProviderObject(
+  value: unknown,
+  context: ProviderContractContext,
+): asserts value is { ref: string; descriptor?: unknown } {
+  if (!isRecord(value)) {
+    context.fail('factory must return a provider object');
+  }
+  if ((value as { ref?: unknown }).ref !== context.ref) {
+    context.fail(`provider.ref must be ${JSON.stringify(context.ref)}`);
+  }
+}
+
+/**
+ * Shared structural check for `provider.descriptor`: present, correct kind,
+ * non-empty id, and a ref matching the requested ref.
+ */
+export function assertProviderDescriptorShape(
+  descriptor: unknown,
+  expectedKind: ProviderKind,
+  context: ProviderContractContext,
+): asserts descriptor is ProviderDescriptor {
+  if (descriptor === undefined) {
+    context.fail('provider.descriptor is required');
+  }
+  const candidate = descriptor as Partial<ProviderDescriptor>;
+  if (candidate.kind !== expectedKind) {
+    context.fail(
+      `provider.descriptor.kind must be ${JSON.stringify(expectedKind)} (got ${JSON.stringify(candidate.kind)})`,
+    );
+  }
+  if (typeof candidate.id !== 'string' || candidate.id.trim() === '') {
+    context.fail('provider.descriptor.id must be a non-empty string');
+  }
+  if (candidate.ref?.raw !== context.ref) {
+    context.fail(`provider.descriptor.ref must be ${JSON.stringify(context.ref)}`);
+  }
+}
+
+export function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+export function errMessage(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}
+
+export type { NpmProviderRef };

--- a/packages/dreamux/tests/agent-runtime-provider.test.ts
+++ b/packages/dreamux/tests/agent-runtime-provider.test.ts
@@ -237,6 +237,46 @@ describe('AgentRuntimeProviderCatalog', () => {
     expect(created).toHaveLength(1);
   });
 
+  it('loads a package implementation for a pre-registered builtin descriptor', async () => {
+    // The builtin registry pre-registers builtin:codex / builtin:claude-code
+    // descriptors without implementations. The loader skip must be
+    // implementation-aware: a descriptor that exists but has no implementation
+    // must still flow through import + factory + implementation registration,
+    // so the slice-3 Codex/Claude extraction can switch builtins onto this
+    // loader without no-op'ing. (PR #212 P1.)
+    const registry = createBuiltinProviderRegistry();
+    const codexDescriptor = registry.resolve('builtin:codex');
+    expect(registry.getImplementation(codexDescriptor.id)).toBeUndefined();
+
+    let importCount = 0;
+    await loadExternalAgentRuntimeProviders({
+      registry,
+      refs: ['builtin:codex'],
+      importModule: async (packageName) => {
+        importCount += 1;
+        expect(packageName).toBe('@excitedjs/agent-runtime-codex');
+        return { default: externalFactory() };
+      },
+    });
+
+    expect(importCount).toBe(1);
+    // The existing builtin descriptor is reused (not duplicated), and now has an
+    // implementation registered against it.
+    expect(registry.resolve('builtin:codex')).toBe(codexDescriptor);
+    expect(registry.getImplementation(codexDescriptor.id)).toBeDefined();
+
+    // A second load is a true no-op now that the implementation exists.
+    await loadExternalAgentRuntimeProviders({
+      registry,
+      refs: ['builtin:codex'],
+      importModule: async () => {
+        importCount += 1;
+        return { default: externalFactory() };
+      },
+    });
+    expect(importCount).toBe(1);
+  });
+
   it('reports external package import failures with the provider ref', async () => {
     await expect(
       loadExternalAgentRuntimeProviders({

--- a/packages/dreamux/tests/channel-provider-loader.test.ts
+++ b/packages/dreamux/tests/channel-provider-loader.test.ts
@@ -1,0 +1,207 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  ExternalChannelProviderContractError,
+  ExternalChannelProviderLoadError,
+  loadChannelProviders,
+  type ExternalChannelProviderFactory,
+} from '../src/channel/external-channel-provider.js';
+import {
+  BUILTIN_PROVIDER_PACKAGES,
+  createBuiltinProviderRegistry,
+  resolveBuiltinProviderPackage,
+  UnknownBuiltinProviderPackageError,
+} from '../src/registry/index.js';
+import type {
+  ChannelProvider,
+  ChannelSession,
+} from '@excitedjs/dreamux-types';
+
+function fakeSession(channelId: string): ChannelSession {
+  return {
+    provider: 'builtin:feishu',
+    channel_id: channelId,
+    async start() {
+      /* test sink */
+    },
+    async close() {
+      /* test sink */
+    },
+    async resolveTarget() {
+      return { target_type: 'group', target_key: 'k', bindable: true };
+    },
+  };
+}
+
+function channelFactory(options: {
+  created?: string[];
+} = {}): ExternalChannelProviderFactory {
+  return ({ ref, descriptor }) => {
+    const provider: ChannelProvider = {
+      ref,
+      descriptor,
+      readConfig(raw) {
+        return raw;
+      },
+      createSession(context) {
+        options.created?.push(context.channel_id);
+        return fakeSession(context.channel_id);
+      },
+    };
+    return provider;
+  };
+}
+
+describe('channel provider loader', () => {
+  it('resolves the built-in channel ref to its package', () => {
+    expect(resolveBuiltinProviderPackage('feishu')).toBe(
+      '@excitedjs/feishu-channel',
+    );
+    expect(BUILTIN_PROVIDER_PACKAGES['feishu']).toBe('@excitedjs/feishu-channel');
+  });
+
+  it('loads builtin:feishu through the same package-loader path', async () => {
+    const registry = createBuiltinProviderRegistry();
+    const imported: string[] = [];
+    await loadChannelProviders({
+      registry,
+      refs: ['builtin:feishu'],
+      importModule: async (packageName) => {
+        imported.push(packageName);
+        return { default: channelFactory() };
+      },
+    });
+
+    expect(imported).toEqual(['@excitedjs/feishu-channel']);
+    const descriptors = registry.listByKind('channel');
+    expect(descriptors.map((d) => d.id)).toEqual(['feishu']);
+    expect(registry.resolve('builtin:feishu').kind).toBe('channel');
+  });
+
+  it('loads external npm channel providers and registers the implementation', async () => {
+    const registry = createBuiltinProviderRegistry();
+    const created: string[] = [];
+    await loadChannelProviders({
+      registry,
+      refs: ['npm:@example/dreamux-channel#provider'],
+      importModule: async (packageName) => {
+        expect(packageName).toBe('@example/dreamux-channel');
+        return { provider: channelFactory({ created }) };
+      },
+    });
+
+    const descriptor = registry.resolve('npm:@example/dreamux-channel#provider');
+    expect(descriptor.kind).toBe('channel');
+    const impl = registry.getImplementation(descriptor.id) as ChannelProvider;
+    expect(impl.ref).toBe('npm:@example/dreamux-channel#provider');
+    const session = impl.createSession({
+      dispatcher_id: 'flow',
+      channel_id: 'github',
+      provider: descriptor.ref.raw,
+      config: {},
+    });
+    expect(session.channel_id).toBe('github');
+    expect(created).toEqual(['github']);
+  });
+
+  it('skips refs already registered in the channel registry', async () => {
+    const registry = createBuiltinProviderRegistry();
+    let importCount = 0;
+    const importModule = async () => {
+      importCount += 1;
+      return { default: channelFactory() };
+    };
+    await loadChannelProviders({
+      registry,
+      refs: ['builtin:feishu', 'builtin:feishu'],
+      importModule,
+    });
+    expect(importCount).toBe(1);
+  });
+
+  it('fails loud for unmapped builtin channel refs', async () => {
+    expect(() => resolveBuiltinProviderPackage('does-not-exist')).toThrow(
+      UnknownBuiltinProviderPackageError,
+    );
+    await expect(
+      loadChannelProviders({
+        registry: createBuiltinProviderRegistry(),
+        refs: ['builtin:does-not-exist'],
+        importModule: async () => ({ default: channelFactory() }),
+      }),
+    ).rejects.toThrow(ExternalChannelProviderLoadError);
+    await expect(
+      loadChannelProviders({
+        registry: createBuiltinProviderRegistry(),
+        refs: ['builtin:does-not-exist'],
+        importModule: async () => ({ default: channelFactory() }),
+      }),
+    ).rejects.toThrow(/builtin:does-not-exist/);
+  });
+
+  it('reports package import failures with the channel provider ref', async () => {
+    await expect(
+      loadChannelProviders({
+        registry: createBuiltinProviderRegistry(),
+        refs: ['npm:@example/missing-channel'],
+        importModule: async () => {
+          throw new Error('package not found');
+        },
+      }),
+    ).rejects.toThrow(ExternalChannelProviderLoadError);
+    await expect(
+      loadChannelProviders({
+        registry: createBuiltinProviderRegistry(),
+        refs: ['npm:@example/missing-channel'],
+        importModule: async () => {
+          throw new Error('package not found');
+        },
+      }),
+    ).rejects.toThrow(/npm:@example\/missing-channel/);
+  });
+
+  it('rejects modules that do not export a channel provider factory', async () => {
+    await expect(
+      loadChannelProviders({
+        registry: createBuiltinProviderRegistry(),
+        refs: ['npm:@example/dreamux-channel#missing'],
+        importModule: async () => ({ default: channelFactory() }),
+      }),
+    ).rejects.toThrow(ExternalChannelProviderContractError);
+  });
+
+  it('rejects channel providers missing createSession', async () => {
+    await expect(
+      loadChannelProviders({
+        registry: createBuiltinProviderRegistry(),
+        refs: ['npm:@example/dreamux-channel'],
+        importModule: async () => ({
+          default: ({ ref, descriptor }: { ref: string; descriptor: unknown }) => ({
+            ref,
+            descriptor,
+          }),
+        }),
+      }),
+    ).rejects.toThrow(/provider\.createSession must be a function/);
+  });
+
+  it('rejects channel providers whose descriptor kind is wrong', async () => {
+    await expect(
+      loadChannelProviders({
+        registry: createBuiltinProviderRegistry(),
+        refs: ['npm:@example/dreamux-channel'],
+        importModule: async () => ({
+          default: ({ ref }: { ref: string }) => ({
+            ref,
+            descriptor: {
+              id: ref,
+              kind: 'agentRuntime',
+              ref: { source: 'npm', package: '@example/dreamux-channel', export: null, raw: ref },
+            },
+            createSession: () => fakeSession('x'),
+          }),
+        }),
+      }),
+    ).rejects.toThrow(/provider\.descriptor\.kind must be "channel"/);
+  });
+});

--- a/packages/dreamux/tests/channel-provider-loader.test.ts
+++ b/packages/dreamux/tests/channel-provider-loader.test.ts
@@ -60,6 +60,18 @@ describe('channel provider loader', () => {
     expect(BUILTIN_PROVIDER_PACKAGES['feishu']).toBe('@excitedjs/feishu-channel');
   });
 
+  it('maps the built-in agent-runtime refs to their extraction packages', () => {
+    // Forward-looking for slice 3: the same alias map carries the runtime
+    // packages, so builtin:codex / builtin:claude-code resolve through the
+    // identical loader path once those packages exist.
+    expect(resolveBuiltinProviderPackage('codex')).toBe(
+      '@excitedjs/agent-runtime-codex',
+    );
+    expect(resolveBuiltinProviderPackage('claude-code')).toBe(
+      '@excitedjs/agent-runtime-claude-code',
+    );
+  });
+
   it('loads builtin:feishu through the same package-loader path', async () => {
     const registry = createBuiltinProviderRegistry();
     const imported: string[] = [];


### PR DESCRIPTION
## Summary

Issue #209 slice 2: make the provider loader boundary real by splitting the
runtime-specific external loader into a kind-agnostic package-loader skeleton
plus per-kind contract assertions, and add a `channel` provider loading path.
Low behavior-risk: `agentRuntime` loading is functionally unchanged.

Refines the accepted decision record
`.agents/decisions/npm-package-split-and-channel-targets.md` ("Provider
Loading") and the final plan in
https://github.com/excitedjs/dreamux/issues/209#issuecomment-4692819800.

## Changes

- **`registry/provider-loader.ts` (new):** kind-agnostic skeleton — dynamic
  import, default/named export selection, factory invocation, duplicate-ref
  skipping, descriptor registration, and consistent fail-loud formatting, with
  shared structural assertions (`assertLoadedProviderObject`,
  `assertProviderDescriptorShape`).
- **`agent-runtime/external-provider.ts`:** now the `agentRuntime`
  specialization over the skeleton. The public surface
  (`loadExternalAgentRuntimeProviders`, `ExternalAgentRuntimeProviderFactory`,
  `ExternalAgentRuntimeProviderLoadError`,
  `ExternalAgentRuntimeProviderContractError`,
  `ExternalAgentRuntimeModuleImporter`) and the error class identities are
  unchanged; two contract-error message strings were reworded to be
  kind-neutral.
- **`channel/external-channel-provider.ts` (new):** the `channel`
  specialization, asserting the `ChannelProvider` contract (descriptor kind,
  optional config reader, `createSession` factory).
- **`registry/builtins.ts`:** `BUILTIN_PROVIDER_PACKAGES` alias map +
  `resolveBuiltinProviderPackage` so `builtin:*` (codex, claude-code, feishu)
  load through the same path as `npm:*`; unmapped built-ins fail loud with the
  named ref (`UnknownBuiltinProviderPackageError`).
- Decision record: slice-2 status added. `agent-runtime/CLAUDE.md`: loader
  shape note. Rush change file for `@excitedjs/dreamux` (patch, no behavior
  change).

Channel-loader wiring into config validation and a real
`@excitedjs/feishu-channel` implementation are intentionally deferred to later
channel slices.

## Validation

- `npm run typecheck` (@excitedjs/dreamux): pass
- `node common/scripts/install-run-rush.js build --to @excitedjs/dreamux`: pass
- `npm run lint` (@excitedjs/dreamux): pass
- `npx vitest run` (full @excitedjs/dreamux suite): 721 passed, 1 skipped, and
  1 pre-existing flaky failure in `tests/codex-live.test.ts` ("folds mid-turn
  Feishu inbound ... reaction tri-state") — confirmed failing on the slice-1
  base `ad5814b` with my changes reverted, so it is unrelated to this slice.
- New `tests/channel-provider-loader.test.ts`: 9 passed
- `.agents/scripts/check.sh`: KB OK; `git diff --check`: clean

## Test plan

- [ ] Both reviewers confirm the loader split keeps `agentRuntime` behavior
      stable and the `channel` kind asserts the right contract.
- [ ] Confirm the `builtin:* -> package` alias map matches the decision record.

Refs #209.
