### PR TITLE
Enable automatic beta releases from next

### DIFF
--- a/.agents/decisions/npm-release-oidc.md
+++ b/.agents/decisions/npm-release-oidc.md
@@ -1,7 +1,7 @@
 # npm release via OIDC trusted publishing
 
 - **Status:** Accepted
-- **Date:** 2026-05-30 (next beta channel added 2026-06-07)
+- **Date:** 2026-05-30 (next beta channel added 2026-06-07; automatic next beta pushes added 2026-06-16)
 - **Affects:** npm publishing of every `shouldPublish` package, `/.github/workflows/`, the rush version mechanism
 - **PR / Issue:** infra/feishu-transport-release; next beta channel — issue #122
 
@@ -42,7 +42,7 @@ Three hard constraints shaped the design:
 
 ## Decision
 
-One workflow, `push: [main]` plus manual dispatch:
+One workflow, `push: [main, next]` plus manual dispatch:
 
 - **`/.github/workflows/release.yml`** — the single release pipeline and the
   workflow every publishable package registers as its trusted publisher. On a
@@ -57,9 +57,9 @@ One workflow, `push: [main]` plus manual dispatch:
   public npm registry. Rush compares every publishable package against npm and
   invokes pnpm publish only for versions that are not already present.
   `id-token: write`, `npm install -g npm@11.5.1`,
-  `NPM_CONFIG_PROVENANCE=true`, no `NODE_AUTH_TOKEN`. Manual dispatch is a
-  retry hook for `main` only; packages are never published from feature
-  branches.
+  `NPM_CONFIG_PROVENANCE=true`, no `NODE_AUTH_TOKEN`. Manual dispatch against
+  `main` is a stable retry hook; stable packages are never published from
+  feature branches.
 
 So **Rush owns versioning and publish orchestration, pnpm owns the registry
 manifest rewrite, npm owns the OIDC/provenance upload**, and all halves are
@@ -77,13 +77,14 @@ npm trusted-publisher entry** (Workflow: `release.yml`) — rather than adding a
 second workflow that would need its own npm registration and reintroduce a
 default-branch dispatch dance:
 
-- A prerelease job is gated to `workflow_dispatch` on branch refs other than
-  `main`. Dispatching `release.yml` against `next` publishes `beta`; dispatching
-  against any other non-main branch publishes `alpha`. `push` fires on main only,
-  and the stable `version`/`publish` jobs are gated to `refs/heads/main`, so
-  feature branch pushes do not publish and tags cannot satisfy the prerelease
-  gate. `concurrency: release-${{ github.ref_name }}` already namespaces branch
-  runs.
+- A prerelease job is gated to branch refs other than `main`, and it runs for
+  either a `push` to `next` or a manual dispatch on any non-main branch. Pushes
+  to `next` publish `beta`; dispatching `release.yml` against `next` also
+  publishes `beta`; dispatching against any other non-main branch publishes
+  `alpha`. The stable `version`/`publish` jobs are gated to `refs/heads/main`,
+  so `main` keeps the stable path, feature branch pushes do not publish, and
+  tags cannot satisfy the prerelease gate. The `release-${{ github.ref_name }}`
+  concurrency group already namespaces branch runs.
 - The dispatch works because `release.yml` already lives on the default branch
   (main) with `workflow_dispatch`, which is what makes the workflow
   dispatchable at all; `workflow_dispatch` then **executes the copy of the file
@@ -149,10 +150,11 @@ default-branch dispatch dance:
   is the one external item to confirm before the first beta dispatch. If a
   package's entry were ever restricted to a specific environment or ref, the
   beta job would need a matching entry.
-- **How to cut and verify prereleases.** For beta, dispatch the `release`
-  workflow (Actions → release → Run workflow) selecting branch `next`; the job
-  publishes `0.12.x-beta.<run_number>` to the `beta` tag. For alpha, dispatch
-  the same workflow selecting a feature branch; the job publishes
+- **How to cut and verify prereleases.** For beta, push or merge to `next`; the
+  `release` workflow automatically publishes `0.12.x-beta.<run_number>` to the
+  `beta` tag. Manual dispatch of the same workflow selecting branch `next`
+  remains a beta retry hook with a fresh run number. For alpha, dispatch the
+  workflow selecting a feature branch; the job publishes
   `0.12.x-alpha.g<short_sha>` to the `alpha` tag. Install-verify with
   `npm install @excitedjs/dreamux@beta` or `npm install @excitedjs/dreamux@alpha`;
   inspect tags with `npm dist-tag ls @excitedjs/dreamux` and confirm `latest`

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,21 +40,21 @@
 # future stricter protection rule must grant github-actions[bot] a bypass.
 #
 # Prerelease channels reuse this same file (and therefore the same npm
