### PR TITLE
Rework Dreamux knowledge base navigation

### DIFF
--- a/.agents/CONTRIBUTING.md
+++ b/.agents/CONTRIBUTING.md
@@ -7,70 +7,57 @@ This file is for *writers* of `.agents/` content. Readers should start at
 
 Before finishing any non-trivial change, ask:
 
-> Did this move a component boundary, a cross-process protocol, a CLI
-> command surface, a release-relevant decision, or an architecture
-> invariant?
+> Did this move a package boundary, a CLI surface, a settled design decision,
+> a Codex / Feishu protocol contract, a state/config format, or a
+> cross-process invariant?
 
-If **yes**: update the KB in the same PR. A correct system with a stale
-KB is worse than a buggy system whose KB tells you exactly where to look.
+If **yes**: update the KB in the same PR. A correct system with a stale KB is
+worse than a buggy system whose KB tells you exactly where to look.
 
-If **no** (bug fix inside one function, an obvious refactor, a TODO):
-don't write a KB entry just to look diligent. The KB earns its keep by
-being terse.
-
-### Typical YES
-
-- new package added / removed under `packages/`
-- a CLI subcommand added / removed / renamed (issue #4 made `dreamux` the
-  unified surface — see [the CLI naming decision](decisions/cli-and-package-naming.md))
-- a settled design decision after debate (write a decision record)
-- a new external dependency that materially shapes the runtime (a
-  database engine swap, a new IPC mechanism)
-- a Codex / Feishu protocol version bump that required code changes
-
-### Typical NO
-
-- a bug fix inside one function whose contract didn't change
-- a test added for an already-documented behavior
-- refactors that don't move boundaries
-- in-progress scratch notes — those go in your PR description, not here
+If **no** (bug fix inside one function, an obvious refactor, a TODO): don't
+write a KB entry just to look diligent. The KB earns its keep by being terse.
 
 ## How to write
 
-- **English.** All KB content in English regardless of conversation
-  language. (Repo-level rule, see [`/CLAUDE.md`](../CLAUDE.md).)
-- **Short.** Bullets over paragraphs. Verify each claim against code
-  before committing — KB drift is more costly than missing content.
-- **Repo-root-absolute links** (start with `/`): `/packages/dreamux/src/...`,
-  `/CLAUDE.md`. Avoid `../../` chains; they break when files move.
-- **Cite the source.** Decision records name the PR / issue / commit
-  that made them concrete. Component docs link the source files they
-  describe.
+- **English.** All KB content is English regardless of conversation language.
+  (Repo-level rule, see [`/CLAUDE.md`](../CLAUDE.md).)
+- **Current facts need source links.** Reference docs point at the files that
+  implement the behavior they describe.
+- **Short and owned.** Each fact has one owner file. Other files link to it
+  instead of restating it.
+- **Links.** Use relative links inside `.agents/` when linking to other KB
+  files. Use repo-root-absolute links (start with `/`) when linking from KB
+  files to source files, package files, or always-loaded repo files such as
+  `/CLAUDE.md`.
+- **Status matters.** Historical material stays preserved, but it must say that
+  it is historical, superseded, or archived.
 
-## Document kinds
+## Document Kinds
 
 | Kind | When to use | Naming |
 |---|---|---|
-| `components/<thing>.md` | A piece big enough to have its own contract / mental model (server, CLI, codex-client, feishu-bot, repo-structure) | kebab-case, no number |
-| `decisions/<slug>.md` | A choice that was debated and settled; future maintainers need the *why* | topic slug, kebab-case, no sequence number |
-| `domains/<area>.md` | A cross-cutting contract that spans multiple components | kebab-case |
-| `proposals/<slug>.md` | An active design under discussion | kebab-case |
-| `research/<slug>.md` | A frozen investigation snapshot; must end with an explicit "disposition" section (Promoted / Deferred / Out of scope) | kebab-case |
-| `rules/<slug>.md` | A process rule that applies to KB authors themselves | kebab-case |
+| `reference/<thing>.md` | Current behavior for a repo piece or operational mental model. Use for "what exists now". | kebab-case, no number |
+| `decisions/<slug>.md` | A choice that was debated and settled. Use for "why was this chosen". | kebab-case, no sequence number |
+| `domains/<area>.md` | A current cross-cutting runtime contract that spans several reference pages. | kebab-case |
+| `glossary.md` | Top-level terminology index for overloaded Dreamux terms. Keep it short and link source/reference docs for behavior. | fixed filename |
+| `proposals/<slug>.md` | Active design proposal only. Once implemented, superseded, or abandoned, move it to `archive/` or promote the settled result to a decision/reference page. | kebab-case |
+| `archive/<kind>/<slug>.md` | Preserved historical material that should not be a default reading path. | keep original slug |
+| `research/<slug>.md` | Frozen investigation snapshot; must end with a disposition section (Promoted / Deferred / Out of scope). | kebab-case |
+| `rules/<slug>.md` | A process rule that applies to KB authors themselves. | kebab-case |
 
-## Decision record template
+## Decision Record Template
 
 ```markdown
 # <decision title>
 
 - **Status:** Accepted | In progress | Superseded by [link]
 - **Date:** YYYY-MM-DD
-- **Affects:** components / packages / surfaces
+- **Affects:** packages / surfaces / invariants
 - **PR / Issue:** link
 
 ## Context
 
-The forces — what made this a decision worth recording.
+The forces that made this a decision worth recording.
 
 ## Decision
 
@@ -78,12 +65,12 @@ What was chosen. One sentence if possible.
 
 ## Consequences
 
-Costs, constraints, foot-guns, and enforcement / guards (tests, lint
-rules, code review checklist).
+Costs, constraints, foot-guns, and enforcement / guards (tests, lint, review
+checklist).
 
-## Alternatives considered (optional)
+## Alternatives Considered
 
-Only when a future reader is likely to ask "why not X?" — keep it short.
+Only when a future reader is likely to ask "why not X?" Keep it short.
 ```
 
 ## Validation
