### PR TITLE
feat(channel): binding store v2 + (channel_id, target_key) routing (#209)

### DIFF
--- a/.agents/decisions/npm-package-split-and-channel-targets.md
+++ b/.agents/decisions/npm-package-split-and-channel-targets.md
@@ -782,7 +782,38 @@ These guards are epic-wide; they land across the issue #209 slices. Status:
   target-enumeration / routing-slice work). So the end-state Channel MCP described
   above (`bind_channel` by `channel_id` + resolveTarget, the standard
   reply/react/list_peers set) is only partially realized: the binding *verbs*
-  moved to core ownership; the channel-neutral *addressing* has not.
+  moved to core ownership; the channel-neutral *addressing* has not (it lands in
+  the binding store v2 slice below).
+- **Binding store v2 + channel target routing — satisfied now:** the persisted
+  channel-binding store moved to `version: 2`. Flat rows now key on
+  `(channel_id, target_key)` and carry `channel_id`, the provider-owned opaque
+  `target_key`, `target_type`, `display`, `canonical_url`, and a `meta` object;
+  the Feishu `chat_id` / `chat_type` selectors moved OUT of core top-level columns
+  INTO `meta`, so the store is channel-neutral. Active uniqueness is
+  `(channel_id, target_key)` — one channel target is active for at most one Team,
+  and re-binding reassigns it (one row per key, `created_at` preserved). Target
+  resolution is provider-owned: the Feishu `ChannelSession.resolveTarget(meta)`
+  maps `{ chat_id, chat_type }` to a stable key (group chats are bindable; P2P is
+  not). Core runs `resolveTarget` at the bind/route *edge* (the dispatcher service
+  facade, via the live channel session) and passes primitives
+  `(channel_id, target_key)` down to the Team service and store, so the store and
+  team service stay session-free. Inbound routing
+  (`DispatcherService.routeChannelInput`) and TeamLeader authorization
+  (`teamLeaderCanUseChannel`) key on `(channel_id, target_key)`: a bound bindable
+  target routes to its TeamLeader; an unbound bindable target and any non-bindable
+  (P2P) target route to the dispatcher; a P2P target short-circuits to the
+  dispatcher BEFORE any binding lookup and can never be bound to a TeamLeader.
+  `channel_id` is the dispatcher-local `dispatchers[].channels[].id`, resolved
+  once by `dispatcherChannelId(config)` — the single source of truth shared by the
+  bind path and the router so a stored binding and an inbound message resolve to
+  the same key. The Channel MCP `bind_channel` / `transfer_back` tools keep
+  `chat_id` terminology and gain an optional `channel_id` (defaults to the sole
+  configured channel; an explicit id must match it). A pre-v2 store fails loud at
+  `dreamux serve` / `dreamux doctor` (and on access) with rebuild guidance —
+  Dreamux 0.x does not migrate it. **Still deferred to a later slice:** moving
+  `reply` / `react` / `list_chat_bots` off the provider-owned `feishu` MCP server
+  onto the generic surface, `list_peers`, and live multi-channel routing (the
+  runtime still runs exactly one Feishu channel per dispatcher).
 
 ## Alternatives Considered
 

--- a/.agents/decisions/top-level-design.md
+++ b/.agents/decisions/top-level-design.md
@@ -858,10 +858,9 @@ forwards to core admin methods `mcp.channel.bind_channel` /
 `mcp.channel.transfer_back`, which delegate to the same `ChannelBindingStore`
 path as before — binding state, routing, and authorization stay core-owned and
 are NOT moved into any provider/runtime package. This is a surface/ownership move
-only: targets are still Feishu group chats addressed by `chat_id`; the
-channel-neutral `channel_id` + `resolveTarget` target model, binding store v2,
-and `list_peers` remain deferred to the routing slice, and `reply` / `react` stay
-on the provider-owned `feishu` MCP server for now.
+only; the channel-neutral `channel_id` + `resolveTarget` target model and binding
+store v2 landed in the next slice (below), while `list_peers` and moving `reply` /
+`react` onto the generic surface remain deferred.
 
 A TeamLeader is a TeamMate identity with `role:
 "team_leader"` and dispatcher owner. Team-owned members are normal TeamMate
@@ -885,14 +884,28 @@ worktree, or — when the Team was created with no `repo` — the plain
 `.workspace/work/<team_name>/` dir), never a separate per-member directory.
 
 Channel binding is persisted as JSON under
-`state/<dispatcher-id>/team/channel-bindings.json`, keyed by the concrete
-`team_name` (issue #199 Slice 4), and is scoped to group chats only. Bound Feishu group inbound is gated and formatted by the
-Feishu channel exactly as before, then routed by Dispatcher Service to the
-owning TeamLeader runtime. Unbound and P2P inbound still route to the
-dispatcher. The Channel MCP `transfer_back` deactivates a binding; `dissolve`
+`state/<dispatcher-id>/team/channel-bindings.json` (issue #209 binding store v2:
+`version: 2`). Flat rows key active bindings on `(channel_id, target_key)` and
+carry `channel_id`, the provider-owned opaque `target_key`, `target_type`,
+`display`, `canonical_url`, a `meta` object (Feishu `chat_id` / `chat_type` live
+here, not as core columns), plus `team_name` / `leader_name` / `active` /
+timestamps. Active uniqueness is `(channel_id, target_key)` — one target is active
+for at most one Team; re-binding reassigns it. Targets are resolved by the channel
+provider's `resolveTarget(meta)`, run by core at the bind/route edge; the Team
+service and store operate on the resolved `(channel_id, target_key)` primitives.
+`channel_id` is the dispatcher-local `dispatchers[].channels[].id`, resolved once
+by `dispatcherChannelId(config)` so the bind path and the inbound router key
+identically. Bound Feishu group inbound is gated and formatted by the Feishu
+channel, then routed by Dispatcher Service to the owning TeamLeader runtime; an
+unbound bindable target and any non-bindable P2P target route to the dispatcher
+(P2P short-circuits before any binding lookup and can never be bound to a
+TeamLeader). The Channel MCP `transfer_back` deactivates a binding; `dissolve`
 transfers active bindings back before closing the team. TeamLeader Feishu MCP
 calls carry their server-derived team principal and can reply/react only in bound
-team channels; the dispatcher keeps the global Feishu management surface.
+team channels (authorization keys on `(channel_id, target_key)`); the dispatcher
+keeps the global Feishu management surface. A pre-v2 store fails loud at
+`dreamux serve` / `dreamux doctor` with rebuild guidance — 0.x does not migrate
+it.
 
 A Team binds to an EXISTING Feishu group chat via the Channel MCP
 `channel.bind_channel` (`team_name` + `chat_id`, after create) through the

--- a/common/changes/@excitedjs/dreamux/i209-binding-store-v2_2026-06-13-00-00.json
+++ b/common/changes/@excitedjs/dreamux/i209-binding-store-v2_2026-06-13-00-00.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "BREAKING: Channel binding store v2 + (channel_id, target_key) routing (issue #209). The persisted channel-binding store (`~/.dreamux/state/<dispatcher>/team/channel-bindings.json`) moves to `version: 2`: flat rows now carry `channel_id`, a provider-owned `target_key`, `target_type`, `display`, `canonical_url`, and a `meta` object (Feishu `chat_id` / `chat_type` move OUT of top-level columns INTO `meta`), alongside the existing team/leader/active/timestamp fields. The active uniqueness key is `(channel_id, target_key)`; one channel target is active for at most one Team (re-binding reassigns it). Inbound routing and TeamLeader authorization now key on `(channel_id, target_key)`: a bound bindable target routes to its TeamLeader, an unbound target and any P2P (non-bindable) target route to the dispatcher, and a P2P target can never be bound to a TeamLeader. Targets are resolved by the channel provider's `resolveTarget(meta)` (Feishu maps `{ chat_id, chat_type }` to a stable key); `channel_id` is the dispatcher-local `dispatchers[].channels[].id`. The Channel MCP `bind_channel` / `transfer_back` tools keep `chat_id` terminology and gain an optional `channel_id` (defaults to the dispatcher's sole configured channel). Rebuild: 0.x does not migrate binding state — a pre-v2 `channel-bindings.json` fails loud at `dreamux serve` / `dreamux doctor` (and on access) with guidance to delete `~/.dreamux/state/<dispatcher>/team/channel-bindings.json` and re-bind the channel(s); Team records and all other state load unchanged.",
+      "type": "minor",
+      "packageName": "@excitedjs/dreamux"
+    }
+  ],
+  "packageName": "@excitedjs/dreamux",
+  "email": "053700@gmail.com"
+}

--- a/common/changes/@excitedjs/feishu-channel/i209-binding-store-v2_2026-06-13-00-00.json
+++ b/common/changes/@excitedjs/feishu-channel/i209-binding-store-v2_2026-06-13-00-00.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "The Feishu channel session now exposes provider-owned target resolution: `FeishuChannelSession.resolveTarget(meta)` maps a `{ chat_id, chat_type }` selector to a neutral `ChannelTarget` (group chats are bindable, P2P chats are not; `target_key` is the chat id). This is the provider half of Dreamux core's binding store v2 + `(channel_id, target_key)` routing (issue #209). Additive — existing session behavior is unchanged; the neutral `ChannelSession` wrapper now delegates to this method instead of duplicating the mapping.",
+      "type": "minor",
+      "packageName": "@excitedjs/feishu-channel"
+    }
+  ],
+  "packageName": "@excitedjs/feishu-channel",
+  "email": "053700@gmail.com"
+}

