### PR TITLE
fix(runtime): skills/extraRoots/set 能力缺口 fail-open + 排空 settle 写入 (#209 修复)

### DIFF
--- a/common/changes/@excitedjs/agent-runtime-codex/i209-skill-extra-roots-failopen_2026-06-14-22-00.json
+++ b/common/changes/@excitedjs/agent-runtime-codex/i209-skill-extra-roots-failopen_2026-06-14-22-00.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Fix: a codex app-server that predates the `skills/extraRoots/set` RPC no longer hard-bricks dispatcher startup (issue #209 slice 6 repair). `CodexRuntime.applySkillExtraRoots()` now distinguishes a capability/version gap — the backend does not implement the method at all, answering with an `unknown variant`/method-not-found error — from a genuine failure of the existing RPC. On a capability gap it fails OPEN: logs a warning and continues skill-blind instead of failing the start, so an older backend comes up rather than landing permanently `stopped`. Every other error (the RPC exists but applying the given roots failed) still fails LOUD, exactly as before. Classification is message-based (the RPC layer drops the JSON-RPC error code) and deliberately narrow.",
+      "type": "patch",
+      "packageName": "@excitedjs/agent-runtime-codex"
+    }
+  ],
+  "packageName": "@excitedjs/agent-runtime-codex",
+  "email": "053700@gmail.com"
+}

--- a/common/changes/@excitedjs/dreamux/i209-drain-settle-captures_2026-06-14-22-00.json
+++ b/common/changes/@excitedjs/dreamux/i209-drain-settle-captures_2026-06-14-22-00.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Fix: `DispatcherService.shutdown()` (via the teammate service `stopAll`) now drains in-flight best-effort settled-turn captures before resolving (issue #209 slice 6 repair). The settle hook dispatches the durable record/turns write (atomic temp+rename) fire-and-forget so it never perturbs the settle path; previously such a write could outlive shutdown and race teardown, surfacing as an ENOTEMPTY cleanup race on slower filesystems. Captures are now tracked and awaited at stop, so a caller awaiting shutdown observes no still-pending writes. No config/state schema or path change and no operator action required.",
+      "type": "patch",
+      "packageName": "@excitedjs/dreamux"
+    }
+  ],
+  "packageName": "@excitedjs/dreamux",
+  "email": "053700@gmail.com"
+}