@@ -94,5 +81,5 @@ Before committing KB changes, run:
 .agents/scripts/check.sh
 ```
 
-It validates internal links and surfaces any orphaned files. Failures
-are noisy on purpose; CI will reject anything the script rejects.
+It validates links, archive reachability, and decision index completeness.
+Failures are noisy on purpose; CI will reject anything the script rejects.

--- a/.agents/archive/README.md
+++ b/.agents/archive/README.md
@@ -1,0 +1,16 @@
+# Archive
+
+This directory preserves historical material that is useful for archaeology but
+should not be a default reading path for current work.
+
+When a proposal is implemented, superseded, or abandoned:
+
+- keep the original content;
+- move it under `archive/`;
+- update its status or the archive index so readers know where current behavior
+  lives;
+- link the current reference or decision from the archive entry.
+
+## Contents
+
+- [Archived proposals](proposals/README.md)

--- a/.agents/archive/proposals/README.md
+++ b/.agents/archive/proposals/README.md
@@ -1,0 +1,11 @@
+# Archived Proposals
+
+These proposals are preserved for historical context. They are not current
+implementation guidance; use the linked decisions and reference docs first.
+
+| Proposal | Current pointer |
+|---|---|
+| [Feishu trusted-bot context](feishu-bot-trust-context.md) | [Feishu introduce](../../domains/feishu-introduce.md), [non-blocking dispatcher inbound](../../domains/non-blocking-dispatcher-inbound.md), [top-level design](../../decisions/top-level-design.md) |
+| [Global `dreamux` bin, `onboard`, and `serve`](global-bin-onboard-serve.md) | [global bin/onboard/serve decision](../../decisions/global-bin-onboard-serve.md), [dispatcher tm packaging](../../decisions/dispatcher-tm-packaging.md) |
+| [Plugin and provider architecture](plugin-provider-architecture.md) | [current architecture](../../reference/current-architecture.md), [provider architecture realignment](../../decisions/provider-architecture-realignment.md), [NPM package split and channel targets](../../decisions/npm-package-split-and-channel-targets.md) |
+| [Post-MVP hardening](post-mvp-hardening.md) | Historical pre-#209 hardening backlog; write a current proposal before implementation |

--- a/.agents/archive/proposals/feishu-bot-trust-context.md
+++ b/.agents/archive/proposals/feishu-bot-trust-context.md
@@ -1,8 +1,9 @@
 # Feishu trusted-bot context + list-chat-bots query + add-then-cancel reactions
 
-- **Status:** Implemented (issue #69 review accepted; the settled behavior now
-  lives in the domain/decision docs linked under Disposition — this proposal is
-  kept as the design-rationale + open-question record)
+- **Status:** Archived historical proposal. Issue #69 was implemented; the
+  settled behavior now lives in the domain/decision docs linked under
+  Disposition. This file is preserved only for design rationale and old open
+  questions.
 - **Date:** 2026-06-05
 - **Affects:** `/packages/dreamux/src/channel/chat-bots-store.ts`,
   `/packages/dreamux/src/channel/feishu-message.ts`,
@@ -14,11 +15,15 @@
   [#62](https://github.com/excitedjs/dreamux/issues/62), first increment #68;
   design review on the issue is accepted with the constraints below)
 
+Archive note: source paths and some implementation names below predate the
+provider/package split. Do not use this proposal as current implementation
+guidance; start with the linked domain and reference docs instead.
+
 ## Context
 
 #68 shipped the typed event-route seam, the `/introduce` hard contract, and the
 `known` / `trusted` peer-bot store (see
-[`domains/feishu-introduce.md`](../domains/feishu-introduce.md)). Two Phase 4
+[`domains/feishu-introduce.md`](../../domains/feishu-introduce.md)). Two Phase 4
 items from #62 were deferred — one-shot discovery context and a list-known-bots
 capability — and a separate channel-behavior tweak (reaction ordering) is folded
 into the same focused change.

--- a/.agents/archive/proposals/global-bin-onboard-serve.md
+++ b/.agents/archive/proposals/global-bin-onboard-serve.md
@@ -3,16 +3,23 @@
 - **Status:** Superseded by accepted decision
 - **Date:** 2026-06-02
 - **Issue:** [issue #18](https://github.com/excitedjs/dreamux/issues/18)
-- **Decision:** [global-bin-onboard-serve](../decisions/global-bin-onboard-serve.md),
-  amended by [dispatcher-tm-packaging](../decisions/dispatcher-tm-packaging.md)
+- **Decision:** [global-bin-onboard-serve](../../decisions/global-bin-onboard-serve.md),
+  amended by [dispatcher-tm-packaging](../../decisions/dispatcher-tm-packaging.md)
 
 This proposal is retained only as the issue #18 design entry point. The
 binding behavior now lives in the accepted decision:
 
+Archive note: the bullets below are a historical bridge from this proposal to
+the accepted decision. Current Dreamux injects bundled skills at runtime by role;
+`dreamux onboard` no longer installs bundled Codex skill symlinks into
+workspace `.codex/skills/`.
+
 - `@excitedjs/dreamux` exports `dreamux` plus the dispatcher-required `tm`
   wrapper.
-- `dreamux onboard` installs bundled Codex skill symlinks into each
-  dispatcher's workspace-local `.codex/skills/` directory.
+- At the time of this proposal, `dreamux onboard` was expected to install
+  bundled Codex skill symlinks into each dispatcher's workspace-local
+  `.codex/skills/` directory. That behavior is now superseded by runtime skill
+  injection.
 - Dispatcher app-server processes use Codex's global default home for auth,
   config, and memory; dreamux does not set `CODEX_HOME`.
 - dreamux-owned state defaults to `~/.dreamux/state/`, and logs default to

--- a/.agents/archive/proposals/plugin-provider-architecture.md
+++ b/.agents/archive/proposals/plugin-provider-architecture.md
@@ -2,7 +2,7 @@
 
 - **Status:** Historical issue #110 proposal; implemented Phase 1 boundaries
   are refined by
-  [provider-architecture-realignment](../decisions/provider-architecture-realignment.md)
+  [provider-architecture-realignment](../../decisions/provider-architecture-realignment.md)
 - **Date:** 2026-06-06
 - **Affects:** plugin mechanism, Capability Registry, dispatcher config,
   Channel providers, Agent Runtime providers, MCP injection, server-hosted
@@ -17,7 +17,7 @@
 The current runtime is intentionally narrow: one dispatcher owns one Feishu
 channel, one Codex app-server child, one Codex thread, and one dispatcher-scoped
 Feishu MCP shim. That MVP boundary is documented in
-[top-level-design](../decisions/top-level-design.md).
+[top-level-design](../../decisions/top-level-design.md).
 
 Issue #110 changes the target architecture. Dreamux needs a full extension
 surface that covers:
@@ -32,7 +32,7 @@ surface that covers:
 Issue #135 later narrows the current provider seam: Feishu is a built-in
 bidirectional channel rather than a runnable ChannelProvider, and the registry
 is an Agent Runtime provider view. Read
-[provider-architecture-realignment](../decisions/provider-architecture-realignment.md)
+[provider-architecture-realignment](../../decisions/provider-architecture-realignment.md)
 before treating this proposal as current implementation guidance.
 
 The architecture must preserve public safety and the issue #98 compatibility
@@ -249,8 +249,8 @@ Restart recovery must preserve the distinction from issue #98:
 
 The proposal is made concrete by these issue #110 decisions:
 
-- [provider references and Capability Registry](../decisions/provider-references-and-capability-registry.md)
-- [Agent Runtime providers](../decisions/agent-runtime-provider.md)
-- [Channel providers](../decisions/channel-provider.md)
-- [server-hosted TeamMate](../decisions/server-hosted-teammate.md)
-- [providerized config and state compatibility](../decisions/providerized-config-state-compatibility.md)
+- [provider references and Capability Registry](../../decisions/provider-references-and-capability-registry.md)
+- [Agent Runtime providers](../../decisions/agent-runtime-provider.md)
+- [Channel providers](../../decisions/channel-provider.md)
+- [server-hosted TeamMate](../../decisions/server-hosted-teammate.md)
+- [providerized config and state compatibility](../../decisions/providerized-config-state-compatibility.md)

--- a/.agents/archive/proposals/post-mvp-hardening.md
+++ b/.agents/archive/proposals/post-mvp-hardening.md
@@ -1,6 +1,6 @@
 # Post-MVP hardening: bounded state, restart reconciliation, access surface
 
-- **Status:** Proposed
+- **Status:** Archived historical proposal
 - **Date:** 2026-06-04
 - **Affects:** dispatcher runtime, turn queue, Feishu access gate, server
   startup, message formatting, CLI/admin surface, diagnostics
@@ -8,6 +8,12 @@
   issue #36 epic review (#42, #44, #46, #49, #53, #55) plus pre-existing
   #22 / #24, and the ultracode review of #58 (bug_001–bug_007). Excludes
   #6 (blocked on the public npm publish of the shared feishu-transport core).
+
+Archive note: this proposal predates the provider/package split and
+non-blocking inbound follow-up work. It preserves the original hardening
+analysis, but many source paths and some implementation assumptions are
+historical. Before implementing any item here, write or update a current
+post-#209 proposal/reference against the present source tree.
 
 ## Context
 

--- a/.agents/decisions/README.md
+++ b/.agents/decisions/README.md
@@ -4,14 +4,49 @@ Decision records use stable topic slugs, not sequence numbers. Do not create
 `0001-...` style names; concurrent agents regularly collide on numbers, while
 topic slugs remain reviewable and merge-friendly.
 
+Decision files preserve history and rationale. For current behavior, start with
+[current architecture](../reference/current-architecture.md), plus the focused
+[state and paths](../reference/state-and-paths.md) and
+[channel runtime](../reference/channel-runtime.md) references when those areas
+are involved, then follow the decision trail.
+
+## Current Architecture Trail
+
+Read these first for today's system shape:
+
+- [provider-architecture-realignment](provider-architecture-realignment.md)
+- [npm-package-split-and-channel-targets](npm-package-split-and-channel-targets.md)
+- [agents-config-normalization](agents-config-normalization.md)
+- [runtime-run-root](runtime-run-root.md)
+- [dispatcher-local-aggregate](dispatcher-local-aggregate.md)
+- [install-model](install-model.md)
+
 ## Browse by Theme
 
 | Theme | Records |
 |---|---|
 | Repository shape | [rush-pnpm-monorepo](rush-pnpm-monorepo.md), [install-model](install-model.md) |
-| Runtime architecture | [top-level-design](top-level-design.md), [issue-110-epic-closure](issue-110-epic-closure.md), [provider-references-and-capability-registry](provider-references-and-capability-registry.md), [agent-runtime-provider](agent-runtime-provider.md), [channel-provider](channel-provider.md), [npm-package-split-and-channel-targets](npm-package-split-and-channel-targets.md), [server-hosted-teammate](server-hosted-teammate.md), [dispatcher-local-aggregate](dispatcher-local-aggregate.md), [providerized-config-state-compatibility](providerized-config-state-compatibility.md), [agents-config-normalization](agents-config-normalization.md), [global-config-dir](global-config-dir.md), [logging](logging.md), [feishu-inbound-attachments](feishu-inbound-attachments.md), [channel-input-runtime-assembly](channel-input-runtime-assembly.md), [runtime-run-root](runtime-run-root.md) |
+| Runtime architecture | [provider-architecture-realignment](provider-architecture-realignment.md), [npm-package-split-and-channel-targets](npm-package-split-and-channel-targets.md), [agents-config-normalization](agents-config-normalization.md), [dispatcher-local-aggregate](dispatcher-local-aggregate.md), [runtime-run-root](runtime-run-root.md), [issue-110-epic-closure](issue-110-epic-closure.md), [top-level-design](top-level-design.md), [provider-references-and-capability-registry](provider-references-and-capability-registry.md), [agent-runtime-provider](agent-runtime-provider.md), [channel-provider](channel-provider.md), [server-hosted-teammate](server-hosted-teammate.md), [providerized-config-state-compatibility](providerized-config-state-compatibility.md), [global-config-dir](global-config-dir.md), [logging](logging.md), [feishu-inbound-attachments](feishu-inbound-attachments.md), [channel-input-runtime-assembly](channel-input-runtime-assembly.md) |
 | Public surface | [cli-and-package-naming](cli-and-package-naming.md), [dispatcher-tm-boundary](dispatcher-tm-boundary.md), [dispatcher-tm-packaging](dispatcher-tm-packaging.md), [global-bin-onboard-serve](global-bin-onboard-serve.md), [global-config-dir](global-config-dir.md) |
 | Release and safeguards | [npm-release-oidc](npm-release-oidc.md), [anti-leak-guardrail](anti-leak-guardrail.md), [no-sync-io-lint-gate](no-sync-io-lint-gate.md) |
+
+## Historical or Superseded Background
+
+These records are intentionally kept in `decisions/` because they are ADRs, but
+they are not the first place to learn current behavior:
+
+- [top-level-design](top-level-design.md) — original MVP baseline; still useful
+  for unchanged local state/log/access foundations.
+- [channel-provider](channel-provider.md) — historical channel-provider
+  boundary, superseded by the package split and channel-target decisions.
+- [dispatcher-tm-boundary](dispatcher-tm-boundary.md) — superseded by
+  server-hosted TeamMate.
+- [global-config-dir](global-config-dir.md) — superseded by top-level design.
+- [server-hosted-teammate](server-hosted-teammate.md) — superseded for current
+  implementation by provider realignment and the package split.
+
+Historical proposals live in [archive/proposals](../archive/proposals/README.md)
+instead of this decision index.
 
 ## Alphabetical Index
 
@@ -33,6 +68,7 @@ topic slugs remain reviewable and merge-friendly.
 - [no-sync-io-lint-gate](no-sync-io-lint-gate.md)
 - [npm-package-split-and-channel-targets](npm-package-split-and-channel-targets.md)
 - [npm-release-oidc](npm-release-oidc.md)
+- [provider-architecture-realignment](provider-architecture-realignment.md)
 - [provider-references-and-capability-registry](provider-references-and-capability-registry.md)
 - [providerized-config-state-compatibility](providerized-config-state-compatibility.md)
 - [runtime-run-root](runtime-run-root.md)

--- a/.agents/decisions/install-model.md
+++ b/.agents/decisions/install-model.md
@@ -65,7 +65,7 @@ now exist, so retiring path 1 is the natural close-out, not a new constraint.
 - **Guards:** the `rush` CI job is the authoritative
   install/typecheck/build/test gate; PRs also run `rush change --verify` against
   the base branch so release-surface changes declare Rush change files.
-  `CLAUDE.md`, `README.md`, and `components/repo-structure.md` all describe the
+  `CLAUDE.md`, `README.md`, and `reference/repo-structure.md` all describe the
   single path; this record supersedes the "two paths" consequence of
   [the Rush + pnpm decision](rush-pnpm-monorepo.md).
 

--- a/.agents/decisions/top-level-design.md
+++ b/.agents/decisions/top-level-design.md
@@ -1,5 +1,10 @@
 # Top-level design
 
+> **Historical baseline.** This decision records the original MVP shape. Large
+> sections below intentionally preserve superseded Feishu/Codex-specific
+> wording; do not use a deep-linked section as current implementation guidance
+> until you have checked the current reference pages and source code.
+
 - **Status:** Accepted for the original MVP; superseded for issue #110
   providerized surfaces by [issue-110-epic-closure](issue-110-epic-closure.md),
   [channel-provider](channel-provider.md), [agent-runtime-provider](agent-runtime-provider.md),
@@ -11,6 +16,20 @@
 - **Date:** 2026-06-03
 - **Affects:** server runtime, dispatcher lifecycle, Feishu channel, Codex MCP, admin/outbound IPC, global config, state files, logs, CLI admin surface, workspace-local bundled skill ownership
 - **PR / Issue:** Local architecture clarification on 2026-06-03; supersedes the persistence and automatic-outbound parts of issue #2, the runtime-dir parts of `global-config-dir`, and loopback HTTP MCP as the default Feishu MCP transport
+
+## Current Reading Note
+
+This file preserves the original MVP baseline and still-current rationale for
+local config, state, access, and log ownership. It is not the shortest current
+architecture map. For current behavior, read these reference pages first:
+
+- [Current architecture](../reference/current-architecture.md)
+- [State and paths](../reference/state-and-paths.md)
+- [Channel runtime](../reference/channel-runtime.md)
+- [Dispatcher skill reference](../reference/dispatcher-skill.md)
+
+Then return here only for the decisions and supersession history behind those
+current facts.
 
 ## Context
 
@@ -350,8 +369,9 @@ deliver/drop, inbound submit, outbound, `/introduce`), and dispatcher lifecycle
 write structured `pino` JSON to these files (and mirror to stderr so a
 foreground `serve` stays visible). Neutral path builders live in
 `src/platform/paths.ts` (with volatile runtime-socket allocation in
-`src/platform/runtime-sockets.ts` and per-runtime log/socket paths in each
-builtin's `src/agent-runtime/builtin/<name>/paths.ts`); logger construction
+`src/platform/runtime-sockets.ts`; runtime-owned log/socket paths live in the
+runtime package that uses them, for example
+`packages/agent-runtime/codex/src/paths.ts`); logger construction
 lives in `src/platform/logger.ts`. Message bodies are never logged; `app_secret`
 is redacted. See [the logging decision](logging.md).
 
@@ -432,8 +452,11 @@ an authorized chat — awareness only) and a `trusted` set (bots introduced by a
 allowlisted `/introduce` — the only set the gate consults to let a peer bot's
 group message through). The two sets must never be conflated: observation never
 grants trust. It also records bot-added baseline bookkeeping (`needsBaseline`,
-`seenEventIds` for idempotent `im.chat.member.bot.added_v1` handling). It is
-server-owned discovery state, safe to delete; it holds no credentials.
+`seenEventIds` for idempotent `im.chat.member.bot.added_v1` handling). The file
+is persisted under the server state root, but the current implementation and
+schema ownership live in the Feishu Channel package
+(`/packages/channel/feishu-channel/src/chat-bots-store.ts`). It is safe to
+delete and holds no credentials.
 
 A Codex app-server runtime listens on a WebSocket-over-Unix-socket endpoint
 (`codex app-server --listen unix://<path>`, connected via `ws+unix://<path>`).

--- a/.agents/domains/feishu-introduce.md
+++ b/.agents/domains/feishu-introduce.md
@@ -4,15 +4,17 @@
   rich attachments are deferred to follow-up PRs — see Deferred below.
 - **Source:** https://github.com/excitedjs/dreamux/issues/62,
   https://github.com/excitedjs/dreamux/issues/87
-- **Affects:** `packages/dreamux/src/feishu/bot.ts`,
-  `packages/dreamux/src/channel/introduce.ts`,
-  `packages/dreamux/src/channel/chat-bots-store.ts`,
-  `packages/dreamux/src/channel/feishu-gate.ts`,
-  `packages/dreamux/src/channel/feishu-message.ts`,
-  `packages/dreamux/src/mcp/feishu-mcp.ts`,
-  `packages/dreamux/src/admin/methods.ts`,
-  `packages/dreamux/src/server.ts`,
-  `packages/dreamux/src/runtime/paths.ts`
+- **Affects:** `/packages/channel/feishu-channel/src/bot.ts`,
+  `/packages/channel/feishu-channel/src/introduce.ts`,
+  `/packages/channel/feishu-channel/src/chat-bots-store.ts`,
+  `/packages/channel/feishu-channel/src/feishu-gate.ts`,
+  `/packages/channel/feishu-channel/src/feishu-message.ts`,
+  `/packages/channel/feishu-channel/src/feishu-channel.ts`,
+  `/packages/channel/feishu-channel/src/feishu-mcp-tools.ts`,
+  `/packages/dreamux/src/mcp/channel-mcp.ts`,
+  `/packages/dreamux/src/admin/methods.ts`,
+  `/packages/dreamux/src/platform/paths.ts`,
+  `/packages/channel/feishu-channel/tests/feishu-introduce.test.ts`
 
 ## Event-route seam (Phase 1)
 
@@ -35,9 +37,9 @@ authorized to run it under the group's policy**. No `@`-mention of our bot is
 required, and the group's `require_mention` setting is ignored on this path.
 
 Authorization (`introduceDenyReason` / `canRunIntroduce` in
-`channel/introduce.ts`) **mirrors the delivery gate `dreamuxFeishuGate` for the
-same `group.policy`**, minus the `@`-mention requirement introduce deliberately
-waives:
+`/packages/channel/feishu-channel/src/introduce.ts`) **mirrors the delivery
+gate `dreamuxFeishuGate` for the same `group.policy`**, minus the `@`-mention
+requirement introduce deliberately waives:
 
 - `block` → never authorized (`group_blocked`); the gate drops every group
   message, and a trust-changing command is no exception.
@@ -68,10 +70,11 @@ introduce.
 > in a brand-new `follow-user` group (after `@`-mentioning the bot) but could
 > never `/introduce` there — it was diagnosed as `chat_not_allowlisted`. Issues
 > #77 and #87 then built on the frozen behavior without revisiting it. The
-> awareness path in `server.ts` (`observeKnownBot`, gated on
-> `allow_chats.includes`) is the *same* hardcoded-`allow_chats` shape one layer
-> up — out of scope here (it tracks `known` bots, not trust), but a candidate
-> for the same follow-user alignment.
+> awareness path now lives in
+> `/packages/channel/feishu-channel/src/feishu-channel.ts` (`observeKnownBot`,
+> gated on `allow_chats.includes`). It is the *same*
+> hardcoded-`allow_chats` shape one layer up — out of scope here (it tracks
+> `known` bots, not trust), but a candidate for the same follow-user alignment.
 
 Detection (`detectIntroduce`) is text-only and strips leading Feishu mention
 placeholder tokens before matching `^/introduce`, so an `@`-prefixed
@@ -109,20 +112,20 @@ A `/introduce` whose sender is not authorized is **not** consumed: it falls
 through to `dreamuxFeishuGate` and is dropped like any other group message —
 most misleadingly as `bot not mentioned`, because the introduce path waives the
 mention requirement that the gate still enforces. To keep this one-glance
-diagnosable, `introduceDenyReason` (`channel/introduce.ts`) is the discriminated
+diagnosable, `introduceDenyReason`
+(`/packages/channel/feishu-channel/src/introduce.ts`) is the discriminated
 source of truth — `canRunIntroduce` is its boolean projection — returning a
 stable, grep-able code: `non_group`, `empty_sender_id`, `group_blocked`,
 `chat_not_allowlisted`, `sender_not_followed`. `group_blocked` is the `block`
 policy; `chat_not_allowlisted` is the `allowlist` policy only (under
 `follow-user` the chat allowlist is ignored, so an off-allowlist sender there is
 `sender_not_followed`, never `chat_not_allowlisted`). When `detectIntroduce`