--- a/packages/channel/feishu-channel/src/feishu-channel.ts
+++ b/packages/channel/feishu-channel/src/feishu-channel.ts
@@ -4,6 +4,7 @@ import {
 } from '@excitedjs/feishu-transport';
 import type {
   AgentRuntimeTurnResult,
+  ChannelTarget,
   InboundDeliveryHooks,
   InboundTurnInput,
 } from '@excitedjs/dreamux-types';
@@ -201,6 +202,28 @@ export class FeishuChannelSession {
 
   messageBelongsToChat(messageId: string, chatId: string): boolean {
     return this.state.messageChats.get(messageId) === chatId;
+  }
+
+  /**
+   * Provider-owned target resolution (issue #209 binding store v2). Normalizes a
+   * Feishu selector `{ chat_id, chat_type }` into a neutral `ChannelTarget` whose
+   * `target_key` is the durable routing key core stores and routes by. For Feishu
+   * the stable key is the chat id itself; group chats are bindable, P2P chats are
+   * not (they always route to the dispatcher). Pure — no platform call.
+   */
+  resolveTarget(meta: unknown): ChannelTarget {
+    const obj = (meta ?? {}) as Record<string, unknown>;
+    const chatId = obj['chat_id'];
+    if (typeof chatId !== 'string' || chatId === '') {
+      throw new Error('feishu resolveTarget requires a non-empty chat_id');
+    }
+    const type = obj['chat_type'] === 'p2p' ? 'p2p' : 'group';
+    return {
+      target_type: type,
+      target_key: chatId,
+      bindable: type === 'group',
+      meta: { chat_id: chatId, chat_type: type },
+    };
   }
 
   private async readChatBots(

--- a/packages/channel/feishu-channel/src/provider.ts
+++ b/packages/channel/feishu-channel/src/provider.ts
@@ -117,19 +117,10 @@ class NeutralFeishuChannelSession implements ChannelSession {
   }
 
   async resolveTarget(meta: unknown): Promise<ChannelTarget> {
-    const obj = (meta ?? {}) as Record<string, unknown>;
-    const chatId = obj['chat_id'];
-    const chatType = obj['chat_type'];
-    if (typeof chatId !== 'string' || chatId === '') {
-      throw new Error('feishu resolveTarget requires a non-empty chat_id');
-    }
-    const type = chatType === 'p2p' ? 'p2p' : 'group';
-    return {
-      target_type: type,
-      target_key: chatId,
-      bindable: type === 'group',
-      meta: { chat_id: chatId, chat_type: type },
-    };
+    // Provider-owned target resolution lives on the raw session so both the
+    // neutral wrapper and the core live path share one implementation (#209
+    // binding store v2).
+    return this.session.resolveTarget(meta);
   }
 
   async reply(input: ChannelReplyInput): Promise<unknown> {

--- a/packages/dreamux/src/admin/methods.ts
+++ b/packages/dreamux/src/admin/methods.ts
@@ -338,9 +338,11 @@ export const adminMethods: Record<string, AdminHandler> = {
   // Channel MCP (issue #209 slice 8): core-hosted generic channel-binding
   // surface, replacing the removed Feishu-specific Team MCP `bind_group` /
   // `transfer_channel_back`. Binding state/routing/authorization stay core-owned;
-  // these delegate to the same Team-service binding store as before. Targets are
-  // still Feishu group chats addressed by `chat_id` (the channel-neutral
-  // `channel_id` + target-key model is the routing slice).
+  // these delegate to the same Team-service binding store as before. Only the
+  // user-facing selector remains Feishu `chat_id` based (group chats, plus the
+  // optional `channel_id`); core's channel-neutral v2 target store and
+  // `(channel_id, target_key)` routing are implemented (issue #209 binding store
+  // v2) and resolve the target at the facade edge.
   'mcp.channel.bind_channel': async (server, params) => {
     const id = mustDispatcherId(params);
     mustExistingDispatcher(server, id);

--- a/packages/dreamux/src/admin/methods.ts
+++ b/packages/dreamux/src/admin/methods.ts
@@ -344,12 +344,16 @@ export const adminMethods: Record<string, AdminHandler> = {
   'mcp.channel.bind_channel': async (server, params) => {
     const id = mustDispatcherId(params);
     mustExistingDispatcher(server, id);
+    // Core resolves channel_id + the provider-owned target at the facade edge and
+    // stores a v2 (channel_id, target_key) row (issue #209 binding store v2).
+    // channel_id is optional and defaults to the dispatcher's sole configured
+    // channel; chat_type is always group (binding is group-only).
+    const channelId = optionalString(params, 'channel_id');
     return server.dispatcherService.bindTeamChannel({
       dispatcherId: id,
       teamId: mustString(params, 'team_name'),
-      provider: 'builtin:feishu',
+      ...(channelId !== null ? { channelId } : {}),
       chatId: mustString(params, 'chat_id'),
-      chatType: 'group',
     });
   },
 
@@ -358,13 +362,12 @@ export const adminMethods: Record<string, AdminHandler> = {
     mustExistingDispatcher(server, id);
     // Return the deactivated binding (or null when nothing was bound) directly,
     // matching `bind_channel` above so the two sibling Channel MCP methods share
-    // one envelope. The eventual standard Channel MCP surface (routing slice) may
-    // revise the shape; until then both verbs return the channel binding.
+    // one envelope.
+    const channelId = optionalString(params, 'channel_id');
     return server.dispatcherService.transferTeamChannelBack({
       dispatcherId: id,
-      provider: 'builtin:feishu',
+      ...(channelId !== null ? { channelId } : {}),
       chatId: mustString(params, 'chat_id'),
-      chatType: 'group',
     });
   },
 
@@ -414,7 +417,6 @@ async function assertFeishuScope(
     dispatcherId,
     teamId: caller.teamId,
     leaderName: caller.leaderName,
-    provider: 'builtin:feishu',
     chatId,
   });
   if (!allowed) {

--- a/packages/dreamux/src/cli/doctor.ts
+++ b/packages/dreamux/src/cli/doctor.ts
@@ -33,6 +33,7 @@ import {
   detectLegacyDispatcherState,
   legacyDispatcherStateMessage,
 } from '../dispatcher-service/legacy-state.js';
+import { detectLegacyChannelBindingStore } from '../dispatcher-service/channel-binding/store.js';
 import { ExecaCommandRunner } from '../onboard/commands.js';
 import {
   defaultServiceNodeProbe,
@@ -159,6 +160,14 @@ export async function runDreamuxDoctor(
         legacy.length === 0
           ? 'no pre-#199 state paths found'
           : legacyDispatcherStateMessage(dispatcher.id, legacy),
+    });
+    // Issue #209 binding store v2: a pre-v2 channel-binding store is the same
+    // fail-loud rebuild signal, surfaced here before a start fails.
+    const bindingLegacy = await detectLegacyChannelBindingStore(dispatcher.id);
+    checks.push({
+      name: `dispatcher ${dispatcher.id} channel bindings`,
+      ok: bindingLegacy === null,
+      detail: bindingLegacy ?? 'channel binding store is current (v2) or absent',
     });
   }
 

--- a/packages/dreamux/src/config/config.ts
+++ b/packages/dreamux/src/config/config.ts
@@ -717,6 +717,25 @@ export function dispatcherFeishuAppId(
 }
 
 /**
+ * The dispatcher-local channel id of the sole Feishu channel
+ * (`dispatchers[].channels[].id`), or `null` when the dispatcher has an
+ * ambiguous (≠1) Feishu channel count. This is the single source of truth for
+ * the `channel_id` half of the `(channel_id, target_key)` binding/routing key
+ * (issue #209 binding store v2): the Channel MCP bind path and the inbound router
+ * both derive `channel_id` from here so a stored binding and an inbound message
+ * resolve to the same key. A runnable dispatcher declares exactly one Feishu
+ * channel (the launch guard enforces it), so this is non-null at runtime.
+ */
+export function dispatcherChannelId(
+  dispatcher: Pick<DispatcherConfig, 'channels'>,
+): string | null {
+  const feishuChannels = dispatcher.channels.filter(
+    (item) => item.provider === BUILTIN_FEISHU_PROVIDER_REF,
+  );
+  return feishuChannels.length === 1 ? feishuChannels[0]!.id : null;
+}
+
+/**
  * Cross-dispatcher Feishu bot-identity uniqueness (a core concern: a per-channel
  * `readConfig` cannot see other dispatchers, but core holds them all). Two
  * dispatchers — enabled or not — declaring the same Feishu `app_id` would

--- a/packages/dreamux/src/dispatcher-service/channel-binding/store.ts
+++ b/packages/dreamux/src/dispatcher-service/channel-binding/store.ts
@@ -1,18 +1,33 @@
 import { readFile } from 'node:fs/promises';
 
+import type { ChannelTarget } from '@excitedjs/dreamux-types';
+
 import { writeFileAtomic } from '../../platform/atomic-write.js';
 import { isNotFound } from '../../platform/fs-errors.js';
 import { dispatcherChannelBindingsPath } from '../../platform/paths.js';
 import { LegacyStateError } from '../legacy-state.js';
 
 export type ChannelProvider = 'builtin:feishu';
-export type ChannelChatType = 'group' | 'p2p';
 
+/**
+ * A flat channel-binding row (issue #209 binding store v2). The durable routing
+ * key is `(channel_id, target_key)`; `target_key` is provider-owned and opaque
+ * to core. Provider-specific selectors (Feishu `chat_id` / `chat_type`) live in
+ * `meta`, never as core top-level columns, so the store stays channel-neutral.
+ */
 export interface ChannelBinding {
+  /** Dispatcher-local channel id (`dispatchers[].channels[].id`). */
+  channel_id: string;
   provider: ChannelProvider;
-  chat_id: string;
-  chat_type: 'group';
-  /** The concrete Team key the chat is bound to (issue #199 Slice 4). */
+  /** Provider target type (e.g. Feishu `group`). */
+  target_type: string;
+  /** Provider-owned stable routing key (Feishu: the chat id). */
+  target_key: string;
+  display: string | null;
+  canonical_url: string | null;
+  /** Provider-specific selector data (Feishu `{ chat_id, chat_type }`). */
+  meta: Record<string, unknown>;
+  /** The concrete Team key the target is bound to (issue #199 Slice 4). */
   team_name: string;
   leader_name: string;
   active: boolean;
@@ -21,38 +36,49 @@ export interface ChannelBinding {
   deactivated_at: number | null;
 }
 
+const STORE_VERSION = 2;
+
 interface ChannelBindingFile {
-  version: 1;
+  version: typeof STORE_VERSION;
   bindings: ChannelBinding[];
 }
 
 export interface BindChannelInput {
   dispatcherId: string;
+  channelId: string;
   provider: ChannelProvider;
-  chatId: string;
-  chatType: ChannelChatType;
+  target: ChannelTarget;
   teamName: string;
   leaderName: string;
 }
 
-export interface TransferChannelBackInput {
+export interface ResolveChannelInput {
   dispatcherId: string;
-  provider: ChannelProvider;
-  chatId: string;
-  chatType: ChannelChatType;
+  channelId: string;
+  targetKey: string;
 }
+
+export type TransferChannelBackInput = ResolveChannelInput;
 
 export class ChannelBindingStore {
   async bind(input: BindChannelInput): Promise<ChannelBinding> {
-    if (input.chatType !== 'group') {
-      throw new Error('Team channel binding supports group chats only');
+    if (!input.target.bindable) {
+      throw new Error(
+        `channel target ${JSON.stringify(input.target.target_key)} (type ` +
+          `${input.target.target_type}) is not bindable; only bindable targets ` +
+          'can be handed to a Team (P2P always routes to the dispatcher)',
+      );
     }
     const file = await this.read(input.dispatcherId);
     const now = Date.now();
     const next: ChannelBinding = {
+      channel_id: input.channelId,
       provider: input.provider,
-      chat_id: input.chatId,
-      chat_type: input.chatType,
+      target_type: input.target.target_type,
+      target_key: input.target.target_key,
+      display: input.target.display ?? null,
+      canonical_url: input.target.canonical_url ?? null,
+      meta: input.target.meta ?? {},
       team_name: input.teamName,
       leader_name: input.leaderName,
       active: true,
@@ -60,24 +86,37 @@ export class ChannelBindingStore {
       updated_at: now,
       deactivated_at: null,
     };
-    const idx = file.bindings.findIndex((binding) =>
-      binding.provider === input.provider && binding.chat_id === input.chatId,
+    // Active uniqueness is `(channel_id, target_key)`: a channel target is active
+    // for at most one Team. Re-binding the same target reassigns it (last-bind-
+    // wins, preserving created_at), so there is always exactly one row per key.
+    const idx = file.bindings.findIndex(
+      (binding) =>
+        binding.channel_id === input.channelId &&
+        binding.target_key === input.target.target_key,
     );
-    if (idx === -1) file.bindings.push(next);
-    else file.bindings[idx] = { ...next, created_at: file.bindings[idx]!.created_at };
+    if (idx === -1) {
+      file.bindings.push(next);
+      await this.write(input.dispatcherId, file);
+      return next;
+    }
+    const merged: ChannelBinding = {
+      ...next,
+      created_at: file.bindings[idx]!.created_at,
+    };
+    file.bindings[idx] = merged;
     await this.write(input.dispatcherId, file);
-    return idx === -1 ? next : file.bindings[idx]!;
+    return merged;
   }
 
-  async transferBack(input: TransferChannelBackInput): Promise<ChannelBinding | null> {
-    if (input.chatType !== 'group') {
-      throw new Error('Team channel transfer supports group chats only');
-    }
+  async transferBack(
+    input: TransferChannelBackInput,
+  ): Promise<ChannelBinding | null> {
     const file = await this.read(input.dispatcherId);
-    const binding = file.bindings.find((entry) =>
-      entry.provider === input.provider &&
-      entry.chat_id === input.chatId &&
-      entry.active,
+    const binding = file.bindings.find(
+      (entry) =>
+        entry.channel_id === input.channelId &&
+        entry.target_key === input.targetKey &&
+        entry.active,
     );
     if (binding === undefined) return null;
     binding.active = false;
@@ -87,53 +126,65 @@ export class ChannelBindingStore {
     return binding;
   }
 
-  async resolve(input: {
-    dispatcherId: string;
-    provider: ChannelProvider;
-    chatId: string;
-    chatType: ChannelChatType;
-  }): Promise<ChannelBinding | null> {
-    if (input.chatType !== 'group') return null;
+  async resolve(input: ResolveChannelInput): Promise<ChannelBinding | null> {
     const file = await this.read(input.dispatcherId);
-    return file.bindings.find((binding) =>
-      binding.provider === input.provider &&
-      binding.chat_id === input.chatId &&
-      binding.active,
-    ) ?? null;
+    return (
+      file.bindings.find(
+        (binding) =>
+          binding.channel_id === input.channelId &&
+          binding.target_key === input.targetKey &&
+          binding.active,
+      ) ?? null
+    );
   }
 
   async list(dispatcherId: string): Promise<ChannelBinding[]> {
     return (await this.read(dispatcherId)).bindings;
   }
 
+  /**
+   * Fail loud if the on-disk store is a pre-v2 shape. Called by the serve/doctor
+   * startup probe so a v1 store is rejected at boot, not lazily on first inbound.
+   */
+  async assertCurrent(dispatcherId: string): Promise<void> {
+    await this.read(dispatcherId);
+  }
+
   private async read(dispatcherId: string): Promise<ChannelBindingFile> {
     let raw: string;
+    const path = dispatcherChannelBindingsPath(dispatcherId);
     try {
-      raw = await readFile(dispatcherChannelBindingsPath(dispatcherId), 'utf8');
+      raw = await readFile(path, 'utf8');
     } catch (err) {
-      if (isNotFound(err)) return { version: 1, bindings: [] };
+      if (isNotFound(err)) return { version: STORE_VERSION, bindings: [] };
       throw err;
     }
     const value = JSON.parse(raw) as Record<string, unknown>;
-    if (value['version'] !== 1 || !Array.isArray(value['bindings'])) {
-      throw new Error(`invalid channel binding store for dispatcher ${dispatcherId}`);
-    }
-    // #199 Slice 5 fail-loud: a pre-Slice-4 binding keyed the chat on the old
-    // `team_id` instead of the concrete `team_name`. Dreamux 0.x does not
-    // migrate it — reject with rebuild guidance rather than reading a row that
-    // can no longer resolve a Team.
-    const legacy = (value['bindings'] as Record<string, unknown>[]).some((row) =>
-      typeof row === 'object' &&
-      row !== null &&
-      !Object.prototype.hasOwnProperty.call(row, 'team_name') &&
-      Object.prototype.hasOwnProperty.call(row, 'team_id'),
-    );
-    if (legacy) {
+    // Pre-v2 fail-loud (issue #209 binding store v2): the old store was
+    // `version: 1`, keyed by `(provider, chat_id)`, with no `channel_id` /
+    // `target_key`. Dreamux 0.x does not migrate it — reject with rebuild
+    // guidance naming the file rather than read a row that cannot route by key.
+    if (value['version'] !== STORE_VERSION || !Array.isArray(value['bindings'])) {
       throw new LegacyStateError(
-        `channel binding store for dispatcher ${dispatcherId} has pre-#199 rows keyed by ` +
-          'team_id instead of team_name. Dreamux 0.x does not migrate old state — delete ' +
-          `${dispatcherChannelBindingsPath(dispatcherId)} and re-bind the channel(s) to rebuild it.`,
+        `channel binding store for dispatcher ${dispatcherId} is not version ` +
+          `${STORE_VERSION} (issue #209 binding store v2). Dreamux 0.x does not ` +
+          `migrate old binding state — delete ${path} and re-bind the channel(s) ` +
+          'to rebuild it.',
       );
+    }
+    for (const row of value['bindings'] as Record<string, unknown>[]) {
+      if (typeof row !== 'object' || row === null) continue;
+      const hasV2Keys =
+        Object.prototype.hasOwnProperty.call(row, 'channel_id') &&
+        Object.prototype.hasOwnProperty.call(row, 'target_key');
+      if (!hasV2Keys) {
+        throw new LegacyStateError(
+          `channel binding store for dispatcher ${dispatcherId} has a pre-v2 row ` +
+            'missing channel_id / target_key (issue #209 binding store v2). Dreamux ' +
+            `0.x does not migrate old binding state — delete ${path} and re-bind ` +
+            'the channel(s) to rebuild it.',
+        );
+      }
     }
     return value as unknown as ChannelBindingFile;
   }
@@ -144,5 +195,24 @@ export class ChannelBindingStore {
   ): Promise<void> {
     const path = dispatcherChannelBindingsPath(dispatcherId);
     await writeFileAtomic(path, `${JSON.stringify(file, null, 2)}\n`);
+  }
+}
+
+/**
+ * Startup/doctor probe (issue #209 binding store v2): return the rebuild message
+ * if a dispatcher's on-disk channel-binding store is a pre-v2 shape, or `null`
+ * when it is current/absent. This surfaces the same fail-loud as a lazy `read()`
+ * at `dreamux serve` / `dreamux doctor`, so a v1 store is caught at boot rather
+ * than on first inbound traffic.
+ */
+export async function detectLegacyChannelBindingStore(
+  dispatcherId: string,
+): Promise<string | null> {
+  try {
+    await new ChannelBindingStore().assertCurrent(dispatcherId);
+    return null;
+  } catch (err) {
+    if (err instanceof LegacyStateError) return err.message;
+    throw err;
   }
 }

--- a/packages/dreamux/src/dispatcher-service/dispatcher/service.ts
+++ b/packages/dreamux/src/dispatcher-service/dispatcher/service.ts
@@ -1,3 +1,5 @@
+import type { ChannelTarget } from '@excitedjs/dreamux-types';
+
 import {
   bundledSkillSourcesForRole,
   type AgentRuntime,
@@ -257,6 +259,17 @@ export class DispatcherAgentService {
   ): boolean {
     const slot = this.slots.get(dispatcherId);
     return slot?.channel.messageBelongsToChat(messageId, chatId) ?? false;
+  }
+
+  /**
+   * Resolve a provider selector to a neutral `ChannelTarget` via the live channel
+   * session (issue #209 binding store v2). Target resolution is provider-owned;
+   * core calls it here for both binding and inbound routing so `target_key` stays
+   * opaque to core. Requires a running dispatcher — both call paths (the bind
+   * tool, the inbound router) run only while the channel session is live.
+   */
+  resolveChannelTarget(dispatcherId: string, meta: unknown): ChannelTarget {
+    return this.mustRunningSlot(dispatcherId).channel.resolveTarget(meta);
   }
 
   async shutdown(): Promise<void> {

--- a/packages/dreamux/src/dispatcher-service/service.ts
+++ b/packages/dreamux/src/dispatcher-service/service.ts
@@ -6,7 +6,7 @@ import type {
 } from '../agent-runtime/index.js';
 import type { InboundDeliveryHooks, InboundTurnInput } from '../agent-runtime/turn.js';
 import type { FeishuInboundEnvelope } from '../channel/feishu/feishu-channel.js';
-import type { DreamuxConfig } from '../config/config.js';
+import { dispatcherChannelId, type DreamuxConfig } from '../config/config.js';
 import type { DispatcherStore } from '../state/dispatcher-store.js';
 import type { DreamuxLogger } from '../platform/logger.js';
 import type { FeishuBot } from '../channel/feishu/bot.js';
@@ -31,11 +31,9 @@ import type {
   TeamMateTurnOrigin,
 } from './teammate/types.js';
 import type {
-  TeamBindChannelInput,
   TeamCreateInput,
   TeamDissolveInput,
   TeamHistoryQuery,
-  TeamTransferChannelBackInput,
 } from './team/types.js';
 
 export interface DispatcherServiceOptions {
@@ -60,8 +58,10 @@ export class DispatcherService {
   readonly dispatchers: DispatcherAgentService;
   readonly teammates: TeamMateAgentService;
   readonly teams: TeamService;
+  private readonly config: DreamuxConfig;
 
   constructor(opts: DispatcherServiceOptions) {
+    this.config = opts.config;
     this.dispatchers = new DispatcherAgentService({
       config: opts.config,
       dispatchers: opts.dispatchers,
@@ -145,26 +145,62 @@ export class DispatcherService {
     return this.dispatchers.feishuMessageBelongsToChat(dispatcherId, messageId, chatId);
   }
 
+  /**
+   * Resolve the dispatcher-local `channel_id` for a dispatcher — the single
+   * source of truth shared by the bind path and the inbound router so a stored
+   * binding and an inbound message resolve to the same `(channel_id, target_key)`
+   * (issue #209 binding store v2). An explicit `requested` id must match the sole
+   * configured channel, so a caller cannot bind under a channel id the router
+   * would never key on.
+   */
+  private resolveChannelId(dispatcherId: string, requested?: string): string {
+    const dispatcher = this.config.dispatchers.find(
+      (entry) => entry.id === dispatcherId,
+    );
+    const channelId = dispatcher ? dispatcherChannelId(dispatcher) : null;
+    if (channelId === null) {
+      throw new Error(
+        `dispatcher '${dispatcherId}' has no single resolvable channel`,
+      );
+    }
+    if (requested !== undefined && requested !== channelId) {
+      throw new Error(
+        `unknown channel_id '${requested}' for dispatcher '${dispatcherId}'; ` +
+          `its configured channel is '${channelId}'`,
+      );
+    }
+    return channelId;
+  }
+
   async routeChannelInput(
     dispatcherId: string,
     input: InboundTurnInput,
     envelope: FeishuInboundEnvelope,
     hooks?: InboundDeliveryHooks,
   ): Promise<AgentRuntimeTurnResult> {
-    const binding = await this.teams.resolveChannel({
-      dispatcherId,
-      provider: envelope.provider,
-      chatId: envelope.chatId,
-      chatType: envelope.chatType,
+    const channelId = this.resolveChannelId(dispatcherId);
+    // The channel owns target resolution; core routes by (channel_id, target_key).
+    const target = this.dispatchers.resolveChannelTarget(dispatcherId, {
+      chat_id: envelope.chatId,
+      chat_type: envelope.chatType,
     });
-    if (binding !== null) {
-      const result = await this.teams.deliverToLeader({
+    // Only a bindable target (a group) can carry an active Team binding; a P2P
+    // (non-bindable) target always routes to the dispatcher, never a TeamLeader.
+    if (target.bindable) {
+      const binding = await this.teams.resolveChannel({
         dispatcherId,
-        teamId: binding.team_name,
-        turn: input,
+        channelId,
+        targetKey: target.target_key,
       });
-      if (result.status === 'submitted') await hooks?.onAccepted?.(input);
-      return result;
+      if (binding !== null) {
+        const result = await this.teams.deliverToLeader({
+          dispatcherId,
+          teamId: binding.team_name,
+          turn: input,
+        });
+        if (result.status === 'submitted') await hooks?.onAccepted?.(input);
+        return result;
+      }
     }
     const runtime = this.dispatchers.getRuntime(dispatcherId);
     if (runtime === null) return { status: 'stopped' };
@@ -252,22 +288,68 @@ export class DispatcherService {
     return this.teams.dissolve(input);
   }
 
-  bindTeamChannel(input: TeamBindChannelInput) {
-    return this.teams.bindChannel(input);
+  /**
+   * Bind a channel target to a Team. Core resolves `channel_id` and runs the
+   * channel's `resolveTarget` (provider-owned) at this edge, then passes the
+   * resolved `(channel_id, target)` down to the Team service / store. The Channel
+   * MCP keeps `chat_id` terminology; `chat_type` is always `group` (binding is
+   * group-only). A non-bindable (P2P) target is rejected fail-loud.
+   */
+  bindTeamChannel(input: {
+    dispatcherId: string;
+    teamId: string;
+    channelId?: string;
+    chatId: string;
+  }) {
+    const channelId = this.resolveChannelId(input.dispatcherId, input.channelId);
+    const target = this.dispatchers.resolveChannelTarget(input.dispatcherId, {
+      chat_id: input.chatId,
+      chat_type: 'group',
+    });
+    return this.teams.bindChannel({
+      dispatcherId: input.dispatcherId,
+      teamId: input.teamId,
+      channelId,
+      provider: 'builtin:feishu',
+      target,
+    });
   }
 
-  transferTeamChannelBack(input: TeamTransferChannelBackInput) {
-    return this.teams.transferChannelBack(input);
+  transferTeamChannelBack(input: {
+    dispatcherId: string;
+    channelId?: string;
+    chatId: string;
+  }) {
+    const channelId = this.resolveChannelId(input.dispatcherId, input.channelId);
+    const target = this.dispatchers.resolveChannelTarget(input.dispatcherId, {
+      chat_id: input.chatId,
+      chat_type: 'group',
+    });
+    return this.teams.transferChannelBack({
+      dispatcherId: input.dispatcherId,
+      channelId,
+      targetKey: target.target_key,
+    });
   }
 
   teamLeaderCanUseChannel(input: {
     dispatcherId: string;
     teamId: string;
     leaderName: string;
-    provider: 'builtin:feishu';
     chatId: string;
   }) {
-    return this.teams.teamLeaderCanUseChannel(input);
+    const channelId = this.resolveChannelId(input.dispatcherId);
+    const target = this.dispatchers.resolveChannelTarget(input.dispatcherId, {
+      chat_id: input.chatId,
+      chat_type: 'group',
+    });
+    return this.teams.teamLeaderCanUseChannel({
+      dispatcherId: input.dispatcherId,
+      teamId: input.teamId,
+      leaderName: input.leaderName,
+      channelId,
+      targetKey: target.target_key,
+    });
   }
 
   async shutdown(): Promise<void> {

--- a/packages/dreamux/src/dispatcher-service/team/service.ts
+++ b/packages/dreamux/src/dispatcher-service/team/service.ts
@@ -196,9 +196,8 @@ export class TeamService {
       if (binding.active && binding.team_name === team.team_id) {
         await this.bindings.transferBack({
           dispatcherId: input.dispatcherId,
-          provider: binding.provider,
-          chatId: binding.chat_id,
-          chatType: binding.chat_type,
+          channelId: binding.channel_id,
+          targetKey: binding.target_key,
         });
       }
     }
@@ -237,15 +236,17 @@ export class TeamService {
     if (team.status === 'closed') {
       throw new Error(`Team ${JSON.stringify(input.teamId)} is closed`);
     }
-    const binding = await this.bindings.bind({
+    // The caller resolved `target` via the channel session; core derives the
+    // leader identity from the active Team record (never trusts a caller-supplied
+    // leader). The store enforces target bindability (P2P is rejected).
+    return this.bindings.bind({
       dispatcherId: input.dispatcherId,
+      channelId: input.channelId,
       provider: input.provider,
-      chatId: input.chatId,
-      chatType: input.chatType,
+      target: input.target,
       teamName: team.team_id,
       leaderName: team.leader_name,
     });
-    return binding;
   }
 
   async transferChannelBack(
@@ -256,9 +257,8 @@ export class TeamService {
 
   async resolveChannel(input: {
     dispatcherId: string;
-    provider: 'builtin:feishu';
-    chatId: string;
-    chatType: 'group' | 'p2p';
+    channelId: string;
+    targetKey: string;
   }): Promise<ChannelBinding | null> {
     const binding = await this.bindings.resolve(input);
     if (binding === null) return null;
@@ -271,14 +271,13 @@ export class TeamService {
     dispatcherId: string;
     teamId: string;
     leaderName: string;
-    provider: 'builtin:feishu';
-    chatId: string;
+    channelId: string;
+    targetKey: string;
   }): Promise<boolean> {
     const binding = await this.bindings.resolve({
       dispatcherId: input.dispatcherId,
-      provider: input.provider,
-      chatId: input.chatId,
-      chatType: 'group',
+      channelId: input.channelId,
+      targetKey: input.targetKey,
     });
     return (
       binding !== null &&
@@ -391,9 +390,15 @@ export class TeamService {
     const active = bindings.find(
       (binding) => binding.active && binding.team_name === team.team_id,
     );
-    return active === undefined
-      ? null
-      : { provider: active.provider, chat_id: active.chat_id };
+    if (active === undefined) return null;
+    // The read-tool summary keeps the `{ provider, chat_id }` shape; the Feishu
+    // chat id is the provider selector stored in `meta` (v2 keeps chat_id out of
+    // the core top-level columns).
+    const chatId = active.meta['chat_id'];
+    return {
+      provider: active.provider,
+      chat_id: typeof chatId === 'string' ? chatId : active.target_key,
+    };
   }
 
   private async memberCount(team: TeamRecord): Promise<number> {

--- a/packages/dreamux/src/dispatcher-service/team/types.ts
+++ b/packages/dreamux/src/dispatcher-service/team/types.ts
@@ -1,3 +1,5 @@
+import type { ChannelTarget } from '@excitedjs/dreamux-types';
+
 import type {
   TeamMateIdentityStatus,
   TeamMateRuntimeStatus,
@@ -57,16 +59,18 @@ export interface TeamDissolveInput {
 export interface TeamBindChannelInput {
   dispatcherId: string;
   teamId: string;
+  /** Dispatcher-local channel id (`dispatchers[].channels[].id`). */
+  channelId: string;
   provider: 'builtin:feishu';
-  chatId: string;
-  chatType: 'group' | 'p2p';
+  /** Provider-resolved target (the caller already ran `resolveTarget`). */
+  target: ChannelTarget;
 }
 
 export interface TeamTransferChannelBackInput {
   dispatcherId: string;
-  provider: 'builtin:feishu';
-  chatId: string;
-  chatType: 'group' | 'p2p';
+  channelId: string;
+  /** Provider-owned routing key (Feishu: the chat id). */
+  targetKey: string;
 }
 
 /**

--- a/packages/dreamux/src/mcp/channel-mcp.ts
+++ b/packages/dreamux/src/mcp/channel-mcp.ts
@@ -117,12 +117,14 @@ async function handleRequest(
 
 function channelTools(): Array<Record<string, unknown>> {
   return [
-    tool('bind_channel', 'Bind an existing Feishu group chat to a Team by team_name (group chats only). After binding, inbound from that chat routes to the Team\'s TeamLeader.', {
+    tool('bind_channel', 'Bind an existing Feishu group chat to a Team by team_name (group chats only). After binding, inbound from that chat routes to the Team\'s TeamLeader. channel_id is optional and defaults to the dispatcher\'s configured channel.', {
       team_name: { type: 'string', minLength: 1, maxLength: 64 },
       chat_id: { type: 'string', minLength: 1 },
+      channel_id: { type: 'string', minLength: 1, maxLength: 64 },
     }, ['team_name', 'chat_id']),
-    tool('transfer_back', 'Return a bound Feishu group chat (by chat_id) to the dispatcher, deactivating the Team binding.', {
+    tool('transfer_back', 'Return a bound Feishu group chat (by chat_id) to the dispatcher, deactivating the Team binding. channel_id is optional and defaults to the dispatcher\'s configured channel.', {
       chat_id: { type: 'string', minLength: 1 },
+      channel_id: { type: 'string', minLength: 1, maxLength: 64 },
     }, ['chat_id']),
   ];
 }
@@ -174,19 +176,29 @@ function mapToolCall(call: ToolCall): { method: string; params: Record<string, u
 }
 
 function bindChannelArgs(value: unknown): Record<string, unknown> {
-  // Group-only bind by team_name + Feishu chat id; no `chat_type` (the binding
-  // store rejects non-group anyway). channel_id/target-key addressing is the
-  // routing slice.
+  // Group-only bind by team_name + Feishu chat id; no `chat_type` (binding is
+  // group-only). channel_id is optional (defaults to the sole configured
+  // channel); core resolves the (channel_id, target_key) v2 binding key.
   const obj = asRecord(value, 'bind_channel arguments');
   return {
     team_name: requireString(obj, 'team_name'),
     chat_id: requireString(obj, 'chat_id'),
+    ...optionalChannelId(obj),
   };
 }
 
 function transferArgs(value: unknown): Record<string, unknown> {
   const obj = asRecord(value, 'transfer_back arguments');
-  return { chat_id: requireString(obj, 'chat_id') };
+  return { chat_id: requireString(obj, 'chat_id'), ...optionalChannelId(obj) };
+}
+
+function optionalChannelId(obj: Record<string, unknown>): Record<string, unknown> {
+  const value = obj['channel_id'];
+  if (value === undefined || value === null) return {};
+  if (typeof value !== 'string' || value === '') {
+    throw new Error('channel_id must be a non-empty string');
+  }
+  return { channel_id: value };
 }
 
 function asToolCallParams(params: unknown): ToolCall {

--- a/packages/dreamux/src/mcp/channel-mcp.ts
+++ b/packages/dreamux/src/mcp/channel-mcp.ts
@@ -10,11 +10,12 @@
  * implementation behind `mcp.channel.*` is the same core binding store the Team
  * service uses.
  *
- * Scope note: this slice moves the MCP *surface* only. Targets are still
- * addressed by Feishu `chat_id` (group chats), not the channel-neutral
- * `channel_id` + `resolveTarget` target model — that, binding store v2, and
- * `list_peers` land in the routing slice. `reply` / `react` stay on the
- * provider-owned `feishu` MCP server for now.
+ * Scope note: only the user-facing Channel MCP selector remains Feishu
+ * `chat_id` based for now (group chats, plus the optional `channel_id`). Core's
+ * channel-neutral v2 target model — provider-owned `resolveTarget`, the
+ * `(channel_id, target_key)` binding store, and routing/authorization — is
+ * implemented (issue #209 binding store v2); `list_peers` is still unimplemented
+ * and `reply` / `react` stay on the provider-owned `feishu` MCP server for now.
  */
 import { createInterface } from 'node:readline';
 import type { Readable, Writable } from 'node:stream';

--- a/packages/dreamux/src/server.ts
+++ b/packages/dreamux/src/server.ts
@@ -49,6 +49,7 @@ import {
   detectLegacyDispatcherState,
   legacyDispatcherStateMessage,
 } from './dispatcher-service/legacy-state.js';
+import { detectLegacyChannelBindingStore } from './dispatcher-service/channel-binding/store.js';
 export {
   IN_PROGRESS_REACTION_EMOJI,
   RECEIVED_REACTION_EMOJI,
@@ -295,10 +296,14 @@ export class Server {
       if (findings.length > 0) {
         messages.push(legacyDispatcherStateMessage(row.dispatcher_id, findings));
       }
+      // Issue #209 binding store v2: a pre-v2 channel-binding store fails loud at
+      // boot with rebuild guidance, not lazily on the first inbound message.
+      const bindingLegacy = await detectLegacyChannelBindingStore(row.dispatcher_id);
+      if (bindingLegacy !== null) messages.push(bindingLegacy);
     }
     if (messages.length > 0) {
       throw new Error(
-        `dreamux serve cannot start — pre-#199 local state found:\n${messages.join('\n')}`,
+        `dreamux serve cannot start — incompatible local state found:\n${messages.join('\n')}`,
       );
     }
   }

--- a/packages/dreamux/tests/channel-binding-store.test.ts
+++ b/packages/dreamux/tests/channel-binding-store.test.ts
@@ -1,0 +1,149 @@
+/**
+ * Channel binding store v2 invariants (issue #209 binding store v2). The store
+ * keys active bindings by `(channel_id, target_key)`; `target_key` is the
+ * provider-owned routing key (Feishu: the chat id) and provider selectors live
+ * in `meta`. These pin: bind/resolve/transfer-back by key, non-bindable (P2P)
+ * rejection, the one-active-row-per-target reassignment rule, and the persisted
+ * v2 shape.
+ */
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import type { ChannelTarget } from '@excitedjs/dreamux-types';
+
+import { ChannelBindingStore } from '../src/dispatcher-service/channel-binding/store.js';
+import {
+  dispatcherChannelBindingsPath,
+  resetRuntimeConfig,
+} from '../src/platform/paths.js';
+
+const DISPATCHER = 'flow';
+
+function groupTarget(chatId: string): ChannelTarget {
+  return {
+    target_type: 'group',
+    target_key: chatId,
+    bindable: true,
+    meta: { chat_id: chatId, chat_type: 'group' },
+  };
+}
+
+function p2pTarget(chatId: string): ChannelTarget {
+  return {
+    target_type: 'p2p',
+    target_key: chatId,
+    bindable: false,
+    meta: { chat_id: chatId, chat_type: 'p2p' },
+  };
+}
+
+describe('ChannelBindingStore v2', () => {
+  let root: string;
+  let previousHome: string | undefined;
+
+  beforeEach(() => {
+    root = mkdtempSync(join(tmpdir(), 'dreamux-binding-v2-'));
+    previousHome = process.env['HOME'];
+    process.env['HOME'] = join(root, 'home');
+    resetRuntimeConfig();
+  });
+
+  afterEach(() => {
+    if (previousHome === undefined) delete process.env['HOME'];
+    else process.env['HOME'] = previousHome;
+    resetRuntimeConfig();
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  it('binds, resolves, and transfers back by (channel_id, target_key)', async () => {
+    const store = new ChannelBindingStore();
+    const bound = await store.bind({
+      dispatcherId: DISPATCHER,
+      channelId: 'primary',
+      provider: 'builtin:feishu',
+      target: groupTarget('chat-a'),
+      teamName: 'alpha',
+      leaderName: 'alpha-leader',
+    });
+    expect(bound).toMatchObject({
+      channel_id: 'primary',
+      target_type: 'group',
+      target_key: 'chat-a',
+      meta: { chat_id: 'chat-a', chat_type: 'group' },
+      team_name: 'alpha',
+      leader_name: 'alpha-leader',
+      active: true,
+    });
+
+    // The persisted file is v2 and keeps chat_id out of the top-level columns.
+    const onDisk = JSON.parse(
+      readFileSync(dispatcherChannelBindingsPath(DISPATCHER), 'utf8'),
+    );
+    expect(onDisk.version).toBe(2);
+    expect(onDisk.bindings[0]).not.toHaveProperty('chat_id');
+    expect(onDisk.bindings[0].meta.chat_id).toBe('chat-a');
+
+    await expect(
+      store.resolve({ dispatcherId: DISPATCHER, channelId: 'primary', targetKey: 'chat-a' }),
+    ).resolves.toMatchObject({ team_name: 'alpha' });
+    // A different channel id never resolves the same target_key.
+    await expect(
+      store.resolve({ dispatcherId: DISPATCHER, channelId: 'other', targetKey: 'chat-a' }),
+    ).resolves.toBeNull();
+
+    const back = await store.transferBack({
+      dispatcherId: DISPATCHER,
+      channelId: 'primary',
+      targetKey: 'chat-a',
+    });
+    expect(back?.active).toBe(false);
+    await expect(
+      store.resolve({ dispatcherId: DISPATCHER, channelId: 'primary', targetKey: 'chat-a' }),
+    ).resolves.toBeNull();
+  });
+
+  it('rejects binding a non-bindable (P2P) target fail-loud', async () => {
+    const store = new ChannelBindingStore();
+    await expect(
+      store.bind({
+        dispatcherId: DISPATCHER,
+        channelId: 'primary',
+        provider: 'builtin:feishu',
+        target: p2pTarget('chat-dm'),
+        teamName: 'alpha',
+        leaderName: 'alpha-leader',
+      }),
+    ).rejects.toThrow(/not bindable/);
+  });
+
+  it('reassigns an active target to a new Team (one active row per key, created_at preserved)', async () => {
+    const store = new ChannelBindingStore();
+    const first = await store.bind({
+      dispatcherId: DISPATCHER,
+      channelId: 'primary',
+      provider: 'builtin:feishu',
+      target: groupTarget('chat-a'),
+      teamName: 'alpha',
+      leaderName: 'alpha-leader',
+    });
+    const second = await store.bind({
+      dispatcherId: DISPATCHER,
+      channelId: 'primary',
+      provider: 'builtin:feishu',
+      target: groupTarget('chat-a'),
+      teamName: 'beta',
+      leaderName: 'beta-leader',
+    });
+    expect(second.team_name).toBe('beta');
+    expect(second.created_at).toBe(first.created_at);
+
+    // Exactly one row for (channel_id, target_key), now active for beta only.
+    const all = await store.list(DISPATCHER);
+    expect(all).toHaveLength(1);
+    await expect(
+      store.resolve({ dispatcherId: DISPATCHER, channelId: 'primary', targetKey: 'chat-a' }),
+    ).resolves.toMatchObject({ team_name: 'beta' });
+  });
+});

--- a/packages/dreamux/tests/channel-routing.test.ts
+++ b/packages/dreamux/tests/channel-routing.test.ts
@@ -1,0 +1,148 @@
+/**
+ * Inbound routing by `(channel_id, target_key)` (issue #209 binding store v2).
+ *
+ * These assert `DispatcherService.routeChannelInput` resolves the SAME
+ * `(channel_id, target_key)` the bind path stores, and takes the right delivery
+ * branch: a bound bindable target → the TeamLeader; an unbound bindable target →
+ * the dispatcher; a non-bindable (P2P) target → the dispatcher with NO binding
+ * lookup at all (P2P never routes to a TeamLeader). The channel session
+ * (`resolveChannelTarget`) and the Team service are stubbed so the routing
+ * decision is exercised without the Feishu gate or a live bot.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { ChannelTarget } from '@excitedjs/dreamux-types';
+
+import { AgentRuntimeProviderCatalog } from '../src/agent-runtime/index.js';
+import type { InboundTurnInput } from '../src/agent-runtime/turn.js';
+import { DispatcherService } from '../src/dispatcher-service/service.js';
+import type { FeishuInboundEnvelope } from '../src/channel/feishu/feishu-channel.js';
+import { createBuiltinProviderRegistry } from '../src/registry/index.js';
+import { DispatcherStore } from '../src/state/dispatcher-store.js';
+import type { DreamuxLogger } from '../src/platform/logger.js';
+import { resetRuntimeConfig } from '../src/platform/paths.js';
+import { testDispatcherConfig, testDreamuxConfig } from './helpers/config.js';
+
+function noopLog(): DreamuxLogger {
+  const log = {
+    info: () => undefined,
+    warn: () => undefined,
+    error: () => undefined,
+    debug: () => undefined,
+    trace: () => undefined,
+    child: () => log,
+  };
+  return log as unknown as DreamuxLogger;
+}
+
+function feishuTarget(chatType: 'group' | 'p2p'): ChannelTarget {
+  return {
+    target_type: chatType,
+    target_key: 'chat-x',
+    bindable: chatType === 'group',
+    meta: { chat_id: 'chat-x', chat_type: chatType },
+  };
+}
+
+function envelope(chatType: 'group' | 'p2p'): FeishuInboundEnvelope {
+  return {
+    provider: 'builtin:feishu',
+    chatId: 'chat-x',
+    chatType,
+    messageId: 'm1',
+  };
+}
+
+const INPUT = { kind: 'channel', text: 'hi', dedupeId: 'm1' } as unknown as InboundTurnInput;
+
+function buildService(): DispatcherService {
+  // testDispatcherConfig defaults the channel id to 'primary'.
+  const config = testDreamuxConfig([testDispatcherConfig({ cwd: '/tmp/routing-cwd' })]);
+  const registry = createBuiltinProviderRegistry();
+  return new DispatcherService({
+    config,
+    dispatchers: new DispatcherStore(config),
+    agentRuntimeProviders: new AgentRuntimeProviderCatalog({ registry }),
+    channelLoggerFactory: () => noopLog(),
+    log: noopLog(),
+  });
+}
+
+describe('routeChannelInput keys by (channel_id, target_key) (#209 binding store v2)', () => {
+  beforeEach(() => resetRuntimeConfig());
+  afterEach(() => {
+    vi.restoreAllMocks();
+    resetRuntimeConfig();
+  });
+
+  it('routes a bound group to the TeamLeader, keyed by the configured channel id', async () => {
+    const service = buildService();
+    vi.spyOn(service.dispatchers, 'resolveChannelTarget').mockImplementation(
+      (_id, meta) => feishuTarget((meta as { chat_type: 'group' | 'p2p' }).chat_type),
+    );
+    const dispatcherRuntime = { channelInput: vi.fn(async () => ({ status: 'submitted' })) };
+    vi.spyOn(service.dispatchers, 'getRuntime').mockReturnValue(
+      dispatcherRuntime as never,
+    );
+    const resolveSpy = vi
+      .spyOn(service.teams, 'resolveChannel')
+      .mockResolvedValue({ team_name: 'alpha' } as never);
+    const deliverSpy = vi
+      .spyOn(service.teams, 'deliverToLeader')
+      .mockResolvedValue({ status: 'submitted' });
+
+    const result = await service.routeChannelInput('flow', INPUT, envelope('group'));
+
+    // The router derives channel_id from config ('primary') — the SAME id the
+    // bind path stores — so the stored binding and the inbound message match.
+    expect(resolveSpy).toHaveBeenCalledWith({
+      dispatcherId: 'flow',
+      channelId: 'primary',
+      targetKey: 'chat-x',
+    });
+    expect(deliverSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ dispatcherId: 'flow', teamId: 'alpha' }),
+    );
+    expect(dispatcherRuntime.channelInput).not.toHaveBeenCalled();
+    expect(result.status).toBe('submitted');
+  });
+
+  it('routes an unbound group to the dispatcher', async () => {
+    const service = buildService();
+    vi.spyOn(service.dispatchers, 'resolveChannelTarget').mockImplementation(
+      (_id, meta) => feishuTarget((meta as { chat_type: 'group' | 'p2p' }).chat_type),
+    );
+    const dispatcherRuntime = { channelInput: vi.fn(async () => ({ status: 'submitted' })) };
+    vi.spyOn(service.dispatchers, 'getRuntime').mockReturnValue(
+      dispatcherRuntime as never,
+    );
+    vi.spyOn(service.teams, 'resolveChannel').mockResolvedValue(null);
+    const deliverSpy = vi.spyOn(service.teams, 'deliverToLeader');
+
+    await service.routeChannelInput('flow', INPUT, envelope('group'));
+
+    expect(deliverSpy).not.toHaveBeenCalled();
+    expect(dispatcherRuntime.channelInput).toHaveBeenCalledTimes(1);
+  });
+
+  it('routes a P2P target to the dispatcher with no binding lookup (never a TeamLeader)', async () => {
+    const service = buildService();
+    vi.spyOn(service.dispatchers, 'resolveChannelTarget').mockImplementation(
+      (_id, meta) => feishuTarget((meta as { chat_type: 'group' | 'p2p' }).chat_type),
+    );
+    const dispatcherRuntime = { channelInput: vi.fn(async () => ({ status: 'submitted' })) };
+    vi.spyOn(service.dispatchers, 'getRuntime').mockReturnValue(
+      dispatcherRuntime as never,
+    );
+    const resolveSpy = vi.spyOn(service.teams, 'resolveChannel');
+    const deliverSpy = vi.spyOn(service.teams, 'deliverToLeader');
+
+    await service.routeChannelInput('flow', INPUT, envelope('p2p'));
+
+    // A non-bindable target short-circuits to the dispatcher BEFORE any binding
+    // lookup — P2P can never be bound to a TeamLeader.
+    expect(resolveSpy).not.toHaveBeenCalled();
+    expect(deliverSpy).not.toHaveBeenCalled();
+    expect(dispatcherRuntime.channelInput).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/dreamux/tests/channel-routing.test.ts
+++ b/packages/dreamux/tests/channel-routing.test.ts
@@ -146,3 +146,64 @@ describe('routeChannelInput keys by (channel_id, target_key) (#209 binding store
     expect(dispatcherRuntime.channelInput).toHaveBeenCalledTimes(1);
   });
 });
+
+describe('resolveChannelId guards the explicit channel_id on bind (#209 binding store v2)', () => {
+  beforeEach(() => resetRuntimeConfig());
+  afterEach(() => {
+    vi.restoreAllMocks();
+    resetRuntimeConfig();
+  });
+
+  it('passes an explicit channel_id that matches the configured channel through to the store', async () => {
+    const service = buildService();
+    vi.spyOn(service.dispatchers, 'resolveChannelTarget').mockReturnValue(
+      feishuTarget('group'),
+    );
+    const bindSpy = vi
+      .spyOn(service.teams, 'bindChannel')
+      .mockResolvedValue({ team_name: 'alpha' } as never);
+
+    await service.bindTeamChannel({
+      dispatcherId: 'flow',
+      teamId: 'alpha',
+      channelId: 'primary',
+      chatId: 'chat-x',
+    });
+
+    expect(bindSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        dispatcherId: 'flow',
+        teamId: 'alpha',
+        channelId: 'primary',
+        provider: 'builtin:feishu',
+        target: expect.objectContaining({ target_key: 'chat-x' }),
+      }),
+    );
+  });
+
+  it('rejects an explicit channel_id that does not match the configured channel (fail-loud, no store write)', () => {
+    const service = buildService();
+    const bindSpy = vi.spyOn(service.teams, 'bindChannel');
+
+    expect(() =>
+      service.bindTeamChannel({
+        dispatcherId: 'flow',
+        teamId: 'alpha',
+        channelId: 'wrong',
+        chatId: 'chat-x',
+      }),
+    ).toThrow(/unknown channel_id 'wrong'/);
+    expect(bindSpy).not.toHaveBeenCalled();
+  });
+
+  it('rejects a dispatcher with no single resolvable channel', () => {
+    const service = buildService();
+    expect(() =>
+      service.bindTeamChannel({
+        dispatcherId: 'ghost',
+        teamId: 'alpha',
+        chatId: 'chat-x',
+      }),
+    ).toThrow(/no single resolvable channel/);
+  });
+});

--- a/packages/dreamux/tests/legacy-state-fail-loud.test.ts
+++ b/packages/dreamux/tests/legacy-state-fail-loud.test.ts
@@ -132,29 +132,10 @@ describe('issue #199 Slice 5 — pre-#199 local state fails loud', () => {
     });
   });
 
-  describe('channel-binding reader rejects pre-#199 team_id rows', () => {
-    it('fails loud on a row keyed by team_id instead of team_name', async () => {
-      writeRaw(dispatcherChannelBindingsPath(DISPATCHER), {
-        version: 1,
-        bindings: [
-          {
-            provider: 'builtin:feishu',
-            chat_id: 'chat-x',
-            chat_type: 'group',
-            team_id: 'gamma',
-            leader_name: 'lead-1',
-            active: true,
-            created_at: 1,
-            updated_at: 1,
-            deactivated_at: null,
-          },
-        ],
-      });
-      const store = new ChannelBindingStore();
-      await expect(store.list(DISPATCHER)).rejects.toThrow(/keyed by team_id/);
-    });
-
-    it('accepts a current team_name-keyed binding', async () => {
+  describe('channel-binding reader rejects pre-v2 stores (#209 binding store v2)', () => {
+    it('fails loud on a pre-v2 (version 1) store with rebuild guidance', async () => {
+      // The old store was version 1, keyed by (provider, chat_id) with no
+      // channel_id / target_key. 0.x does not migrate it.
       writeRaw(dispatcherChannelBindingsPath(DISPATCHER), {
         version: 1,
         bindings: [
@@ -172,9 +153,61 @@ describe('issue #199 Slice 5 — pre-#199 local state fails loud', () => {
         ],
       });
       const store = new ChannelBindingStore();
+      await expect(store.list(DISPATCHER)).rejects.toThrow(
+        /not version 2 .*delete .*channel-bindings\.json/s,
+      );
+    });
+
+    it('fails loud on a v2 store with a row missing channel_id / target_key', async () => {
+      writeRaw(dispatcherChannelBindingsPath(DISPATCHER), {
+        version: 2,
+        bindings: [
+          {
+            provider: 'builtin:feishu',
+            chat_id: 'chat-x',
+            chat_type: 'group',
+            team_name: 'gamma',
+            leader_name: 'lead-1',
+            active: true,
+            created_at: 1,
+            updated_at: 1,
+            deactivated_at: null,
+          },
+        ],
+      });
+      const store = new ChannelBindingStore();
+      await expect(store.list(DISPATCHER)).rejects.toThrow(
+        /missing channel_id \/ target_key/,
+      );
+    });
+
+    it('accepts a current v2 binding keyed by (channel_id, target_key)', async () => {
+      writeRaw(dispatcherChannelBindingsPath(DISPATCHER), {
+        version: 2,
+        bindings: [
+          {
+            channel_id: 'primary',
+            provider: 'builtin:feishu',
+            target_type: 'group',
+            target_key: 'chat-x',
+            display: null,
+            canonical_url: null,
+            meta: { chat_id: 'chat-x', chat_type: 'group' },
+            team_name: 'gamma',
+            leader_name: 'lead-1',
+            active: true,
+            created_at: 1,
+            updated_at: 1,
+            deactivated_at: null,
+          },
+        ],
+      });
+      const store = new ChannelBindingStore();
       const bindings = await store.list(DISPATCHER);
       expect(bindings).toHaveLength(1);
       expect(bindings[0]!.team_name).toBe('gamma');
+      expect(bindings[0]!.target_key).toBe('chat-x');
+      expect(bindings[0]!.channel_id).toBe('primary');
     });
   });
 });

--- a/packages/dreamux/tests/legacy-state-fail-loud.test.ts
+++ b/packages/dreamux/tests/legacy-state-fail-loud.test.ts
@@ -8,7 +8,10 @@ import {
   legacyDispatcherStateMessage,
 } from '../src/dispatcher-service/legacy-state.js';
 import { TeamMateIdentityStore } from '../src/dispatcher-service/teammate/identity-store.js';
-import { ChannelBindingStore } from '../src/dispatcher-service/channel-binding/store.js';
+import {
+  ChannelBindingStore,
+  detectLegacyChannelBindingStore,
+} from '../src/dispatcher-service/channel-binding/store.js';
 import {
   dispatcherChannelBindingsPath,
   dispatcherTeamDir,
@@ -208,6 +211,53 @@ describe('issue #199 Slice 5 — pre-#199 local state fails loud', () => {
       expect(bindings[0]!.team_name).toBe('gamma');
       expect(bindings[0]!.target_key).toBe('chat-x');
       expect(bindings[0]!.channel_id).toBe('primary');
+    });
+  });
+
+  // The serve/doctor boot probe (`detectLegacyChannelBindingStore`) is the wiring
+  // that surfaces the store fail-loud at startup rather than lazily on first
+  // inbound. Pin it directly: a pre-v2 store yields the rebuild message, an
+  // absent or current v2 store yields null (boot proceeds).
+  describe('detectLegacyChannelBindingStore (serve/doctor boot probe, #209)', () => {
+    it('returns the rebuild message for a pre-v2 store', async () => {
+      writeRaw(dispatcherChannelBindingsPath(DISPATCHER), {
+        version: 1,
+        bindings: [{ provider: 'builtin:feishu', chat_id: 'chat-x' }],
+      });
+      const message = await detectLegacyChannelBindingStore(DISPATCHER);
+      expect(message).toMatch(/not version 2 .*delete .*channel-bindings\.json/s);
+    });
+
+    it('returns null when the store is absent (fresh dispatcher)', async () => {
+      await expect(
+        detectLegacyChannelBindingStore(DISPATCHER),
+      ).resolves.toBeNull();
+    });
+
+    it('returns null for a current v2 store', async () => {
+      writeRaw(dispatcherChannelBindingsPath(DISPATCHER), {
+        version: 2,
+        bindings: [
+          {
+            channel_id: 'primary',
+            provider: 'builtin:feishu',
+            target_type: 'group',
+            target_key: 'chat-x',
+            display: null,
+            canonical_url: null,
+            meta: { chat_id: 'chat-x', chat_type: 'group' },
+            team_name: 'gamma',
+            leader_name: 'lead-1',
+            active: true,
+            created_at: 1,
+            updated_at: 1,
+            deactivated_at: null,
+          },
+        ],
+      });
+      await expect(
+        detectLegacyChannelBindingStore(DISPATCHER),
+      ).resolves.toBeNull();
     });
   });
 });

--- a/packages/dreamux/tests/smoke.test.ts
+++ b/packages/dreamux/tests/smoke.test.ts
@@ -910,12 +910,12 @@ describe('dreamux MVP smoke', () => {
     // #188: the TeamLeader address is a concrete, never-reused name; channel
     // scope checks resolve against this stored name, not `${teamId}-leader`.
     const leaderName = createdTeam.team.leader_name;
+    // Bind the group: core resolves channel_id + the provider target and stores
+    // a v2 (channel_id, target_key) row (issue #209 binding store v2).
     await server.dispatcherService.bindTeamChannel({
       dispatcherId: 'flow',
       teamId: 'alpha',
-      provider: 'builtin:feishu',
       chatId: 'chat-team',
-      chatType: 'group',
     });
     await bot.inject(fakeInbound('chat-team', 'team hello', 'msg-team'));
     await waitFor(() => codexInputs.some((input) => input.includes('team hello')));
@@ -954,9 +954,7 @@ describe('dreamux MVP smoke', () => {
 
     await server.dispatcherService.transferTeamChannelBack({
       dispatcherId: 'flow',
-      provider: 'builtin:feishu',
       chatId: 'chat-team',
-      chatType: 'group',
     });
     await bot.inject(fakeInbound('chat-team', 'dispatcher again', 'msg-back'));
     await waitFor(() => codexInputs.length === 1);

--- a/packages/dreamux/tests/team-service.test.ts
+++ b/packages/dreamux/tests/team-service.test.ts
@@ -120,6 +120,16 @@ class FakeProvider implements AgentRuntimeProvider {
 /** The dispatcher workspace cwd for the current test; set in beforeEach. */
 let dispatcherCwd: string;
 
+/** A Feishu group `ChannelTarget` as the channel session's resolveTarget emits. */
+function feishuGroupTarget(chatId: string) {
+  return {
+    target_type: 'group',
+    target_key: chatId,
+    bindable: true,
+    meta: { chat_id: chatId, chat_type: 'group' },
+  };
+}
+
 function buildServices(): {
   teams: TeamService;
   teammates: TeamMateAgentService;
@@ -540,26 +550,29 @@ describe('TeamService', () => {
     const bound = await teams.bindChannel({
       dispatcherId: 'flow',
       teamId: 'gamma',
+      channelId: 'primary',
       provider: 'builtin:feishu',
-      chatId: 'oc_existing_group',
-      chatType: 'group',
+      target: feishuGroupTarget('chat-existing-group'),
     });
     expect(bound).toMatchObject({
+      channel_id: 'primary',
       provider: 'builtin:feishu',
-      chat_id: 'oc_existing_group',
+      target_type: 'group',
+      target_key: 'chat-existing-group',
+      meta: { chat_id: 'chat-existing-group', chat_type: 'group' },
     });
-    // The bound group resolves to the Team, and status surfaces it.
+    // The bound target resolves to the Team by (channel_id, target_key), and
+    // status surfaces it with the chat id from meta.
     await expect(
       teams.resolveChannel({
         dispatcherId: 'flow',
-        provider: 'builtin:feishu',
-        chatId: 'oc_existing_group',
-        chatType: 'group',
+        channelId: 'primary',
+        targetKey: 'chat-existing-group',
       }),
     ).resolves.toMatchObject({ team_name: 'gamma' });
     expect((await teams.status('flow', 'gamma')).binding).toEqual({
       provider: 'builtin:feishu',
-      chat_id: 'oc_existing_group',
+      chat_id: 'chat-existing-group',
     });
   });
 
@@ -661,9 +674,9 @@ describe('TeamService', () => {
     await teams.bindChannel({
       dispatcherId: 'flow',
       teamId: 'auth-team',
+      channelId: 'primary',
       provider: 'builtin:feishu',
-      chatId: 'chat-auth',
-      chatType: 'group',
+      target: feishuGroupTarget('chat-auth'),
     });
     const listed = await teams.list('flow');
     const authRow = listed.find((row) => row.team_name === 'auth-team');


### PR DESCRIPTION
## What & why

Issue #209, next slice: **binding store v2 + `(channel_id, target_key)` channel target routing**. This makes core's binding/routing/auth key on a stable, provider-owned target key instead of a raw Feishu `chat_id` column, so non-Feishu channels can bind later without core learning their selector shapes.

Base branch: `feature/i209-npm-package-split` (built on slice 8, `a8b347f`).

## Changes

### Provider half — `@excitedjs/feishu-channel`
- `FeishuChannelSession.resolveTarget(meta)` maps a `{ chat_id, chat_type }` selector to a neutral `ChannelTarget` (`target_type`, `target_key` = chat id, `bindable` — group `true`, p2p `false`, `meta`). Additive; the neutral `ChannelSession` wrapper now delegates instead of duplicating the mapping.

### Core — `@excitedjs/dreamux`
- **Store v2** (`channel-binding/store.ts`): flat `version: 2` rows carry `channel_id`, provider-owned `target_key`, `target_type`, `display`, `canonical_url`, `meta` (Feishu `chat_id`/`chat_type` now live *in* `meta`, not as top-level columns), plus team/leader/active/timestamp fields. Active uniqueness is `(channel_id, target_key)`; re-binding reassigns the one row (preserves `created_at`). `bind` rejects non-bindable (P2P) targets fail-loud. `resolve`/`transferBack` key on `{dispatcherId, channelId, targetKey}`.
- **Resolve-at-the-edge**: the dispatcher service facade resolves `meta → ChannelTarget` via the live channel session (`DispatcherAgentService.resolveChannelTarget`), then drives the session-free Team service + store on `(channel_id, target_key)` primitives.
- **Routing** (`dispatcher-service/service.ts`): bound bindable target → TeamLeader; unbound bindable target and any P2P (non-bindable) target → dispatcher. P2P short-circuits before any binding lookup, so it can never be bound to a leader.
- **`channel_id` sourcing**: single helper `dispatcherChannelId(config)` (the dispatcher-local `dispatchers[].channels[].id`) shared by bind + route so a stored binding and an inbound message key identically. Explicit `channel_id` on bind/transfer must match the sole configured channel.
- **Channel MCP** (`mcp/channel-mcp.ts`, `admin/methods.ts`): `bind_channel` / `transfer_back` keep `chat_id` terminology and gain an optional `channel_id` (defaults to the dispatcher's sole channel).
- **Fail-loud legacy**: a pre-v2 `channel-bindings.json` (wrong `version`, or v2 rows missing `channel_id`/`target_key`) throws `LegacyStateError` at `dreamux serve` / `dreamux doctor` and on access. 0.x does not migrate.

### Tests
- `channel-binding-store.test.ts` (new): bind/resolve/transfer by key, persisted v2 shape (`chat_id` in `meta`, not top-level), P2P reject, reassignment (one row, `created_at` preserved).
- `channel-routing.test.ts` (new): deterministic `routeChannelInput` — bound group → leader, unbound → dispatcher, P2P → dispatcher with no `resolveChannel` call.
- `legacy-state-fail-loud.test.ts`, `team-service.test.ts`, `smoke.test.ts` updated to v2 API.

### Docs / changelog
- Rush change files for `@excitedjs/dreamux` (BREAKING + Rebuild guidance) and `@excitedjs/feishu-channel` (additive).
- `.agents/decisions/npm-package-split-and-channel-targets.md` + `top-level-design.md` updated.

## Checks
- `rush build` ✅ · `rush lint` ✅ · `rush change --verify` ✅
- `@excitedjs/dreamux` 608 tests ✅ (incl. 8 new) · `@excitedjs/feishu-channel` 98 tests ✅ (`DREAMUX_SKIP_LIVE_CODEX=1`)
- gitleaks clean; no real Feishu identifiers, internal domains, tokens, or machine-local paths.

## Residual risks
- The P2P-via-Feishu-gate end-to-end path is covered deterministically in `channel-routing.test.ts` via spies rather than through the full Feishu gate (smoke still covers bound-group→leader and unbound→dispatcher end-to-end).
- Live multi-channel routing remains deferred — runtime runs exactly one Feishu channel per dispatcher (`dispatcherChannelId` returns null when ambiguous).
- `reply` / `react` / `list_chat_bots` still live on the `feishu` MCP server; `list_peers` not implemented.

Do not merge — for review.
