### PR TITLE
feat(channel): 实时多通道运行时路由 (#209)

### DIFF
--- a/.agents/decisions/npm-package-split-and-channel-targets.md
+++ b/.agents/decisions/npm-package-split-and-channel-targets.md
@@ -30,9 +30,11 @@ the implementation is still mostly host-local:
   `dispatchers[].channels[]` envelope. Since the multi-channel config slice
   (#209) it accepts multiple channels with unique dispatcher-local ids and
   delegates provider-specific validation to each channel provider's `readConfig`
-  (no Feishu-specific checks in core). Live multi-channel routing is still a
-  follow-up: a runnable dispatcher must declare exactly one `builtin:feishu`
-  channel (fail-loud at server start otherwise).
+  (no Feishu-specific checks in core). Live multi-channel routing has landed: a
+  runnable dispatcher MAY declare more than one `builtin:feishu` channel — the
+  dispatcher service runs one live session per channel, each connecting as its
+  own bot — and only a channel naming an unwired (non-feishu) provider fails loud
+  at server start. See "Live multi-channel routing" below.
 - `/packages/dreamux/src/dispatcher-service/channel-binding/store.ts` stores
   version 1 rows keyed by `(provider, chat_id)`, which cannot distinguish
   multiple channel instances or non-chat channel targets.
@@ -796,15 +798,13 @@ These guards are epic-wide; they land across the issue #209 slices. Status:
   phase, like agent runtimes). External `npm:` channel providers are not loaded at
   config time yet (`readConfigFile` loads only external agent-runtime refs); an
   `npm:` channel ref fails loud as an unloaded external provider until a generic
-  channel loader lands. This is the config-layer half of the channel work: **live
-  multi-channel routing is deferred** — a runnable dispatcher must declare exactly
-  one `builtin:feishu` channel, enforced fail-loud at the **dispatcher runtime
-  boundary** (`assertRunnableChannelShape` in the dispatcher service launch guard
-  rejects more than one channel or a non-feishu channel; state seeding stays
-  fail-soft so this is the one intended place that rejects an unrunnable shape)
-  rather than at config load, so config can express the general shape while the
-  runtime catches up. Binding store v2 and target-key routing remain later
-  slices; the Channel MCP *surface* move landed in the next slice (below).
+  channel loader lands. This is the config-layer half of the channel work; **live
+  multi-channel routing has since landed** (see "Live multi-channel routing"
+  below). The dispatcher runtime boundary (`assertRunnableChannelShape`) now only
+  rejects a channel naming an unwired (non-feishu) provider; state seeding stays
+  fail-soft so this is the one intended place that rejects an unrunnable shape.
+  Binding store v2 and target-key routing remain later slices; the Channel MCP
+  *surface* move landed in the next slice (below).
 - **Channel MCP surface move — SUPERSEDED by the owner scope correction below.**
   An interim slice moved the binding verbs off Team MCP onto a separate
   core-hosted generic `channel` MCP server (the `channel-mcp` shim,
@@ -833,15 +833,16 @@ These guards are epic-wide; they land across the issue #209 slices. Status:
   target routes to its TeamLeader; an unbound bindable target and any non-bindable
   (P2P) target route to the dispatcher; a P2P target short-circuits to the
   dispatcher BEFORE any binding lookup and can never be bound to a TeamLeader.
-  `channel_id` is the dispatcher-local `dispatchers[].channels[].id`, resolved
-  once by `dispatcherChannelId(config)` — the single source of truth shared by the
-  bind path and the router so a stored binding and an inbound message resolve to
-  the same key. The `bind_channel` / `transfer_back` tools (on the **Team MCP** —
-  see the reversal below) take a provider selector `meta` (Feishu: `{ chat_id }`)
-  and an optional `channel_id` (defaults to the sole configured channel; an
-  explicit id must match it). A pre-v2 store fails loud at `dreamux serve` /
-  `dreamux doctor` (and on access) with rebuild guidance — Dreamux 0.x does not
-  migrate it.
+  `channel_id` is the dispatcher-local `dispatchers[].channels[].id`. For inbound
+  it is the channel the message arrived through (the originating live session tags
+  it — see "Live multi-channel routing" below); for the bind path it is the
+  `channel_id` arg (a single-channel dispatcher defaults to its sole channel). The
+  `bind_channel` / `transfer_back` tools (on the **Team MCP** — see the reversal
+  below) take a provider selector `meta` (Feishu: `{ chat_id }`) and an optional
+  `channel_id` (defaults to the sole configured channel; required when more than
+  one is configured; an explicit id must name a configured channel). A pre-v2
+  store fails loud at `dreamux serve` / `dreamux doctor` (and on access) with
+  rebuild guidance — Dreamux 0.x does not migrate it.
 - **Final hardening (package-boundary guards) — satisfied now:** the
   remaining §Validation Guards that were only "currently true" by inspection now
   have repo-wide regression tests (`packages/dreamux/tests/package-boundary-guards.test.ts`):
@@ -888,14 +889,28 @@ These guards are epic-wide; they land across the issue #209 slices. Status:
   engines read the same physical skills; ordinary teammate/team_member roles still
   receive none; no workspace mutation and no symlink/copy model. Runtime packages
   still depend on `@excitedjs/dreamux-types` only.
-- **Deferred — accepted follow-up (NOT part of this epic's shipped scope): live
-  multi-channel runtime routing.** Config validation already accepts N channels
-  with unique ids and provider-owned `readConfig`, but the *runtime* runs exactly
-  one `builtin:feishu` channel per dispatcher and fails loud on any other shape at
-  the dispatcher launch guard (`assertRunnableChannelShape`). Running N sessions
-  and routing inbound across them by `channel_id` is a multi-session feature
-  accepted by the owner as a follow-up; the config-layer task is done. Where this
-  is currently unsupported it fails loud rather than silently degrading.
+- **Live multi-channel routing — satisfied now:** a dispatcher may declare more
+  than one `builtin:feishu` channel and the dispatcher service runs one live
+  session per channel, each connecting as its OWN bot from that channel's config
+  `{ app_id, app_secret }` (the state row keeps the PRIMARY/first channel's bot
+  identity; per-channel state/access dirs stay shared per-dispatcher). The slot
+  holds `channels: Map<channel_id, session>`. Each session tags its own
+  `channel_id` onto every inbound turn it delivers, so `routeChannelInput` keys the
+  `(channel_id, target_key)` binding lookup on the channel the message ACTUALLY
+  arrived through — not a single config-derived channel. Egress (the Feishu
+  `reply` / `react` MCP tools) dispatches to a session by `channel_id`: a
+  TeamLeader's reply egresses the bot of the channel its OWN active binding names
+  (resolved by `TeamService.resolveLeaderChannel` by `target_key` across the
+  dispatcher's channels), and a dispatcher reply omits it to use the primary
+  channel. `assertRunnableChannelShape` now rejects only an unwired (non-feishu)
+  channel; `bind_channel` requires an explicit `channel_id` when more than one is
+  configured. Legacy single-channel dispatchers are unchanged (the sole channel
+  resolves exactly as before). **Deferred edges (documented, not shipped):** a
+  dispatcher-initiated reply to a NON-primary channel needs an explicit
+  `channel_id` (the dispatcher prompt teaching it is a follow-up); cross-dispatcher
+  Feishu `bot_app_id` uniqueness covers only the primary channel; and a second
+  channel provider kind (beyond `builtin:feishu`) is still not wired (the generic
+  channel loader / ACP adapter remain out of scope).
 
 ## Alternatives Considered
 

--- a/common/changes/@excitedjs/dreamux/i209-live-multi-channel-routing_2026-06-14-18-00.json
+++ b/common/changes/@excitedjs/dreamux/i209-live-multi-channel-routing_2026-06-14-18-00.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Live multi-channel runtime routing (issue #209). A dispatcher may now declare more than one builtin:feishu channel; the dispatcher service runs one live session per channel, each connecting as its own bot from that channel's config {app_id, app_secret}. Inbound events route by the originating channel's channel_id plus the provider-resolved target — `(channel_id, target_key)` — so a message arriving on a secondary channel keys its binding under that channel. Outbound reply/react dispatch to a session by channel_id: a TeamLeader's reply egresses the bot of the channel its active binding names; a dispatcher reply uses the primary (first) channel. The dispatcher launch guard (assertRunnableChannelShape) now rejects only a channel naming an unwired (non-feishu) provider, not a >1 channel count; `bind_channel` requires an explicit channel_id when more than one channel is configured. The state row keeps the PRIMARY channel's bot identity. Single-channel dispatchers are unchanged. No config/state schema or path change and no operator action required. Not covered this slice: a dispatcher-initiated reply to a non-primary channel needs an explicit channel_id; cross-dispatcher bot_app_id uniqueness covers only the primary channel; non-feishu channel providers remain unwired.",
+      "type": "minor",
+      "packageName": "@excitedjs/dreamux"
+    }
+  ],
+  "packageName": "@excitedjs/dreamux",
+  "email": "053700@gmail.com"
+}

--- a/packages/dreamux/src/admin/methods.ts
+++ b/packages/dreamux/src/admin/methods.ts
@@ -90,12 +90,13 @@ export const adminMethods: Record<string, AdminHandler> = {
     const id = mustDispatcherId(params);
     mustExistingDispatcher(server, id);
     mustRunningDispatcher(server, id);
-    await assertFeishuScope(server, id, params);
+    const channelId = await assertFeishuScope(server, id, params);
     try {
       return await server.dispatcherService.callFeishuMcpTool({
         dispatcherId: id,
         toolName: 'reply',
         arguments: params ?? {},
+        ...(channelId !== undefined ? { channelId } : {}),
       });
     } catch (err) {
       throw new AdminError('OUTBOUND_FAILED', parseMessage(err));
@@ -106,12 +107,13 @@ export const adminMethods: Record<string, AdminHandler> = {
     const id = mustDispatcherId(params);
     mustExistingDispatcher(server, id);
     mustRunningDispatcher(server, id);
-    await assertFeishuScope(server, id, params);
+    const channelId = await assertFeishuScope(server, id, params);
     try {
       return await server.dispatcherService.callFeishuMcpTool({
         dispatcherId: id,
         toolName: 'react',
         arguments: params ?? {},
+        ...(channelId !== undefined ? { channelId } : {}),
       });
     } catch (err) {
       throw new AdminError('REACTION_FAILED', parseMessage(err));
@@ -382,13 +384,21 @@ export const adminMethods: Record<string, AdminHandler> = {
   },
 };
 
+/**
+ * Authorize a Feishu egress (reply/react) and resolve which channel it leaves
+ * through. A dispatcher caller egresses the primary channel (returns undefined →
+ * the default). A TeamLeader may only act on a chat it is bound to, and its reply
+ * egresses the bound channel's bot — resolved here from the leader's own active
+ * binding (issue #209 live multi-channel routing) and returned so the tool call
+ * targets that channel.
+ */
 async function assertFeishuScope(
   server: Server,
   dispatcherId: string,
   params: Record<string, unknown> | undefined,
-): Promise<void> {
+): Promise<string | undefined> {
   const caller = callerPrincipal(dispatcherId, params);
-  if (caller.kind !== 'team_leader') return;
+  if (caller.kind !== 'team_leader') return undefined;
   const chatId = optionalString(params, 'chat_id');
   if (chatId === null) {
     throw new AdminError(
@@ -410,18 +420,20 @@ async function assertFeishuScope(
       'TeamLeader may react/reply only to messages observed in bound team channels',
     );
   }
-  const allowed = await server.dispatcherService.teamLeaderCanUseChannel({
-    dispatcherId,
-    teamId: caller.teamId,
-    leaderName: caller.leaderName,
-    chatId,
-  });
+  const { allowed, channelId } =
+    await server.dispatcherService.teamLeaderCanUseChannel({
+      dispatcherId,
+      teamId: caller.teamId,
+      leaderName: caller.leaderName,
+      chatId,
+    });
   if (!allowed) {
     throw new AdminError(
       'CHANNEL_SCOPE_DENIED',
       'TeamLeader may use Feishu only for bound team channels',
     );
   }
+  return channelId ?? undefined;
 }
 
 function callerPrincipal(

--- a/packages/dreamux/src/channel/feishu/feishu-channel.ts
+++ b/packages/dreamux/src/channel/feishu/feishu-channel.ts
@@ -53,24 +53,36 @@ export interface CreateFeishuChannelSessionHostOptions {
   log: DreamuxLogger;
   botFactory?: (row: DispatcherRow, secret: string) => FeishuBot;
   skipBotSecret?: boolean;
+  /**
+   * Per-channel bot identity (issue #209 live multi-channel routing). When set,
+   * the session connects as THIS channel's bot instead of the dispatcher row's
+   * single bot, so a dispatcher can run one session per configured Feishu
+   * channel. Omitted for the legacy single-channel path, where the row's
+   * `bot_app_id` / `bot_secret_ref` (which the sole channel seeds) is identical.
+   */
+  channel?: { appId: string; appSecret: string };
 }
 
 /**
  * Construct the package Feishu session from host inputs: resolve the bot secret
- * + app id from the dispatcher row/config, and supply the host state/cache dirs.
- * The `(row, secret)` bot-factory test seam is wrapped into the package's neutral
- * `() => FeishuBot` factory.
+ * + app id from the per-channel config (live multi-channel) or the dispatcher
+ * row/config (legacy single-channel), and supply the host state/cache dirs. The
+ * `(row, secret)` bot-factory test seam is wrapped into the package's neutral
+ * `() => FeishuBot` factory. State and attachment-cache dirs stay per-dispatcher
+ * (one trust/access policy per dispatcher), shared across its channels.
  */
 export function createFeishuChannelSession(
   opts: CreateFeishuChannelSessionHostOptions,
 ): FeishuChannelSession {
+  const appId = opts.channel?.appId ?? opts.row.bot_app_id;
   const secret =
     opts.skipBotSecret === true
       ? ''
-      : resolveBotSecret(opts.row.bot_secret_ref, opts.config);
+      : (opts.channel?.appSecret ??
+        resolveBotSecret(opts.row.bot_secret_ref, opts.config));
   return new FeishuChannelSession({
     dispatcherId: opts.dispatcherId,
-    appId: opts.row.bot_app_id,
+    appId,
     appSecret: secret,
     stateDir: dispatcherDir(opts.dispatcherId),
     attachmentCacheDir: dispatcherFeishuAttachmentCacheDir(opts.dispatcherId),

--- a/packages/dreamux/src/config/config.ts
+++ b/packages/dreamux/src/config/config.ts
@@ -707,17 +707,19 @@ export function dispatcherFeishuConfig(
 }
 
 /**
- * Best-effort Feishu bot app id for a dispatcher's state row. Returns the sole
- * Feishu channel's `app_id`, or `''` when the dispatcher has an ambiguous (≠1)
- * Feishu channel count. Such a dispatcher is not runnable (the dispatcher
- * service launch guard rejects it), so this placeholder is never used for live
- * routing; it keeps store seeding fail-soft so the unrunnable shape fails at the
- * one intended runtime boundary instead of during state construction.
+ * The Feishu bot app id for a dispatcher's state row: its PRIMARY (first) Feishu
+ * channel's `app_id`, or `''` when the dispatcher declares no Feishu channel.
+ * With live multi-channel routing each channel connects as its own bot, so the
+ * row's single identity is the primary one; the cross-dispatcher uniqueness check
+ * (`assertUniqueFeishuAppIds`) and the store's per-row uniqueness guard both key
+ * on this primary id (a secondary channel's bot identity is out of scope for that
+ * uniqueness check). For a single-channel dispatcher this is the sole channel,
+ * unchanged.
  */
 export function dispatcherFeishuAppId(
   dispatcher: Pick<DispatcherConfig, 'channels'>,
 ): string {
-  return soleFeishuConfigFromChannels(dispatcher.channels)?.app_id ?? '';
+  return dispatcherFeishuChannels(dispatcher)[0]?.config.app_id ?? '';
 }
 
 /**
@@ -737,6 +739,29 @@ export function dispatcherChannelId(
     (item) => item.provider === BUILTIN_FEISHU_PROVIDER_REF,
   );
   return feishuChannels.length === 1 ? feishuChannels[0]!.id : null;
+}
+
+/**
+ * Every Feishu channel a dispatcher declares, as `(channel_id, { app_id,
+ * app_secret })` (issue #209 live multi-channel routing). Each channel carries
+ * its own bot identity in its config block — the provider's `readConfig`
+ * validated `app_id` / `app_secret` are non-empty at load — so a dispatcher can
+ * run more than one Feishu bot at once, each keyed by its dispatcher-local
+ * `channels[].id`. For a single-channel dispatcher this is the same sole channel
+ * {@link dispatcherChannelId} / {@link dispatcherFeishuAppId} resolve, so legacy
+ * routing is unchanged. Order follows declaration order; the first is the
+ * dispatcher's primary channel (the default egress channel and the bot identity
+ * the state row seeds).
+ */
+export function dispatcherFeishuChannels(
+  dispatcher: Pick<DispatcherConfig, 'channels'>,
+): Array<{ channelId: string; config: DispatcherFeishuConfig }> {
+  return dispatcher.channels
+    .filter((item) => item.provider === BUILTIN_FEISHU_PROVIDER_REF)
+    .map((item) => ({
+      channelId: item.id,
+      config: item.config as unknown as DispatcherFeishuConfig,
+    }));
 }
 
 /**

--- a/packages/dreamux/src/dispatcher-service/dispatcher/runnable-channel.ts
+++ b/packages/dreamux/src/dispatcher-service/dispatcher/runnable-channel.ts
@@ -2,9 +2,11 @@
  * The runnable-channel-shape guard (issue #209 multi-channel config).
  *
  * Config accepts the general multi-channel shape (`dispatchers[].channels[]` may
- * hold more than one channel, and a channel may name any registered provider),
- * but live multi-channel routing is a follow-up slice. A *runnable* dispatcher
- * must therefore declare exactly one channel and it must be `builtin:feishu`.
+ * hold more than one channel, and a channel may name any registered provider).
+ * Live multi-channel routing now runs one Feishu session per channel, so a
+ * runnable dispatcher MAY declare more than one channel — but every channel must
+ * be `builtin:feishu`, the only provider wired into the dispatcher service in
+ * this phase. A channel naming any other (not-yet-wired) provider fails loud here.
  *
  * This guard is the single intended runtime boundary where every "accepted by
  * config, not yet runnable" shape fails loud — state construction (the dispatcher
@@ -20,15 +22,12 @@ export function assertRunnableChannelShape(dispatcher: {
   channels: DispatcherChannelConfig[];
 }): void {
   const { id, channels } = dispatcher;
-  if (channels.length > 1) {
+  const unwired = channels.find(
+    (channel) => channel.provider !== BUILTIN_FEISHU_PROVIDER_REF,
+  );
+  if (unwired !== undefined) {
     throw new Error(
-      `dispatcher '${id}' declares ${channels.length} channels; live multi-channel routing is a follow-up slice, so a runnable dispatcher must declare exactly one ${BUILTIN_FEISHU_PROVIDER_REF} channel`,
-    );
-  }
-  const channelRef = channels[0]?.provider ?? BUILTIN_FEISHU_PROVIDER_REF;
-  if (channelRef !== BUILTIN_FEISHU_PROVIDER_REF) {
-    throw new Error(
-      `dispatcher '${id}' channel ${JSON.stringify(channelRef)} is not wired; only ${BUILTIN_FEISHU_PROVIDER_REF} is built in this phase`,
+      `dispatcher '${id}' channel ${JSON.stringify(unwired.provider)} is not wired; only ${BUILTIN_FEISHU_PROVIDER_REF} is built in this phase`,
     );
   }
 }

--- a/packages/dreamux/src/dispatcher-service/dispatcher/service.ts
+++ b/packages/dreamux/src/dispatcher-service/dispatcher/service.ts
@@ -21,6 +21,7 @@ import {
 } from '../../channel/feishu/feishu-mcp-surface.js';
 import {
   BUILTIN_CODEX_PROVIDER_REF,
+  dispatcherFeishuChannels,
   type DreamuxConfig,
 } from '../../config/config.js';
 import { assertRunnableChannelShape } from './runnable-channel.js';
@@ -54,6 +55,7 @@ export interface DispatcherAgentServiceOptions {
   log: DreamuxLogger;
   routeChannelInput?: (
     dispatcherId: string,
+    channelId: string,
     input: import('../../agent-runtime/turn.js').InboundTurnInput,
     envelope: FeishuInboundEnvelope,
     hooks?: import('../../agent-runtime/turn.js').InboundDeliveryHooks,
@@ -63,7 +65,13 @@ export interface DispatcherAgentServiceOptions {
 export interface DispatcherAgentSlot {
   row: DispatcherRow;
   runtime: AgentRuntime;
-  channel: FeishuChannelSession;
+  /**
+   * Live channel sessions keyed by dispatcher-local `channel_id` (issue #209
+   * live multi-channel routing). A single-channel dispatcher holds one entry;
+   * iteration order follows channel declaration order, so the first is the
+   * primary (default egress) channel.
+   */
+  channels: Map<string, FeishuChannelSession>;
   log: DreamuxLogger;
 }
 
@@ -79,6 +87,13 @@ export interface FeishuChannelToolCall {
   dispatcherId: string;
   toolName: FeishuMcpToolName;
   arguments: unknown;
+  /**
+   * Which channel's bot the egress (reply/react) leaves through (issue #209 live
+   * multi-channel routing). Omitted → the dispatcher's primary (first) channel,
+   * so a single-channel dispatcher is unchanged. A TeamLeader's reply carries the
+   * channel resolved from its active binding so it always egresses the bound bot.
+   */
+  channelId?: string;
 }
 
 const COMPLETION_DELIVERY_CACHE_LIMIT = 512;
@@ -119,10 +134,15 @@ export class DispatcherAgentService {
   async stopDispatcher(id: string): Promise<void> {
     const slot = this.slots.get(id);
     if (slot === undefined) return;
-    try {
-      await slot.channel.close();
-    } catch (err) {
-      slot.log.error({ dispatcher_id: id, err: errInfo(err) }, 'error closing bot');
+    for (const [channelId, session] of slot.channels) {
+      try {
+        await session.close();
+      } catch (err) {
+        slot.log.error(
+          { dispatcher_id: id, channel_id: channelId, err: errInfo(err) },
+          'error closing bot',
+        );
+      }
     }
     try {
       await slot.runtime.stop();
@@ -248,7 +268,10 @@ export class DispatcherAgentService {
       return handleFeishuListChatBots(input.dispatcherId, input.arguments);
     }
     const slot = this.mustRunningSlot(input.dispatcherId);
-    return slot.channel.handleMcpTool(input.toolName, input.arguments);
+    return this.sessionFor(slot, input.channelId).handleMcpTool(
+      input.toolName,
+      input.arguments,
+    );
   }
 
   feishuMessageBelongsToChat(
@@ -257,18 +280,61 @@ export class DispatcherAgentService {
     chatId: string,
   ): boolean {
     const slot = this.slots.get(dispatcherId);
-    return slot?.channel.messageBelongsToChat(messageId, chatId) ?? false;
+    if (slot === undefined) return false;
+    // A message belongs to the chat if ANY live channel session observed it; a
+    // dispatcher's bots see disjoint chats, so this stays unambiguous.
+    for (const session of slot.channels.values()) {
+      if (session.messageBelongsToChat(messageId, chatId)) return true;
+    }
+    return false;
+  }
+
+  /**
+   * Pick the channel session egress/target resolution runs through. A known
+   * `channelId` selects that channel's bot; otherwise the primary (first) channel
+   * — so single-channel dispatchers are unchanged. Fails loud if a requested
+   * channel is not live.
+   */
+  private sessionFor(
+    slot: DispatcherAgentSlot,
+    channelId?: string,
+  ): FeishuChannelSession {
+    if (channelId !== undefined) {
+      const session = slot.channels.get(channelId);
+      if (session === undefined) {
+        throw new Error(
+          `dispatcher '${slot.row.dispatcher_id}' has no live channel '${channelId}'`,
+        );
+      }
+      return session;
+    }
+    const first = slot.channels.values().next().value;
+    if (first === undefined) {
+      throw new Error(
+        `dispatcher '${slot.row.dispatcher_id}' has no live channel session`,
+      );
+    }
+    return first;
   }
 
   /**
    * Resolve a provider selector to a neutral `ChannelTarget` via the live channel
    * session (issue #209 binding store v2). Target resolution is provider-owned;
    * core calls it here for both binding and inbound routing so `target_key` stays
-   * opaque to core. Requires a running dispatcher — both call paths (the bind
-   * tool, the inbound router) run only while the channel session is live.
+   * opaque to core. The originating/selected `channelId` picks the session (live
+   * multi-channel); omitted resolves through the primary channel. Requires a
+   * running dispatcher — both call paths (the bind tool, the inbound router) run
+   * only while a channel session is live.
    */
-  resolveChannelTarget(dispatcherId: string, meta: unknown): ChannelTarget {
-    return this.mustRunningSlot(dispatcherId).channel.resolveTarget(meta);
+  resolveChannelTarget(
+    dispatcherId: string,
+    meta: unknown,
+    channelId?: string,
+  ): ChannelTarget {
+    return this.sessionFor(
+      this.mustRunningSlot(dispatcherId),
+      channelId,
+    ).resolveTarget(meta);
   }
 
   async shutdown(): Promise<void> {
@@ -285,11 +351,11 @@ export class DispatcherAgentService {
     const dispatcherConfig = this.opts.config.dispatchers.find(
       (dispatcher) => dispatcher.id === id,
     );
-    // Config accepts the general multi-channel shape (issue #209), but live
-    // routing is a follow-up slice: fail loud here — the one intended runtime
-    // boundary — for any not-yet-runnable shape rather than silently wiring only
-    // the first channel. State seeding stays fail-soft so this is the only place
-    // that rejects it.
+    // Config accepts the general multi-channel shape (issue #209). Live routing
+    // now runs one Feishu session per channel; this guard stays the single
+    // runtime boundary that fails loud on a not-yet-runnable shape (a channel
+    // naming an unwired provider). State seeding stays fail-soft so this is the
+    // only place that rejects it.
     if (dispatcherConfig !== undefined) {
       assertRunnableChannelShape(dispatcherConfig);
     }
@@ -303,18 +369,6 @@ export class DispatcherAgentService {
     // and keeps the launch path self-validating.
     const cwd = await ensureDispatcherWorkspace(this.opts.config, id);
     const channelLog = this.opts.channelLoggerFactory(id);
-    const channel = createFeishuChannelSession({
-      dispatcherId: id,
-      row,
-      config: this.opts.config,
-      log: channelLog,
-      ...(this.opts.botFactory !== undefined
-        ? { botFactory: this.opts.botFactory }
-        : {}),
-      ...(this.opts.skipBotSecret !== undefined
-        ? { skipBotSecret: this.opts.skipBotSecret }
-        : {}),
-    });
     // The dispatcher prompt is runtime-injected via the runtime's systemPrompt
     // capability. 'replace' runtimes (codex) consume the full prompt as their
     // base instructions; 'append' runtimes (claude-code) receive a focused
@@ -335,18 +389,63 @@ export class DispatcherAgentService {
       log: loggerToLevelFn(channelLog),
     });
 
+    // One live session per configured Feishu channel, each connecting as its own
+    // bot (issue #209 live multi-channel routing). A single-channel dispatcher
+    // gets one session, identical to before. The defensive no-config path keeps
+    // the legacy single row-bot session under the conventional 'primary' id.
+    const channelSpecs =
+      dispatcherConfig !== undefined
+        ? dispatcherFeishuChannels(dispatcherConfig)
+        : [];
+    const specs =
+      channelSpecs.length > 0
+        ? channelSpecs
+        : [{ channelId: 'primary', config: undefined }];
+    const channels = new Map<string, FeishuChannelSession>();
+
     try {
       await runtime.start();
-      await channel.start({
-        submitTurn: (turn, envelope, hooks) =>
-          this.opts.routeChannelInput?.(id, turn, envelope, hooks) ??
-          runtime.channelInput(turn, hooks),
-      });
+      for (const spec of specs) {
+        const session = createFeishuChannelSession({
+          dispatcherId: id,
+          row,
+          config: this.opts.config,
+          log: channelLog,
+          ...(spec.config !== undefined
+            ? {
+                channel: {
+                  appId: spec.config.app_id,
+                  appSecret: spec.config.app_secret,
+                },
+              }
+            : {}),
+          ...(this.opts.botFactory !== undefined
+            ? { botFactory: this.opts.botFactory }
+            : {}),
+          ...(this.opts.skipBotSecret !== undefined
+            ? { skipBotSecret: this.opts.skipBotSecret }
+            : {}),
+        });
+        const channelId = spec.channelId;
+        // Register before start so a session whose start() throws is still
+        // closed by the catch below (it would otherwise leak — not yet mapped).
+        channels.set(channelId, session);
+        // Each session tags its own channel_id onto every inbound turn it
+        // delivers, so the router keys on the channel the message actually
+        // arrived through rather than re-deriving a single channel from config.
+        await session.start({
+          submitTurn: (turn, envelope, hooks) =>
+            this.opts.routeChannelInput?.(id, channelId, turn, envelope, hooks) ??
+            runtime.channelInput(turn, hooks),
+        });
+      }
     } catch (err) {
-      try {
-        await channel.close();
-      } catch {
-        /* best effort */
+      for (const session of channels.values()) {
+        try {
+          await session.close();
+        } catch {
+          /* best effort */
+        }
       }
       try {
         await runtime.stop();
@@ -359,7 +458,7 @@ export class DispatcherAgentService {
     this.slots.set(id, {
       row,
       runtime,
-      channel,
+      channels,
       log: channelLog,
     });
     this.opts.log.info(

--- a/packages/dreamux/src/dispatcher-service/service.ts
+++ b/packages/dreamux/src/dispatcher-service/service.ts
@@ -6,7 +6,7 @@ import type {
 } from '../agent-runtime/index.js';
 import type { InboundDeliveryHooks, InboundTurnInput } from '../agent-runtime/turn.js';
 import type { FeishuInboundEnvelope } from '../channel/feishu/feishu-channel.js';
-import { dispatcherChannelId, type DreamuxConfig } from '../config/config.js';
+import { dispatcherFeishuChannels, type DreamuxConfig } from '../config/config.js';
 import type { DispatcherStore } from '../state/dispatcher-store.js';
 import type { DreamuxLogger } from '../platform/logger.js';
 import type { FeishuBot } from '../channel/feishu/bot.js';
@@ -75,8 +75,8 @@ export class DispatcherService {
       ...(opts.skipBotSecret !== undefined
         ? { skipBotSecret: opts.skipBotSecret }
         : {}),
-      routeChannelInput: (id, turn, envelope, hooks) =>
-        this.routeChannelInput(id, turn, envelope, hooks),
+      routeChannelInput: (id, channelId, turn, envelope, hooks) =>
+        this.routeChannelInput(id, channelId, turn, envelope, hooks),
     });
     this.teammates = new TeamMateAgentService({
       config: opts.config,
@@ -157,33 +157,56 @@ export class DispatcherService {
     const dispatcher = this.config.dispatchers.find(
       (entry) => entry.id === dispatcherId,
     );
-    const channelId = dispatcher ? dispatcherChannelId(dispatcher) : null;
-    if (channelId === null) {
+    const ids = dispatcher
+      ? dispatcherFeishuChannels(dispatcher).map((channel) => channel.channelId)
+      : [];
+    if (requested !== undefined) {
+      if (!ids.includes(requested)) {
+        throw new Error(
+          `unknown channel_id '${requested}' for dispatcher '${dispatcherId}'; ` +
+            `its configured channels are ${
+              ids.length > 0 ? ids.map((id) => `'${id}'`).join(', ') : '(none)'
+            }`,
+        );
+      }
+      return requested;
+    }
+    // No explicit channel: a single-channel dispatcher resolves unambiguously
+    // (legacy). With more than one channel the caller MUST name one, since
+    // binding/egress under the wrong channel would key the wrong target.
+    if (ids.length === 0) {
       throw new Error(
-        `dispatcher '${dispatcherId}' has no single resolvable channel`,
+        `dispatcher '${dispatcherId}' has no resolvable Feishu channel`,
       );
     }
-    if (requested !== undefined && requested !== channelId) {
+    if (ids.length > 1) {
       throw new Error(
-        `unknown channel_id '${requested}' for dispatcher '${dispatcherId}'; ` +
-          `its configured channel is '${channelId}'`,
+        `dispatcher '${dispatcherId}' has ${ids.length} channels; ` +
+          'channel_id is required to select one',
       );
     }
-    return channelId;
+    return ids[0]!;
   }
 
   async routeChannelInput(
     dispatcherId: string,
+    channelId: string,
     input: InboundTurnInput,
     envelope: FeishuInboundEnvelope,
     hooks?: InboundDeliveryHooks,
   ): Promise<AgentRuntimeTurnResult> {
-    const channelId = this.resolveChannelId(dispatcherId);
+    // `channelId` is the channel the message actually arrived through (the
+    // originating live session tags it), so a multi-channel dispatcher keys on
+    // the right channel rather than re-deriving a single one from config.
     // The channel owns target resolution; core routes by (channel_id, target_key).
-    const target = this.dispatchers.resolveChannelTarget(dispatcherId, {
-      chat_id: envelope.chatId,
-      chat_type: envelope.chatType,
-    });
+    const target = this.dispatchers.resolveChannelTarget(
+      dispatcherId,
+      {
+        chat_id: envelope.chatId,
+        chat_type: envelope.chatType,
+      },
+      channelId,
+    );
     // Only a bindable target (a group) can carry an active Team binding; a P2P
     // (non-bindable) target always routes to the dispatcher, never a TeamLeader.
     if (target.bindable) {
@@ -307,6 +330,7 @@ export class DispatcherService {
     const target = this.dispatchers.resolveChannelTarget(
       input.dispatcherId,
       input.meta,
+      channelId,
     );
     return this.teams.bindChannel({
       dispatcherId: input.dispatcherId,
@@ -326,6 +350,7 @@ export class DispatcherService {
     const target = this.dispatchers.resolveChannelTarget(
       input.dispatcherId,
       input.meta,
+      channelId,
     );
     return this.teams.transferChannelBack({
       dispatcherId: input.dispatcherId,
@@ -334,24 +359,34 @@ export class DispatcherService {
     });
   }
 
-  teamLeaderCanUseChannel(input: {
+  /**
+   * Whether a TeamLeader may use a chat for Feishu egress, and through which
+   * channel (issue #209 live multi-channel routing). The leader's egress channel
+   * is resolved from its OWN active binding for the chat — not a single
+   * config-derived channel — so a leader bound on a secondary channel replies
+   * through that channel's bot. Returns the resolved `channelId` (null when the
+   * leader has no active binding for the chat) so the reply/react path egresses
+   * the bound bot.
+   */
+  async teamLeaderCanUseChannel(input: {
     dispatcherId: string;
     teamId: string;
     leaderName: string;
     chatId: string;
-  }) {
-    const channelId = this.resolveChannelId(input.dispatcherId);
+  }): Promise<{ allowed: boolean; channelId: string | null }> {
+    // Feishu target resolution is channel-agnostic (target_key === chat_id), so
+    // resolving via the primary session yields the same key every channel would.
     const target = this.dispatchers.resolveChannelTarget(input.dispatcherId, {
       chat_id: input.chatId,
       chat_type: 'group',
     });
-    return this.teams.teamLeaderCanUseChannel({
+    const channelId = await this.teams.resolveLeaderChannel({
       dispatcherId: input.dispatcherId,
       teamId: input.teamId,
       leaderName: input.leaderName,
-      channelId,
       targetKey: target.target_key,
     });
+    return { allowed: channelId !== null, channelId };
   }
 
   async shutdown(): Promise<void> {

--- a/packages/dreamux/src/dispatcher-service/team/service.ts
+++ b/packages/dreamux/src/dispatcher-service/team/service.ts
@@ -267,23 +267,32 @@ export class TeamService {
     return binding;
   }
 
-  async teamLeaderCanUseChannel(input: {
+  /**
+   * The dispatcher-local `channel_id` a TeamLeader is bound to for a target, or
+   * null when it has no active binding there (issue #209 live multi-channel
+   * routing). Searches the dispatcher's bindings by `target_key` across ALL
+   * channels — the leader does not declare which channel it is on — and confirms
+   * the active row belongs to this `(teamId, leaderName)` and an open Team. The
+   * caller uses the returned channel to authorize and to egress the bound bot.
+   */
+  async resolveLeaderChannel(input: {
     dispatcherId: string;
     teamId: string;
     leaderName: string;
-    channelId: string;
     targetKey: string;
-  }): Promise<boolean> {
-    const binding = await this.bindings.resolve({
-      dispatcherId: input.dispatcherId,
-      channelId: input.channelId,
-      targetKey: input.targetKey,
-    });
-    return (
-      binding !== null &&
-      binding.team_name === input.teamId &&
-      binding.leader_name === input.leaderName
+  }): Promise<string | null> {
+    const bindings = await this.bindings.list(input.dispatcherId);
+    const match = bindings.find(
+      (binding) =>
+        binding.active &&
+        binding.target_key === input.targetKey &&
+        binding.team_name === input.teamId &&
+        binding.leader_name === input.leaderName,
     );
+    if (match === undefined) return null;
+    const team = await this.store.get(input.dispatcherId, match.team_name);
+    if (team === null || team.status === 'closed') return null;
+    return match.channel_id;
   }
 
   async deliverToLeader(input: {

--- a/packages/dreamux/tests/channel-routing.test.ts
+++ b/packages/dreamux/tests/channel-routing.test.ts
@@ -91,9 +91,9 @@ describe('routeChannelInput keys by (channel_id, target_key) (#209 binding store
       .spyOn(service.teams, 'deliverToLeader')
       .mockResolvedValue({ status: 'submitted' });
 
-    const result = await service.routeChannelInput('flow', INPUT, envelope('group'));
+    const result = await service.routeChannelInput('flow', 'primary', INPUT, envelope('group'));
 
-    // The router derives channel_id from config ('primary') — the SAME id the
+    // The originating session tags the channel_id ('primary') — the SAME id the
     // bind path stores — so the stored binding and the inbound message match.
     expect(resolveSpy).toHaveBeenCalledWith({
       dispatcherId: 'flow',
@@ -119,7 +119,7 @@ describe('routeChannelInput keys by (channel_id, target_key) (#209 binding store
     vi.spyOn(service.teams, 'resolveChannel').mockResolvedValue(null);
     const deliverSpy = vi.spyOn(service.teams, 'deliverToLeader');
 
-    await service.routeChannelInput('flow', INPUT, envelope('group'));
+    await service.routeChannelInput('flow', 'primary', INPUT, envelope('group'));
 
     expect(deliverSpy).not.toHaveBeenCalled();
     expect(dispatcherRuntime.channelInput).toHaveBeenCalledTimes(1);
@@ -137,7 +137,7 @@ describe('routeChannelInput keys by (channel_id, target_key) (#209 binding store
     const resolveSpy = vi.spyOn(service.teams, 'resolveChannel');
     const deliverSpy = vi.spyOn(service.teams, 'deliverToLeader');
 
-    await service.routeChannelInput('flow', INPUT, envelope('p2p'));
+    await service.routeChannelInput('flow', 'primary', INPUT, envelope('p2p'));
 
     // A non-bindable target short-circuits to the dispatcher BEFORE any binding
     // lookup — P2P can never be bound to a TeamLeader.
@@ -196,7 +196,7 @@ describe('resolveChannelId guards the explicit channel_id on bind (#209 binding 
     expect(bindSpy).not.toHaveBeenCalled();
   });
 
-  it('rejects a dispatcher with no single resolvable channel', () => {
+  it('rejects a dispatcher with no resolvable Feishu channel', () => {
     const service = buildService();
     expect(() =>
       service.bindTeamChannel({
@@ -204,6 +204,6 @@ describe('resolveChannelId guards the explicit channel_id on bind (#209 binding 
         teamId: 'alpha',
         meta: { chat_id: 'chat-x' },
       }),
-    ).toThrow(/no single resolvable channel/);
+    ).toThrow(/no resolvable Feishu channel/);
   });
 });

--- a/packages/dreamux/tests/dispatcher-store.test.ts
+++ b/packages/dreamux/tests/dispatcher-store.test.ts
@@ -219,13 +219,11 @@ describe('dispatcher store feishu channel resolution (multi-channel config)', ()
     expect(store.get('flow')?.bot_app_id).toBe('app-flow');
   });
 
-  it('stays fail-soft (no throw, empty bot app id) on an ambiguous >1 feishu channel count', () => {
-    // The store is state construction, not a runtime boundary: a dispatcher with
-    // an ambiguous (≠1) feishu channel count is unrunnable, but that fail-loud
-    // belongs at the dispatcher service launch guard (assertRunnableChannelShape),
-    // not here. Store seeding must tolerate the shape with a best-effort empty bot
-    // app id so the failure surfaces at the one intended boundary (issue #209
-    // review).
+  it('seeds the PRIMARY (first) channel bot app id on a multi-feishu dispatcher (#209 live multi-channel)', () => {
+    // Live multi-channel routing runs one bot per channel; the state row carries
+    // the dispatcher's primary (first) channel identity, and the store's per-row
+    // bot_app_id uniqueness keys on that primary id. A secondary channel's bot is
+    // out of scope for that uniqueness check.
     let store: DispatcherStore | undefined;
     expect(() => {
       store = new DispatcherStore({
@@ -248,6 +246,6 @@ describe('dispatcher store feishu channel resolution (multi-channel config)', ()
         ],
       });
     }).not.toThrow();
-    expect(store?.get('flow')?.bot_app_id).toBe('');
+    expect(store?.get('flow')?.bot_app_id).toBe('app-a');
   });
 });

--- a/packages/dreamux/tests/multi-channel-routing.test.ts
+++ b/packages/dreamux/tests/multi-channel-routing.test.ts
@@ -1,0 +1,452 @@
+/**
+ * Live multi-channel runtime routing (issue #209).
+ *
+ * A dispatcher may now declare more than one `builtin:feishu` channel and run a
+ * live session per channel, each connecting as its own bot. These tests prove:
+ *  - inbound routes by the ORIGINATING channel_id (+ provider-resolved target),
+ *    so a message arriving on a secondary channel keys its binding under that
+ *    channel — not a single config-derived channel;
+ *  - binding on a multi-channel dispatcher requires an explicit channel_id, and
+ *    a single-channel dispatcher still resolves its sole channel (legacy);
+ *  - a P2P (non-bindable) target still short-circuits to the dispatcher, never a
+ *    TeamLeader, regardless of channel count;
+ *  - multiple channel sessions are actually live (one bot per channel), and
+ *    egress (reply/react) dispatches to the selected channel's bot;
+ *  - no generic Channel MCP / `list_peers` surface is introduced — egress stays
+ *    on the Feishu MCP tools, channel_id-scoped.
+ */
+import { mkdtempSync, mkdirSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type {
+  AgentRuntime,
+  AgentRuntimeCapabilities,
+  AgentRuntimeCreateContext,
+  AgentRuntimeContextSnapshot,
+  AgentRuntimeLastResult,
+  AgentRuntimeProvider,
+  AgentRuntimeStatus,
+  AgentRuntimeSystemInput,
+  AgentRuntimeTurnResult,
+  ChannelTarget,
+  InboundTurnInput,
+} from '@excitedjs/dreamux-types';
+
+import { AgentRuntimeProviderCatalog } from '../src/agent-runtime/index.js';
+import { DispatcherService } from '../src/dispatcher-service/service.js';
+import type { FeishuInboundEnvelope } from '../src/channel/feishu/feishu-channel.js';
+import {
+  createFakeFeishuBot,
+  type FakeFeishuBot,
+  type FeishuInboundEvent,
+} from '../src/channel/feishu/bot.js';
+import { feishuMcpTools } from '../src/channel/feishu/feishu-mcp-surface.js';
+import { saveDispatcherAccess } from '@excitedjs/feishu-channel';
+import {
+  BUILTIN_FEISHU_PROVIDER_REF,
+  type DispatcherChannelConfig,
+} from '../src/config/config.js';
+import { createBuiltinProviderRegistry } from '../src/registry/index.js';
+import { DispatcherStore } from '../src/state/dispatcher-store.js';
+import type { DreamuxLogger } from '../src/platform/logger.js';
+import { dispatcherDir, resetRuntimeConfig } from '../src/platform/paths.js';
+import { testDispatcherConfig, testDreamuxConfig } from './helpers/config.js';
+
+function noopLog(): DreamuxLogger {
+  const log = {
+    info: () => undefined,
+    warn: () => undefined,
+    error: () => undefined,
+    debug: () => undefined,
+    trace: () => undefined,
+    child: () => log,
+  };
+  return log as unknown as DreamuxLogger;
+}
+
+function feishuChannel(
+  id: string,
+  appId: string,
+  appSecret: string,
+): DispatcherChannelConfig {
+  return {
+    id,
+    provider: BUILTIN_FEISHU_PROVIDER_REF,
+    config: { app_id: appId, app_secret: appSecret } as never,
+  };
+}
+
+function groupTarget(chatId: string): ChannelTarget {
+  return {
+    target_type: 'group',
+    target_key: chatId,
+    bindable: true,
+    meta: { chat_id: chatId, chat_type: 'group' },
+  };
+}
+
+function p2pTarget(chatId: string): ChannelTarget {
+  return {
+    target_type: 'p2p',
+    target_key: chatId,
+    bindable: false,
+    meta: { chat_id: chatId, chat_type: 'p2p' },
+  };
+}
+
+function envelope(chatId: string, chatType: 'group' | 'p2p'): FeishuInboundEnvelope {
+  return { provider: BUILTIN_FEISHU_PROVIDER_REF, chatId, chatType, messageId: 'm1' };
+}
+
+const INPUT = { kind: 'channel', text: 'hi', dedupeId: 'm1' } as unknown as InboundTurnInput;
+
+const TWO_CHANNELS = [
+  feishuChannel('primary', 'app-a', 'secret-a'),
+  feishuChannel('secondary', 'app-b', 'secret-b'),
+];
+
+function buildService(channels: DispatcherChannelConfig[]): DispatcherService {
+  const config = testDreamuxConfig([
+    testDispatcherConfig({ cwd: '/tmp/mc-routing-cwd', channels }),
+  ]);
+  const registry = createBuiltinProviderRegistry();
+  return new DispatcherService({
+    config,
+    dispatchers: new DispatcherStore(config),
+    agentRuntimeProviders: new AgentRuntimeProviderCatalog({ registry }),
+    channelLoggerFactory: () => noopLog(),
+    log: noopLog(),
+  });
+}
+
+describe('inbound routes by the originating channel_id (#209 live multi-channel)', () => {
+  beforeEach(() => resetRuntimeConfig());
+  afterEach(() => {
+    vi.restoreAllMocks();
+    resetRuntimeConfig();
+  });
+
+  it('keys the binding lookup on the channel the message arrived through', async () => {
+    const service = buildService(TWO_CHANNELS);
+    vi.spyOn(service.dispatchers, 'resolveChannelTarget').mockImplementation(
+      (_id, meta) => groupTarget((meta as { chat_id: string }).chat_id),
+    );
+    const dispatcherRuntime = { channelInput: vi.fn(async () => ({ status: 'submitted' })) };
+    vi.spyOn(service.dispatchers, 'getRuntime').mockReturnValue(dispatcherRuntime as never);
+    const resolveSpy = vi.spyOn(service.teams, 'resolveChannel').mockResolvedValue(null);
+
+    await service.routeChannelInput('flow', 'secondary', INPUT, envelope('chat-b', 'group'));
+    await service.routeChannelInput('flow', 'primary', INPUT, envelope('chat-a', 'group'));
+
+    expect(resolveSpy).toHaveBeenNthCalledWith(1, {
+      dispatcherId: 'flow',
+      channelId: 'secondary',
+      targetKey: 'chat-b',
+    });
+    expect(resolveSpy).toHaveBeenNthCalledWith(2, {
+      dispatcherId: 'flow',
+      channelId: 'primary',
+      targetKey: 'chat-a',
+    });
+  });
+
+  it('delivers a message on a secondary channel to that channel-bound TeamLeader', async () => {
+    const service = buildService(TWO_CHANNELS);
+    vi.spyOn(service.dispatchers, 'resolveChannelTarget').mockImplementation(
+      (_id, meta) => groupTarget((meta as { chat_id: string }).chat_id),
+    );
+    vi.spyOn(service.teams, 'resolveChannel').mockImplementation(async (input) =>
+      input.channelId === 'secondary'
+        ? ({ team_name: 'beta' } as never)
+        : null,
+    );
+    const deliverSpy = vi
+      .spyOn(service.teams, 'deliverToLeader')
+      .mockResolvedValue({ status: 'submitted' });
+    const dispatcherRuntime = { channelInput: vi.fn(async () => ({ status: 'submitted' })) };
+    vi.spyOn(service.dispatchers, 'getRuntime').mockReturnValue(dispatcherRuntime as never);
+
+    await service.routeChannelInput('flow', 'secondary', INPUT, envelope('chat-b', 'group'));
+
+    expect(deliverSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ dispatcherId: 'flow', teamId: 'beta' }),
+    );
+    expect(dispatcherRuntime.channelInput).not.toHaveBeenCalled();
+  });
+
+  it('still short-circuits a P2P target to the dispatcher on a multi-channel dispatcher', async () => {
+    const service = buildService(TWO_CHANNELS);
+    vi.spyOn(service.dispatchers, 'resolveChannelTarget').mockImplementation(
+      (_id, meta) => p2pTarget((meta as { chat_id: string }).chat_id),
+    );
+    const dispatcherRuntime = { channelInput: vi.fn(async () => ({ status: 'submitted' })) };
+    vi.spyOn(service.dispatchers, 'getRuntime').mockReturnValue(dispatcherRuntime as never);
+    const resolveSpy = vi.spyOn(service.teams, 'resolveChannel');
+
+    await service.routeChannelInput('flow', 'secondary', INPUT, envelope('dm-1', 'p2p'));
+
+    expect(resolveSpy).not.toHaveBeenCalled();
+    expect(dispatcherRuntime.channelInput).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('binding requires an explicit channel on a multi-channel dispatcher (#209)', () => {
+  beforeEach(() => resetRuntimeConfig());
+  afterEach(() => {
+    vi.restoreAllMocks();
+    resetRuntimeConfig();
+  });
+
+  it('rejects a bind with no channel_id when more than one channel is configured', () => {
+    const service = buildService(TWO_CHANNELS);
+    const bindSpy = vi.spyOn(service.teams, 'bindChannel');
+    expect(() =>
+      service.bindTeamChannel({ dispatcherId: 'flow', teamId: 'beta', meta: { chat_id: 'chat-b' } }),
+    ).toThrow(/has 2 channels; channel_id is required/);
+    expect(bindSpy).not.toHaveBeenCalled();
+  });
+
+  it('binds under the named channel', async () => {
+    const service = buildService(TWO_CHANNELS);
+    vi.spyOn(service.dispatchers, 'resolveChannelTarget').mockReturnValue(groupTarget('chat-b'));
+    const bindSpy = vi
+      .spyOn(service.teams, 'bindChannel')
+      .mockResolvedValue({ team_name: 'beta' } as never);
+
+    await service.bindTeamChannel({
+      dispatcherId: 'flow',
+      teamId: 'beta',
+      channelId: 'secondary',
+      meta: { chat_id: 'chat-b' },
+    });
+
+    expect(bindSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ channelId: 'secondary', provider: 'builtin:feishu' }),
+    );
+  });
+
+  it('a single-channel dispatcher still binds without an explicit channel_id (legacy)', async () => {
+    const service = buildService([feishuChannel('primary', 'app-a', 'secret-a')]);
+    vi.spyOn(service.dispatchers, 'resolveChannelTarget').mockReturnValue(groupTarget('chat-a'));
+    const bindSpy = vi
+      .spyOn(service.teams, 'bindChannel')
+      .mockResolvedValue({ team_name: 'alpha' } as never);
+
+    await service.bindTeamChannel({ dispatcherId: 'flow', teamId: 'alpha', meta: { chat_id: 'chat-a' } });
+
+    expect(bindSpy).toHaveBeenCalledWith(expect.objectContaining({ channelId: 'primary' }));
+  });
+});
+
+// ── Minimal fake runtime so the dispatcher can actually start. ──────────────
+const FAKE_CAPABILITIES: AgentRuntimeCapabilities = {
+  resume: { supported: false },
+  steer: { supported: false },
+  events: { kind: 'synthesized' },
+  last: { supported: false },
+  context: { supported: false },
+  systemPrompt: { mode: 'replace' },
+  teammateCompletion: [],
+};
+
+class FakeRuntime implements AgentRuntime {
+  readonly providerRef = 'builtin:codex';
+  private status: AgentRuntimeStatus = 'declared';
+  async start(): Promise<void> {
+    this.status = 'ready';
+  }
+  async resume(): Promise<void> {}
+  async stop(): Promise<void> {
+    this.status = 'stopped';
+  }
+  async channelInput(): Promise<AgentRuntimeTurnResult> {
+    return { status: 'submitted', turnId: 't' };
+  }
+  async systemInput(_n: AgentRuntimeSystemInput): Promise<AgentRuntimeTurnResult> {
+    return { status: 'skipped' };
+  }
+  getStatus(): AgentRuntimeStatus {
+    return this.status;
+  }
+  getThreadId(): string | null {
+    return null;
+  }
+  wasThreadResumed(): boolean {
+    return false;
+  }
+  async getLast(): Promise<AgentRuntimeLastResult | null> {
+    return null;
+  }
+  async getContext(): Promise<AgentRuntimeContextSnapshot | null> {
+    return null;
+  }
+  getCapabilities(): AgentRuntimeCapabilities {
+    return FAKE_CAPABILITIES;
+  }
+}
+
+class FakeProvider implements AgentRuntimeProvider {
+  readonly ref = 'builtin:codex';
+  constructor(readonly descriptor: AgentRuntimeProvider['descriptor']) {}
+  getCapabilities(): AgentRuntimeCapabilities {
+    return FAKE_CAPABILITIES;
+  }
+  createRuntime(_context: AgentRuntimeCreateContext): AgentRuntime {
+    return new FakeRuntime();
+  }
+}
+
+describe('multiple channel sessions are live, one bot per channel (#209)', () => {
+  let root: string;
+  let previousHome: string | undefined;
+
+  beforeEach(() => {
+    root = mkdtempSync(join(tmpdir(), 'dx-mc-'));
+    mkdirSync(join(root, 'workspace'));
+    previousHome = process.env['HOME'];
+    process.env['HOME'] = join(root, 'home');
+    resetRuntimeConfig();
+  });
+  afterEach(() => {
+    if (previousHome === undefined) delete process.env['HOME'];
+    else process.env['HOME'] = previousHome;
+    resetRuntimeConfig();
+    rmSync(root, { recursive: true, force: true, maxRetries: 10, retryDelay: 50 });
+  });
+
+  function buildStartableService(channels: DispatcherChannelConfig[]): {
+    service: DispatcherService;
+    secrets: string[];
+    bots: Map<string, FakeFeishuBot>;
+  } {
+    const config = testDreamuxConfig([
+      testDispatcherConfig({ cwd: join(root, 'workspace'), channels }),
+    ]);
+    const registry = createBuiltinProviderRegistry();
+    const descriptor = registry.resolve('builtin:codex');
+    registry.registerImplementation(descriptor.id, new FakeProvider(descriptor));
+    const secrets: string[] = [];
+    const bots = new Map<string, FakeFeishuBot>();
+    const service = new DispatcherService({
+      config,
+      dispatchers: new DispatcherStore(config),
+      agentRuntimeProviders: new AgentRuntimeProviderCatalog({ registry }),
+      channelLoggerFactory: () => noopLog(),
+      // One bot per channel; the per-channel secret flows in here, so the
+      // recorded list proves a distinct session was built for each channel and
+      // the bots map lets a test drive inbound through a specific channel's bot.
+      botFactory: (_row, secret) => {
+        secrets.push(secret);
+        const bot = createFakeFeishuBot(`bot-${secret}`);
+        bots.set(secret, bot);
+        return bot;
+      },
+      log: noopLog(),
+    });
+    return { service, secrets, bots };
+  }
+
+  function inboundEvent(chatId: string, text: string, msgId: string): FeishuInboundEvent {
+    return {
+      messageId: msgId,
+      chatId,
+      chatType: 'group',
+      senderId: 'sender-test',
+      senderType: 'user',
+      senderName: '',
+      messageType: 'text',
+      rawContent: JSON.stringify({ text }),
+      parsedText: text,
+      mentions: [],
+      createTime: String(Date.now()),
+      raw: { event: { message: { chat_id: chatId, message_id: msgId } } },
+    } as unknown as FeishuInboundEvent;
+  }
+
+  it('starts one session per channel with its own bot identity, and egress targets a channel', async () => {
+    const { service, secrets } = buildStartableService(TWO_CHANNELS);
+
+    await service.startDispatcher('flow');
+
+    // One bot per channel, each with its OWN per-channel secret.
+    expect(secrets.sort()).toEqual(['secret-a', 'secret-b']);
+
+    // Egress dispatches to a live channel; an unknown channel fails loud.
+    await expect(
+      service.callFeishuMcpTool({
+        dispatcherId: 'flow',
+        toolName: 'reply',
+        arguments: { chat_id: 'chat-b', text: 'hi' },
+        channelId: 'secondary',
+      }),
+    ).resolves.toBeDefined();
+    await expect(
+      service.callFeishuMcpTool({
+        dispatcherId: 'flow',
+        toolName: 'reply',
+        arguments: { chat_id: 'chat-b', text: 'hi' },
+        channelId: 'nope',
+      }),
+    ).rejects.toThrow(/no live channel 'nope'/);
+
+    await service.stopDispatcher('flow');
+  });
+
+  it('routes inbound from a live secondary bot under that channel_id (#209)', async () => {
+    const { service, bots } = buildStartableService(TWO_CHANNELS);
+
+    // Allowlist the secondary chat so the gate delivers without a mention. The
+    // access policy is per-dispatcher, shared across its channels.
+    await saveDispatcherAccess(dispatcherDir('flow'), {
+      version: 2,
+      allow_users: [],
+      group: { policy: 'allowlist', allow_chats: ['chat-b'], require_mention: false },
+      observed_chats: [],
+      warnings: [],
+      last_gate: null,
+    } as never);
+
+    await service.startDispatcher('flow');
+
+    // The router resolves the binding by (channel_id, target_key); capture the
+    // lookup to prove the ORIGINATING session SOURCES the channel_id rather than
+    // a hand-fed argument. Return null so it falls through to the dispatcher.
+    const resolveSpy = vi.spyOn(service.teams, 'resolveChannel').mockResolvedValue(null);
+
+    // Drive a real inbound message through the SECONDARY channel's live bot.
+    const secondaryBot = bots.get('secret-b');
+    expect(secondaryBot).toBeDefined();
+    await secondaryBot!.inject(inboundEvent('chat-b', 'hi', 'm-sec-1'));
+
+    await vi.waitFor(() => expect(resolveSpy).toHaveBeenCalled());
+    expect(resolveSpy).toHaveBeenCalledWith({
+      dispatcherId: 'flow',
+      channelId: 'secondary',
+      targetKey: 'chat-b',
+    });
+
+    await service.stopDispatcher('flow');
+  });
+
+  it('a single-channel dispatcher starts exactly one session (legacy unchanged)', async () => {
+    const { service, secrets } = buildStartableService([
+      feishuChannel('primary', 'app-a', 'secret-a'),
+    ]);
+    await service.startDispatcher('flow');
+    expect(secrets).toEqual(['secret-a']);
+    await service.stopDispatcher('flow');
+  });
+});
+
+describe('no generic Channel MCP / list_peers surface (#209)', () => {
+  it('feishu egress stays on the Feishu MCP tools, with no peer-listing tool', () => {
+    const names = feishuMcpTools().map((tool) => tool['name']);
+    expect(names).not.toContain('list_peers');
+    // The only outbound/peer tools are the Feishu-owned ones; channel_id is a
+    // parameter on these, not a new generic "channel" MCP surface.
+    expect(new Set(names)).toEqual(new Set(['reply', 'react', 'list_chat_bots']));
+  });
+});

--- a/packages/dreamux/tests/runnable-channel.test.ts
+++ b/packages/dreamux/tests/runnable-channel.test.ts
@@ -1,10 +1,12 @@
 /**
- * Dispatcher runtime-boundary guard (issue #209 multi-channel config review).
+ * Dispatcher runtime-boundary guard (issue #209 live multi-channel routing).
  *
  * `assertRunnableChannelShape` is the single intended place where a config that
- * is *accepted* (multi-channel shape) but *not yet runnable* (live routing is a
- * follow-up slice) fails loud. These tests pin all four shapes so the boundary
- * cannot regress: state seeding stays fail-soft, this guard does the rejecting.
+ * is *accepted* but *not yet runnable* fails loud. Live routing now runs one
+ * Feishu session per channel, so MORE THAN ONE Feishu channel is runnable; only
+ * a channel naming an unwired (non-feishu) provider is rejected. These tests pin
+ * the boundary so it cannot regress: state seeding stays fail-soft, this guard
+ * does the rejecting.
  */
 import { describe, expect, it } from 'vitest';
 
@@ -30,25 +32,24 @@ describe('assertRunnableChannelShape', () => {
     ).not.toThrow();
   });
 
-  it('rejects more than one channel (two feishu)', () => {
+  it('accepts more than one builtin:feishu channel (live multi-channel routing)', () => {
     expect(() =>
       assertRunnableChannelShape({
         id: 'flow',
         channels: [feishu('primary', 'app-a'), feishu('secondary', 'app-b')],
       }),
-    ).toThrow(/declares 2 channels; live multi-channel routing is a follow-up/);
+    ).not.toThrow();
   });
 
-  it('rejects a mixed multi-channel dispatcher (one feishu + one non-feishu)', () => {
-    // The store's feishu-only filter would pass this (exactly one feishu), so the
-    // runtime boundary is the only thing that catches it. The >1-channel branch
-    // fires first, before per-channel wiring.
+  it('rejects a mixed multi-channel dispatcher (an unwired non-feishu channel)', () => {
+    // A feishu channel runs fine, but the non-feishu channel names a provider the
+    // dispatcher service does not wire in this phase, so the whole shape fails loud.
     expect(() =>
       assertRunnableChannelShape({
         id: 'flow',
         channels: [feishu('primary', 'app-flow'), nonFeishu('secondary')],
       }),
-    ).toThrow(/declares 2 channels; live multi-channel routing is a follow-up/);
+    ).toThrow(/is not wired; only builtin:feishu is built in this phase/);
   });
 
   it('rejects a single non-feishu channel as not wired', () => {

--- a/packages/dreamux/tests/team-service.test.ts
+++ b/packages/dreamux/tests/team-service.test.ts
@@ -576,6 +576,60 @@ describe('TeamService', () => {
     });
   });
 
+  it('resolves the egress channel a TeamLeader is bound to (#209 live multi-channel)', async () => {
+    // A TeamLeader's reply must egress the bot of the channel its active binding
+    // names — not the dispatcher's primary. resolveLeaderChannel returns that
+    // channel for the bound (target, team, leader), and null for any mismatch.
+    const repo = await initGitRepo(join(root, 'leader-egress-repo'));
+    const { teams } = buildServices();
+
+    const created = await teams.create({
+      dispatcherId: 'flow',
+      name: 'delta',
+      intent: 'work',
+      repoCwd: repo,
+      leaderAgentRuntime: 'flow',
+    });
+    const leaderName = created.team.leader_name;
+
+    await teams.bindChannel({
+      dispatcherId: 'flow',
+      teamId: 'delta',
+      channelId: 'secondary',
+      provider: 'builtin:feishu',
+      target: feishuGroupTarget('chat-delta'),
+    });
+
+    // Bound leader → the channel its binding names (the egress bot selector).
+    await expect(
+      teams.resolveLeaderChannel({
+        dispatcherId: 'flow',
+        teamId: 'delta',
+        leaderName,
+        targetKey: 'chat-delta',
+      }),
+    ).resolves.toBe('secondary');
+
+    // A different target / leader / team has no active binding here → null, so a
+    // leader can never egress through a channel it is not actually bound to.
+    await expect(
+      teams.resolveLeaderChannel({
+        dispatcherId: 'flow',
+        teamId: 'delta',
+        leaderName,
+        targetKey: 'chat-other',
+      }),
+    ).resolves.toBeNull();
+    await expect(
+      teams.resolveLeaderChannel({
+        dispatcherId: 'flow',
+        teamId: 'delta',
+        leaderName: 'tl-someone-else',
+        targetKey: 'chat-delta',
+      }),
+    ).resolves.toBeNull();
+  });
+
   it('history paginates by cursor and rejects an invalid cursor (#182 PR-7 P2)', async () => {
     const repo = await initGitRepo(join(root, 'history-page-repo'));
     const { teams } = buildServices();


### PR DESCRIPTION
## 背景

属于 issue #209。此前一个 dispatcher 虽然在配置层面可以声明多个 `builtin:feishu` 通道，但运行时只有一个通道真正生效，其余在启动时 fail-loud。本切片实现**实时多通道运行时路由**：多个已配置的通道可以同时在线，入站事件按稳定的 `channel_id` + provider 解析出的 target 经核心路由。

ACP adapter 不在范围内；不引入通用 Channel MCP；不引入 `list_peers` 之类的 peer 列举能力；Team/通道绑定与路由状态仍由核心拥有；P2P 私聊仍归 dispatcher，不可绑定到 TeamLeader。

## 改动

- **一通道一会话**：dispatcher 为每个 `builtin:feishu` 通道运行一个独立的 live session，各自用该通道 config 的 `{app_id, app_secret}` 以自己的 bot 身份连接。单通道 dispatcher 行为不变。
- **入站按来源 channel_id 路由**：发起会话给每个入站 turn 打上自己的 `channel_id`,核心按 `(channel_id, target_key)` 查绑定 —— 二级通道上到达的消息把绑定 key 在该通道下,而不是从配置反推单一通道。
- **出站按 channel_id 派发**：TeamLeader 的 reply 从其有效绑定所指通道的 bot 出口(经 `TeamService.resolveLeaderChannel` 解析);dispatcher 的 reply 走主(首个)通道。
- **启动守卫放宽**:`assertRunnableChannelShape` 仅拒绝声明了未接线(非 feishu)provider 的通道,不再因通道数 >1 而拒绝。
- **绑定要求显式通道**:配置了多个通道时 `bind_channel` 必须带显式 `channel_id`;单通道仍可省略(legacy)。
- 状态 row 仍保存主通道的 bot 身份。

## 测试

- `multi-channel-routing.test.ts`:入站按来源 `channel_id` 路由(含**经 live 二级 bot 注入真实入站、断言核心在 `'secondary'` 下路由**的端到端用例,证明会话自身产出 channel_id 而非被手喂);二级通道消息投递到该通道绑定的 TeamLeader;多通道下 P2P 仍短路到 dispatcher;多个 session 确实在线(一通道一 bot,按 per-channel secret 记录);出站按 channelId 派发(未知通道 fail-loud);单通道仅一个 session;无 `list_peers`、Feishu MCP 工具名仍为 `reply`/`react`/`list_chat_bots`。
- `team-service.test.ts`:`resolveLeaderChannel` 对绑定在 `'secondary'` 的 leader 返回 `'secondary'`,target/leader 不匹配时返回 `null`(出站通道选择的来源)。
- leader 出站为**组合式覆盖**:`resolveLeaderChannel → 'secondary'`(team-service)与 `callFeishuMcpTool({channelId:'secondary'})` 解析 / `'nope'` 拒绝(multi-channel)分别证明两端;`admin/methods.ts` 中把 channelId 透传进调用的胶水未由单一 e2e 用例串联。
- P2P **绑定**拒绝(非 routing)由既有 `channel-binding-store.test.ts`(`rejects binding a non-bindable (P2P) target fail-loud` → `/not bindable/`)覆盖。
- `runnable-channel.test.ts` / `channel-routing.test.ts` / `dispatcher-store.test.ts` 随签名与多通道语义更新。

门禁:`rush build` ✓、`rush lint` ✓、`rush test` ✓(634 passed,退出码 0;日志中的堆栈来自 fail-soft 用例的合成失败)。

## 残留风险 / 后续

- dispatcher 主动 reply 到非主通道需显式 `channel_id`。
- 跨 dispatcher 的 `bot_app_id` 唯一性仅覆盖主通道。
- 非 feishu 通道 provider 仍未接线。

无 config/state schema 或路径变更,无需操作员动作;已附 `rush change`(minor)。