-matches but the reason is
-non-null, `server.ts` emits one channel log `introduce detected but not
-authorized` carrying only `chat_id`/`sender_id`/`message_id`/`reason` (never the
-message body, mentioned peer open_ids, or mention names), then continues into
-the **unchanged** gate. This is observability only: gate decisions, trust
-writes, baseline arming, and authorized-introduce consume behavior are
-unchanged.
+matches but the reason is non-null, `FeishuChannelSession` emits one channel log
+`introduce detected but not authorized` carrying only
+`chat_id`/`sender_id`/`message_id`/`reason` (never the message body, mentioned
+peer open_ids, or mention names), then continues into the **unchanged** gate.
+This is observability only: gate decisions, trust writes, baseline arming, and
+authorized-introduce consume behavior are unchanged.
 
 ## Awareness vs trust
 
@@ -157,27 +160,30 @@ entity" after a drop, and is never consulted by the gate.
 
 When `/introduce` newly trusts a bot — or the bot is added to a chat — the chat
 is flagged `needsBaseline` and its `baselineGeneration` is bumped
-(`chat-bots-store.ts`). On the next **delivered** group message,
-`formatFeishuMessageForCodex` appends a one-shot `<group_bots>` block listing the
-chat's **trusted** bots (name + open_id), so the model can map a peer bot's
-open_id to a name. Passive `known` bots are deliberately not pushed here; they
-are queried on demand via `list_chat_bots`.
+(`/packages/channel/feishu-channel/src/chat-bots-store.ts`). On the next
+**delivered** group message, `formatFeishuMessageForRuntime` appends a one-shot
+`<group_bots>` block listing the chat's **trusted** bots (name + open_id), so
+the model can map a peer bot's open_id to a name. Passive `known` bots are
+deliberately not pushed here; they are queried on demand via `list_chat_bots`.
 
 The clear is **commit-after-notify and generation-safe**: the deliver path
 snapshots the generation before enqueue and clears `needsBaseline` only after
-`enqueueInbound` returns `submitted`, and only via `clearBaselineIfCurrent`,
-which no-ops if a newer `/introduce` / bot-added bumped the generation
-mid-enqueue. `duplicate` / `stopped` / `failed` leave the context pending.
+the Channel delivery route returns `submitted`, and only via
+`clearBaselineIfCurrent`, which no-ops if a newer `/introduce` / bot-added
+bumped the generation mid-delivery. `duplicate` / `stopped` / `failed` leave
+the context pending.
 
 ## `list_chat_bots` query tool
 
 A model-facing Feishu MCP tool returns a chat's `known` and `trusted` peer bots
 as two separated arrays of `{ open_id, name? }`, for context recovery after
-compaction. The Feishu channel module owns the tool definition and handler. The
-stdio MCP shim forwards `mcp.list_chat_bots` over the 0600 admin socket, and
-the Dispatcher Service routes it to the channel handler, which reads the
-`chat-bots-store` directly (no running slot required). Same transport shape as
-`reply` / `react`; no operator CLI surface.
+compaction. The Feishu channel package owns the tool definition and handler in
+`/packages/channel/feishu-channel/src/feishu-mcp-tools.ts` and
+`/packages/channel/feishu-channel/src/provider.ts`. The generic `channel-mcp`
+stdio shim forwards the provider tool call over the 0600 admin socket, and the
+Dispatcher Service routes it to the channel handler, which reads
+`chat-bots-store` directly when no live session is required. Same transport
+shape as `reply` / `react`; no operator CLI surface.
 
 ## Deferred to follow-up PRs
 

--- a/.agents/domains/non-blocking-dispatcher-inbound.md
+++ b/.agents/domains/non-blocking-dispatcher-inbound.md
@@ -2,7 +2,14 @@
 
 - **Status:** Implemented runtime contract for issue #63
 - **Source:** https://github.com/excitedjs/dreamux/issues/63
-- **Affects:** `/packages/dreamux/src/dispatcher/turn-manager.ts`, `/packages/dreamux/src/agent-runtime/codex-runtime.ts`, `/packages/dreamux/src/codex/events.ts`, `/packages/dreamux/src/server.ts`, `/packages/dreamux/tests/fake-codex.ts`, `/packages/dreamux/tests/codex-live.test.ts`
+- **Affects:** `/packages/agent-runtime/codex/src/turn-manager.ts`,
+  `/packages/agent-runtime/codex/src/events.ts`,
+  `/packages/channel/feishu-channel/src/feishu-channel.ts`,
+  `/packages/channel/feishu-channel/src/feishu-message.ts`,
+  `/packages/dreamux/src/dispatcher-service/dispatcher/service.ts`,
+  `/packages/dreamux/tests/fake-codex.ts`,
+  `/packages/dreamux/tests/codex-live.test.ts`,
+  `/packages/agent-runtime/codex/tests/turn-manager.test.ts`
 
 ## Locked Scope
 
@@ -17,7 +24,8 @@ the current synchronous operation returns and the ReAct loop advances.
 
 Do not add a dreamux submission mutex. Do not add a production turn observer.
 Do not call `turn/steer` for normal Feishu inbound. Do not maintain a local
-`activeTurnId`. Do not aggregate messages until turn completion.
+`activeTurnId` as the delivery routing authority. Do not aggregate messages
+until turn completion.
 
 ## Codex Contract
 
@@ -38,8 +46,11 @@ The source path is:
 - only `NoActiveTurn` falls through to spawning a new regular turn.
 
 This dissolves the v2 stale-state gap. Since dreamux never calls `turn/steer`
-and never keeps an `activeTurnId`, there is no stale-id path that can produce
-`NoActiveTurn` and drop an accepted message.
+for normal inbound and never decides delivery from a locally cached active turn
+id, there is no stale-id path that can produce `NoActiveTurn` and drop an
+accepted message. The Codex runtime may still keep internal turn ids for
+completion collection, interrupts, and teardown bookkeeping; those ids are not
+the inbound routing authority.
 
 ## Pre-Issue #63 Artifact
 
@@ -61,7 +72,7 @@ flowchart LR
 messages from reaching Codex.
 
 The channel added one `RECEIVED_REACTION_EMOJI` after the old Codex runtime
-`enqueueInbound()` path returned true. Issue #63 replaced this
+`enqueueInbound()` path returned true. Issue #63 replaced this historical path
 with a three-state channel-owned reaction flow.
 
 ## Runtime Model
@@ -83,7 +94,7 @@ inbound.
 
 ## Code Changes
 
-`packages/dreamux/src/dispatcher/turn-manager.ts`
+`/packages/agent-runtime/codex/src/turn-manager.ts`
 
 - Remove same-chat coalescing and the completion-gated `drainLoop()` /
   `processBatch()` queue as the inbound submission gate.
@@ -93,17 +104,19 @@ inbound.
   `turn/start` immediately.
 - Return a delivery result to the runtime/server so the channel can switch the
   reaction to in-progress at the `turn/start` acceptance point.
-- Do not track active turn ids. Do not call `turn/steer`.
+- Do not use active turn ids as inbound routing state. Do not call `turn/steer`
+  for normal inbound.
 
-`packages/dreamux/src/agent-runtime/codex-runtime.ts`
+`/packages/dreamux/src/dispatcher-service/dispatcher/service.ts`
 
-- Keep owning the Codex client and thread id.
-- Replace the synchronous boolean `enqueueInbound()` result with an async
-  delivery result from `TurnManager.enqueue()`, including duplicate/submitted
-  information and submission errors.
-- Do not introduce a mutex, observer, or active/idle branch.
+- Keep the Dispatcher Service as the neutral runtime/channel bridge.
+- Forward each Channel provider delivery request to the selected Agent Runtime
+  and return the real `InboundDeliveryResult`, including
+  duplicate/submitted/failed information.
+- Do not introduce a dispatcher-level mutex, production observer, or
+  active/idle branch.
 
-`packages/dreamux/src/codex/events.ts`
+`/packages/agent-runtime/codex/src/events.ts`
 
 - Split the current `runTurn()` shape so production inbound can call a
   `submitTurnStart()`-style helper that sends `turn/start` and resolves on the
@@ -113,13 +126,13 @@ inbound.
   helper if still useful.
 - Do not add a `turn/steer` helper for normal Feishu inbound.
 
-`packages/dreamux/src/channel/feishu-channel.ts`
+`/packages/channel/feishu-channel/src/feishu-channel.ts`
 
 - In `FeishuChannelSession`'s inbound message handler, add the received emoji
   immediately after the access gate passes and `message_id` dedupe reports a
   miss. Do not react to dropped messages or duplicate redeliveries.
-- After `runtime.enqueueInbound()` reports `turn/start` acceptance, replace the
-  received reaction with the in-progress emoji.
+- After the Channel delivery route returns a submitted `InboundDeliveryResult`,
+  replace the received reaction with the in-progress emoji.
 - In the channel-owned `reply` MCP handler, keep clearing the channel-owned
   reaction for `input.messageId` after the model reply is sent.
 - Replace the single `receivedReactions` map with a channel-owned inbound
@@ -133,7 +146,7 @@ inbound.
   removes the just-added reaction and does not store it; the previous reaction is
   already taken by `clearInboundReaction`, which read the ledger before any store.
 
-`packages/dreamux/src/channel/feishu-message.ts`
+`/packages/channel/feishu-channel/src/feishu-message.ts`
 
 - Keep the existing discrete `<feishu_message>` envelope and routing metadata
   (`chat_id`, `message_id`, `sender_id`, `sender_name`, `create_time`) so the

--- a/.agents/glossary.md
+++ b/.agents/glossary.md
@@ -1,0 +1,24 @@
+# Glossary
+
+Short definitions for overloaded Dreamux terms. Source code remains
+authoritative for behavior.
+
+| Term | Meaning |
+|---|---|
+| Agent Runtime | Provider seam that launches and controls one agent session, regardless of role. Built-ins include `builtin:codex` and `builtin:claude-code`. |
+| Channel | Provider seam that connects Dreamux to an external communication surface and owns provider-specific tools and target resolution. |
+| Channel provider ref | Config string such as `builtin:feishu` or `npm:<package>#<export>` that resolves through the provider registry. |
+| Channel id | Dispatcher-local `dispatchers[].channels[].id`; used to select a configured channel instance. |
+| Channel target | Provider-normalized destination/source key used for routing and binding, such as a Feishu group chat target. |
+| Dispatcher | Long-lived agent owned by `dreamux serve`; it receives accepted channel input and can call Dreamux MCP tools. |
+| Dispatcher Service | Core Dreamux module that owns dispatcher runtime lifecycle, TeamMate lifecycle, Team lifecycle, and channel binding/routing. |
+| TeamMate | Named, semi-resident agent controlled by the dispatcher through the TeamMate MCP. |
+| Team | Grouping of a TeamLeader and team-owned members, addressed by `team_name`. |
+| TeamLeader | Team-owned agent that can receive a bound channel target and coordinate TeamMate/member work. |
+| Binding | Core Team MCP state that hands a channel target to a TeamLeader until transferred back. |
+| Principal | Caller identity used by core services to scope visibility and permissions, for example dispatcher, team leader, team member, or internal team service. |
+| Provider registry | Process-local registry/loader for `agentRuntime` and `channel` providers. |
+| MCP shim | Stdio server injected into an agent runtime and forwarding tool calls to Dreamux core or a provider session. |
+| Primary channel | First channel declared by a dispatcher; used as the default egress channel when no `channel_id` is provided. |
+| Work directory | Plain dispatcher-local `.workspace/work/<name>/` directory used when TeamMate/Team creation omits a repo object. |
+| Managed worktree | Dreamux-created Git worktree under `.workspace/worktree/`, requested by an explicit managed repo object. |

--- a/.agents/reference/channel-runtime.md
+++ b/.agents/reference/channel-runtime.md
@@ -1,0 +1,112 @@
+# Reference: channel runtime
+
+This is the current Channel/Feishu runtime map. It is a reference page, not a
+decision record. For detailed Feishu behavior, follow the domain documents and
+then verify the current source.
+
+## Channel Provider Seam
+
+Dreamux core owns the neutral Channel provider contract. A Channel provider
+creates sessions, resolves provider-owned targets, exposes provider tools, and
+maps inbound channel events into neutral runtime input.
+
+The built-in Feishu provider lives outside the host package:
+
+- package: `@excitedjs/feishu-channel`
+- provider ref: `builtin:feishu`
+- source: `/packages/channel/feishu-channel/`
+
+Dreamux core loads it through the same registry/catalog shape as external
+Channel providers. The Feishu package depends on
+`@excitedjs/dreamux-types` and `@excitedjs/feishu-transport`; it does not import
+the Dreamux host package.
+
+Key source:
+
+- `/packages/dreamux/src/channel/catalog.ts`
+- `/packages/dreamux/src/channel/external-channel-provider.ts`
+- `/packages/dreamux/src/registry/`
+- `/packages/channel/feishu-channel/src/provider.ts`
+
+## Channel Sessions
+
+Each live dispatcher owns a map of Channel sessions keyed by dispatcher-local
+`channel_id`. The first configured channel is the primary/default egress
+channel.
+
+For Feishu, the session owns:
+
+- long-connection event handling through `FeishuBot`;
+- access and mention gating;
+- `/introduce` trust changes;
+- known/trusted peer-bot state;
+- inbound message formatting and attachment normalization;
+- channel-owned reaction state;
+- Feishu MCP tool backing.
+
+Key source:
+
+- `/packages/dreamux/src/dispatcher-service/dispatcher/service.ts`
+- `/packages/channel/feishu-channel/src/feishu-channel.ts`
+- `/packages/channel/feishu-channel/src/bot.ts`
+- `/packages/channel/feishu-transport/`
+
+## Provider Tools And MCP
+
+The Feishu package owns its tool names and JSON schemas:
+
+- `reply`
+- `react`
+- `list_chat_bots`
+
+Dreamux core injects a generic `channel-mcp` stdio shim. The shim is a conduit:
+it serves provider-supplied `tools/list` metadata and forwards `tools/call` to
+neutral admin methods, which route the call back to the live Channel session or
+sessionless provider handler.
+
+Key source:
+
+- `/packages/channel/feishu-channel/src/feishu-mcp-tools.ts`
+- `/packages/channel/feishu-channel/src/provider.ts`
+- `/packages/dreamux/src/mcp/channel-mcp.ts`
+- `/packages/dreamux/src/admin/methods.ts`
+
+## Channel Targets And Binding
+
+Channel providers normalize routing endpoints into `ChannelTarget` objects.
+For Feishu group chat routing, the target carries provider-owned metadata such
+as `chat_id` and `chat_type`.
+
+Team channel binding is core-owned Team MCP state:
+
+- `bind_channel({ team_name, channel_id?, meta })`
+- `transfer_back({ channel_id?, meta })`
+
+The `meta` object is provider-owned target selector input. For Feishu, that is
+typically `{ "chat_id": "..." }`.
+
+Key source:
+
+- `/packages/dreamux/src/dispatcher-service/channel-binding/`
+- `/packages/dreamux/src/mcp/team-mcp.ts`
+- `/packages/channel/feishu-channel/src/provider.ts`
+
+## Feishu Domain Contracts
+
+Current cross-cutting Feishu contracts live in domain docs:
+
+- [Feishu introduce](../domains/feishu-introduce.md)
+- [Non-blocking dispatcher inbound](../domains/non-blocking-dispatcher-inbound.md)
+
+Use those pages for `/introduce`, trusted bot context, reaction timing, and
+Codex `turn/start` folding details.
+
+## Decision Trail
+
+- [NPM package split and channel targets](../decisions/npm-package-split-and-channel-targets.md)
+- [Provider architecture realignment](../decisions/provider-architecture-realignment.md)
+- [Channel provider](../decisions/channel-provider.md)
+- [Channel input runtime assembly](../decisions/channel-input-runtime-assembly.md)
+- [Feishu inbound attachments](../decisions/feishu-inbound-attachments.md)
+- Archived background:
+  [plugin/provider architecture proposal](../archive/proposals/plugin-provider-architecture.md)