--- a/packages/agent-runtime/codex/src/runtime.ts
+++ b/packages/agent-runtime/codex/src/runtime.ts
@@ -389,9 +389,16 @@ export class CodexRuntime implements AgentRuntime {
    * immediate children are skill dirs, so a `skill-dir` source maps to the
    * *parent* of its own directory; roots are deduped (the bundled Dreamux skills
    * share one parent). Empty input skips the RPC entirely (a fresh per-runtime
-   * app-server starts with no extra roots, so nothing to clear). Errors are
-   * fatal to the start: a dispatcher/leader that cannot load its operational
-   * skills must fail loud, not run skill-blind.
+   * app-server starts with no extra roots, so nothing to clear).
+   *
+   * Error handling distinguishes two failure modes (issue #209 slice 6 repair):
+   *   1. The app-server does not implement `skills/extraRoots/set` at all — a
+   *      capability/version skew against an older codex backend (it answers with
+   *      an `unknown variant`/method-not-found error). This is NOT a real
+   *      failure: fail open, warn, and continue skill-blind rather than bricking
+   *      startup against every backend that predates the RPC.
+   *   2. The RPC exists but applying the given roots genuinely failed — fail
+   *      loud, exactly as before, so real misconfiguration is not masked.
    */
   private async applySkillExtraRoots(): Promise<void> {
     if (this.client === null) throw new Error('client not initialized');
@@ -405,7 +412,19 @@ export class CodexRuntime implements AgentRuntime {
       ),
     ];
     if (extraRoots.length === 0) return;
-    await this.client.request('skills/extraRoots/set', { extraRoots });
+    try {
+      await this.client.request('skills/extraRoots/set', { extraRoots });
+    } catch (err) {
+      if (isUnsupportedRpcMethodError(err)) {
+        this.log(
+          'warn',
+          `skills/extraRoots/set unsupported by this app-server; continuing skill-blind (${extraRoots.length} extra root(s) not applied)`,
+          err,
+        );
+        return;
+      }
+      throw err;
+    }
     this.log(
       'info',
       `applied ${extraRoots.length} skill extra root(s): ${extraRoots.join(', ')}`,
@@ -777,4 +796,39 @@ export class CodexRuntime implements AgentRuntime {
   private setStatus(s: AgentRuntimeStatus): void {
     this.status = s;
   }
+}
+
+/**
+ * Classify an RPC rejection as a capability/version gap — the app-server does
+ * not implement the requested method at all — rather than a genuine failure of
+ * an existing method.
+ *
+ * The rpc layer collapses codex's structured error to `Error(message)` (it
+ * drops the JSON-RPC error code), so the *message* is all we have. codex
+ * surfaces an unimplemented method as a serde enum-deserialization failure of
+ * the request's `method` field — `unknown variant \`<method>\`, expected one of
+ * …` — while a spec-compliant JSON-RPC peer answers method-not-found (-32601).
+ * We match those canonical phrasings only; the test stays deliberately narrow
+ * so a real error from an *existing* method (a bad root path, a permission
+ * failure) is NOT swallowed and still fails loud.
+ *
+ * The match is message-based by necessity: the rpc layer drops the structured
+ * JSON-RPC error code, so the message is all we have. The one residual
+ * false-positive is a server that *implements* the method but rejects a bad
+ * *param value* with an "unknown variant `<value>`" serde error. That is safe
+ * for our sole caller — `skills/extraRoots/set` takes a `string[]` of paths,
+ * which codex never enum-rejects — but a future caller passing an enum-typed
+ * param should not reuse this classifier blindly.
+ */
+export function isUnsupportedRpcMethodError(err: unknown): boolean {
+  const message = (
+    err instanceof Error ? err.message : String(err)
+  ).toLowerCase();
+  return (
+    message.includes('unknown variant') ||
+    message.includes('method not found') ||
+    message.includes('unknown method') ||
+    message.includes('no such method') ||
+    message.includes('unsupported method')
+  );
 }

--- a/packages/agent-runtime/codex/tests/skill-extra-roots.test.ts
+++ b/packages/agent-runtime/codex/tests/skill-extra-roots.test.ts
@@ -11,12 +11,13 @@ import { dirname, join } from 'node:path';
 
 import { describe, it, expect } from 'vitest';
 
-import { CodexRuntime } from '../src/runtime.js';
+import { CodexRuntime, isUnsupportedRpcMethodError } from '../src/runtime.js';
 import type {
   AgentRuntimeIdentity,
   AgentRuntimePathContext,
   AgentRuntimeSkillSource,
   AgentRuntimeStateCallbacks,
+  DreamuxLogger,
 } from '@excitedjs/dreamux-types';
 
 const SKILL_LAYOUT = 'skill-dir';
@@ -29,6 +30,8 @@ class FakeClient {
   readonly methods: string[] = [];
   readonly extraRootsCalls: string[][] = [];
   failExtraRoots = false;
+  /** When set, `skills/extraRoots/set` rejects with this error instead. */
+  extraRootsError: Error | null = null;
 
   onClose(): void {}
   onNotification(): void {}
@@ -49,6 +52,9 @@ class FakeClient {
     }
     if (method === 'skills/extraRoots/set') {
       this.extraRootsCalls.push((params as { extraRoots: string[] }).extraRoots);
+      if (this.extraRootsError !== null) {
+        throw this.extraRootsError;
+      }
       if (this.failExtraRoots) {
         throw new Error('codex rejected skills/extraRoots/set');
       }
@@ -59,6 +65,29 @@ class FakeClient {
     }
     throw new Error(`unexpected method ${method}`);
   }
+}
+
+interface CapturedLog {
+  level: 'info' | 'warn' | 'error' | 'debug' | 'trace';
+  msg: string;
+}
+
+/** A DreamuxLogger that records every line so a test can assert the warning. */
+function capturingLogger(sink: CapturedLog[]): DreamuxLogger {
+  const record =
+    (level: CapturedLog['level']) =>
+    (msg: string): void => {
+      sink.push({ level, msg });
+    };
+  const logger = {
+    info: record('info'),
+    warn: record('warn'),
+    error: record('error'),
+    debug: record('debug'),
+    trace: record('trace'),
+    child: () => logger,
+  };
+  return logger as unknown as DreamuxLogger;
 }
 
 class FakeProcess {
@@ -84,6 +113,7 @@ function noopState(): AgentRuntimeStateCallbacks {
 function buildRuntime(
   client: FakeClient,
   skillSources: AgentRuntimeSkillSource[],
+  logger?: DreamuxLogger,
 ): CodexRuntime {
   const identity: AgentRuntimeIdentity = { runtime_id: 'flow', checkpoint_id: null };
   return new CodexRuntime(identity, {
@@ -94,6 +124,7 @@ function buildRuntime(
     skillSources,
     codexProcessFactory: () => new FakeProcess() as never,
     codexClientFactory: () => client as never,
+    ...(logger !== undefined ? { logger } : {}),
   });
 }
 
@@ -137,5 +168,73 @@ describe('codex skills/extraRoots/set injection', () => {
     await expect(runtime.start()).rejects.toThrow(/extraRoots/);
     // The failure happens before any thread is started.
     expect(client.methods).not.toContain('thread/start');
+  });
+
+  it('fails open (warns, continues) when the app-server does not implement the RPC', async () => {
+    // A codex backend that predates `skills/extraRoots/set` answers with a serde
+    // enum-deserialization failure of the request `method` field. That is a
+    // capability/version gap, not a real failure — startup must continue
+    // skill-blind instead of bricking the dispatcher (issue #209 slice 6 repair).
+    const client = new FakeClient();
+    client.extraRootsError = new Error(
+      'Invalid request: unknown variant `skills/extraRoots/set`, expected one of `initialize`, `thread/start`, `skills/list`, `skills/config/write`, `memory/dream`',
+    );
+    const logs: CapturedLog[] = [];
+    const runtime = buildRuntime(
+      client,
+      [skillSource('/pkg/skills/dispatcher')],
+      capturingLogger(logs),
+    );
+
+    await expect(runtime.start()).resolves.toBeUndefined();
+    await runtime.stop();
+
+    // The RPC was attempted, then downgraded to a warning, and thread/start
+    // still ran — the dispatcher comes up, just without the extra roots.
+    expect(client.extraRootsCalls).toEqual([[dirname('/pkg/skills/dispatcher')]]);
+    expect(client.methods).toContain('thread/start');
+    const warn = logs.find((l) => l.level === 'warn');
+    expect(warn?.msg).toMatch(/unsupported by this app-server; continuing skill-blind/);
+    // No error was logged for a capability gap.
+    expect(logs.some((l) => l.level === 'error')).toBe(false);
+  });
+
+  it('still fails loud for a real error from an existing RPC (not swallowed)', async () => {
+    // The method exists but applying the roots genuinely failed (e.g. a bad
+    // path / permission). This must NOT be mistaken for a capability gap.
+    const client = new FakeClient();
+    client.extraRootsError = new Error('failed to register extra root: permission denied');
+    const runtime = buildRuntime(client, [skillSource('/pkg/skills/dispatcher')]);
+
+    await expect(runtime.start()).rejects.toThrow(/permission denied/);
+    expect(client.methods).not.toContain('thread/start');
+  });
+});
+
+describe('isUnsupportedRpcMethodError', () => {
+  it('classifies capability/version-gap rejections as unsupported', () => {
+    for (const msg of [
+      'Invalid request: unknown variant `skills/extraRoots/set`, expected one of `initialize`',
+      'Method not found',
+      'unknown method skills/extraRoots/set',
+      'no such method',
+      'unsupported method: skills/extraRoots/set',
+    ]) {
+      expect(isUnsupportedRpcMethodError(new Error(msg))).toBe(true);
+    }
+  });
+
+  it('does not classify real errors from an existing method as unsupported', () => {
+    for (const msg of [
+      'failed to register extra root: permission denied',
+      'codex rejected skills/extraRoots/set',
+      'invalid root path',
+      'internal error',
+    ]) {
+      expect(isUnsupportedRpcMethodError(new Error(msg))).toBe(false);
+    }
+    // Non-Error inputs degrade to their string form, never throwing.
+    expect(isUnsupportedRpcMethodError('method not found')).toBe(true);
+    expect(isUnsupportedRpcMethodError(null)).toBe(false);
   });
 });

--- a/packages/dreamux/src/dispatcher-service/teammate/service.ts
+++ b/packages/dreamux/src/dispatcher-service/teammate/service.ts
@@ -158,6 +158,15 @@ export class TeamMateAgentService {
   private readonly worktrees = new WorktreeManager();
   private readonly live = new Map<string, LiveTeamMate>();
   private submissionSeq = 0;
+  /**
+   * In-flight best-effort settled-turn captures (issue #209 slice 6 repair). The
+   * settle hook fires `deliverTurnSettled` fire-and-forget so it never perturbs
+   * the settle path, but its durable record/turns writes (atomic temp+rename)
+   * would otherwise outlive `stopAll()` and race teardown. Tracking the promises
+   * here lets shutdown drain them, so a caller that awaits `stopAll()` observes
+   * no still-pending writes.
+   */
+  private readonly inFlightSettleCaptures = new Set<Promise<void>>();
 
   constructor(private readonly opts: TeamMateAgentServiceOptions) {
     this.identities = new TeamMateIdentityStore({
@@ -759,6 +768,14 @@ export class TeamMateAgentService {
       await live.runtime.stop();
       this.live.delete(key);
     }
+    // Drain any best-effort settled-turn captures dispatched before/at stop so a
+    // caller awaiting shutdown sees no still-pending durable writes racing
+    // teardown (issue #209 slice 6 repair). A capture may enqueue another while
+    // we await (a settle landing during stop), so loop until quiescent. Captures
+    // self-isolate errors, so allSettled never throws.
+    while (this.inFlightSettleCaptures.size > 0) {
+      await Promise.allSettled([...this.inFlightSettleCaptures]);
+    }
   }
 
   getLiveRuntime(dispatcherId: string, name: string): AgentRuntime | null {
@@ -907,7 +924,9 @@ export class TeamMateAgentService {
             onTurnSettled: (settled: TurnSettledSignal): void => {
               const settledRuntime = liveRuntime;
               if (settledRuntime === null) return;
-              void this.deliverTurnSettled(
+              // Track the fire-and-forget capture so shutdown can drain it; the
+              // promise self-isolates all errors, so this never rejects.
+              const capture = this.deliverTurnSettled(
                 dispatcherId,
                 identity.name,
                 identity,
@@ -917,6 +936,10 @@ export class TeamMateAgentService {
                 turnOrigins,
                 onTeamMateCompletion,
               );
+              this.inFlightSettleCaptures.add(capture);
+              void capture.finally(() => {
+                this.inFlightSettleCaptures.delete(capture);
+              });
             },
           }
         : {}),

--- a/packages/dreamux/tests/teammate-completion-e2e.test.ts
+++ b/packages/dreamux/tests/teammate-completion-e2e.test.ts
@@ -55,11 +55,29 @@ class FakeRuntime implements AgentRuntime {
   private turns = 0;
   private activeTurnId: string | null = null;
   readonly delivered: CompletionEnvelope[] = [];
+  /** Optional barrier so a test can hold a settle-capture in flight. */
+  private getLastGate: Promise<void> | null = null;
 
   constructor(
     private readonly context: AgentRuntimeCreateContext,
     private readonly instanceId: number,
   ) {}
+
+  /**
+   * Arm a one-shot barrier inside `getLast()`. The next settle-capture that
+   * reaches `getLast` parks until the returned release fn is called — letting a
+   * test prove `stopAll()` drains an in-flight capture rather than racing it.
+   */
+  gateGetLast(): () => void {
+    let release: () => void = () => undefined;
+    this.getLastGate = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    return () => {
+      this.getLastGate = null;
+      release();
+    };
+  }
 
   async start(): Promise<void> {
     this.status = 'ready';
@@ -113,6 +131,7 @@ class FakeRuntime implements AgentRuntime {
   }
 
   async getLast(): Promise<AgentRuntimeLastResult> {
+    if (this.getLastGate !== null) await this.getLastGate;
     return this.activeTurnId === null
       ? { text: 'reviewer final answer' }
       : { text: null };
@@ -442,6 +461,51 @@ describe('reverse delivery end-to-end (Seam ①→②→③ through the facade)'
     );
 
     await facade.shutdown();
+  });
+
+  it('shutdown() drains an in-flight settled-turn capture (deterministic; ENOTEMPTY guard)', async () => {
+    // The macOS CI flake was a best-effort settled-turn capture (atomic
+    // temp+rename into teammate/records|turns) still in flight when teardown ran.
+    // shutdown() now drains those captures; prove that on any OS by holding one
+    // capture open (gate getLast) and asserting shutdown() does NOT resolve until
+    // the capture is released — without weakening the behavior assertions above.
+    const descriptor = createBuiltinProviderRegistry().resolve('builtin:codex');
+    const provider = new FakeProvider(descriptor);
+    const facade = buildFacade(provider, adminSocketPath);
+
+    await facade.startDispatcher('flow');
+    const spawned = await facade.spawnTeamMate({
+      dispatcherId: 'flow',
+      name: 'reviewer',
+      intent: 'work',
+      prompt: 'Review the change.',
+      cwd: workspace(root),
+    });
+
+    const teammateRuntime = provider.runtimes[1]!;
+    const turnId =
+      spawned.turn.status === 'submitted' ? spawned.turn.turn_id : 'unreachable';
+
+    // Arm the barrier, then fire a settle: the capture parks inside getLast, so
+    // its durable record/turns write has NOT happened yet.
+    const releaseCapture = teammateRuntime.gateGetLast();
+    teammateRuntime.settle('completed', turnId);
+    await flush();
+
+    // shutdown() must block on the in-flight capture rather than racing it.
+    let shutdownResolved = false;
+    const shutdownPromise = facade.shutdown().then(() => {
+      shutdownResolved = true;
+    });
+    // Give shutdown ample time to stop the runtimes and reach the drain; while
+    // the capture is gated it can never resolve, so this stays false.
+    await sleep(50);
+    expect(shutdownResolved).toBe(false);
+
+    // Releasing the capture lets it finish its write; shutdown then resolves.
+    releaseCapture();
+    await shutdownPromise;
+    expect(shutdownResolved).toBe(true);
   });
 
   it('reverse-delivers one completion for multiple sends steered into the current turn', async () => {


### PR DESCRIPTION
针对 PR #223（`feature/i209-npm-package-split`）的两处定向修复。

## 1. `skills/extraRoots/set` 在旧 app-server 上致命导致 dispatcher 无法启动

对应 owner 反馈 https://github.com/excitedjs/dreamux/pull/223#issuecomment-4700975065。

**核实**：`CodexRuntime.applySkillExtraRoots()`（`packages/agent-runtime/codex/src/runtime.ts`，在 `start` 路径上 `initialize` 之后、`thread/start` 之前被 `await`）无差别地发起 `skills/extraRoots/set`。早于该 RPC 的 codex 后端会以 `unknown variant`/method-not-found 拒绝，导致 `dispatcher failed to start`，dispatcher 永久 `stopped`（通道连上但不再处理流量）。

**修复**：区分两种失败语义——
- **能力/版本缺口**（后端根本不实现该方法，回 `unknown variant`/`method not found`/`unknown method`/`no such method`/`unsupported method`）：**fail open**，记 `warn`（`unsupported by this app-server; continuing skill-blind`）并继续 skill-blind，不再 brick 启动；
- **该 RPC 存在但应用 roots 真正失败**（坏路径、权限等）：**保持 fail loud**，与原行为一致，不掩盖真实错误。

协议形状（`InitializeResponse`）不暴露受支持方法集，故采用基于错误消息的健壮分类器（rpc 层丢弃了 JSON-RPC error code，消息是唯一可用信息），匹配刻意收窄。docstring 记录了唯一残留的误判边界（一个*实现了*该方法但因坏枚举参数值回 `unknown variant` 的后端会被吞——对唯一调用方 `skills/extraRoots/set` 安全，因其参数是 `string[]` 路径，codex 不会枚举拒绝）。

**测试**（`skill-extra-roots.test.ts`）：新增 unsupported-RPC 路径（启动成功 + 续到 `thread/start` + 记 warn + 无 error）、真实错误路径（仍 `rejects`、不到 `thread/start`）、以及 `isUnsupportedRpcMethodError` 分类器的正/负样本。

## 2. CI flake：macOS 上 `teammate/records` 清理 ENOTEMPTY

失败 check：rush（macos-latest），`teammate-completion-e2e.test.ts > coalesces duplicate settled events for the same teammate turn`。

**核实**：settle 钩子以 fire-and-forget（`void this.deliverTurnSettled(...)`）发起 durable 的 record/turns 原子写（temp+rename），以免扰动 settle 时序。重复 settle 的捕获（#2/#3）不被 `waitFor(returned_turns===1)` 覆盖，可在 teardown 时仍在途，与递归删除竞争 → 慢文件系统上 `rmdir` 报 ENOTEMPTY。

**修复**：teammate 服务现在跟踪这些在途捕获，`stopAll()`（即 `DispatcherService.shutdown()`）在停止 runtime 后排空它们；`runtime.stop()` 自身可能再触发一个 `stopped` settle，故用 `while` 循环排空直至静默。等待 shutdown 的调用方因此观察不到仍在途的写入。未改任何 config/state schema 或路径，无需操作员动作。

**测试**：新增确定性用例——用屏障把一个捕获按在途（gate `getLast`），断言 `shutdown()` 在释放前**不**resolve、释放后 resolve。在任意 OS（含 Linux）上都能验证排空逻辑，而非依赖触发该 flake 的 macOS 时序。

## 验证

- `rush build` ✓、`rush lint` ✓、`rush test` ✓（退出码 0）。
- `@excitedjs/agent-runtime-codex`：27 passed；`@excitedjs/dreamux`：635 passed | 2 skipped（含新增 drain 用例）。
- `rush change --verify` 0；两份 patch change file（codex / dreamux）。
- 日志中的堆栈来自既有 fail-soft 合成失败用例，非测试失败。

## 残留风险

- Fix #1 由分类器对真实 codex 错误消息的匹配 + 真实错误路径仍 fail-loud 的回归用例验证；分类是消息匹配，未来若有调用方传枚举型参数需另行评估（docstring 已注明）。
- Fix #2 的确定性 drain 用例在 Linux 上验证逻辑；macOS 文件系统竞争本身仅能由 CI 复核（已在测试注释与此说明）。

不自行合并。
