### PR TITLE
feat(types): public types-API audit for @excitedjs/dreamux-types (#209)

### DIFF
--- a/.agents/decisions/npm-package-split-and-channel-targets.md
+++ b/.agents/decisions/npm-package-split-and-channel-targets.md
@@ -158,6 +158,37 @@ Core adapts its logger to this shape. Provider packages own their own minimal
 console fallback when core does not pass a logger. That fallback is
 implementation code and does not belong in the types package.
 
+### Public surface boundaries (issue #209 types-API audit)
+
+The type package also publishes the *factory* contract, so an external
+provider's default export is typed against the same shape core's loader calls:
+
+- `ProviderFactoryContext<TDescriptor>` / `ProviderFactory<TProvider, TDescriptor>`
+  mirror the loader call (`{ ref, descriptor }` → provider). Kind-specific aliases
+  `AgentRuntimeProviderFactory` / `ChannelProviderFactory` carry the already-narrowed
+  descriptor so a package assigns `provider.descriptor` without a cast.
+- Descriptors are narrowed by kind: `AgentRuntimeProviderDescriptor`
+  (`kind: 'agentRuntime'`) and `ChannelProviderDescriptor` (`kind: 'channel'`);
+  `AgentRuntimeProvider.descriptor` / `ChannelProvider.descriptor` use them.
+- The package owns its environment shape: `DreamuxEnvironment`
+  (`Record<string, string | undefined>`). No public declaration references a
+  `@types/node` global (`NodeJS.*`, `Buffer`); a guard test enforces this so the
+  contract never drags host typings into an external provider package.
+- `AgentRuntimeProvider.readConfig` may return `TConfig | Promise<TConfig>`
+  (parity with `ChannelProvider.readConfig`); core awaits it at config load.
+
+Root-export minimization: the `exports` map publishes only the package root, so
+the names re-exported by `src/index.ts` ARE the public API. Helper shapes a
+provider reaches only contextually — a property of a public interface, or a
+parameter of a *required* interface method — stay `export`ed from their source
+module (the emitted `.d.ts` resolves them transitively) but are NOT root
+re-exported. Parameters of *optional* interface methods (e.g. `ChannelToolCall`
+on `ChannelSession.handleTool?`) are NOT contextually inferred under `strict`, so
+those stay root exports. A root-export allowlist test pins the surface so later
+slices grow it deliberately, and the expanded external-provider fixture proves
+the allowlist is sufficient to author a full provider importing from the root
+only.
+
 ## Provider Loading
 
 Dreamux core owns provider loading. The current runtime-specific external

--- a/common/changes/@excitedjs/agent-runtime-claude-code/i209-types-api-audit_2026-06-14-12-00.json
+++ b/common/changes/@excitedjs/agent-runtime-claude-code/i209-types-api-audit_2026-06-14-12-00.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Type the package's default factory export against the published `AgentRuntimeProviderFactory` contract and validate+narrow the seed descriptor to the `agentRuntime` kind (issue #209 types-API audit). `ClaudeCodeProviderFactoryContext` is now a back-compat alias of `ProviderFactoryContext<AgentRuntimeProviderDescriptor>`. No runtime behavior change.",
+      "type": "patch",
+      "packageName": "@excitedjs/agent-runtime-claude-code"
+    }
+  ],
+  "packageName": "@excitedjs/agent-runtime-claude-code",
+  "email": "053700@gmail.com"
+}

--- a/common/changes/@excitedjs/agent-runtime-codex/i209-types-api-audit_2026-06-14-12-00.json
+++ b/common/changes/@excitedjs/agent-runtime-codex/i209-types-api-audit_2026-06-14-12-00.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Type the package's default factory export against the published `AgentRuntimeProviderFactory` contract and validate+narrow the seed descriptor to the `agentRuntime` kind (issue #209 types-API audit). `CodexProviderFactoryContext` is now a back-compat alias of `ProviderFactoryContext<AgentRuntimeProviderDescriptor>`. No runtime behavior change.",
+      "type": "patch",
+      "packageName": "@excitedjs/agent-runtime-codex"
+    }
+  ],
+  "packageName": "@excitedjs/agent-runtime-codex",
+  "email": "053700@gmail.com"
+}

--- a/common/changes/@excitedjs/dreamux-types/i209-types-api-audit_2026-06-14-12-00.json
+++ b/common/changes/@excitedjs/dreamux-types/i209-types-api-audit_2026-06-14-12-00.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Public types-API audit (issue #209). Remove `@types/node` host globals from the public contract: `AgentRuntimeDiagnosticRunner` options + `AgentRuntimeDiagnosticContext.env` now use the package-owned `DreamuxEnvironment` (`Record<string, string | undefined>`) instead of `NodeJS.ProcessEnv`; a guard test forbids `NodeJS.*` / `Buffer` from reappearing. Publish the provider factory contract: `ProviderFactoryContext<TDescriptor>` / `ProviderFactory<TProvider, TDescriptor>` plus kind-specific aliases `AgentRuntimeProviderFactory` / `ChannelProviderFactory`. Narrow descriptors by kind: new `AgentRuntimeProviderDescriptor` / `ChannelProviderDescriptor`, and `AgentRuntimeProvider.descriptor` is now `agentRuntime`-narrowed. `AgentRuntimeProvider.readConfig` may now return `TConfig | Promise<TConfig>` (parity with `ChannelProvider.readConfig`). Root-export minimization: the package root no longer re-exports purely-contextual helper shapes (`AgentRuntimeDiagnosticContext`, `AgentRuntimeResumeCapability`, `AgentRuntimeResumeCheckpoint`, `ChannelSender`); they remain exported from their source module and resolve transitively through the public interfaces, but are no longer importable by name. A root-export allowlist test pins the surface. Update the stale `channel.ts` header that implied a generic Channel MCP.",
+      "type": "minor",
+      "packageName": "@excitedjs/dreamux-types"
+    }
+  ],
+  "packageName": "@excitedjs/dreamux-types",
+  "email": "053700@gmail.com"
+}

--- a/common/changes/@excitedjs/dreamux/i209-types-api-audit_2026-06-14-12-00.json
+++ b/common/changes/@excitedjs/dreamux/i209-types-api-audit_2026-06-14-12-00.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Support async Agent Runtime `readConfig` end-to-end (issue #209 types-API audit, F4). The host `AgentRuntimeProvider.readConfig` now allows `DispatcherProviderConfig | Promise<...>` and config load awaits it, matching `ChannelProvider.readConfig`; a rejected/thrown parse still fails loud. No operator-facing config/state change. Also drops two vestigial type re-exports from `agent-runtime/types.ts` that `@excitedjs/dreamux-types` no longer root-exports.",
+      "type": "patch",
+      "packageName": "@excitedjs/dreamux"
+    }
+  ],
+  "packageName": "@excitedjs/dreamux",
+  "email": "053700@gmail.com"
+}

--- a/common/changes/@excitedjs/feishu-channel/i209-types-api-audit_2026-06-14-12-00.json
+++ b/common/changes/@excitedjs/feishu-channel/i209-types-api-audit_2026-06-14-12-00.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Type the package's default factory export against the published `ChannelProviderFactory` contract and use the kind-narrowed `ChannelProviderDescriptor` for the builtin descriptor (issue #209 types-API audit). No runtime behavior change.",
+      "type": "patch",
+      "packageName": "@excitedjs/feishu-channel"
+    }
+  ],
+  "packageName": "@excitedjs/feishu-channel",
+  "email": "053700@gmail.com"
+}

--- a/packages/agent-runtime/claude-code/src/provider.ts
+++ b/packages/agent-runtime/claude-code/src/provider.ts
@@ -17,7 +17,10 @@ import type {
   AgentRuntime,
   AgentRuntimeCreateContext,
   AgentRuntimeProvider,
+  AgentRuntimeProviderDescriptor,
+  AgentRuntimeProviderFactory,
   ProviderDescriptor,
+  ProviderFactoryContext,
 } from '@excitedjs/dreamux-types';
 
 /**
@@ -28,7 +31,12 @@ import type {
  * tests wire the resident-process seam without changing the provider.
  */
 export interface ClaudeCodeAgentRuntimeProviderOptions {
-  /** The registry descriptor for `builtin:claude-code`. Defaults to a minimal one. */
+  /**
+   * The registry descriptor for `builtin:claude-code`. Defaults to a minimal
+   * one. Accepted wide (`ProviderDescriptor`) so a host that resolved it from
+   * its registry need not pre-narrow the kind; the factory validates it is an
+   * `agentRuntime` descriptor.
+   */
   descriptor?: ProviderDescriptor;
   /** Optional host-level bin resolver (default: identity on the config bin). */
   resolveBinPath?: (bin: string) => string;
@@ -54,7 +62,7 @@ export const CLAUDE_CODE_AGENT_RUNTIME_CAPABILITIES: AgentRuntimeCapabilities = 
   ],
 };
 