--- a/.agents/reference/current-architecture.md
+++ b/.agents/reference/current-architecture.md
@@ -1,0 +1,186 @@
+# Reference: current architecture
+
+This is the short current-state map. It is a reference page, not a decision
+record. For rationale, follow the linked decisions and then verify behavior in
+source before making changes.
+
+## Process Model
+
+`dreamux serve` runs one local Node process. The server owns admin IPC,
+configuration loading, provider registries, durable state, and one
+`DispatcherRuntimeService` per enabled dispatcher.
+
+Key source:
+
+- `/packages/dreamux/src/server.ts`
+- `/packages/dreamux/src/dispatcher-service/service.ts`
+- `/packages/dreamux/src/dispatcher-service/dispatcher/service.ts`
+
+## Configuration
+
+The operator config is JSON at `~/.dreamux/config.json`.
+
+Current file shape:
+
+- `agents[]` declares named Agent Runtime configs.
+- `dispatchers[]` declares dispatcher ids, explicit `cwd`, `channels[]`, and
+  `agentRuntime`, which references an `agents[].id`.
+- `dispatchers[].channels[]` entries carry a dispatcher-local `id`, a channel
+  provider ref, and provider-owned config.
+
+Current load behavior:
+
+- Agent Runtime provider refs and Channel provider refs are loaded before config
+  validation.
+- Dispatcher channel ids must be unique within one dispatcher.
+- A dispatcher may not declare the same channel provider ref twice.
+- Old Feishu/Codex-specific config shapes fail loud with rebuild guidance.
+
+Key source:
+
+- `/packages/dreamux/src/config/config.ts`
+- `/packages/dreamux/src/agent-runtime/external-provider.ts`
+- `/packages/dreamux/src/channel/external-channel-provider.ts`
+
+## Provider Seams
+
+Dreamux has two provider seams:
+
+- `agentRuntime`: launches dispatcher, teammate, TeamLeader, and future member
+  agents through one role-aware runtime interface.
+- `channel`: creates channel sessions, resolves channel targets, and owns
+  provider-specific MCP tools.
+
+Built-in provider packages are loaded through the same registry/catalog shape as
+external provider refs.
+
+Current built-ins:
+
+- `builtin:codex` -> `@excitedjs/agent-runtime-codex`
+- `builtin:claude-code` -> `@excitedjs/agent-runtime-claude-code`
+- `builtin:feishu` -> `@excitedjs/feishu-channel`
+
+Key source:
+
+- `/packages/dreamux/src/registry/`
+- `/packages/dreamux/src/agent-runtime/catalog.ts`
+- `/packages/dreamux/src/channel/catalog.ts`
+- `/packages/dreamux/src/registry/builtins.ts`
+
+See also [Channel runtime](channel-runtime.md) for Channel session, target, and
+provider-tool details.
+
+## Dispatcher Runtime
+
+Each live dispatcher owns:
+
+- one selected Agent Runtime instance
+- a map of live Channel sessions keyed by dispatcher-local `channel_id`
+- provider-owned channel MCP shims for channel tools
+- Team and TeamMate MCP shims owned by Dreamux core
+
+The first declared channel is the primary/default egress channel. A dispatcher
+with multiple channel providers can route and egress by `channel_id`; with only
+`builtin:feishu` wired today, normal configs have one Feishu channel.
+
+Key source:
+
+- `/packages/dreamux/src/dispatcher-service/dispatcher/service.ts`
+- `/packages/dreamux/src/dispatcher-service/dispatcher/mcp-descriptors.ts`
+- `/packages/dreamux/src/mcp/channel-mcp.ts`
+- `/packages/dreamux/src/mcp/team-mcp.ts`
+- `/packages/dreamux/src/mcp/teammate-mcp.ts`
+
+## Channels And Feishu
+
+The Channel provider owns provider-specific session behavior. The built-in
+Feishu provider (`builtin:feishu`) lives in
+`/packages/channel/feishu-channel/`; it owns long-connection handling, access
+and mention gates, `/introduce`, peer-bot trust state, inbound formatting,
+reaction state, target resolution, and its `reply` / `react` /
+`list_chat_bots` tool surface.
+
+Dreamux core injects the generic `channel-mcp` shim and routes tool calls back
+to the live Channel session or provider sessionless handler.
+
+Read [Channel runtime](channel-runtime.md) first, then the domain contracts:
+
+- [Feishu introduce](../domains/feishu-introduce.md)
+- [Non-blocking dispatcher inbound](../domains/non-blocking-dispatcher-inbound.md)
+
+## Teams And TeamMates
+
+The Dispatcher Service owns TeamMate and Team state. TeamMates are named,
+semi-resident agents. `spawn` creates one, `send` submits follow-up turns and
+reopens closed agents, and read tools (`history`, `list`, `status`, `last`) do
+not start a runtime.
+
+Team lifecycle is addressed by `team_name`. Channel binding is a Team MCP
+capability:
+
+- `bind_channel({ team_name, channel_id?, meta })`
+- `transfer_back({ channel_id?, meta })`
+
+`channel_id` defaults to the dispatcher's sole configured channel and is
+required only when the dispatcher has more than one configured channel.
+`meta` is provider-owned selector input, for example `{ "chat_id": "..." }` for
+a Feishu group chat.
+
+Key source:
+
+- `/packages/dreamux/src/dispatcher-service/teammate/`
+- `/packages/dreamux/src/dispatcher-service/team/`
+- `/packages/dreamux/src/dispatcher-service/channel-binding/`
+- `/packages/dreamux/src/mcp/team-mcp.ts`
+
+## State, Cache, Run Files, And Logs
+
+Path construction belongs in `/packages/dreamux/src/platform/paths.ts`. The
+current ownership map is in [State and paths](state-and-paths.md).
+
+High-level split:
+
+- `~/.dreamux/config.json`: operator-owned config.
+- `~/.dreamux/run/`: volatile run files and socket fallback root.
+- `~/.dreamux/state/`: durable server-owned dispatcher, Feishu, Team, and
+  TeamMate state.
+- `~/.dreamux/cache/`: rebuildable cache such as completion spill files and
+  Feishu attachments.
+- `~/.dreamux/logs/`: server, runtime, and MCP shim logs.
+- `~/.codex/`: Codex-owned global auth/config/memory, not Dreamux state.
+
+Key source:
+
+- `/packages/dreamux/src/platform/paths.ts`
+- `/packages/dreamux/src/platform/runtime-sockets.ts`
+
+## Bundled Skills
+
+Dreamux ships bundled skills under `/packages/dreamux/skills/`. Core selects
+skill sources by role:
+
+- Dispatcher and TeamLeader roles receive Dreamux operational skills.
+- Ordinary TeamMate and team-member roles receive none by default.
+- Codex applies skill roots through `skills/extraRoots/set`.
+- Claude Code receives add-dir-compatible roots through `--add-dir`.
+
+Dreamux no longer installs workspace `.codex/skills` symlinks during onboard or
+runtime startup.
+
+Key source:
+
+- `/packages/dreamux/src/agent-runtime/bundled-skill-sources.ts`
+- `/packages/agent-runtime/codex/src/skill-roots.ts`
+- `/packages/agent-runtime/claude-code/src/args.ts`
+- `/packages/agent-runtime/claude-code/src/runtime.ts`
+
+## Decision Trail
+
+- [Provider architecture realignment](../decisions/provider-architecture-realignment.md)
+- [NPM package split and channel targets](../decisions/npm-package-split-and-channel-targets.md)
+- [Top-level design](../decisions/top-level-design.md) for unchanged local
+  state/log/access foundations
+- [Runtime run root](../decisions/runtime-run-root.md)
+- [Agents config normalization](../decisions/agents-config-normalization.md)
+- Historical proposal:
+  [plugin/provider architecture proposal](../archive/proposals/plugin-provider-architecture.md)

--- a/.agents/reference/dispatcher-skill.md
+++ b/.agents/reference/dispatcher-skill.md
@@ -1,7 +1,7 @@
-# Component: dispatcher skill
+# Reference: dispatcher skill
 
-`/packages/dreamux/skills/` contains the bundled Codex skills that Dreamux
-ships in the npm package:
+`/packages/dreamux/skills/` contains the bundled Dreamux skills that Dreamux
+ships in the npm package for supported agent runtimes:
 
 - `dispatcher` teaches dispatcher app-server sessions how to delegate product
   work to TeamMates. The default interface is the server-hosted TeamMate MCP:
@@ -50,12 +50,16 @@ ships in the npm package:
   `team_id` / machine-local cwd/worktree rows are gone in #199 Slice 1), and
   `dissolve` a Team. The `create_group` (create-a-new-group) and raw `ledger`
   verbs were retired.