-# trusted-publisher entry, Workflow: release.yml). Manual dispatch against
-# `next` publishes `beta`; dispatch against any other non-main branch publishes
-# `alpha`. Stable version/publish jobs are gated to main and never run on
-# prerelease branches. Prerelease publishes never move `latest`. They are
-# ephemeral: an in-tree prerelease version is applied, built, packed, audited,
-# and published, but commits and pushes NOTHING back. Prerelease apply does NOT
-# delete pending Rush change files, so a later stable release still consumes
-# them. Beta uses `beta.<github.run_number>`; alpha uses `alpha.<short_sha>` so
-# branch builds are tied to source.
+# trusted-publisher entry, Workflow: release.yml). Pushes to `next` publish
+# `beta`; manual dispatch against `next` also publishes `beta`; dispatch against
+# any other non-main branch publishes `alpha`. Stable version/publish jobs are
+# gated to main and never run on prerelease branches. Prerelease publishes never
+# move `latest`. They are ephemeral: an in-tree prerelease version is applied,
+# built, packed, audited, and published, but commits and pushes NOTHING back.
+# Prerelease apply does NOT delete pending Rush change files, so a later stable
+# release still consumes them. Beta uses `beta.<github.run_number>`; alpha uses
+# `alpha.<short_sha>` so branch builds are tied to source.
 
 name: release
 
 on:
   push:
-    branches: [main]
+    branches: [main, next]
   workflow_dispatch:
 
 concurrency:
@@ -186,12 +186,12 @@ jobs:
 
   prerelease:
     name: publish prerelease to npm beta/alpha dist-tag (OIDC)
-    # This job is reachable solely via workflow_dispatch, because `on.push`
-    # listens only to main. Dispatching against main runs stable jobs and skips
-    # this one. Dispatching against next publishes beta. Dispatching against any
-    # other branch publishes alpha. Gate on full refs so a tag named next/main
-    # can never satisfy the branch policy.
-    if: github.event_name == 'workflow_dispatch' && startsWith(github.ref, 'refs/heads/') && github.ref != 'refs/heads/main'
+    # Pushes to next publish beta automatically. Dispatching against main runs
+    # stable jobs and skips this one. Dispatching against next publishes beta.
+    # Dispatching against any other branch publishes alpha. Gate on full refs so
+    # a tag named next/main can never satisfy the branch policy, and keep alpha
+    # publish manual-only even if push triggers are broadened later.
+    if: startsWith(github.ref, 'refs/heads/') && github.ref != 'refs/heads/main' && (github.event_name == 'workflow_dispatch' || github.ref == 'refs/heads/next')
     runs-on: ubuntu-latest
     timeout-minutes: 20
     permissions:


### PR DESCRIPTION
## Summary

- Trigger the release workflow on pushes to both `main` and `next`.
- Let the existing prerelease job run automatically for `next` pushes while keeping alpha publishes manual-only.
- Update the npm release decision record to document the automatic `next` beta path and unchanged manual dispatch behavior.

## Behavior Matrix

| Event / ref | Stable version/publish | Prerelease publish | Dist tag |
| --- | --- | --- | --- |
| `push` to `main` | Yes | No | `latest` |
| `push` to `next` | No | Yes | `beta` |
| `workflow_dispatch` on `main` | Yes | No | `latest` |
| `workflow_dispatch` on `next` | No | Yes | `beta` |
| `workflow_dispatch` on another branch | No | Yes | `alpha` |
| `push` to another branch | No | No | n/a |
| `workflow_dispatch` on a tag | No | No | n/a |

## Verification

- `git diff --check` passed.
- `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.7 .github/workflows/release.yml` passed with no diagnostics.
- `npx --yes js-yaml .github/workflows/release.yml` parsed the workflow and confirmed push branches `main,next` plus all three jobs.
- A local job-gate matrix check passed for `push/main`, `push/next`, `workflow_dispatch/main`, `workflow_dispatch/next`, `workflow_dispatch/feature`, `push/feature`, and `workflow_dispatch` on a tag.
- `.agents/scripts/check.sh` passed: `KB OK (35 files reachable from root.md)`.
- `node common/scripts/install-run-rush.js change --verify --target-branch origin/next --no-fetch` passed; Rush reported no relevant package changes.

No registry publish command was run.