-const DEFAULT_CLAUDE_CODE_DESCRIPTOR: ProviderDescriptor = {
+const DEFAULT_CLAUDE_CODE_DESCRIPTOR: AgentRuntimeProviderDescriptor = {
   id: 'claude-code',
   kind: 'agentRuntime',
   ref: {
@@ -63,6 +71,19 @@ const DEFAULT_CLAUDE_CODE_DESCRIPTOR: ProviderDescriptor = {
     raw: BUILTIN_CLAUDE_CODE_PROVIDER_REF,
   },
 };
+
+/** Validate + narrow a seed descriptor to the Agent Runtime kind. */
+function asAgentRuntimeDescriptor(
+  descriptor: ProviderDescriptor,
+): AgentRuntimeProviderDescriptor {
+  if (descriptor.kind !== 'agentRuntime') {
+    throw new Error(
+      `@excitedjs/agent-runtime-claude-code: descriptor.kind must be ` +
+        `'agentRuntime' (got ${JSON.stringify(descriptor.kind)})`,
+    );
+  }
+  return { ...descriptor, kind: descriptor.kind };
+}
 
 /**
  * Create the built-in Claude Code `AgentRuntimeProvider`. It implements the
@@ -79,7 +100,10 @@ export function createClaudeCodeAgentRuntimeProvider(
   const resolveBinPath = options.resolveBinPath ?? ((bin: string) => bin);
   return {
     ref: BUILTIN_CLAUDE_CODE_PROVIDER_REF,
-    descriptor: options.descriptor ?? DEFAULT_CLAUDE_CODE_DESCRIPTOR,
+    descriptor:
+      options.descriptor === undefined
+        ? DEFAULT_CLAUDE_CODE_DESCRIPTOR
+        : asAgentRuntimeDescriptor(options.descriptor),
     getCapabilities: () => CLAUDE_CODE_AGENT_RUNTIME_CAPABILITIES,
     readConfig(rawConfig, context) {
       return readDispatcherClaudeCodeConfig(
@@ -132,15 +156,13 @@ export function createClaudeCodeAgentRuntimeProvider(
 export { dispatcherClaudeCodeConfig };
 
 /**
- * The context Dreamux core's generic provider package-loader passes to a
- * package's factory export: the canonical ref and the seed descriptor the
- * provider echoes back. Structurally matches core's `ProviderFactoryContext`
- * without importing core.
+ * The context Dreamux core's generic provider package-loader passes to this
+ * package's factory export. A back-compat alias of the public
+ * {@link ProviderFactoryContext}, narrowed to the Agent Runtime descriptor kind
+ * so the factory assigns `descriptor` without a cast.
  */
-export interface ClaudeCodeProviderFactoryContext {
-  ref: string;
-  descriptor: ProviderDescriptor;
-}
+export type ClaudeCodeProviderFactoryContext =
+  ProviderFactoryContext<AgentRuntimeProviderDescriptor>;
 
 /**
  * Default export — the factory Dreamux core's generic provider-loader selects
@@ -158,8 +180,8 @@ export interface ClaudeCodeProviderFactoryContext {
  * first-class, loadable `AgentRuntimeProvider` for the generic loader and for
  * external embedders.
  */
-export default function claudeCodeAgentRuntimeProviderFactory(
-  context: ClaudeCodeProviderFactoryContext,
-): AgentRuntimeProvider<DispatcherClaudeCodeConfig> {
-  return createClaudeCodeAgentRuntimeProvider({ descriptor: context.descriptor });
-}
+const claudeCodeAgentRuntimeProviderFactory: AgentRuntimeProviderFactory<DispatcherClaudeCodeConfig> =
+  (context) =>
+    createClaudeCodeAgentRuntimeProvider({ descriptor: context.descriptor });
+
+export default claudeCodeAgentRuntimeProviderFactory;

--- a/packages/agent-runtime/codex/src/provider.ts
+++ b/packages/agent-runtime/codex/src/provider.ts
@@ -22,7 +22,10 @@ import type {
   AgentRuntimeCreateContext,
   AgentRuntimeMcpServer,
   AgentRuntimeProvider,
+  AgentRuntimeProviderDescriptor,
+  AgentRuntimeProviderFactory,
   ProviderDescriptor,
+  ProviderFactoryContext,
 } from '@excitedjs/dreamux-types';
 
 /**
@@ -35,7 +38,12 @@ import type {
  * process/WS/home seams without changing the provider.
  */
 export interface CodexAgentRuntimeProviderOptions {
-  /** The registry descriptor for `builtin:codex`. Defaults to a minimal one. */
+  /**
+   * The registry descriptor for `builtin:codex`. Defaults to a minimal one.
+   * Accepted wide (`ProviderDescriptor`) so a host that resolved it from its
+   * registry need not pre-narrow the kind; the factory validates it is an
+   * `agentRuntime` descriptor.
+   */
   descriptor?: ProviderDescriptor;
   /**
    * Allocate a fresh volatile rendezvous socket path per app-server start. The
@@ -91,11 +99,24 @@ export const CODEX_AGENT_RUNTIME_CAPABILITIES: AgentRuntimeCapabilities = {
   ],
 };
 
-const DEFAULT_CODEX_DESCRIPTOR: ProviderDescriptor = {
+const DEFAULT_CODEX_DESCRIPTOR: AgentRuntimeProviderDescriptor = {
   id: 'codex',
   kind: 'agentRuntime',
   ref: { source: 'builtin', id: 'codex', raw: BUILTIN_CODEX_PROVIDER_REF },
 };
+
+/** Validate + narrow a seed descriptor to the Agent Runtime kind. */
+function asAgentRuntimeDescriptor(
+  descriptor: ProviderDescriptor,
+): AgentRuntimeProviderDescriptor {
+  if (descriptor.kind !== 'agentRuntime') {
+    throw new Error(
+      `@excitedjs/agent-runtime-codex: descriptor.kind must be 'agentRuntime' ` +
+        `(got ${JSON.stringify(descriptor.kind)})`,
+    );
+  }
+  return { ...descriptor, kind: descriptor.kind };
+}
 
 /**
  * Create the built-in Codex `AgentRuntimeProvider`. It implements the neutral
@@ -109,7 +130,10 @@ export function createCodexAgentRuntimeProvider(
 ): AgentRuntimeProvider<DispatcherCodexConfig> {
   return {
     ref: BUILTIN_CODEX_PROVIDER_REF,
-    descriptor: options.descriptor ?? DEFAULT_CODEX_DESCRIPTOR,
+    descriptor:
+      options.descriptor === undefined
+        ? DEFAULT_CODEX_DESCRIPTOR
+        : asAgentRuntimeDescriptor(options.descriptor),
     getCapabilities: () => CODEX_AGENT_RUNTIME_CAPABILITIES,
     readConfig(rawConfig, context) {
       return readDispatcherCodexConfig(rawConfig, context.file, context.prefix);
@@ -180,15 +204,13 @@ export function codexRuntimeArgsForMcpServers(
 }
 
 /**
- * The context Dreamux core's generic provider package-loader passes to a
- * package's factory export: the canonical ref and the seed descriptor the
- * provider echoes back. Structurally matches core's `ProviderFactoryContext`
- * without importing core.
+ * The context Dreamux core's generic provider package-loader passes to this
+ * package's factory export. A back-compat alias of the public
+ * {@link ProviderFactoryContext}, narrowed to the Agent Runtime descriptor kind
+ * so the factory assigns `descriptor` without a cast.
  */
-export interface CodexProviderFactoryContext {
-  ref: string;
-  descriptor: ProviderDescriptor;
-}
+export type CodexProviderFactoryContext =
+  ProviderFactoryContext<AgentRuntimeProviderDescriptor>;
 
 /**
  * Default export — the factory Dreamux core's generic provider-loader selects
@@ -207,8 +229,7 @@ export interface CodexProviderFactoryContext {
  * converging core's launcher onto the neutral context so it can drive the loaded
  * provider directly is later-slice work.
  */
-export default function codexAgentRuntimeProviderFactory(
-  context: CodexProviderFactoryContext,
-): AgentRuntimeProvider<DispatcherCodexConfig> {
-  return createCodexAgentRuntimeProvider({ descriptor: context.descriptor });
-}
+const codexAgentRuntimeProviderFactory: AgentRuntimeProviderFactory<DispatcherCodexConfig> =
+  (context) => createCodexAgentRuntimeProvider({ descriptor: context.descriptor });
+
+export default codexAgentRuntimeProviderFactory;

--- a/packages/channel/feishu-channel/src/provider.ts
+++ b/packages/channel/feishu-channel/src/provider.ts
@@ -21,6 +21,8 @@
 import type {
   ChannelInboundEnvelope,
   ChannelProvider,
+  ChannelProviderDescriptor,
+  ChannelProviderFactory,
   ChannelReactInput,
   ChannelReplyInput,
   ChannelRoutes,
@@ -30,7 +32,6 @@ import type {
   ChannelToolCall,
   ChannelToolDescriptor,
   DreamuxLogger,
-  ProviderDescriptor,
 } from '@excitedjs/dreamux-types';
 import {
   FeishuChannelSession,
@@ -46,7 +47,7 @@ export interface FeishuChannelConfig {
   appSecret: string;
 }
 
-const DEFAULT_FEISHU_DESCRIPTOR: ProviderDescriptor & { kind: 'channel' } = {
+const DEFAULT_FEISHU_DESCRIPTOR: ChannelProviderDescriptor = {
   id: 'feishu',
   kind: 'channel',
   ref: { source: 'builtin', id: 'feishu', raw: BUILTIN_FEISHU_PROVIDER_REF },
@@ -227,9 +228,7 @@ export function createFeishuChannelProvider(): ChannelProvider<FeishuChannelConf
  * core-owned adapter instead (see the module doc); this keeps the package a
  * loader-real `ChannelProvider`.
  */
-export default function feishuChannelProviderFactory(_context: {
-  ref: string;
-  descriptor: ProviderDescriptor;
-}): ChannelProvider<FeishuChannelConfig> {
-  return createFeishuChannelProvider();
-}
+const feishuChannelProviderFactory: ChannelProviderFactory<FeishuChannelConfig> =
+  () => createFeishuChannelProvider();
+
+export default feishuChannelProviderFactory;

--- a/packages/dreamux-types/src/agent-runtime.ts
+++ b/packages/dreamux-types/src/agent-runtime.ts
@@ -17,7 +17,11 @@
  * can be authored against it today.
  */
 import type { DreamuxLogger } from './logger.js';
-import type { ProviderDescriptor } from './provider.js';
+import type {
+  AgentRuntimeProviderDescriptor,
+  DreamuxEnvironment,
+  ProviderFactory,
+} from './provider.js';
 import type {
   InboundDeliveryHooks,
   InboundDeliveryResult,
@@ -46,6 +50,14 @@ export type AgentRuntimeRole =
 export interface AgentRuntimeSkillSource {
   name: string;
   path: string;
+  /**
+   * How the runtime should mount `path` into its engine. An open string, not a
+   * closed union: a new runtime may define its own layout without a types bump.
+   * Standard layouts core emits today are `skill-dir` (a single skill directory,
+   * e.g. a Codex `skills/extraRoots` entry) and `claude-skills-parent` (the
+   * parent of a `.claude/skills` tree, e.g. a Claude `--add-dir` root). A runtime
+   * that does not recognize a layout should ignore that source, not fail.
+   */
   layout: string;
   source: 'dreamux-core' | string;
 }
@@ -73,13 +85,18 @@ export type AgentRuntimeResumeCapability =
 export interface AgentRuntimeCapabilities {
   /** Whether this runtime can resume a prior checkpoint, and which checkpoint id it expects. */
   resume: AgentRuntimeResumeCapability;
-  /** Whether a follow-up turn can steer/fold into an active turn. */
+  /**
+   * Whether a follow-up turn delivered while a turn is active folds into that
+   * turn rather than queueing behind it. Purely behavioral: there is no separate
+   * "steer" method — core still delivers through `channelInput`/`systemInput`,
+   * and this flag only tells core whether mid-turn delivery is absorbed.
+   */
   steer: { supported: boolean };
   /** How runtime events are surfaced to Dreamux. */
   events: { kind: 'push' | 'synthesized' };
-  /** Whether the runtime can report the last assistant/user-visible result. */
+  /** Whether {@link AgentRuntime.getLast} can report the last result. */
   last: { supported: boolean };
-  /** Whether the runtime can report context-window usage. */
+  /** Whether {@link AgentRuntime.getContext} can report context-window usage. */
   context: { supported: boolean };
   /**
    * How the launcher-supplied role/system prompt content is applied: `replace`
@@ -179,12 +196,12 @@ export interface AgentRuntimeDiagnosticRunner {
   check(
     command: string,
     args: string[],
-    options?: { env?: NodeJS.ProcessEnv },
+    options?: { env?: DreamuxEnvironment },
   ): Promise<boolean>;
   capture(
     command: string,
     args: string[],
-    options?: { env?: NodeJS.ProcessEnv },
+    options?: { env?: DreamuxEnvironment },
   ): Promise<string>;
 }
 
@@ -264,6 +281,11 @@ export interface AgentRuntimeCreateContext<TConfig = unknown> {
    * `systemPrompt.mode` capability. Optional: teammate launches may omit it.
    */
   systemPromptContent?: string;
+  /**
+   * MCP servers the launcher injects for this runtime instance. Already fully
+   * resolved by core: an empty array means "no MCP servers", and the provider
+   * must launch exactly these — it must not infer, append, or mutate the list.
+   */
   mcpServers: readonly AgentRuntimeMcpServer[];
   /**
    * Bundled skill sources core selected for this role. Empty for roles that
@@ -299,12 +321,24 @@ export interface AgentRuntime {
   getStatus(): AgentRuntimeStatus;
   getThreadId(): string | null;
   wasThreadResumed(): boolean;
+  /**
+   * The last assistant/user-visible result, or `null` when unavailable.
+   * A runtime whose `capabilities.last.supported` is false returns `null`
+   * rather than throwing or blocking — core treats `null` as "not reported".
+   */
   getLast(): Promise<AgentRuntimeLastResult | null>;
+  /**
+   * Context-window usage, or `null` when unavailable. A runtime whose
+   * `capabilities.context.supported` is false returns `null` rather than
+   * throwing or blocking.
+   */
   getContext(): Promise<AgentRuntimeContextSnapshot | null>;
   getCapabilities(): AgentRuntimeCapabilities;
   /**
-   * Deliver a teammate-completion envelope upward. Optional: a runtime whose
-   * capabilities declare no `teammateCompletion` shapes may not support it.
+   * Deliver a teammate-completion envelope upward. Optional, and feature-detected
+   * by presence: a runtime that declares no `capabilities.teammateCompletion`
+   * shapes should omit this method entirely rather than ship a throwing/no-op
+   * stub, since callers test for the method, not the capability array.
    */
   completionInput?(
     completion: CompletionEnvelope,
@@ -319,7 +353,7 @@ export interface AgentRuntime {
 export interface AgentRuntimeDiagnosticContext<TConfig = unknown> {
   runtime_id: string;
   config: TConfig;
-  env: NodeJS.ProcessEnv;
+  env: DreamuxEnvironment;
   scope: 'foreground' | 'managedService';
 }
 
@@ -327,6 +361,10 @@ export interface AgentRuntimeDiagnosticContext<TConfig = unknown> {
  * A provider's self-reported diagnostics: it DECLARES the bin checks doctor
  * should dedup + execute, and RUNS its own non-bin internal checks. Doctor
  * iterates providers and calls these instead of branching on a builtin ref.
+ *
+ * Optional on {@link AgentRuntimeProvider}: a provider with no diagnostic surface
+ * omits it. The host supplies the {@link AgentRuntimeDiagnosticRunner} to
+ * `runDiagnostic`; the provider only implements the checks, never the runner.
  */
 export interface AgentRuntimeDiagnostic<TConfig = unknown> {
   binChecks(context: AgentRuntimeDiagnosticContext<TConfig>): AgentRuntimeBinCheck[];
@@ -342,12 +380,18 @@ export interface AgentRuntimeDiagnostic<TConfig = unknown> {
  */
 export interface AgentRuntimeProvider<TConfig = unknown> {
   readonly ref: string;
-  readonly descriptor: ProviderDescriptor;
+  readonly descriptor: AgentRuntimeProviderDescriptor;
   getCapabilities(): AgentRuntimeCapabilities;
+  /**
+   * Parse + validate this provider's own config block. May return synchronously
+   * or as a promise; Dreamux core awaits the result, mirroring
+   * `ChannelProvider.readConfig`. A parse/validation failure must throw (the host
+   * fails loud), never return a partially-valid config.
+   */
   readConfig?(
     rawConfig: Record<string, unknown>,
     context: AgentRuntimeProviderConfigReadContext,
-  ): TConfig;
+  ): TConfig | Promise<TConfig>;
   /**
    * Self-reported doctor diagnostics. Optional: a provider with no diagnostic
    * surface may omit it.
@@ -355,6 +399,17 @@ export interface AgentRuntimeProvider<TConfig = unknown> {
   diagnostic?: AgentRuntimeDiagnostic<TConfig>;
   createRuntime(context: AgentRuntimeCreateContext<TConfig>): AgentRuntime;
 }
+
+/**
+ * The default (or `npm:pkg#export`-selected) factory export an Agent Runtime
+ * package ships. Its {@link ProviderFactoryContext} carries the already-narrowed
+ * {@link AgentRuntimeProviderDescriptor}, so the package assigns
+ * `provider.descriptor` from the seed without a cast.
+ */
+export type AgentRuntimeProviderFactory<TConfig = unknown> = ProviderFactory<
+  AgentRuntimeProvider<TConfig>,
+  AgentRuntimeProviderDescriptor
+>;
 
 /** Re-export so provider packages can take a logger in their own contexts. */
 export type { DreamuxLogger };

--- a/packages/dreamux-types/src/channel.ts
+++ b/packages/dreamux-types/src/channel.ts
@@ -2,16 +2,20 @@
  * Channel provider-authoring contracts (declaration-only).
  *
  * The neutral Channel provider seam external channel packages author against.
- * Dreamux core owns binding state, routing, authorization, and the generic
- * Channel MCP shim; a channel provider owns platform I/O, provider-specific
- * tools, inbound normalization, target resolution, and message ownership facts.
+ * Dreamux core owns binding state, routing, and authorization (binding a channel
+ * to a Team is a core Team-MCP capability, not a generic Channel MCP); a channel
+ * provider owns platform I/O, provider-specific tools, inbound normalization,
+ * target resolution, and message ownership facts.
  *
  * These contracts are forward-looking for the channel-provider slices. They live
  * here because external channel packages must compile against
  * `@excitedjs/dreamux-types` only and must not import `@excitedjs/dreamux`.
  */
 import type { DreamuxLogger } from './logger.js';
-import type { ProviderDescriptor } from './provider.js';
+import type {
+  ChannelProviderDescriptor,
+  ProviderFactory,
+} from './provider.js';
 
 export interface ChannelTarget {
   target_type: string;
@@ -108,13 +112,22 @@ export interface ChannelSession {
   start(routes: ChannelRoutes): Promise<void>;
   close(): Promise<void>;
   resolveTarget(meta: unknown): Promise<ChannelTarget>;
+  /** Send a reply. Omit entirely if the platform has no outbound reply path. */
   reply?(input: ChannelReplyInput): Promise<unknown>;
+  /** Add a reaction. Omit entirely if the platform has no reaction surface. */
   react?(input: ChannelReactInput): Promise<unknown>;
+  /** Provider-specific MCP tools. Omit if the provider exposes none. */
   tools?(context: ChannelToolListContext): readonly ChannelToolDescriptor[];
+  /**
+   * Handle a provider-specific tool call. Omit when `tools` is omitted; the two
+   * go together. These optional members are absent, not no-op stubs, when the
+   * platform does not support them — core feature-detects by presence.
+   */
   handleTool?(
     call: ChannelToolCall,
     context: ChannelToolContext,
   ): Promise<unknown>;
+  /** Decide message ownership for routing. Omit if the platform cannot. */
   messageBelongsToTarget?(
     input: ChannelMessageTargetCheck,
   ): boolean | Promise<boolean>;
@@ -122,10 +135,21 @@ export interface ChannelSession {
 
 export interface ChannelProvider<TConfig = unknown> {
   readonly ref: string;
-  readonly descriptor: ProviderDescriptor & { kind: 'channel' };
+  readonly descriptor: ChannelProviderDescriptor;
   readConfig?(
     raw: unknown,
     context: ChannelConfigContext,
   ): TConfig | Promise<TConfig>;
   createSession(context: ChannelSessionCreateContext<TConfig>): ChannelSession;
 }
+
+/**
+ * The default (or `npm:pkg#export`-selected) factory export a Channel package
+ * ships. Its {@link ProviderFactoryContext} carries the already-narrowed
+ * {@link ChannelProviderDescriptor}, so the package assigns `provider.descriptor`
+ * from the seed without a cast.
+ */
+export type ChannelProviderFactory<TConfig = unknown> = ProviderFactory<
+  ChannelProvider<TConfig>,
+  ChannelProviderDescriptor
+>;

--- a/packages/dreamux-types/src/index.ts
+++ b/packages/dreamux-types/src/index.ts
@@ -8,12 +8,27 @@
  * This package emits declarations only: there is no runtime JS contract surface
  * and no runtime dependencies. See
  * `.agents/decisions/npm-package-split-and-channel-targets.md`.
+ *
+ * Root-export policy (issue #209 overexposure audit): the names below are the
+ * intentional public surface an external provider author names directly. Helper
+ * shapes that a provider only reaches *contextually* — through a property of one
+ * of these interfaces or an implemented method's parameter — are intentionally
+ * NOT re-exported here even though they remain `export`ed from their source
+ * module (so the emitted `.d.ts` still resolves them transitively). The
+ * `exports` map publishes only this root, so an un-re-exported name is genuinely
+ * unnameable by consumers. `tests/root-exports.test.ts` locks this allowlist so
+ * future slices grow the surface deliberately, not by accident.
  */
 export type { DreamuxLogger } from './logger.js';
 export type {
+  AgentRuntimeProviderDescriptor,
   BuiltinProviderRef,
+  ChannelProviderDescriptor,
+  DreamuxEnvironment,
   NpmProviderRef,
   ProviderDescriptor,
+  ProviderFactory,
+  ProviderFactoryContext,
   ProviderKind,
   ProviderRef,
   ProviderRefSource,
@@ -33,7 +48,6 @@ export type {
   AgentRuntimeContextSnapshot,
   AgentRuntimeCreateContext,
   AgentRuntimeDiagnostic,
-  AgentRuntimeDiagnosticContext,
   AgentRuntimeDiagnosticRunner,
   AgentRuntimeDoctorResult,
   AgentRuntimeIdentity,
@@ -42,8 +56,7 @@ export type {
   AgentRuntimePathContext,
   AgentRuntimeProvider,
   AgentRuntimeProviderConfigReadContext,
-  AgentRuntimeResumeCapability,
-  AgentRuntimeResumeCheckpoint,
+  AgentRuntimeProviderFactory,
   AgentRuntimeResumeInput,
   AgentRuntimeRole,
   AgentRuntimeSkillSource,
@@ -60,10 +73,10 @@ export type {
   ChannelInboundEnvelope,
   ChannelMessageTargetCheck,
   ChannelProvider,
+  ChannelProviderFactory,
   ChannelReactInput,
   ChannelReplyInput,
   ChannelRoutes,
-  ChannelSender,
   ChannelSession,
   ChannelSessionCreateContext,
   ChannelTarget,

--- a/packages/dreamux-types/src/provider.ts
+++ b/packages/dreamux-types/src/provider.ts
@@ -45,3 +45,48 @@ export interface ProviderDescriptor {
   kind: ProviderKind;
   ref: ProviderRef;
 }
+
+/** A descriptor narrowed to the Agent Runtime kind. */
+export type AgentRuntimeProviderDescriptor = ProviderDescriptor & {
+  kind: 'agentRuntime';
+};
+
+/** A descriptor narrowed to the Channel kind. */
+export type ChannelProviderDescriptor = ProviderDescriptor & {
+  kind: 'channel';
+};
+
+/**
+ * A Dreamux-owned environment map: variable name → value (or `undefined` when
+ * unset). Declaration-only and host-neutral so provider packages never reference
+ * a Node process-env typings global in their public surface — this is the
+ * sanctioned neutral env shape (issue #209 public-types audit, P0).
+ */
+export type DreamuxEnvironment = Record<string, string | undefined>;
+
+/**
+ * The context Dreamux core hands a provider package's factory export. Mirrors the
+ * core loader's call exactly — the canonical `ref` and the seed `descriptor` the
+ * provider must echo back on its own `descriptor`. `TDescriptor` lets kind-
+ * specific factory aliases carry the already-narrowed descriptor kind.
+ */
+export interface ProviderFactoryContext<
+  TDescriptor extends ProviderDescriptor = ProviderDescriptor,
+> {
+  /** Canonical provider ref, e.g. `npm:some-pkg#provider` or `builtin:codex`. */
+  ref: string;
+  /** Seed descriptor the provider must echo back on its own `descriptor`. */
+  descriptor: TDescriptor;
+}
+
+/**
+ * A provider package's factory export (default export, or the named export a
+ * `npm:pkg#export` ref selects). Dreamux core invokes it with a
+ * {@link ProviderFactoryContext} and registers the returned provider.
+ */
+export type ProviderFactory<
+  TProvider,
+  TDescriptor extends ProviderDescriptor = ProviderDescriptor,
+> = (
+  context: ProviderFactoryContext<TDescriptor>,
+) => TProvider | Promise<TProvider>;

--- a/packages/dreamux-types/tests/fixtures.test.ts
+++ b/packages/dreamux-types/tests/fixtures.test.ts
@@ -11,14 +11,54 @@ import { describe, it, expect } from 'vitest';
 import {
   EXTERNAL_RUNTIME_CAPABILITIES,
   describeConfigContext,
+  fixtureChannelFactory,
   fixtureChannelProvider,
+  fixtureRuntimeFactory,
   fixtureRuntimeProvider,
 } from './fixtures/external-provider.js';
 
 describe('external provider fixture', () => {
   it('declares neutral runtime capabilities', () => {
     expect(EXTERNAL_RUNTIME_CAPABILITIES.events.kind).toBe('synthesized');
-    expect(EXTERNAL_RUNTIME_CAPABILITIES.teammateCompletion).toEqual([]);
+    expect(EXTERNAL_RUNTIME_CAPABILITIES.teammateCompletion).toEqual([
+      { kind: 'fixturePlainTurn', description: 'deliver as a plain user turn' },
+    ]);
+  });
+
+  it('narrows provider descriptors to their kind (P2)', () => {
+    expect(fixtureRuntimeProvider.descriptor.kind).toBe('agentRuntime');
+    expect(fixtureChannelProvider.descriptor.kind).toBe('channel');
+  });
+
+  it('factories echo the seed descriptor from the loader context (P1)', () => {
+    const runtime = fixtureRuntimeFactory({
+      ref: 'npm:@example/fixture-runtime',
+      descriptor: fixtureRuntimeProvider.descriptor,
+    });
+    expect(runtime.descriptor.kind).toBe('agentRuntime');
+    const channel = fixtureChannelFactory({
+      ref: 'npm:@example/fixture-channel',
+      descriptor: fixtureChannelProvider.descriptor,
+    });
+    expect(channel.descriptor.kind).toBe('channel');
+  });
+
+  it('delivers a completion upward through the optional completionInput', async () => {
+    const runtime = fixtureRuntimeProvider.createRuntime({
+      identity: { runtime_id: 'd1', checkpoint_id: null },
+      role: 'dispatcher',
+      config: { model: 'm' },
+      cwd: '/tmp/fixture',
+      mcpServers: [],
+    });
+    expect(runtime.completionInput).toBeDefined();
+    const result = await runtime.completionInput?.({
+      source: 'teammate',
+      id: 't1',
+      status: 'completed',
+      result: 'done',
+    });
+    expect(result).toEqual({ status: 'accepted' });
   });
 
   it('formats a config-read context', () => {
@@ -34,7 +74,9 @@ describe('external provider fixture', () => {
 
   it('implements a full AgentRuntimeProvider against types only', async () => {
     expect(fixtureRuntimeProvider.descriptor.kind).toBe('agentRuntime');
-    const config = fixtureRuntimeProvider.readConfig?.(
+    // `readConfig` is sync-or-async (parity with `ChannelProvider.readConfig`,
+    // F4); awaiting covers both shapes.
+    const config = await fixtureRuntimeProvider.readConfig?.(
       { model: 'fixture-model' },
       {
         providerRef: 'npm:@example/fixture-runtime',

--- a/packages/dreamux-types/tests/fixtures/external-provider.ts
+++ b/packages/dreamux-types/tests/fixtures/external-provider.ts
@@ -3,28 +3,50 @@
  *
  * This file imports Dreamux contracts from `@excitedjs/dreamux-types` ONLY and
  * implements a complete Agent Runtime provider (descriptor + `readConfig` +
- * `getCapabilities` + `createRuntime` returning a live `AgentRuntime` handle)
- * and a Channel provider, the way an external provider package in another
- * repository would. It must never import `@excitedjs/dreamux`. The fixture is
- * type-checked by the package's test typecheck; the runtime assertions live in
+ * `getCapabilities` + optional `diagnostic` + `createRuntime` returning a live
+ * `AgentRuntime` handle, including the optional `completionInput`) and a Channel
+ * provider (with the optional `reply` / `react` / `tools` / `handleTool` /
+ * `messageBelongsToTarget`), the way an external provider package in another
+ * repository would. It also exercises the published provider factory contracts
+ * (`AgentRuntimeProviderFactory` / `ChannelProviderFactory`).
+ *
+ * It must never import `@excitedjs/dreamux`. Because it imports from the package
+ * ROOT only, it doubles as the over-exposure oracle: every type it must name to
+ * implement these surfaces has to be a root export. The fixture is type-checked
+ * by the package's test typecheck; the runtime assertions live in
  * `fixtures.test.ts`.
  */
 import type {
   AgentRuntime,
+  AgentRuntimeBinCheck,
   AgentRuntimeCapabilities,
   AgentRuntimeContextSnapshot,
   AgentRuntimeCreateContext,
+  AgentRuntimeDiagnostic,
+  AgentRuntimeDoctorResult,
   AgentRuntimeLastResult,
   AgentRuntimeProvider,
   AgentRuntimeProviderConfigReadContext,
+  AgentRuntimeProviderDescriptor,
+  AgentRuntimeProviderFactory,
   AgentRuntimeStatus,
   AgentRuntimeTurnResult,
+  ChannelInboundEnvelope,
+  ChannelMessageTargetCheck,
   ChannelProvider,
+  ChannelProviderDescriptor,
+  ChannelProviderFactory,
+  ChannelReactInput,
+  ChannelReplyInput,
+  ChannelRoutes,
   ChannelSession,
   ChannelTarget,
+  ChannelToolCall,
+  ChannelToolDescriptor,
+  CompletionEnvelope,
   DreamuxLogger,
   InboundTurnInput,
-  ProviderDescriptor,
+  TeamMateCompletionDeliveryResult,
 } from '@excitedjs/dreamux-types';
 
 export const EXTERNAL_RUNTIME_CAPABILITIES: AgentRuntimeCapabilities = {
@@ -34,7 +56,9 @@ export const EXTERNAL_RUNTIME_CAPABILITIES: AgentRuntimeCapabilities = {
   last: { supported: false },
   context: { supported: false },
   systemPrompt: { mode: 'append' },
-  teammateCompletion: [],
+  teammateCompletion: [
+    { kind: 'fixturePlainTurn', description: 'deliver as a plain user turn' },
+  ],
 };
 
 export function describeConfigContext(
@@ -103,9 +127,16 @@ class FixtureRuntime implements AgentRuntime {
   getCapabilities(): AgentRuntimeCapabilities {
     return EXTERNAL_RUNTIME_CAPABILITIES;
   }
+
+  async completionInput(
+    completion: CompletionEnvelope,
+  ): Promise<TeamMateCompletionDeliveryResult> {
+    this.logger?.info('fixture completion', { id: completion.id });
+    return { status: 'accepted' };
+  }
 }
 
-const runtimeDescriptor: ProviderDescriptor = {
+const runtimeDescriptor: AgentRuntimeProviderDescriptor = {
   id: 'fixture-runtime',
   kind: 'agentRuntime',
   ref: {
@@ -113,6 +144,22 @@ const runtimeDescriptor: ProviderDescriptor = {
     package: '@example/fixture-runtime',
     export: null,
     raw: 'npm:@example/fixture-runtime',
+  },
+};
+
+/**
+ * An optional diagnostic the host's doctor pass drives. The host supplies the
+ * command runner; the fixture only declares bin checks and runs its own check.
+ */
+const fixtureRuntimeDiagnostic: AgentRuntimeDiagnostic<FixtureRuntimeConfig> = {
+  binChecks(): AgentRuntimeBinCheck[] {
+    return [{ name: 'fixture', bin: 'fixture-cli', args: ['--version'] }];
+  },
+  async runDiagnostic(context, runner): Promise<AgentRuntimeDoctorResult> {
+    const ok = await runner.check('fixture-cli', ['--version'], {
+      env: context.env,
+    });
+    return { ok, detail: ok ? 'fixture ready' : 'fixture missing', errors: [] };
   },
 };
 
@@ -127,10 +174,18 @@ export const fixtureRuntimeProvider: AgentRuntimeProvider<FixtureRuntimeConfig> 
       const model = typeof rawConfig.model === 'string' ? rawConfig.model : 'default';
       return { model };
     },
+    diagnostic: fixtureRuntimeDiagnostic,
     createRuntime(context) {
       return new FixtureRuntime(context);
     },
   };
+
+/**
+ * The package's default export an external runtime ships: the loader invokes it
+ * with the seed `ProviderFactoryContext`, narrowed to the Agent Runtime kind.
+ */
+export const fixtureRuntimeFactory: AgentRuntimeProviderFactory<FixtureRuntimeConfig> =
+  (context) => ({ ...fixtureRuntimeProvider, descriptor: context.descriptor });
 
 class FixtureChannelSession implements ChannelSession {
   readonly provider = 'npm:@example/fixture-channel';
@@ -142,8 +197,14 @@ class FixtureChannelSession implements ChannelSession {
     this.logger = logger;
   }
 
-  async start(): Promise<void> {
+  async start(routes: ChannelRoutes): Promise<void> {
     this.logger?.info('fixture channel started', { channel_id: this.channel_id });
+    const envelope: ChannelInboundEnvelope = {
+      provider: this.provider,
+      channel_id: this.channel_id,
+      target: { target_type: 'group', target_key: 'demo', bindable: true },
+    };
+    await routes.deliver(envelope);
   }
 
   async close(): Promise<void> {}
@@ -157,9 +218,32 @@ class FixtureChannelSession implements ChannelSession {
       bindable: true,
     };
   }
+
+  async reply(input: ChannelReplyInput): Promise<unknown> {
+    this.logger?.info('reply', { key: input.target.target_key });
+    return { delivered: true };
+  }
+
+  async react(input: ChannelReactInput): Promise<unknown> {
+    return { reacted: input.reaction };
+  }
+
+  tools(): readonly ChannelToolDescriptor[] {
+    return [{ name: 'echo', description: 'echo a message' }];
+  }
+
+  // Optional ChannelSession methods: a strict implementer names these param
+  // types (they are not contextually inferred for optional members).
+  async handleTool(call: ChannelToolCall): Promise<unknown> {
+    return { echoed: call.name };
+  }
+
+  messageBelongsToTarget(input: ChannelMessageTargetCheck): boolean {
+    return input.target.target_key === input.message_id;
+  }
 }
 
-const descriptor: ProviderDescriptor & { kind: 'channel' } = {
+const channelDescriptor: ChannelProviderDescriptor = {
   id: 'fixture-channel',
   kind: 'channel',
   ref: {
@@ -172,8 +256,14 @@ const descriptor: ProviderDescriptor & { kind: 'channel' } = {
 
 export const fixtureChannelProvider: ChannelProvider = {
   ref: 'npm:@example/fixture-channel',
-  descriptor,
+  descriptor: channelDescriptor,
   createSession(context) {
     return new FixtureChannelSession(context.channel_id, context.logger);
   },
 };
+
+/** The package's default export an external channel ships. */
+export const fixtureChannelFactory: ChannelProviderFactory = (context) => ({
+  ...fixtureChannelProvider,
+  descriptor: context.descriptor,
+});

--- a/packages/dreamux-types/tests/no-host-types.test.ts
+++ b/packages/dreamux-types/tests/no-host-types.test.ts
@@ -1,0 +1,49 @@
+/**
+ * Host-types guard (issue #209 public-types audit, P0).
+ *
+ * `@excitedjs/dreamux-types` is the neutral, host-agnostic provider contract.
+ * Its public declarations must never reference `@types/node` globals such as
+ * `NodeJS.*` or `Buffer` — those would drag a host typings dependency into every
+ * external provider package and re-expose the leak P0 removed (the
+ * `AgentRuntimeDiagnosticRunner` env + `AgentRuntimeDiagnosticContext.env` used
+ * `NodeJS.ProcessEnv`; they now use the package-owned `DreamuxEnvironment`).
+ *
+ * The scan is intentionally literal (whole-token), so the source carries no
+ * `NodeJS` / `Buffer` text at all — not even in prose — keeping the guard
+ * unambiguous. Use `DreamuxEnvironment` instead of `NodeJS.ProcessEnv`, and
+ * `Uint8Array` / `ArrayBuffer` (or an opaque shape) instead of `Buffer`.
+ */
+import { readdirSync, readFileSync, statSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+import { describe, it, expect } from 'vitest';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const srcRoot = join(here, '..', 'src');
+
+function walk(dir: string): string[] {
+  const out: string[] = [];
+  for (const entry of readdirSync(dir)) {
+    const full = join(dir, entry);
+    if (statSync(full).isDirectory()) {
+      out.push(...walk(full));
+    } else if (full.endsWith('.ts')) {
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+const BANNED = [/\bNodeJS\b/, /\bBuffer\b/];
+
+describe('dreamux-types carries no @types/node host globals', () => {
+  for (const file of walk(srcRoot)) {
+    it(`${file.slice(srcRoot.length + 1)} references no NodeJS./Buffer host type`, () => {
+      const text = readFileSync(file, 'utf8');
+      for (const pattern of BANNED) {
+        expect(pattern.test(text)).toBe(false);
+      }
+    });
+  }
+});

--- a/packages/dreamux-types/tests/root-exports.test.ts
+++ b/packages/dreamux-types/tests/root-exports.test.ts
@@ -1,0 +1,122 @@
+/**
+ * Root-export allowlist guard (issue #209 overexposure audit, section B).
+ *
+ * `@excitedjs/dreamux-types` publishes only its package root (the `exports` map
+ * exposes `.` → `dist/index.d.ts` and nothing deeper). So the set of names
+ * re-exported by `src/index.ts` IS the public API an external provider author
+ * can name. This test pins that set to an explicit allowlist so a later slice
+ * cannot casually widen the surface — adding a root export now requires updating
+ * this list, which is the deliberate review checkpoint.
+ *
+ * Helper shapes a provider only reaches contextually (e.g.
+ * `AgentRuntimeDiagnosticContext` — a param of the *required* `AgentRuntimeDiagnostic`
+ * methods, contextually inferred — `ChannelSender`, and the vestigial
+ * `AgentRuntimeResumeCapability` / `AgentRuntimeResumeCheckpoint`) stay
+ * `export`ed from their source module — the emitted `.d.ts` resolves them
+ * transitively — but are intentionally absent here. The expanded
+ * `tests/fixtures/external-provider.ts` proves this allowlist is *sufficient*:
+ * it implements the full provider surface (incl. diagnostics, the factory
+ * contract, and the optional channel tool/reply/react methods) importing from
+ * the root only. Note: params of *optional* interface methods (e.g.
+ * `ChannelToolCall` on `handleTool?`) are NOT contextually inferred under
+ * `strict`, so those stay root-exported.
+ */
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+import { describe, it, expect } from 'vitest';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const indexFile = join(here, '..', 'src', 'index.ts');
+
+/** The intended public root API. Keep sorted; grow only by deliberate review. */
+const ALLOWLIST = [
+  'AgentRuntime',
+  'AgentRuntimeBinCheck',
+  'AgentRuntimeCapabilities',
+  'AgentRuntimeContextSnapshot',
+  'AgentRuntimeCreateContext',
+  'AgentRuntimeDiagnostic',
+  'AgentRuntimeDiagnosticRunner',
+  'AgentRuntimeDoctorResult',
+  'AgentRuntimeIdentity',
+  'AgentRuntimeLastResult',
+  'AgentRuntimeMcpServer',
+  'AgentRuntimePathContext',
+  'AgentRuntimeProvider',
+  'AgentRuntimeProviderConfigReadContext',
+  'AgentRuntimeProviderDescriptor',
+  'AgentRuntimeProviderFactory',
+  'AgentRuntimeResumeInput',
+  'AgentRuntimeRole',
+  'AgentRuntimeSkillSource',
+  'AgentRuntimeStateCallbacks',
+  'AgentRuntimeStatus',
+  'AgentRuntimeSystemInput',
+  'AgentRuntimeTurnResult',
+  'BuiltinProviderRef',
+  'ChannelConfigContext',
+  'ChannelInboundEnvelope',
+  'ChannelMessageTargetCheck',
+  'ChannelProvider',
+  'ChannelProviderDescriptor',
+  'ChannelProviderFactory',
+  'ChannelReactInput',
+  'ChannelReplyInput',
+  'ChannelRoutes',
+  'ChannelSession',
+  'ChannelSessionCreateContext',
+  'ChannelTarget',
+  'ChannelToolCall',
+  'ChannelToolContext',
+  'ChannelToolDescriptor',
+  'ChannelToolListContext',
+  'CompletionDeliveryShape',
+  'CompletionEnvelope',
+  'DreamuxEnvironment',
+  'DreamuxLogger',
+  'InboundAttachment',
+  'InboundDeliveryHooks',
+  'InboundDeliveryResult',
+  'InboundTurnInput',
+  'NoticeInjectionResult',
+  'NpmProviderRef',
+  'ProviderDescriptor',
+  'ProviderFactory',
+  'ProviderFactoryContext',
+  'ProviderKind',
+  'ProviderRef',
+  'ProviderRefSource',
+  'TeamMateCompletionDeliveryResult',
+  'TurnSettledSignal',
+];
+
+/** Parse the names re-exported by every `export type { ... } from '...'` block. */
+function rootExportNames(): string[] {
+  const source = readFileSync(indexFile, 'utf8');
+  const names = new Set<string>();
+  const block = /export\s+type\s+\{([^}]*)\}\s+from/g;
+  let match: RegExpExecArray | null;
+  while ((match = block.exec(source)) !== null) {
+    for (const raw of match[1].split(',')) {
+      const name = raw.trim();
+      if (name !== '') names.add(name);
+    }
+  }
+  return [...names].sort();
+}
+
+describe('dreamux-types root export surface', () => {
+  it('matches the reviewed allowlist exactly (no casual widening)', () => {
+    expect(rootExportNames()).toEqual([...ALLOWLIST].sort());
+  });
+
+  it('re-exports only types (declaration-only: no value exports)', () => {
+    const source = readFileSync(indexFile, 'utf8');
+    // Every re-export block must be `export type {`, never a value `export {`.
+    expect(/\bexport\s+\{/.test(source.replace(/export\s+type\s+\{/g, ''))).toBe(
+      false,
+    );
+  });
+});

--- a/packages/dreamux/src/agent-runtime/types.ts
+++ b/packages/dreamux/src/agent-runtime/types.ts
@@ -56,8 +56,6 @@ export type {
   AgentRuntimeRole,
   AgentRuntimeSkillSource,
   CompletionDeliveryShape,
-  AgentRuntimeResumeCheckpoint,
-  AgentRuntimeResumeCapability,
   AgentRuntimeCapabilities,
   CompletionEnvelope,
   TeamMateCompletionDeliveryResult,
@@ -208,7 +206,7 @@ export interface AgentRuntimeProvider {
   readConfig?(
     rawConfig: Record<string, unknown>,
     context: AgentRuntimeProviderConfigReadContext,
-  ): DispatcherProviderConfig;
+  ): DispatcherProviderConfig | Promise<DispatcherProviderConfig>;
   /**
    * Self-reported doctor diagnostics. Optional: a provider with no diagnostic
    * surface (no bin, no internal state) may omit it; doctor then reports a

--- a/packages/dreamux/src/config/config.ts
+++ b/packages/dreamux/src/config/config.ts
@@ -287,7 +287,7 @@ async function readConfigFile(
     refs: agentProviderRefs(parsed),
     importModule: overrides.externalAgentRuntimeModuleImporter,
   });
-  return mergeWithDefaults(parsed, file, providerRegistry);
+  return await mergeWithDefaults(parsed, file, providerRegistry);
 }
 
 export async function assertNoLegacyTomlOnly(
@@ -337,18 +337,18 @@ function providerRegistryFor(overrides: ConfigPathOverrides): ProviderRegistry {
   return overrides.providerRegistry ?? createBuiltinProviderRegistry();
 }
 
-function mergeWithDefaults(
+async function mergeWithDefaults(
   raw: unknown,
   file: string,
   providerRegistry: ProviderRegistry,
-): DreamuxConfig {
+): Promise<DreamuxConfig> {
   if (!isPlainObject(raw)) {
     throw new Error(`dreamux config error in ${file}: top-level must be an object`);
   }
   rejectTopLevelCodex(raw, file);
   rejectUnknownKeys(raw, new Set(['agents', 'dispatchers']), file, '');
 
-  const agents = readAgents(raw['agents'], file, providerRegistry);
+  const agents = await readAgents(raw['agents'], file, providerRegistry);
   return {
     agents,
     dispatchers: readDispatchers(raw['dispatchers'], file, agents, providerRegistry),
@@ -383,11 +383,11 @@ function rejectTopLevelCodex(raw: Record<string, unknown>, file: string): void {
  * `agents`, a non-object entry, a missing/empty `id`, a duplicate `id`, or a
  * provider that is registered but not runnable each throws with the file named.
  */
-function readAgents(
+async function readAgents(
   rawAgents: unknown,
   file: string,
   providerRegistry: ProviderRegistry,
-): Record<string, ResolvedAgentConfig> {
+): Promise<Record<string, ResolvedAgentConfig>> {
   if (rawAgents === undefined) return {};
   if (!Array.isArray(rawAgents)) {
     throw new Error(
@@ -434,15 +434,19 @@ function readAgents(
           'agentRuntime provider before config validation.',
       );
     }
+    // A provider's `readConfig` may be sync or async (parity with
+    // `ChannelProvider.readConfig`); await covers both and preserves fail-loud —
+    // a thrown or rejected parse aborts config load.
+    const parsedConfig =
+      (await runtimeProvider.readConfig?.(rawConfig, {
+        providerRef: provider.ref,
+        agentId: id,
+        file,
+        prefix: `${prefix}config.`,
+      })) ?? rawConfig;
     out[id] = {
       provider: provider.ref,
-      config:
-        runtimeProvider.readConfig?.(rawConfig, {
-          providerRef: provider.ref,
-          agentId: id,
-          file,
-          prefix: `${prefix}config.`,
-        }) ?? rawConfig,
+      config: parsedConfig,
     };
   }
   return out;

--- a/packages/dreamux/tests/global-config.test.ts
+++ b/packages/dreamux/tests/global-config.test.ts
@@ -785,6 +785,81 @@ describe('global config (~/.dreamux/config.json)', () => {
     expect(providerRegistry.getImplementation(providerRef)).not.toBeUndefined();
   });
 
+  it('awaits an external runtime provider whose readConfig is async (#209 F4)', async () => {
+    const providerRef = 'npm:@example/dreamux-async-runtime#provider';
+    writeConfigObject(
+      testConfigFileObject({
+        agents: [
+          { id: 'flow', provider: providerRef, config: { provider_option: 'kept' } },
+        ],
+        dispatchers: [{ id: 'flow', agentRuntime: 'flow' }],
+      }),
+    );
+
+    // Agent-runtime readConfig is now sync-or-async (parity with
+    // ChannelProvider.readConfig); core awaits the result at config load.
+    const asyncFactory: ExternalAgentRuntimeProviderFactory = ({
+      ref,
+      descriptor,
+    }) => ({
+      ref,
+      descriptor,
+      getCapabilities: () => EXTERNAL_RUNTIME_CAPABILITIES,
+      async readConfig(rawConfig) {
+        await Promise.resolve();
+        return { ...rawConfig, parsed_async: true };
+      },
+      createRuntime() {
+        throw new Error('async runtime config test does not create a runtime');
+      },
+    });
+
+    const { config } = await loadConfigWithBuiltins({
+      configDir,
+      externalAgentRuntimeModuleImporter: async () => ({ provider: asyncFactory }),
+    });
+
+    expect(config.agents['flow']).toEqual({
+      provider: providerRef,
+      config: { provider_option: 'kept', parsed_async: true },
+    });
+  });
+
+  it('fails loud when an external runtime async readConfig rejects (#209 F4)', async () => {
+    const providerRef = 'npm:@example/dreamux-bad-runtime#provider';
+    writeConfigObject(
+      testConfigFileObject({
+        agents: [{ id: 'flow', provider: providerRef, config: {} }],
+        dispatchers: [{ id: 'flow', agentRuntime: 'flow' }],
+      }),
+    );
+
+    const rejectingFactory: ExternalAgentRuntimeProviderFactory = ({
+      ref,
+      descriptor,
+    }) => ({
+      ref,
+      descriptor,
+      getCapabilities: () => EXTERNAL_RUNTIME_CAPABILITIES,
+      async readConfig() {
+        await Promise.resolve();
+        throw new Error('async config validation failed: bad flow');
+      },
+      createRuntime() {
+        throw new Error('rejecting runtime config test does not create a runtime');
+      },
+    });
+
+    await expect(
+      loadConfigWithBuiltins({
+        configDir,
+        externalAgentRuntimeModuleImporter: async () => ({
+          provider: rejectingFactory,
+        }),
+      }),
+    ).rejects.toThrow(/async config validation failed: bad flow/);
+  });
+
   it('fails loudly when an external npm runtime package cannot be imported', async () => {
     writeConfigObject(
       testConfigFileObject({


### PR DESCRIPTION
## 背景

针对 issue #209 的一轮独立 `@excitedjs/dreamux-types` 公共类型 API 审计（含 seed 的过度暴露审计）。本 PR 修复公共契约，并保持该包**仅声明、零依赖**。基线分支 `feature/i209-npm-package-split`。**请勿自行合并。**

## 修复项

**P0 — 移除 `@types/node` 宿主全局**
- `AgentRuntimeDiagnosticRunner` 的 `options.env` 与 `AgentRuntimeDiagnosticContext.env` 改用包自有的 `DreamuxEnvironment`（`Record<string, string | undefined>`），不再出现 `NodeJS.ProcessEnv`。
- 新增 `tests/no-host-types.test.ts`：扫描 `src/**`，禁止 `NodeJS.`/`Buffer` 重新出现（连注释文本都不允许，保证守卫无歧义）。

**P1 — 发布 provider 工厂契约**
- 新增 `ProviderFactoryContext<TDescriptor>` / `ProviderFactory<TProvider, TDescriptor>`，以及按 kind 收窄的别名 `AgentRuntimeProviderFactory` / `ChannelProviderFactory`。
- codex / claude-code / feishu-channel 三个内置包的默认导出改为针对该公共契约定型；各包对 seed descriptor 做校验+收窄（`asAgentRuntimeDescriptor` / 直接使用窄类型），无需 cast。`Codex/ClaudeCodeProviderFactoryContext` 保留为公共类型的向后兼容别名。
- 外部 provider fixture 扩写为完整 provider（含 diagnostics、工厂、channel 的 reply/react/tools/handleTool/messageBelongsToTarget、completionInput），仅从包根导入。

**P2 — descriptor.kind 收窄**
- 新增 `AgentRuntimeProviderDescriptor`（`kind: 'agentRuntime'`）与 `ChannelProviderDescriptor`（`kind: 'channel'`）；`AgentRuntimeProvider.descriptor` 收窄到 agentRuntime，channel 维持收窄。fixture 测试断言 runtime=`agentRuntime`、channel=`channel`，并覆盖工厂回显 descriptor。

**公共措辞清理**
- `channel.ts` 头注释删去 “generic Channel MCP shim” 的过期表述（PR #221 之后已无通用 Channel MCP）；改述为 “绑定是核心 Team-MCP 能力”。

**F4 — readConfig 异步化（低风险，已实现）**
- `AgentRuntimeProvider.readConfig` 现允许返回 `TConfig | Promise<TConfig>`（与 `ChannelProvider.readConfig` 对齐）。核心 `config.ts` 的 `readAgents`/`mergeWithDefaults` 改为 `async` 并 `await`，fail-loud 保持（抛出/reject 即中止加载）。新增异步成功 + 异步 reject 两条用例。
- 范围确认：核心唯一消费 agent-runtime `readConfig` 结果的点是 `config.ts`；`doctor` 消费的是已解析后的 config，无同步消费者破坏。channel 侧仍显式拒绝异步（本期范围外，已在 PR 描述指出该不对称）。

**F5–F8 — TSDoc 澄清**
- `steer` 为纯行为（无独立 API）；`getLast`/`getContext` 不支持时返回 `null`（不抛/不挂起）；`completionInput?` 以方法存在性 feature-detect（核心实际按方法存在性而非 capability 数组判断——已据实改写，未虚构核心行为）；`AgentRuntimeSkillSource.layout` 为开放字符串并记录标准布局 `skill-dir`/`claude-skills-parent`；`mcpServers` 由 launcher 注入、空数组=无 MCP、provider 不得推断/改写。

## 过度暴露 / root-export 最小化（已检查）

> 应要求明确说明：本 PR 已做 API 过度暴露检查。

`exports` 仅发布包根，因此 `src/index.ts` 的 re-export 集合**即**公共 API。结论是按“编译器即裁判”逐项验证（`tsc -p tsconfig.tests.json` + 全仓 `rush build`），而非机械删除：

**已 de-root-export（4 项，安全且有据）**
- `AgentRuntimeDiagnosticContext` — `AgentRuntimeDiagnostic` 的**必选**方法参数，对象字面量/类实现均可上下文推断；且核心自有宿主变体，仓内无根导入。
- `AgentRuntimeResumeCapability` / `AgentRuntimeResumeCheckpoint` — 仅嵌套于 capabilities，核心 `types.ts` 的 re-export 为无消费者的残留，已一并清理。
- `ChannelSender` — 仅作为 `ChannelInboundEnvelope.sender` 的数据字段，构造时字面量上下文推断。

**有据保留（关键决策）**
- `ProviderRef`/`NpmProviderRef`/`BuiltinProviderRef`/`ProviderRefSource`/`ProviderKind`：核心 `registry.ts`/`provider-ref.ts` 从包根 re-export 供大量仓内引用，`exports` 无子路径，必须保留在根。
- `AgentRuntimeDiagnosticRunner`/`AgentRuntimeBinCheck`/`AgentRuntimeDoctorResult`：核心宿主 `AgentRuntimeDiagnostic` 按名引用（前两者为 provider 构造的返回值）。
- `CompletionDeliveryShape`：核心 `external-provider.ts` 按名做契约校验。
- `InboundAttachment`：是公共 `InboundTurnInput.attachments` 的属性类型，且前瞻性已在 TSDoc 标注。
- `ChannelToolCall`/`ChannelToolContext`/`ChannelToolListContext`/`ChannelMessageTargetCheck`：**可选**接口方法的参数。实测表明 `strict` 下可选方法参数**不会**被上下文推断（feishu 的 `handleTool?` 实现即触发 implicit-any），故外部作者实现这些可选方法时需按名标注 → 保留为根导出。
- `DreamuxEnvironment`：P0 引入的“官方中立 env 形状”，供编写 diagnostics 的作者命名使用。

**守卫**：新增 `tests/root-exports.test.ts`，把根导出集合钉死为显式 allowlist（后续切片只能经评审显式扩面）；扩写后的 fixture 仅从根导入即可实现完整 provider，证明 allowlist **充分**。

## 约束遵守
- `@excitedjs/dreamux-types` 仍仅声明、零依赖；provider/类型包不 import `@excitedjs/dreamux`（import-boundary 测试保障）。
- 未新增运行时 JS 表面。公共安全：无内部 ID/私有链接/密钥/私有 registry。文档/注释英文。

## 验证
- `rush build` ✅（7/7）、`rush lint` ✅、`rush test`（`DREAMUX_SKIP_LIVE_CODEX=1`）✅。
- `dreamux-types`：`tsc -p tsconfig.json` + `tsconfig.tests.json` ✅；vitest 24/24 ✅。
- 核心 `global-config.test.ts` 56/56 ✅（含两条新增 F4 用例）。
- `.agents/scripts/check.sh` ✅（KB OK, 34 文件可达）。
- `rush change --verify --target-branch origin/feature/i209-npm-package-split` ✅（5 个变更文件齐全）。
- 提交通过 gitleaks pre-commit（no leaks）。

## 残留风险 / 留待后续
- channel `readConfig` 异步对称性：核心仍显式拒绝异步 channel `readConfig`（本期范围外，仅做了 agent-runtime 侧的异步对齐，已在上文指出该不对称）。
- root-export 最小化偏保守：受核心 re-export 层（registry/provider-ref/types.ts 从包根 re-export 以保仓内稳定）约束，进一步收窄需较大且有风险的核心重构，本 PR 不纳入；allowlist 守卫已确保表面不会无意增长。