-- `channel` MCP is injected for dispatcher-only channel binding (core-hosted,
-  #209 slice 8): `bind_channel` hands an existing Feishu group chat to a Team by
-  `team_name` + `chat_id`, and `transfer_back` returns a bound group (by
-  `chat_id`) to the dispatcher. This replaces the removed `team.bind_group` /
-  `team.transfer_channel_back` / `team.create.bind_group` surfaces (no aliases).
-  TeamLeader member work still uses the caller-scoped TeamMate MCP.
+- Channel binding is on the **Team MCP**, not on the provider channel MCP:
+  `bind_channel({ team_name, channel_id?, meta })` hands an existing channel
+  target to a Team, and `transfer_back({ channel_id?, meta })` returns a bound
+  target to the dispatcher. `channel_id` selects a configured dispatcher channel
+  and defaults to the sole channel when unambiguous; `meta` is the provider
+  selector (for Feishu group chats, `{ "chat_id": "..." }`). The removed
+  `team.bind_group` / `team.transfer_channel_back` /
+  `team.create.bind_group` surfaces have no aliases. Provider-owned tools such
+  as Feishu `reply`, `react`, and `list_chat_bots` remain behind the `channel`
+  MCP shim.
 - `dreamux-maintenance` covers installed Dreamux diagnosis and safe operation.
 
 They are not installed through Codex plugin marketplaces. Core injects them at
@@ -78,7 +82,7 @@ and [the npm package split record](../decisions/npm-package-split-and-channel-ta
 
 | Path | Role |
 |---|---|
-| `/packages/dreamux/skills/<skill-name>/` | Bundled skill directory shipped in the npm package, injected at runtime by role |
+| `/packages/dreamux/skills/.claude/skills/<skill-name>/` | Bundled skill directory shipped in the npm package, injected at runtime by role |
 | `/packages/dreamux/bin/tm` | Public wrapper that forwards to the package-local `@excitedjs/tm` executable |
 
 ## Runtime Boundary
@@ -134,8 +138,9 @@ workspace:
   parent roots via `skills/extraRoots/set` after initialize and before thread
   start/resume, reapplying after every app-server restart; Claude Code emits
   `--add-dir` for add-dir-compatible sources
-- a Codex `skills/extraRoots/set` failure fails the start loud — a
-  dispatcher/leader must not run skill-blind
+- a Codex `skills/extraRoots/set` unsupported/method-missing response warns and
+  continues skill-blind for older app-servers; real root-application errors
+  still fail the start loud
 - an old `<dispatcher cwd>/.codex/skills` symlink dir from a prior version is
   left untouched (Codex lists the skill twice but does not fail) and is safe to
   delete; startup neither creates nor recreates it

--- a/.agents/reference/repo-structure.md
+++ b/.agents/reference/repo-structure.md
@@ -1,4 +1,4 @@
-# Component: repo structure
+# Reference: repo structure
 
 Rush + pnpm monorepo since issue #4. Packages are wired through pnpm
 `workspace:*` and installed via the rush path only (see
@@ -134,23 +134,15 @@ multi-package release notes precise while still using Rush as the validator.
 
 ## Runtime and Codex state
 
-| Path | Purpose | Source of truth |
-|---|---|---|
-| `~/.dreamux/config.json` | User-editable dreamux config, dispatcher declarations, and local Feishu credentials. Created by `dreamux onboard`; `dreamux serve` fails loudly if it is missing. | The operator |
-| `~/.dreamux/run/` | Volatile run files: `admin.sock` (+ lock), `restart-intent.json`, and the `sockets/` fallback root for ephemeral Codex sockets. Safe to clear while no server runs (issue #182). | The server |
-| `~/.dreamux/state/` | Durable server-owned state: per-dispatcher status/access files and `teammate/` ledgers. | The server |
-| `~/.dreamux/state/<id>/status.json` | Dispatcher runtime status and saved Codex `thread_id`. | The server |
-| `~/.dreamux/state/<id>/access.json` | Dispatcher-local Feishu access gate state. | The server / operator tools |
-| `~/.dreamux/cache/<id>/` | Rebuildable cache: completion `spill/` files and `feishu-attachments/`. Not durable state; safe to clear while no server runs (issue #182 PR-2). | The server |
-| `~/.dreamux/logs/` | Server and per-dispatcher logs, including Codex app-server logs. | The server |
-| `~/.codex/` | Codex global default home: auth, memory, and config used by dispatcher app-server processes. | The operator / Codex |
+The current config, workspace, state, run, cache, log, and external-home
+ownership map lives in [State and paths](state-and-paths.md). Keep detailed
+path semantics there so the repo-structure page stays focused on package and
+install shape.
 
-The split is load-bearing: a
-`rm -rf ~/.dreamux/run ~/.dreamux/cache ~/.dreamux/state ~/.dreamux/logs`
-recovery (only while no server is running) never loses user-edited dreamux
-settings or global Codex auth.
-Dispatcher app-server processes do not set `CODEX_HOME`; they use Codex's
-global default home for auth, memory, and config. Bundled skills are injected at
-runtime by role (#209 slice 6), not written into the workspace. See
-[top-level-design](../decisions/top-level-design.md) and
+At a high level, Dreamux owns `~/.dreamux/` for config/run/state/cache/logs, and
+Codex owns `~/.codex/` for its auth, memory, and config. Dispatcher app-server
+processes do not set `CODEX_HOME`; they use Codex's global default home.
+Bundled skills are injected at runtime by role (#209 slice 6), not written into
+the workspace. See [State and paths](state-and-paths.md),
+[top-level-design](../decisions/top-level-design.md), and
 [dispatcher-tm-packaging](../decisions/dispatcher-tm-packaging.md).

--- a/.agents/reference/state-and-paths.md
+++ b/.agents/reference/state-and-paths.md
@@ -1,0 +1,148 @@
+# Reference: state and paths
+
+This is the current ownership map for Dreamux local files. It is a reference
+page, not a decision record. For rationale, follow the linked decisions.
+
+Path builders belong in `/packages/dreamux/src/platform/paths.ts`; volatile
+runtime socket allocation belongs in
+`/packages/dreamux/src/platform/runtime-sockets.ts`.
+
+## Operator Config
+
+`~/.dreamux/config.json` is the only Dreamux operator-editable config source.
+
+It declares:
+
+- `agents[]`: Agent Runtime provider configs, such as `builtin:codex` or
+  `builtin:claude-code`.
+- `dispatchers[]`: dispatcher id, explicit `cwd`, configured `channels[]`, and
+  `agentRuntime`.
+- `dispatchers[].channels[]`: dispatcher-local channel id, Channel provider ref,
+  and provider-owned channel config.
+
+`dreamux serve` fails loudly when the config is missing, when an enabled
+dispatcher has no explicit `cwd`, or when providerized config cannot be parsed.
+The operator fix path is to run `dreamux onboard` or rebuild the config by hand.
+
+Key source:
+
+- `/packages/dreamux/src/config/config.ts`
+- `/packages/dreamux/src/config/config-helpers.ts`
+- `/packages/dreamux/src/cli/commands/onboard.ts`
+- `/packages/dreamux/src/onboard/run.ts`
+
+## Dispatcher Workspace
+
+Each dispatcher has an explicit `cwd`. Dreamux-managed TeamMate and Team work
+areas live under that dispatcher workspace, not under `~/.dreamux`.
+
+Current workspace paths:
+
+- `<dispatcher cwd>/.workspace/work/<name>/`: default plain work directory when
+  TeamMate or Team creation omits `repo`.
+- `<dispatcher cwd>/.workspace/worktree/<repo-slug>/<slug>/`: Dreamux-managed
+  Git worktree when the request explicitly asks for `repo: { mode:
+  'managed' }`.
+
+`.workspace/` self-ignores with a `*` `.gitignore` so generated work areas do
+not become repo content. Managed worktree creation fails loud if the destination
+would live under `~/.dreamux`.
+
+Key source:
+
+- `/packages/dreamux/src/dispatcher-service/dispatcher-workspace.ts`
+- `/packages/dreamux/src/dispatcher-service/teammate/workspaces.ts`
+- `/packages/dreamux/src/dispatcher-service/teammate/worktree-manager.ts`
+- `/packages/dreamux/src/dispatcher-service/teammate/worktree-paths.ts`
+- `/packages/dreamux/src/dispatcher-service/team/service.ts`
+
+## Server-Owned State
+
+`~/.dreamux/state/` is durable server-owned state. It is not an operator config
+surface.
+
+Important children:
+
+- `~/.dreamux/state/<dispatcher-id>/status.json`: dispatcher runtime status and
+  saved Agent Runtime thread/session identity.
+- `~/.dreamux/state/<dispatcher-id>/access.json`: dispatcher-local Feishu access
+  gate state.
+- `~/.dreamux/state/<dispatcher-id>/chat-bots.json`: Feishu known/trusted peer
+  bot store owned by the Feishu Channel provider.
+- `~/.dreamux/state/<dispatcher-id>/teammate/`: TeamMate durable task ledgers.
+- `~/.dreamux/state/<dispatcher-id>/team/`: Team durable ledgers and channel
+  binding state.
+
+Legacy identity records that point at old under-state worktree paths are read
+verbatim. Dreamux does not rewrite or delete them during ordinary startup.
+
+Key source:
+
+- `/packages/dreamux/src/platform/paths.ts`
+- `/packages/dreamux/src/state/dispatcher-store.ts`
+- `/packages/dreamux/src/dispatcher-service/teammate/identity-store.ts`
+- `/packages/dreamux/src/dispatcher-service/teammate/turns-store.ts`
+- `/packages/dreamux/src/dispatcher-service/team/store.ts`
+- `/packages/channel/feishu-channel/src/chat-bots-store.ts`
+
+## Run Files
+
+`~/.dreamux/run/` is volatile. It is safe to clear while no Dreamux server is
+running.
+
+Current run files:
+
+- `admin.sock` and its lock.
+- `restart-intent.json`.
+- `sockets/` fallback root for runtime rendezvous sockets.
+
+When available, `$XDG_RUNTIME_DIR/dreamux/sockets/` is preferred for runtime
+sockets. Socket paths are random per start, live only in process memory, and are
+not persisted to durable state.
+
+Key source:
+
+- `/packages/dreamux/src/platform/paths.ts`
+- `/packages/dreamux/src/platform/runtime-sockets.ts`
+- `/packages/dreamux/src/admin/socket.ts`
+
+## Cache And Logs
+
+`~/.dreamux/cache/<dispatcher-id>/` is rebuildable cache:
+
+- `spill/`: over-budget TeamMate completion payloads.
+- `feishu-attachments/`: bounded inbound Feishu attachment downloads.
+
+`~/.dreamux/logs/` is server-owned log output, split by component. Codex
+app-server logs use `~/.dreamux/logs/codex-app-server/<dispatcher>.log`; MCP
+shim diagnostics use component directories such as `channel-mcp/`, `team-mcp/`,
+and `teammate-mcp/`.
+
+Key source:
+
+- `/packages/dreamux/src/platform/paths.ts`
+- `/packages/dreamux/src/platform/logger.ts`
+- `/packages/channel/feishu-channel/src/provider.ts`
+
+## External Homes
+
+`~/.codex/` is Codex's own global home for auth, config, and memory. Dreamux
+dispatcher app-server processes follow Codex there; Dreamux does not create
+dispatcher-private `CODEX_HOME` directories for the MVP.
+
+Dreamux bundled skills are injected at runtime by role. They are not installed
+as workspace `.codex/skills` symlinks during `onboard` or runtime startup.
+
+Key source:
+
+- `/packages/dreamux/src/agent-runtime/bundled-skill-sources.ts`
+- `/packages/agent-runtime/codex/src/skill-roots.ts`
+- `/packages/agent-runtime/claude-code/src/args.ts`
+
+## Decision Trail
+
+- [Top-level design](../decisions/top-level-design.md)
+- [Runtime run root](../decisions/runtime-run-root.md)
+- [Providerized config and state compatibility](../decisions/providerized-config-state-compatibility.md)
+- [Provider architecture realignment](../decisions/provider-architecture-realignment.md)
+- [NPM package split and channel targets](../decisions/npm-package-split-and-channel-targets.md)

--- a/.agents/root.md
+++ b/.agents/root.md
@@ -1,140 +1,98 @@
 # dreamux knowledge base
 
 This is the on-demand knowledge base for the `excitedjs/dreamux` repo.
-Always-loaded rules live in [`/CLAUDE.md`](../CLAUDE.md); navigate to here
-when you need the *why* behind a piece of code or a decision history.
+Always-loaded operating rules live in [`/CLAUDE.md`](../CLAUDE.md).
 
-## What dreamux is
+Use this KB for current reference, architecture intent, and decision history.
+For current behavior, read the linked source code too.
 
-A long-running Node process that hosts N **Dispatchers**. Each Dispatcher binds
-one or more Channel providers (built-in `builtin:feishu` today, at most one
-channel per provider ref), one Agent Runtime provider (`builtin:codex`,
-`builtin:claude-code`, or an installed `npm:` Agent Runtime provider), and
-Dreamux-owned MCP surfaces for Teams and TeamMate scheduling/retrieval. All
-inbound chats for a dispatcher enter that dispatcher's runtime context; channel
-outbound is sent only when the runtime calls a provider-specific channel MCP
-tool exposed by that Channel provider. Channel binding/transfer-back is not a
-generic Channel MCP capability: it lives on the core-owned Team MCP as
-`bind_channel` / `transfer_back`. The current architecture is split between the
-original local-runtime baseline and the issue #209 provider package split:
+## Start Here
 
-- [Top-level design](decisions/top-level-design.md) — original MVP baseline;
-  still authoritative for unchanged local state/log ownership, Feishu access,
-  admin IPC, and process-local inbound limitations.
-- [Plugin and provider architecture](proposals/plugin-provider-architecture.md)
-  — issue #110 historical proposal for provider refs, Capability Registry,
-  Channel providers, Agent Runtime providers, and server-hosted TeamMate; the
-  current target is refined by the provider architecture realignment.
-- [Issue #110 Epic closure check](decisions/issue-110-epic-closure.md) —
-  closure checklist for what Phase 1 implemented and what remains deferred.
-- [Provider architecture realignment](decisions/provider-architecture-realignment.md)
-  — issue #135 target that refines #110/#126: one `AgentRuntime` for all roles,
-  Dispatcher Service as a real module, two plugin seams only (`agentRuntime` +
-  `channel`), registry demoted to a provider loader, Feishu pulled out of the
-  plugin seam.
-- [NPM package split and channel targets](decisions/npm-package-split-and-channel-targets.md)
-  — issue #209 package-boundary and target-routing decision: a published
-  type-only contract package, built-in runtime/channel npm packages, core-owned
-  `bind_channel`, channel-owned target resolution, and built-in skill injection
-  without workspace symlinks.
+- [Current architecture](reference/current-architecture.md) — compact current
+  system map with source-code pointers.
+- [Repository structure](reference/repo-structure.md) — package layout,
+  install/build/test path, Rush change files, and public package/bin surface.
+- [State and paths](reference/state-and-paths.md) — current config, workspace,
+  state, run, cache, log, and external-home ownership.
+- [Channel runtime](reference/channel-runtime.md) — Channel provider sessions,
+  Feishu tools, target routing, and binding.
+- [Glossary](glossary.md) — short definitions for overloaded Dreamux terms.
+- [Decision index](decisions/README.md) — ADRs, with current-trail and
+  historical-background sections.
+- [KB contributing guide](CONTRIBUTING.md) — document kinds, link rules, and
+  validation.
 
-Background and older issue context:
-
-- [#1 Proposal](https://github.com/excitedjs/dreamux/issues/1) — original proposal
-- [#2 Engineering plan](https://github.com/excitedjs/dreamux/issues/2) — implementation-ready spec
-- [#4 Monorepo + harness](https://github.com/excitedjs/dreamux/issues/4) — current repo shape
-- [#18 Global bin onboarding](https://github.com/excitedjs/dreamux/issues/18) — `dreamux onboard` / `dreamux serve` design
-
-## Repo layout (monorepo since issue #4)
-
-```
-/                                  rush monorepo root
-├── rush.json                      rush + pnpm config
-├── common/                        rush scaffolding (config + bootstrap)
-├── packages/
-│   ├── dreamux/                   @excitedjs/dreamux — the host server
-│   │   ├── bin/                   dreamux and tm launchers
-│   │   ├── skills/                bundled dispatcher Codex skill
-│   │   ├── src/                   admin, cli, dispatcher, provider catalogs,
-│   │   │                          platform paths, and MCP shims
-│   │   ├── tests/                 vitest (smoke + live-codex + bin-launcher + onboard)
-│   │   └── db/migrations/         legacy SQLite migrations targeted for removal
-│   ├── channel/
-│   │   ├── feishu-transport/      @excitedjs/feishu-transport — platform-I/O core
-│   │   │                          (sole @larksuiteoapi/node-sdk importer)
-│   │   └── feishu-channel/        @excitedjs/feishu-channel — Feishu channel
-│   │                              provider package behind `builtin:feishu`
-│   └── eslint-config/             @excitedjs/eslint-config — shared lint config
-│                                  (private; no-sync-IO gate, issue #85)
-├── bin/                           thin redirectors → packages/dreamux/bin/
-├── .agents/                       this knowledge base
-├── .github/workflows/             CI
-└── CLAUDE.md                      always-loaded operating rules (AGENTS.md is a symlink)
-```
-
-## Navigation
-
-- [`components/`](components/) — one doc per piece (repo-structure and
-  dispatcher-skill today; server / codex-client / feishu-bot / cli to be
-  added as they stabilize).
-- [`decisions/top-level-design.md`](decisions/top-level-design.md) — current
-  top-level design; read this before runtime, Feishu, MCP, config, state, or
-  dispatcher-lifecycle work.
-- [`decisions/README.md`](decisions/README.md) — accepted decision records,
-  indexed by topic slug. Do not prefix new records with sequence numbers.
-- [`proposals/global-bin-onboard-serve.md`](proposals/global-bin-onboard-serve.md)
-  — superseded issue #18 proposal; accepted behavior lives in
-  [`decisions/global-bin-onboard-serve.md`](decisions/global-bin-onboard-serve.md).
-- [`proposals/post-mvp-hardening.md`](proposals/post-mvp-hardening.md) —
-  consolidated post-MVP hardening proposal (bounded state, restart/startup
-  reconciliation, access surface, message-format, CLI/diagnostic robustness);
-  groups the deferred epic follow-ups + the #58 ultracode findings into the next
-  workstream.
-- [`proposals/plugin-provider-architecture.md`](proposals/plugin-provider-architecture.md)
-  — issue #110 proposal for plugin/provider architecture. Its settled boundary
-  is recorded in the provider, channel, runtime, TeamMate, and compatibility
-  decisions.
-- [`proposals/feishu-bot-trust-context.md`](proposals/feishu-bot-trust-context.md)
-  — issue #69 follow-up to #62: trusted-bot next-message context, a
-  `list_chat_bots` query tool, and add-then-cancel reaction ordering
-  (implemented; settled behavior in `domains/feishu-introduce.md` +
-  `domains/non-blocking-dispatcher-inbound.md`).
-- [`domains/non-blocking-dispatcher-inbound.md`](domains/non-blocking-dispatcher-inbound.md)
-  — final issue #63 runtime model for accepted Feishu inbound: every accepted
-  deduped message submits `turn/start`, and reactions move through the
-  received / in-progress / cleared states.
-- [`domains/feishu-introduce.md`](domains/feishu-introduce.md)
-  — issue #62 first increment: the Feishu typed event-route seam, and the group
-  `/introduce` hard contract (no `@`-mention required; the sender must be
-  allowlisted; awareness never grants trust).
-- `proposals/`, `research/`, `rules/` — add here when material grows past a
-  single file's worth.
-- [`CONTRIBUTING.md`](CONTRIBUTING.md) — when to update this KB, how to
-  format docs, the knowledge-delta protocol.
-- [`scripts/check.sh`](scripts/check.sh) — link / orphan checker. Run
-  before any KB-touching commit.
-
-## When to read which
+## Task Routes
 
 | You're about to ... | Read first |
 |---|---|
-| add/change the dispatcher Codex skill or `tm` wrapper | [`components/dispatcher-skill.md`](components/dispatcher-skill.md) |
-| change dispatcher `tm` packaging, PATH injection, or skill install location | [`decisions/dispatcher-tm-packaging.md`](decisions/dispatcher-tm-packaging.md) |
-| add/change a package, move source between packages | [`components/repo-structure.md`](components/repo-structure.md) |
-| modify runtime state, dispatcher lifecycle, Feishu MCP, access gating, or config shape | [`decisions/top-level-design.md`](decisions/top-level-design.md) |
-| move sockets / run files, or touch the `~/.dreamux/run` vs `state` split | [`decisions/runtime-run-root.md`](decisions/runtime-run-root.md) |
-| verify issue #110 closure or provider Epic boundaries | [`decisions/issue-110-epic-closure.md`](decisions/issue-110-epic-closure.md) |
-| change Feishu inbound attachment downloads, cache, or Codex-facing message body | [`decisions/feishu-inbound-attachments.md`](decisions/feishu-inbound-attachments.md) |
-| browse decisions by topic | [`decisions/README.md`](decisions/README.md) |
-| understand why rush + pnpm | [`decisions/rush-pnpm-monorepo.md`](decisions/rush-pnpm-monorepo.md) |
-| install / build / test the repo, or wonder why `npm ci` is gone | [`decisions/install-model.md`](decisions/install-model.md) |
-| rename or restructure the public CLI / package | [`decisions/cli-and-package-naming.md`](decisions/cli-and-package-naming.md) |
-| implement issue #18 global bin / onboard / serve | [`proposals/global-bin-onboard-serve.md`](proposals/global-bin-onboard-serve.md) + [`decisions/global-bin-onboard-serve.md`](decisions/global-bin-onboard-serve.md) |
-| add / change a config key (`~/.dreamux/config.json`) | [`decisions/top-level-design.md`](decisions/top-level-design.md) first, then historical context in [`decisions/global-config-dir.md`](decisions/global-config-dir.md) |
-| change provider refs, Agent Runtime providers, channel plugin reservations, channel target bindings, or server-hosted TeamMate | [`decisions/provider-architecture-realignment.md`](decisions/provider-architecture-realignment.md) + [`decisions/provider-references-and-capability-registry.md`](decisions/provider-references-and-capability-registry.md) + [`decisions/npm-package-split-and-channel-targets.md`](decisions/npm-package-split-and-channel-targets.md) |
-| touch the anti-leak guardrail (`.gitleaks.toml`, `.npmrc`, CI / hook) | [`decisions/anti-leak-guardrail.md`](decisions/anti-leak-guardrail.md) |
-| touch npm publishing / the release workflows | [`decisions/npm-release-oidc.md`](decisions/npm-release-oidc.md) |
-| change dispatcher inbound delivery, turn submission, or received-reaction timing | [`domains/non-blocking-dispatcher-inbound.md`](domains/non-blocking-dispatcher-inbound.md) + [`decisions/top-level-design.md`](decisions/top-level-design.md) + read the source |
-| add or verify Rush change files | [`components/repo-structure.md#rush-change-files`](components/repo-structure.md#rush-change-files) |
-| write a new decision record / new component doc | [`CONTRIBUTING.md`](CONTRIBUTING.md) |
-| modify the server runtime / Codex protocol handling | [`decisions/top-level-design.md`](decisions/top-level-design.md) + read the source |
+| answer "how is Dreamux shaped now?" | [Current architecture](reference/current-architecture.md), then source |
+| add/change a package or move source between packages | [Repository structure](reference/repo-structure.md) |
+| install/build/test the repo or debug workspace install issues | [Repository structure](reference/repo-structure.md), [install model](decisions/install-model.md) |
+| add or verify Rush change files | [Repository structure: Rush change files](reference/repo-structure.md#rush-change-files) |
+| modify config loading, `agents[]`, `dispatchers[]`, provider refs, or config compatibility | [Current architecture](reference/current-architecture.md), [agents config normalization](decisions/agents-config-normalization.md), [providerized config compatibility](decisions/providerized-config-state-compatibility.md) |
+| modify state/cache/run/log paths | [State and paths](reference/state-and-paths.md), [runtime run root](decisions/runtime-run-root.md), [top-level design](decisions/top-level-design.md) |
+| modify provider loading, Agent Runtime providers, Channel providers, or capabilities | [Current architecture](reference/current-architecture.md), [Channel runtime](reference/channel-runtime.md), [Provider architecture realignment](decisions/provider-architecture-realignment.md), [provider refs and registry](decisions/provider-references-and-capability-registry.md), [NPM package split and channel targets](decisions/npm-package-split-and-channel-targets.md) |
+| modify dispatcher runtime lifecycle or MCP injection | [Current architecture](reference/current-architecture.md), [dispatcher local aggregate](decisions/dispatcher-local-aggregate.md), source |
+| modify TeamMate / Team lifecycle, read surfaces, or bundled dispatcher skills | [Dispatcher skill reference](reference/dispatcher-skill.md), [provider architecture realignment](decisions/provider-architecture-realignment.md), [top-level design](decisions/top-level-design.md) |
+| modify channel binding or channel target routing | [Channel runtime](reference/channel-runtime.md), [NPM package split and channel targets](decisions/npm-package-split-and-channel-targets.md), source |
+| modify Feishu inbound, `/introduce`, trusted bot context, or reaction timing | [Channel runtime](reference/channel-runtime.md), [Feishu introduce](domains/feishu-introduce.md), [non-blocking dispatcher inbound](domains/non-blocking-dispatcher-inbound.md), source |
+| modify Feishu attachment download/cache behavior | [Feishu inbound attachments](decisions/feishu-inbound-attachments.md) |
+| modify onboard, daemon, uninstall, or public CLI names | [Global bin/onboard/serve](decisions/global-bin-onboard-serve.md), [CLI and package naming](decisions/cli-and-package-naming.md) |
+| modify the anti-leak guardrail, `.gitleaks.toml`, `.npmrc`, CI, or hooks | [Anti-leak guardrail](decisions/anti-leak-guardrail.md) |
+| modify npm publishing or release workflows | [NPM release OIDC](decisions/npm-release-oidc.md) |
+| inspect historical hardening backlog | [Archived Post-MVP hardening](archive/proposals/post-mvp-hardening.md) |
+| write or move KB content | [KB contributing guide](CONTRIBUTING.md) |
+
+## Document Kinds
+
+- `reference/` — current behavior and operational mental models. Prefer this
+  for "what exists now".
+- `decisions/` — accepted, superseded, or historical ADRs. Prefer this for
+  "why was this chosen".
+- `domains/` — current cross-cutting runtime contracts that span multiple
+  reference pages, such as Feishu gate, trust, and inbound timing contracts.
+- `proposals/` — active design proposals only.
+- `archive/` — preserved historical material. It is intentionally reachable but
+  not part of the default task path.
+
+## Current Reference
+
+- [Current architecture](reference/current-architecture.md)
+- [Repository structure](reference/repo-structure.md)
+- [State and paths](reference/state-and-paths.md)
+- [Channel runtime](reference/channel-runtime.md)
+- [Dispatcher skill and TeamMate workflow](reference/dispatcher-skill.md)
+- [Glossary](glossary.md)
+
+## Decisions
+
+Start with [decisions/README.md](decisions/README.md). Decision files preserve
+history and rationale; when you need current behavior, pair them with
+[Current architecture](reference/current-architecture.md) and source.
+
+## Domains
+
+- [Feishu introduce](domains/feishu-introduce.md)
+- [Non-blocking dispatcher inbound](domains/non-blocking-dispatcher-inbound.md)
+
+## Active Proposals
+
+There are no active proposals in this snapshot.
+
+Move an active proposal out of `proposals/` once it is implemented,
+superseded, or abandoned; preserve the old text under `archive/` when the
+history still matters.
+
+## Archive
+
+- [Archive index](archive/README.md)
+- [Archived proposals](archive/proposals/README.md)
+
+## Validation
+
+Run before any KB-touching commit:
+
+```bash
+.agents/scripts/check.sh
+```

--- a/.agents/scripts/check.sh
+++ b/.agents/scripts/check.sh
@@ -2,10 +2,11 @@
 # Validate the .agents/ knowledge base.
 #
 # Checks:
-#   1. every repo-root-absolute link target (`/foo/bar`) inside .agents/
-#      resolves to a file or directory that exists
+#   1. every internal Markdown link inside .agents/ resolves to a file or
+#      directory that exists
 #   2. every .md file under .agents/ is reachable from .agents/root.md
 #      (link graph; flags orphans)
+#   3. every decision record is listed in .agents/decisions/README.md
 #
 # Exits 0 on success, non-zero with a noisy list of failures otherwise.
 # Run before committing KB changes, and from CI.
@@ -17,20 +18,25 @@ REPO_ROOT="$(cd -- "$KB_ROOT/.." &> /dev/null && pwd)"
 
 errors=0
 
-# ---------- 1) repo-root-absolute links resolve ----------
-# Match `](/...)` style links — the convention CONTRIBUTING.md mandates.
-while IFS= read -r line; do
-  file="${line%%:*}"
-  link="${line#*:}"
-  # Strip line-number prefix and the surrounding `](...)`.
-  target="$(echo "$link" | sed -E 's/.*\]\((\/[^)#]+)(#[^)]*)?\).*/\1/')"
+# ---------- 1) internal Markdown links resolve ----------
+# Match each Markdown inline link target. External URLs and same-page anchors are
+# skipped; repo-root-absolute and relative links must resolve.
+while IFS= read -r entry; do
+  file="${entry%%:*}"
+  target="${entry#*:}"
+  target="${target%%#*}"
   [ -z "$target" ] && continue
-  full="$REPO_ROOT$target"
+  case "$target" in
+    http://*|https://*|mailto:*|\#*) continue ;;
+    /*) full="$REPO_ROOT$target" ;;
+    *) full="$(cd -- "$(dirname -- "$file")" 2>/dev/null && realpath -m -- "$target")" ;;
+  esac
   if [ ! -e "$full" ]; then
-    echo "broken link in $file -> $target (resolved to $full)" >&2
+    rel_file="${file#"$REPO_ROOT"/}"
+    echo "broken markdown link in $rel_file -> $target (resolved to $full)" >&2
     errors=$((errors + 1))
   fi
-done < <(grep -rEn --include='*.md' ']\(/[^)]+\)' "$KB_ROOT" 2>/dev/null || true)
+done < <(find "$KB_ROOT" -type f -name '*.md' -print0 | xargs -0 perl -ne 'while (/\]\(([^)]+)\)/g) { print "$ARGV:$1\n" }' 2>/dev/null || true)
 
 # ---------- 2) orphan detection ----------
 # Build the set of every .md file under .agents/, minus root.md itself.
@@ -53,9 +59,9 @@ while [ ${#queue[@]} -gt 0 ]; do
   queue=("${queue[@]:1}")
   curfile="$KB_ROOT/$cur"
   [ -f "$curfile" ] || continue
-  while IFS= read -r raw; do
-    # Match either `](foo.md)` or `](foo/)` or absolute /.agents/foo.md.
-    target="$(echo "$raw" | sed -E 's/.*\]\(([^)#]+)(#[^)]*)?\).*/\1/')"
+  while IFS= read -r target; do
+    # Match either `](foo.md)` or absolute `](/.agents/foo.md)`.
+    target="${target%%#*}"
     [ -z "$target" ] && continue
     case "$target" in
       http*|mailto:*) continue ;;
@@ -83,7 +89,7 @@ while [ ${#queue[@]} -gt 0 ]; do
       seen["$next"]=1
       queue+=("$next")
     fi
-  done < <(grep -E ']\([^)]+\)' "$curfile" 2>/dev/null || true)
+  done < <(perl -ne 'while (/\]\(([^)]+)\)/g) { print "$1\n" }' "$curfile" 2>/dev/null || true)
 done
 
 for rel in "${!all[@]}"; do
@@ -92,6 +98,25 @@ for rel in "${!all[@]}"; do
     errors=$((errors + 1))
   fi
 done
+
+# ---------- 3) decision index completeness ----------
+decision_index="$KB_ROOT/decisions/README.md"
+decision_index_entries="$(
+  awk '
+    /^## Alphabetical Index$/ { in_index = 1; next }
+    /^## / && in_index { exit }
+    in_index { print }
+  ' "$decision_index"
+)"
+while IFS= read -r f; do
+  slug="$(basename "$f" .md)"
+  [ "$slug" = "README" ] && continue
+  expected="- [$slug]($slug.md)"
+  if ! printf '%s\n' "$decision_index_entries" | grep -Fxq -- "$expected"; then
+    echo "decision missing from alphabetical index: .agents/decisions/$slug.md" >&2
+    errors=$((errors + 1))
+  fi
+done < <(find "$KB_ROOT/decisions" -maxdepth 1 -type f -name '*.md' | sort)
 
 if [ "$errors" -gt 0 ]; then
   echo "" >&2

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,254 +1,107 @@
-# dreamux — repository operating rules
+# dreamux repository operating rules
 
-Always loaded. On-demand context lives in [`.agents/`](.agents/root.md);
-read it when you need the *why* behind a decision or a component.
+Always loaded. Keep this file to guardrails that must be present in every
+agent context. On-demand architecture and reference material lives in
+[`.agents/root.md`](.agents/root.md).
 
-When CLAUDE.md and the KB disagree, CLAUDE.md is authoritative — the KB
-is an on-demand reference, not a binding rule. If you find a contradiction,
-fix it in the same PR.
+When this file and `.agents/` disagree, this file is authoritative for operating
+rules. For architecture facts, read the current source first, then the linked
+KB entry.
 
 ## Communication
 
 - Reply to the user in **Chinese**.
-- Write all repo docs (README, `.agents/`, code comments, commit messages,
-  PR descriptions) in **English**, regardless of conversation language.
+- Write all repo docs, `.agents/` docs, code comments, commit messages, and PR
+  descriptions in **English**.
 
-## Repository shape
+## Current Source Of Truth
 
-`excitedjs/dreamux` is a **Rush + pnpm monorepo** since issue #4.
+- Current architecture entry point: [`.agents/reference/current-architecture.md`](.agents/reference/current-architecture.md).
+- Repository/package layout: [`.agents/reference/repo-structure.md`](.agents/reference/repo-structure.md).
+- State/cache/run/log paths: [`.agents/reference/state-and-paths.md`](.agents/reference/state-and-paths.md).
+- Channel/Feishu runtime: [`.agents/reference/channel-runtime.md`](.agents/reference/channel-runtime.md).
+- Task routing and KB index: [`.agents/root.md`](.agents/root.md).
+- KB writing rules: [`.agents/CONTRIBUTING.md`](.agents/CONTRIBUTING.md).
 
-- `/packages/<name>/` holds packages. Publishable today: `@excitedjs/dreamux`
-  (the host), `@excitedjs/dreamux-types` (declaration-only provider-authoring
-  contracts, #209 slice 1), `@excitedjs/agent-runtime-codex` (the built-in Codex
-  Agent Runtime behind `builtin:codex`, #209 slice 3 — depends on
-  `@excitedjs/dreamux-types` only, never on core),
-  `@excitedjs/agent-runtime-claude-code` (the built-in Claude Code Agent Runtime
-  behind `builtin:claude-code`, #209 slice 4 — depends on
-  `@excitedjs/dreamux-types` only, never on core), `@excitedjs/feishu-transport`
-  (the platform-I/O core, sole owner of the `@larksuiteoapi/node-sdk` import),
-  and `@excitedjs/feishu-channel` (the built-in Feishu `ChannelProvider` behind
-  `builtin:feishu`, #209 slice 5 — the live Feishu channel session, access/trust,
-  inbound normalization, and MCP tool backing; depends on
-  `@excitedjs/dreamux-types` + `@excitedjs/feishu-transport` only, never on core) —
-  see the channel refactor (#4). Private (unpublished):
-  `@excitedjs/eslint-config`, the shared ESLint flat config that is the single
-  source of the synchronous-blocking-IO ban (#85).
-- `/rush.json`, `/common/config/rush/`, `/common/scripts/install-run-rush.js`
-  are the rush + pnpm scaffolding.
-- `/bin/dreamux` is a source-checkout convenience shim that forwards to
-  `/packages/dreamux/bin/dreamux`; the package also includes a `tm` wrapper
-  used by dispatcher skills — see
-  `.agents/decisions/dispatcher-tm-packaging.md`.
-- `/.agents/` is the on-demand knowledge base. Start at `.agents/root.md`.
+Before answering architecture/domain questions, verify against source code. The
+KB explains intent and history; code is the current behavior.
 
-**One install path — the monorepo path.** Build and test through rush:
+## Build And Test
 
-```
-node common/scripts/install-run-rush.js update   # then build / test
+`excitedjs/dreamux` is a Rush + pnpm monorepo. Use the monorepo path only:
+
+```bash
+node common/scripts/install-run-rush.js update
 node common/scripts/install-run-rush.js build
 node common/scripts/install-run-rush.js test
 ```
 
-The per-package npm path (`cd packages/dreamux && npm install`) is **retired**:
-`@excitedjs/dreamux` depends on `@excitedjs/feishu-transport` via the pnpm
-`workspace:*` protocol, which `npm` cannot resolve. The release workflow
-publishes a pnpm-packed tarball, where pnpm rewrites `workspace:*` to real
-registry versions before npm uploads it, so external
-`npm install @excitedjs/dreamux` is unaffected — only the in-repo per-package
-path is gone. There is no committed per-package `package-lock.json`.
+Do not use per-package `npm install`; workspace dependencies use `workspace:*`.
 
-Reasoning: `.agents/decisions/install-model.md` (which retires the
-two-paths consequence of `.agents/decisions/rush-pnpm-monorepo.md`).
+## Always-Binding Rules
 
-## CLI surface
+- **Public repo red line:** never commit internal identifiers, secrets, private
+  registry URLs, internal hostnames, or real Feishu ids/tokens. `.gitleaks.toml`
+  and `.npmrc` are shared canonical guardrails with the sibling repo; if a
+  guardrail false-positives, stop and ask rather than editing a local allowlist.
+- **No synchronous blocking IO in package source:** `/packages/*/src/**` must
+  use async fs/process APIs. `rush lint` enforces the shared
+  `@excitedjs/eslint-config` no-sync-IO gate.
+- **No runtime dependencies on dev tools:** bin launchers execute compiled
+  `dist/` with plain `node`; do not reintroduce `tsx`.
+- **Launcher path handling:** new bin launchers must follow the
+  `/packages/dreamux/bin/dreamux` symlink-walk shape.
+- **Path contracts:** host-owned path builders belong in
+  `/packages/dreamux/src/platform/paths.ts`; volatile runtime socket allocation
+  belongs in `/packages/dreamux/src/platform/runtime-sockets.ts`; runtime-owned
+  path derivation belongs in the runtime package that uses it (for example
+  `/packages/agent-runtime/codex/src/paths.ts`).
+- **No legacy architecture rollback:** do not reintroduce `runtime_dir`,
+  SQLite-backed dispatcher state, `~/.codex-host/`, legacy global CLI aliases,
+  or workspace `.codex/skills` installation unless a new decision record
+  explicitly supersedes the current architecture.
+- **Codex protocol bumps:** update the
+  `@excitedjs/agent-runtime-codex` package first. Core must stay behind the
+  neutral `AgentRuntimeProvider` interface.
+- **Teammate reverse delivery:** Codex completion delivery depends on codex
+  0.137+ `thread/inject_items`; older versions fail loudly instead of silently
+  dropping completion.
+- **Live Codex tests:** tests that require a real Codex install fail loudly when
+  Codex is missing. Use `DREAMUX_SKIP_LIVE_CODEX=1` only when the environment
+  intentionally lacks Codex.
 
-The user-facing CLI is the single global bin `dreamux`. Current command tree:
-`onboard`, `uninstall`, `serve`, `status`, `doctor`,
-`daemon install|uninstall|start|stop|restart`,
-`dispatcher add|remove|list|status|start|stop`, `channel-mcp`, `teammate-mcp`,
-`team-mcp`, `config path|show`, and `changelog [--json]`. `dreamux changelog` prints the
-installed package's rush-generated `CHANGELOG.md` (or `CHANGELOG.json` with
-`--json`) — an offline read of the installed version, the upgrade-time
-information entry point for the 0.x fail-loud + rebuild policy (issue #98).
-`dreamux serve` is the foreground server entry point. The
-`daemon` group wraps the native user-level service manager (Linux
-`systemctl --user`, macOS `launchctl`); `daemon uninstall` removes only the
-service unit, whereas top-level `dreamux uninstall` removes
-config/run/cache/state/logs too. `daemon restart --notify-resumed --dispatcher <id>` drops a one-shot
-restart marker before restarting, so a resumed dispatcher gets a
-`Restart completed.` turn injected — see issue #78. Do not reintroduce
-global aliases such as `dreamux-server` or `server-ctl`; issue #18 explicitly
-removed the legacy global-bin transition period.
-
-## Knowledge-delta protocol
+## Knowledge Delta
 
 Before finishing a non-trivial PR, ask:
 
-> Did this move a package boundary, a CLI surface, a settled design
-> decision, a Codex / Feishu protocol contract, or a cross-process invariant?
+> Did this move a package boundary, CLI surface, settled design decision,
+> Codex / Feishu protocol contract, state/config format, or cross-process
+> invariant?
 
-If yes → update `.agents/` in the same PR. The full protocol and document
-kinds are in [`.agents/CONTRIBUTING.md`](.agents/CONTRIBUTING.md).
+If yes, update `.agents/` in the same PR and run:
 
-Run `.agents/scripts/check.sh` before committing KB changes; CI rejects
-what the script rejects.
+```bash
+.agents/scripts/check.sh
+```
 
-## Config, state, and logs (top-level design)
+## Changelog Responsibility
 
-Current architecture is documented in
-[`.agents/decisions/top-level-design.md`](.agents/decisions/top-level-design.md).
-That record wins over older runtime-dir / SQLite decisions.
+Dreamux 0.x handles incompatible config/state changes by fail-loud plus manual
+rebuild. Any change that can block or break a user's upgrade needs a Rush change
+file. Use `rush change`; never hand-edit generated changelogs.
 
-- `~/.dreamux/config.json` — the only dreamux operator-editable config
-  source. It holds dispatcher declarations and local Feishu credentials.
-  `dreamux serve` must fail loudly when it is missing and tell the operator
-  to run `dreamux onboard`. Each dispatcher MUST declare an explicit `cwd`
-  (issue #182 PR-4): `dreamux serve` fails loud at startup if any enabled
-  dispatcher has no `cwd` — there is no fallback to a state directory. A
-  missing `cwd` directory is created (mkdir -p); an unusable one fails loud.
-  `dreamux doctor` diagnoses the same per-dispatcher contract.
-- `<dispatcher cwd>/.workspace/worktree/<repo-slug>/<slug>/` — Dreamux-managed
-  TeamMate/Team Git worktrees (issue #182 PR-4), relocated out of
-  `~/.dreamux/state/<id>/teammate/worktrees/`. They live in the dispatcher's
-  own workspace, never under `~/.dreamux`; `.workspace/` self-ignores (a `*`
-  .gitignore) so they never become repo content. `<repo-slug>` is
-  `<sanitized-basename>-<sha256(repo-root):12>`, disambiguating same-named repos
-  across Team/TeamMate usage. Managed worktree creation fails loud if the
-  workspace resolves under `~/.dreamux`. Legacy identity records pointing at the
-  old under-state path are read verbatim (no rewrite, no deletion).
-- `<dispatcher cwd>/.workspace/work/<name>/` — the **default** TeamMate/Team work
-  directory (issue #199), used when `teammate.spawn` / `team.create` omits
-  `repo`. A plain `mkdir -p` directory, NOT a git worktree, so the dispatcher cwd
-  need not be a git repo (no git command runs; `source_repo` is reported `null`).
-  It shares the self-ignored `.workspace/` boundary and the under-`~/.dreamux`
-  fail-loud guard. Only an explicit `repo: { mode: 'managed' }` creates a git
-  worktree under `.workspace/worktree/`; `repo: { mode: 'reuse-cwd' }` runs in the
-  given path.
-- `~/.dreamux/state/` — durable server-owned state: per-dispatcher
-  `status.json`, `access.json`, and `teammate/` task ledgers. Safe to remove
-  when the operator intentionally wants to discard server state.
-- `~/.dreamux/run/` — volatile run files (issue #182): `admin.sock` (+ lock),
-  `restart-intent.json`, and the `sockets/` fallback root for runtime
-  rendezvous sockets (preferred root is `$XDG_RUNTIME_DIR/dreamux/sockets/`).
-  Runtime socket paths are random per start, live only in process memory, and
-  are never persisted to durable state. Safe to clear while no server runs;
-  see `.agents/decisions/runtime-run-root.md`.
-- `~/.dreamux/cache/<dispatcher-id>/` — rebuildable cache (issue #182 PR-2):
-  `spill/` for over-budget teammate completion results (only the path is
-  inlined into a dispatcher turn) and `feishu-attachments/` for inbound
-  attachment downloads. Not durable state; safe to delete while no server runs.
-  Completion spill was relocated out of shared `/tmp`, attachments out of
-  `state/<dispatcher-id>/`.
-- `~/.dreamux/logs/` — server-owned logs, split by component; Codex
-  app-server logs use `~/.dreamux/logs/codex-app-server/<dispatcher>.log`, and
-  MCP shim diagnostics use component directories such as `channel-mcp/` and
-  `teammate-mcp/`.
-- `~/.codex/` — Codex's own global home for auth, config, and memory.
-  Dispatcher app-server processes follow Codex here; dreamux must not create
-  dispatcher-private `CODEX_HOME` directories for the MVP.
-- Bundled Dreamux skills are injected at runtime by role (issue #209 slice 6),
-  not symlinked into the workspace. `dreamux onboard` and runtime startup no
-  longer write `<dispatcher cwd>/.codex/skills`; core selects the bundled
-  `skillSources` for the Dispatcher and TeamLeader roles only and the runtime
-  package applies them (Codex `skills/extraRoots/set`, Claude Code `--add-dir`).
-  Pre-existing old `.codex/skills` symlinks are left untouched (codex lists the
-  skill twice but does not fail); operators may delete that directory.
+Typical upgrade blockers include config/state/cache/run/log path semantics,
+persisted file formats, onboard/daemon behavior, bundled skills, dispatcher
+cwd/work directory contracts, and any manual rebuild requirement.
 
-Do not reintroduce `runtime_dir`, SQLite-backed dispatcher state, or
-`~/.codex-host/` as dreamux runtime state unless a new decision record
-explicitly supersedes the top-level design.
-
-## Always-binding engineering rules
-
-- **Public repo — never commit company-internal content. (Red line.)**
-  `excitedjs/dreamux` is a public open-source repo. Feishu identifiers
-  (`ou_`/`oc_`/`cli_`), internal tokens/secrets, private-mirror registry URLs,
-  internal hostnames — none of it ever goes in a commit; a leaked commit is
-  public and permanent. The anti-leak guardrail enforces this: the committed
-  `.gitleaks.toml`, the `gitleaks protect --staged` pre-commit hook
-  (`common/git-hooks/pre-commit`), and a full-history `gitleaks detect`
-  CI gate. `.gitleaks.toml` and `.npmrc` are a **shared canonical kept
-  byte-identical with the claudemux repo** — do not edit them in only one repo;
-  if gitleaks false-positives, stop and ask rather than adding a local
-  allowlist, and sync any config change across both repos.
-- **No synchronous blocking IO in package source. (#85.)** dreamux is one
-  event loop hosting N dispatchers; a `*Sync` fs/`child_process` call stalls
-  every dispatcher. `n/no-sync` (plus import / syntax backstops, shared via
-  `@excitedjs/eslint-config`) makes `/packages/*/src/**` a hard error; use
-  `node:fs/promises` and the async `child_process` API. `tests/**` allows sync
-  `fs` fixtures but still bans sync `child_process` (two audited exemptions
-  carry reasoned `eslint-disable`s). `runtime/logger.ts` keeps
-  `pino.destination({ sync: true })` deliberately — a config flag, not a `*Sync`
-  call. Enforced by `rush lint` (CI + pre-commit). The config is pure-syntactic,
-  so `no-floating-promises` is unavailable: audit a newly-`async` function's
-  callers by hand. See `.agents/decisions/no-sync-io-lint-gate.md`.
-- **No new runtime dependencies on dev tools.** PR #6 removed `tsx`; do
-  not reintroduce it for bin launchers. The launchers exec `node` on
-  compiled `dist/` output.
-- **Bin launchers resolve their own location through symlinks** so they
-  work from any cwd and via `~/bin/<x>` shortcuts. The POSIX symlink-walk
-  loop in `/packages/dreamux/bin/dreamux` is the reference shape; reuse it
-  verbatim for any new launcher.
-- **Neutral path builders go in `src/platform/paths.ts` only (volatile
-  runtime-socket allocation in `src/platform/runtime-sockets.ts`); per-runtime
-  path derivation lives in each builtin's
-  `src/agent-runtime/builtin/<name>/paths.ts`.**
-  Cross-process file contracts (the admin socket path, dispatcher state files,
-  logs) drift silently if any other file constructs them by raw string
-  concatenation.
-- **Codex protocol bumps run through the `@excitedjs/agent-runtime-codex` package's
-  `src/handshake.ts` first** (the in-core
-  `packages/dreamux/src/agent-runtime/builtin/codex/handshake.ts` is now a
-  re-export shim — #209 slice 3). Any RPC before `initialize` is rejected with
-  `Not initialized` on codex 0.134+ — confirmed end-to-end in
-  `tests/codex-0135-live.test.ts`.
-- **Teammate reverse-delivery requires codex 0.137+.** `completionInput`
-  delivers a finished teammate's result to the dispatcher via
-  `thread/inject_items` (codex 0.137+; see issue #147), then triggers a turn.
-  Older codex versions lack that RPC, so completion delivery fails loudly with a
-  0.137 hint rather than silently dropping. The proactive doctor/version gate for
-  this lives with the per-runtime `diagnostic` capability (issue #148).
-- **Tests that depend on a real codex install fail loudly when codex is
-  missing**, not silent skip. Opt-in skip via `DREAMUX_SKIP_LIVE_CODEX=1`
-  (see `tests/codex-0135-live.test.ts`'s docstring).
-
-## Changelog responsibility (user-visible upgrade blockers)
-
-In 0.x dreamux does **not** ship automatic schema migrations: incompatible
-config/state is handled by fail-loud + an explicit rebuild (issue #98). The
-changelog is the only upgrade-time information channel, so any change that can
-block or break a user's upgrade **must** ship a rush change file describing it.
-
-A change is an upgrade blocker if it touches any of:
-
-- config file schema or field semantics;
-- user directory structure or runtime/state/cache paths;
-- `access` / `state` / `status` / `restart-intent` (and similar) persisted file
-  formats;
-- `onboard` / `daemon` / service-unit behavior;
-- bundled skills, dispatcher working directory, or `.codex/skills` structure;
-- anything a user or an LLM must manually rebuild, delete, or migrate across the
-  upgrade.
-
-Rules:
-
-- Write the note via `rush change` (it feeds the rush-generated
-  `packages/dreamux/CHANGELOG.md` / `CHANGELOG.json`). Never hand-edit the
-  generated changelog files — a release regenerates them and the edit is lost.
-- In the change comment, lead breaking notes with a `BREAKING:` line and, when
-  the user must act, a `Rebuild:` line naming the exact file/path to recreate,
-  so a model reading `dreamux changelog --json` can parse the required action.
-- The matching read path is the bundled `dreamux-maintenance` skill's
-  "Upgrade Flow": install new package → `dreamux changelog` → handle
-  breaking/rebuild notes → `daemon restart` / `onboard`.
+For breaking notes, lead with `BREAKING:` and include `Rebuild:` when the user
+must recreate a file/path.
 
 ## Commits
 
-- Use real author identity. If `git commit` complains about an
-  auto-detected email (whoami@hostname), set `user.email` / `user.name`
-  explicitly per-commit via `git -c user.email=... -c user.name=...`.
-- Commit messages: short subject (50 chars), body wrapped, explain *why*.
-  Reference the issue / PR when relevant.
-- Co-author trailer: add `Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>`
-  to commits authored with this agent (matches the trailer used in
-  PR #3, #5, #6).
+- Use real author identity. If git reports an auto-detected email, set
+  `user.email` / `user.name` explicitly for the commit.
+- Commit messages: short subject, wrapped body, explain why, reference issues or
+  PRs when relevant.
+- Co-author trailer for this agent:
+  `Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>`.

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # dreamux
 
-Rush + pnpm monorepo for `@excitedjs/dreamux` — a local dispatcher host that
-runs N **Dispatchers** in one Node process. Each dispatcher binds a Channel
-provider, an Agent Runtime provider, and Dreamux-owned MCP surfaces for channel
-reply and TeamMate work.
+Rush + pnpm monorepo for `@excitedjs/dreamux`, a local dispatcher host that
+runs N **Dispatchers** in one Node process. A dispatcher binds one Agent Runtime
+provider, one or more Channel providers, and Dreamux-owned MCP surfaces for
+TeamMate, Team, and channel-tool work.
 
 Replaces the "Claude Code as dispatcher" pattern from
 [claudemux](https://github.com/excitedjs/claudemux).
@@ -13,45 +13,49 @@ Design background:
 [#2 Engineering plan](https://github.com/excitedjs/dreamux/issues/2) ·
 [#4 Monorepo + harness](https://github.com/excitedjs/dreamux/issues/4).
 
-## Where to look
+## Where To Look
 
 | Looking for | Read |
 |---|---|
-| The package itself (install, run, configure, Phase 1 verification, config reference, testing) | [`packages/dreamux/README.md`](packages/dreamux/README.md) |
-| Dispatcher skill and tm packaging | [`.agents/decisions/dispatcher-tm-packaging.md`](.agents/decisions/dispatcher-tm-packaging.md) |
-| Plugin/provider architecture and #110 closure boundary | [`.agents/proposals/plugin-provider-architecture.md`](.agents/proposals/plugin-provider-architecture.md), [`.agents/decisions/issue-110-epic-closure.md`](.agents/decisions/issue-110-epic-closure.md) |
+| The package itself (install, run, configure, config reference, testing) | [`packages/dreamux/README.md`](packages/dreamux/README.md) |
+| Current architecture map | [`.agents/reference/current-architecture.md`](.agents/reference/current-architecture.md) |
+| Monorepo layout reference | [`.agents/reference/repo-structure.md`](.agents/reference/repo-structure.md) |
+| State/cache/run/log ownership | [`.agents/reference/state-and-paths.md`](.agents/reference/state-and-paths.md) |
+| Channel and Feishu runtime | [`.agents/reference/channel-runtime.md`](.agents/reference/channel-runtime.md) |
+| Provider architecture and package split | [`.agents/decisions/provider-architecture-realignment.md`](.agents/decisions/provider-architecture-realignment.md), [`.agents/decisions/npm-package-split-and-channel-targets.md`](.agents/decisions/npm-package-split-and-channel-targets.md) |
+| Issue #110 closure boundary | [`.agents/decisions/issue-110-epic-closure.md`](.agents/decisions/issue-110-epic-closure.md) |
 | Architecture, decisions, knowledge-delta protocol | [`.agents/root.md`](.agents/root.md) |
+| Historical proposals | [`.agents/archive/README.md`](.agents/archive/README.md) |
 | Always-loaded agent operating rules | [`CLAUDE.md`](CLAUDE.md) (`AGENTS.md` is a symlink) |
-| Monorepo layout reference | [`.agents/components/repo-structure.md`](.agents/components/repo-structure.md) |
-| Why Rush + pnpm | [`.agents/decisions/rush-pnpm-monorepo.md`](.agents/decisions/rush-pnpm-monorepo.md) |
-| Why the monorepo path is the only install path | [`.agents/decisions/install-model.md`](.agents/decisions/install-model.md) |
-| Why `@excitedjs/dreamux` + `dreamux` CLI + the two legacy aliases | [`.agents/decisions/cli-and-package-naming.md`](.agents/decisions/cli-and-package-naming.md) |
 
-## Repo layout
+## Repo Layout
 
-```
+```text
 /
 ├── packages/
-│   ├── dreamux/           @excitedjs/dreamux — the host server
-│   └── channel/
-│       ├── feishu-transport/   @excitedjs/feishu-transport — platform-I/O core
-│       └── feishu-channel/     @excitedjs/feishu-channel — channel layer (placeholder)
-├── bin/                   thin forwarders → packages/dreamux/bin/
-├── rush.json              rush + pnpm + Node version pins
-├── common/
-│   ├── config/rush/       command-line.json, .npmrc, version-policies.json
-│   └── scripts/install-run-rush.js   minimal rush bootstrap
-├── .agents/               on-demand knowledge base
-├── .github/workflows/     CI: rush change/typecheck/build/test, shellcheck, KB check, author/gitleaks gates
-├── CLAUDE.md              always-loaded operating rules
-└── AGENTS.md              symlink → CLAUDE.md
+│   ├── dreamux/                 @excitedjs/dreamux host server
+│   ├── dreamux-types/           declaration-only provider contracts
+│   ├── dreamux-utils/           shared runtime utilities
+│   ├── agent-runtime/
+│   │   ├── codex/               builtin:codex runtime package
+│   │   └── claude-code/         builtin:claude-code runtime package
+│   ├── channel/
+│   │   ├── feishu-transport/    platform I/O core
+│   │   └── feishu-channel/      builtin:feishu channel package
+│   └── eslint-config/           private shared lint config
+├── bin/                         thin forwarders to packages/dreamux/bin/
+├── rush.json                    Rush + pnpm + Node version pins
+├── common/                      Rush config and bootstrap
+├── .agents/                     on-demand knowledge base
+├── .github/workflows/           CI
+├── CLAUDE.md                    always-loaded operating rules
+└── AGENTS.md                    symlink to CLAUDE.md
 ```
 
-## Quick start
+## Quick Start
 
-The monorepo path is the single supported install path (the workspace now
-spans three packages wired with `workspace:*`, which `npm` cannot resolve —
-see [the install-model decision](.agents/decisions/install-model.md)):
+The monorepo path is the single supported install path (workspace packages use
+`workspace:*`, which per-package `npm install` cannot resolve):
 
 ```bash
 node common/scripts/install-run-rush.js update
@@ -60,8 +64,7 @@ node common/scripts/install-run-rush.js test
 ./packages/dreamux/bin/dreamux serve
 ```
 
-Full quick start, config reference, and Phase 1 verification path are in the
-package README:
+Full quick start, config reference, and verification paths are in
 [`packages/dreamux/README.md`](packages/dreamux/README.md).
 
 Repo-root `bin/dreamux` is a thin source-checkout shim that forwards to

--- a/rush.json
+++ b/rush.json
@@ -7,9 +7,10 @@
  *   - Node >= 22.7.0: matches the runtime requirement of the dreamux server
  *     (per @excitedjs/dreamux package.json's engines.node field).
  *
- * Projects today (@excitedjs/dreamux-types declaration-only contracts,
- * @excitedjs/dreamux host, @excitedjs/feishu-transport core,
- * @excitedjs/feishu-channel placeholder), wired with pnpm workspace:*.
+ * Projects today include @excitedjs/dreamux, @excitedjs/dreamux-types,
+ * @excitedjs/dreamux-utils, the built-in agent-runtime packages, the Feishu
+ * channel/transport packages, and the unpublished shared ESLint config, wired
+ * with pnpm workspace:*.
  * More packages go under packages/<name>/ and get registered in the
  * `projects` array below.
  *


### PR DESCRIPTION
## Summary

- Trim `CLAUDE.md` to always-loaded guardrails and route architecture facts into focused KB references.
- Rework `.agents/` navigation around current reference pages, a glossary, stronger task routes, and archived historical proposals.
- Update domain/source pointers for the post-#209 package layout and strengthen the KB checker for links, reachability, and decision-index coverage.

## Verification

- `.agents/scripts/check.sh`
- `git diff --check`
- README/CLAUDE local Markdown link check
- `node common/scripts/install-run-rush.js change --verify --no-fetch`
- gitleaks pre-commit hook
- TeamMate reviews: Claude and Claude-seed final/focused reviews reported no P0/P1 blockers
