### PR TITLE
fix(team): close 一个 team member 时不要清理 team 的共享 worktree

### DIFF
--- a/common/changes/@excitedjs/dreamux/fix-team-member-close-worktree-cleanup_2026-06-18-00-00.json
+++ b/common/changes/@excitedjs/dreamux/fix-team-member-close-worktree-cleanup_2026-06-18-00-00.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Fix: closing a team member (or the team leader outside dissolve) no longer cleans up the Team's shared worktree. A `team_member` / `team_leader` borrows the Team's one shared worktree (a member spawn injects the shared workspace; the leader sits at the team root), so `TeammateService.close()` used to run `WorktreeManager.cleanup()` on that shared worktree — `git worktree remove`-ing the live shared directory out from under the leader and every other member whenever it was `managed` + `delete-on-close` and clean/merged. close() now only cleans the worktree for a dispatcher-owned `teammate` (which owns its own worktree); the Team's shared worktree is owned by the Team and is cleaned exactly once at `dissolve`.",
+      "type": "patch",
+      "packageName": "@excitedjs/dreamux"
+    }
+  ],
+  "packageName": "@excitedjs/dreamux",
+  "email": "053700@gmail.com"
+}

--- a/packages/dreamux/src/service/teammate-service/index.ts
+++ b/packages/dreamux/src/service/teammate-service/index.ts
@@ -227,12 +227,25 @@ export class TeammateService {
   async close(input: Pick<CloseTeamMateInput, 'note'>): Promise<TeamMateCloseResult> {
     requireLifecycleText(input.note, 'TeamMate close note');
     await this.stop();
-    const closed = await this.deps.identities.update(this.current(), {
+    const identity = this.current();
+    // A `team_member` / `team_leader` BORROWS the Team's one shared worktree (a
+    // member spawn requires a `sharedWorkspace`, and the leader sits at the team
+    // root) — it does not own it. Running `cleanup()` here would
+    // `git worktree remove` the live shared dir out from under the leader and
+    // every other member; a clean, already-merged shared worktree would actually
+    // be deleted. The shared worktree's lifecycle belongs to the Team and is
+    // cleaned exactly once at `dissolve`. Only a dispatcher-owned `teammate`
+    // cleans its worktree on close.
+    const worktree =
+      identity.role === 'teammate'
+        ? await this.mustWorktrees().cleanup(identity)
+        : identity.worktree;
+    const closed = await this.deps.identities.update(identity, {
       status: 'closed',
       closedAt: Date.now(),
       closeNote: input.note,
       lastSeenAt: Date.now(),
-      worktree: await this.mustWorktrees().cleanup(this.current()),
+      worktree,
     });
     this.identity = closed;
     this.state = new TeamMateRuntimeStateStore(this.deps.identities, closed);

--- a/packages/dreamux/tests/team-collection-read-path.test.ts
+++ b/packages/dreamux/tests/team-collection-read-path.test.ts
@@ -1,7 +1,11 @@
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
-import { mkdirSync, mkdtempSync, rmSync } from 'node:fs';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
+
+const execFileAsync = promisify(execFile);
 
 import type {
   AgentRuntime,
@@ -286,5 +290,109 @@ describe('TeamCollection create without a prompt fires no leader turn', () => {
     const status = await (await teams.get('beta')).status();
     expect(status.leader).not.toBeNull();
     expect(status.member_count).toBe(0);
+  });
+});
+
+/**
+ * Regression: closing a team member must NOT clean up the Team's shared
+ * worktree. A member borrows the team's one managed worktree (spawn injects the
+ * shared workspace), so its `close()` used to run `WorktreeManager.cleanup()`
+ * on that shared worktree — `git worktree remove`-ing the live dir out from
+ * under the leader and every other member when it was `delete-on-close` and
+ * clean. The shared worktree is owned by the Team and must only be cleaned at
+ * `dissolve`. This exercises the real delete path (a fresh managed worktree at
+ * base HEAD is clean and reachable, so the old code's retain guard would NOT
+ * save it).
+ */
+describe('closing a team member must not remove the shared team worktree', () => {
+  let root: string;
+  let previousHome: string | undefined;
+
+  beforeEach(() => {
+    root = mkdtempSync(join(tmpdir(), 'dreamux-team-member-close-'));
+    previousHome = process.env['HOME'];
+    process.env['HOME'] = join(root, 'home');
+    mkdirSync(process.env['HOME'], { recursive: true });
+  });
+
+  afterEach(() => {
+    if (previousHome === undefined) delete process.env['HOME'];
+    else process.env['HOME'] = previousHome;
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  it('preserves the managed/delete-on-close worktree on member close; only dissolve removes it', async () => {
+    // A real source repo so the managed worktree is a real `git worktree`.
+    const sourceRepo = join(root, 'source');
+    mkdirSync(sourceRepo, { recursive: true });
+    const git = async (args: string[]): Promise<string> => {
+      const { stdout } = await execFileAsync('git', args, { cwd: sourceRepo });
+      return stdout;
+    };
+    await git(['init', '-q']);
+    await git(['config', 'user.email', 'test@example.com']);
+    await git(['config', 'user.name', 'Test']);
+    writeFileSync(join(sourceRepo, 'README.md'), '# source\n');
+    await git(['add', '.']);
+    await git(['commit', '-qm', 'init']);
+    const countWorktrees = async (): Promise<number> =>
+      (await git(['worktree', 'list', '--porcelain']))
+        .split('\n')
+        .filter((line) => line.startsWith('worktree ')).length;
+
+    const workspace = join(root, 'workspace');
+    mkdirSync(workspace, { recursive: true });
+    const runtimes: FakeRuntime[] = [];
+    const config = testDreamuxConfig([
+      testDispatcherConfig({
+        id: 'dispatcher-a',
+        cwd: workspace,
+        agentRuntime: 'agent-a',
+        runtimeProvider: FAKE_RUNTIME_REF,
+      }),
+    ]);
+    const log = noopLog();
+    const teams = new TeamCollection({
+      dispatcherId: 'dispatcher-a',
+      config,
+      agentRuntimeProviders: fakeRuntimeCatalog(runtimes),
+      worktrees: new WorktreeManager(),
+      bindings: new ChannelBindingStore(),
+      identities: new TeamMateIdentityStore({ warn: log.warn.bind(log) }),
+      turnsStore: new TeamMateTurnsStore({ warn: log.warn.bind(log) }),
+      router: new CompletionRouter({ dispatcherId: 'dispatcher-a', log }),
+      initiatorFor: async () => null,
+      isShuttingDown: () => false,
+      mcpServersForTeamMate: () => [],
+      log,
+    });
+
+    // Create the team on a MANAGED, delete-on-close worktree of the source repo.
+    await teams.create({
+      name: 'gamma',
+      leaderAgentRuntime: 'agent-a',
+      intent: 'lead gamma',
+      repoCwd: sourceRepo,
+      worktree: { mode: 'managed', cleanup: 'delete-on-close' },
+      prompt: 'lead',
+    });
+    // source repo's main worktree + the team's managed worktree.
+    expect(await countWorktrees()).toBe(2);
+
+    const team = await teams.get('gamma');
+    const spawn = await team.spawnTeamMate({
+      name: 'worker',
+      prompt: 'do the work',
+      agentRuntime: 'agent-a',
+      intent: 'member work',
+    });
+
+    // Closing the member must leave the shared team worktree intact.
+    await team.teammates.close({ name: spawn.teammate.name, note: 'member done' });
+    expect(await countWorktrees()).toBe(2);
+
+    // Dissolve is the one place that cleans the shared worktree.
+    await team.dissolve({ teamId: 'gamma', note: 'team done' });
+    expect(await countWorktrees()).toBe(1);
   });
 });


### PR DESCRIPTION
## Bug

`team_member` / `team_leader` 借用 Team 的**唯一共享 worktree**(member spawn 注入 sharedWorkspace,leader 落在 team 根),并不拥有它。但 `TeammateService.close()` 会对这个借来的 worktree 跑 `WorktreeManager.cleanup()`——所以 close 掉**一个** member,就可能把这个还活着的共享目录 `git worktree remove` 掉,把 leader 和所有其他 member 的工作目录一起带走。

触发条件:共享 worktree 是 `managed` + `delete-on-close` 且干净(`retainedState` 只在脏 / 有未合并 / 有未推送且不可达提交时才保留;干净且已合并的会被真的删除)。

## 修复

`close()` 只对 dispatcher-owned 的 `teammate`(拥有自己的 worktree)清理;Team 的共享 worktree 归 Team 所有,只在 `dissolve` 时清理一次(`TeamService.dissolve` 已有显式 cleanup 调用)。

## 验证

- 新增真实 git 回归测试(managed/delete-on-close 的 team worktree):close member 后共享 worktree 仍在,只有 dissolve 才移除。**已确认该测试在修复前的代码上会失败**(close member 后 worktree 数从 2 掉到 1)。
- `rush build` / `rush lint` / 全量 489 测试 / `.agents/scripts/check.sh` 全绿。
- 附 Rush change file(`@excitedjs/dreamux`,patch)。

## 异构 review 结论

codex(correctness)+ claude(design/contract/test)双 APPROVE。复核确认 dispatcher-scope 的 spawn 路径**不存在**同根因的独立 footgun:`reuse-cwd` 记成 `mode:'reuse-cwd'`,`cleanup()` 对非 managed 早返回(不删任何东西);`managed` 在 `<ws>/.workspace/worktree/...` 下分配**全新唯一路径**(`assertManagedWorktreeAvailable` 防撞),清理它本就正确。之前一度怀疑的 "reuse-cwd → managed/delete-on-close" 其实是 **team member 借用 team 共享 worktree** 的行为(sharedWorkspace 原样返回),正是本 PR 修复的 bug。因此无需单独 follow-up。

非阻塞 nit(未在本 PR 处理):close() 对非 `teammate` 角色由 throw 变 no-op(dispatcher 从不 close,无影响);已关闭 member 的 `cleanup_state` 仍为 `managed-active`(纯展示)。