### PR TITLE
fix(team): dissolve 后同步 worktree cleanup_state 到 leader 和 members (#237)

### DIFF
--- a/common/changes/@excitedjs/dreamux/fix-dissolve-sync-worktree-cleanup-state_2026-06-18-00-00.json
+++ b/common/changes/@excitedjs/dreamux/fix-dissolve-sync-worktree-cleanup-state_2026-06-18-00-00.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Fix (completes #236): `team.dissolve` now syncs the cleaned worktree state to the TeamLeader and every member, so `team.status` / `teammate.status` no longer report `cleanup_state: managed-active` for a shared worktree that dissolve already removed (issue #237). Since a `team_member` / `team_leader` borrows the Team's one shared worktree and skips cleanup on its own `close` (#236), dissolve is the single authoritative cleanup site; it now propagates the identity `WorktreeManager.cleanup()` returned to the leader and members (via a new `TeammateService.applyWorktreeCleanup` / `TeammateOps.applyWorktreeCleanup`) so persisted and displayed state match reality everywhere. Behavior-only state-consistency fix; actual worktree cleanup was already correct.",
+      "type": "patch",
+      "packageName": "@excitedjs/dreamux"
+    }
+  ],
+  "packageName": "@excitedjs/dreamux",
+  "email": "053700@gmail.com"
+}

--- a/packages/dreamux/src/service/team-service/index.ts
+++ b/packages/dreamux/src/service/team-service/index.ts
@@ -99,23 +99,35 @@ export class TeamService {
         });
       }
     }
-    for (const member of await this.members()) {
+    const members = await this.members();
+    for (const member of members) {
       await this.opts.teammates.close({
         name: member.name,
         note: input.note,
       });
     }
     await this.leader.close({ note: input.note });
+    // `dissolve` is the single authoritative cleanup site for the Team's shared
+    // worktree (issue #236): members and the leader borrow it and skip cleanup on
+    // their own `close`, so only this call removes it.
+    const cleaned = await this.opts.worktrees.cleanup({
+      source_cwd: this.record.repo_cwd,
+      source_repo: this.record.source_repo,
+      worktree: this.record.worktree,
+    });
     this.record = await this.opts.store.update(this.record, {
       status: 'closed',
       closedAt: Date.now(),
       closeNote: input.note,
-      worktree: await this.opts.worktrees.cleanup({
-        source_cwd: this.record.repo_cwd,
-        source_repo: this.record.source_repo,
-        worktree: this.record.worktree,
-      }),
+      worktree: cleaned,
     });
+    // Propagate that single result to every borrower so a leader/member
+    // `cleanup_state` does not stay `managed-active` after the worktree is gone
+    // (issue #237). They share the one worktree, so the same identity applies.
+    await this.leader.applyWorktreeCleanup(cleaned);
+    for (const member of members) {
+      await this.opts.teammates.applyWorktreeCleanup(member.name, cleaned);
+    }
     const summary = await this.status();
     // Evict so a later `get` rebuilds from disk and reads `status: closed`.
     this.opts.evict();

--- a/packages/dreamux/src/service/teammate-collection/index.ts
+++ b/packages/dreamux/src/service/teammate-collection/index.ts
@@ -139,6 +139,12 @@ export interface TeammateOps {
   spawn(input: Omit<SpawnTeamMateRequest, 'sharedWorkspace'>): Promise<TeamMateSpawnResult>;
   send(input: SendTeamMateInput): Promise<TeamMateSendResult>;
   close(input: CloseTeamMateInput): Promise<TeamMateCloseResult>;
+  /**
+   * Sync a member's persisted worktree to the Team's authoritative `dissolve`
+   * cleanup result (issue #237), so a borrowed shared worktree's `cleanup_state`
+   * does not stay `managed-active` after the Team removed it.
+   */
+  applyWorktreeCleanup(name: string, worktree: TeamMateWorktreeIdentity): Promise<void>;
   list(): Promise<TeamMateRuntimeStatus[]>;
   status(name: string): Promise<TeamMateRuntimeStatus>;
   history(input: Omit<TeamMateHistoryQuery, 'teamId'>): Promise<TeamMateHistoryResult>;
@@ -300,6 +306,14 @@ export class TeammateCollection implements TeammateOps {
     const entity = await this.mustEntity(input.name);
     const closed = await entity.close({ note: input.note });
     return closed;
+  }
+
+  async applyWorktreeCleanup(
+    name: string,
+    worktree: TeamMateWorktreeIdentity,
+  ): Promise<void> {
+    const entity = await this.mustEntity(name);
+    await entity.applyWorktreeCleanup(worktree);
   }
 
   async list(): Promise<TeamMateRuntimeStatus[]> {

--- a/packages/dreamux/src/service/teammate-collection/index.ts
+++ b/packages/dreamux/src/service/teammate-collection/index.ts
@@ -139,12 +139,6 @@ export interface TeammateOps {
   spawn(input: Omit<SpawnTeamMateRequest, 'sharedWorkspace'>): Promise<TeamMateSpawnResult>;
   send(input: SendTeamMateInput): Promise<TeamMateSendResult>;
   close(input: CloseTeamMateInput): Promise<TeamMateCloseResult>;
-  /**
-   * Sync a member's persisted worktree to the Team's authoritative `dissolve`
-   * cleanup result (issue #237), so a borrowed shared worktree's `cleanup_state`
-   * does not stay `managed-active` after the Team removed it.
-   */
-  applyWorktreeCleanup(name: string, worktree: TeamMateWorktreeIdentity): Promise<void>;
   list(): Promise<TeamMateRuntimeStatus[]>;
   status(name: string): Promise<TeamMateRuntimeStatus>;
   history(input: Omit<TeamMateHistoryQuery, 'teamId'>): Promise<TeamMateHistoryResult>;
@@ -308,6 +302,13 @@ export class TeammateCollection implements TeammateOps {
     return closed;
   }
 
+  /**
+   * Sync a member's persisted worktree to the Team's authoritative `dissolve`
+   * cleanup result (issue #237), so a borrowed shared worktree's `cleanup_state`
+   * does not stay `managed-active` after the Team removed it. Concrete-only (off
+   * `TeammateOps`): only `TeamService.dissolve`, which holds the concrete
+   * collection, calls this — it is not part of the admin-facing teammate surface.
+   */
   async applyWorktreeCleanup(
     name: string,
     worktree: TeamMateWorktreeIdentity,

--- a/packages/dreamux/src/service/teammate-service/index.ts
+++ b/packages/dreamux/src/service/teammate-service/index.ts
@@ -263,7 +263,16 @@ export class TeammateService {
    * persisted (and displayed, via `status`) state matches reality everywhere.
    */
   async applyWorktreeCleanup(worktree: TeamMateWorktreeIdentity): Promise<void> {
-    const updated = await this.deps.identities.update(this.current(), { worktree });
+    const identity = this.current();
+    // Only a borrowed Team worktree is synced from the Team's dissolve cleanup. A
+    // dispatcher-owned `teammate` owns its worktree and updates it on its own
+    // `close`; overwriting it from the team result would be wrong, so fail loud.
+    if (identity.role !== 'team_leader' && identity.role !== 'team_member') {
+      throw new Error(
+        `applyWorktreeCleanup is only valid for a team_leader/team_member, not ${JSON.stringify(identity.role)}`,
+      );
+    }
+    const updated = await this.deps.identities.update(identity, { worktree });
     this.identity = updated;
     this.state = new TeamMateRuntimeStateStore(this.deps.identities, updated);
   }

--- a/packages/dreamux/src/service/teammate-service/index.ts
+++ b/packages/dreamux/src/service/teammate-service/index.ts
@@ -46,6 +46,7 @@ import {
   type TeamMateSendResult,
   type TeamMateTurnOrigin,
   type TeamMateTurnResult,
+  type TeamMateWorktreeIdentity,
 } from '../teammate-collection/types.js';
 import type { DreamuxConfig } from '../../config/config.js';
 import type { AgentRuntimeProviderCatalog } from '../../agent-runtime/index.js';
@@ -250,6 +251,21 @@ export class TeammateService {
     this.identity = closed;
     this.state = new TeamMateRuntimeStateStore(this.deps.identities, closed);
     return { teammate: toStatus(closed, null) };
+  }
+
+  /**
+   * Sync this entity's persisted worktree to the result of the Team's single
+   * authoritative cleanup at `dissolve` (issue #237). A `team_member` /
+   * `team_leader` borrows the Team's shared worktree and skips cleanup on its own
+   * `close`, so without this its recorded `cleanup_state` would stay
+   * `managed-active` after dissolve removed the worktree. dissolve hands every
+   * borrower the same identity `WorktreeManager.cleanup()` returned, so the
+   * persisted (and displayed, via `status`) state matches reality everywhere.
+   */
+  async applyWorktreeCleanup(worktree: TeamMateWorktreeIdentity): Promise<void> {
+    const updated = await this.deps.identities.update(this.current(), { worktree });
+    this.identity = updated;
+    this.state = new TeamMateRuntimeStateStore(this.deps.identities, updated);
   }
 
   status(): TeamMateRuntimeStatus {

--- a/packages/dreamux/tests/team-collection-read-path.test.ts
+++ b/packages/dreamux/tests/team-collection-read-path.test.ts
@@ -396,3 +396,98 @@ describe('closing a team member must not remove the shared team worktree', () =>
     expect(await countWorktrees()).toBe(1);
   });
 });
+
+/**
+ * Regression (issue #237): after `dissolve` removes the Team's shared worktree,
+ * every borrower's recorded `cleanup_state` must reflect that — not stay
+ * `managed-active`. Since members/leader skip cleanup on their own close (#236),
+ * dissolve propagates its single authoritative cleanup result to the leader and
+ * each member.
+ */
+describe('team dissolve syncs cleanup_state to the leader and members (#237)', () => {
+  let root: string;
+  let previousHome: string | undefined;
+
+  beforeEach(() => {
+    root = mkdtempSync(join(tmpdir(), 'dreamux-team-dissolve-state-'));
+    previousHome = process.env['HOME'];
+    process.env['HOME'] = join(root, 'home');
+    mkdirSync(process.env['HOME'], { recursive: true });
+  });
+
+  afterEach(() => {
+    if (previousHome === undefined) delete process.env['HOME'];
+    else process.env['HOME'] = previousHome;
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  it('reports cleanup_state "deleted" for the leader and members after dissolve', async () => {
+    const sourceRepo = join(root, 'source');
+    mkdirSync(sourceRepo, { recursive: true });
+    const git = async (args: string[]): Promise<string> => {
+      const { stdout } = await execFileAsync('git', args, { cwd: sourceRepo });
+      return stdout;
+    };
+    await git(['init', '-q']);
+    await git(['config', 'user.email', 'test@example.com']);
+    await git(['config', 'user.name', 'Test']);
+    writeFileSync(join(sourceRepo, 'README.md'), '# source\n');
+    await git(['add', '.']);
+    await git(['commit', '-qm', 'init']);
+
+    const workspace = join(root, 'workspace');
+    mkdirSync(workspace, { recursive: true });
+    const runtimes: FakeRuntime[] = [];
+    const config = testDreamuxConfig([
+      testDispatcherConfig({
+        id: 'dispatcher-a',
+        cwd: workspace,
+        agentRuntime: 'agent-a',
+        runtimeProvider: FAKE_RUNTIME_REF,
+      }),
+    ]);
+    const log = noopLog();
+    const teams = new TeamCollection({
+      dispatcherId: 'dispatcher-a',
+      config,
+      agentRuntimeProviders: fakeRuntimeCatalog(runtimes),
+      worktrees: new WorktreeManager(),
+      bindings: new ChannelBindingStore(),
+      identities: new TeamMateIdentityStore({ warn: log.warn.bind(log) }),
+      turnsStore: new TeamMateTurnsStore({ warn: log.warn.bind(log) }),
+      router: new CompletionRouter({ dispatcherId: 'dispatcher-a', log }),
+      initiatorFor: async () => null,
+      isShuttingDown: () => false,
+      mcpServersForTeamMate: () => [],
+      log,
+    });
+
+    await teams.create({
+      name: 'delta',
+      leaderAgentRuntime: 'agent-a',
+      intent: 'lead delta',
+      repoCwd: sourceRepo,
+      worktree: { mode: 'managed', cleanup: 'delete-on-close' },
+      prompt: 'lead',
+    });
+    const team = await teams.get('delta');
+    const spawn = await team.spawnTeamMate({
+      name: 'worker',
+      prompt: 'do the work',
+      agentRuntime: 'agent-a',
+      intent: 'member work',
+    });
+    const memberName = spawn.teammate.name;
+
+    // Sanity: before dissolve the leader's worktree is live.
+    const before = await team.status();
+    expect(before.leader!.repo?.cleanup_state).toBe('managed-active');
+
+    const dissolved = await team.dissolve({ teamId: 'delta', note: 'team done' });
+
+    // The worktree is actually gone, AND the persisted/displayed state agrees.
+    expect(dissolved.leader!.repo?.cleanup_state).toBe('deleted');
+    const member = await team.teammates.status(memberName);
+    expect(member.repo?.cleanup_state).toBe('deleted');
+  });
+});


### PR DESCRIPTION
Fixes #237. 这是 #236 的状态传播补全。

## 问题

`team_member` / `team_leader` 借用 Team 的唯一共享 worktree,在各自 `close` 时跳过清理(#236),所以 `dissolve` 是唯一真正删除该 worktree 的地方。但 dissolve 只把清理后的 worktree 写回了 **team record**,leader 和 members 各自 identity 里的 worktree 副本仍是 `cleanup_state: managed-active`。于是 worktree 实际已删,`team.status`(展示 leader)/`teammate.status` 却仍显示 active,误导运维。

## 修复

dissolve 把 `WorktreeManager.cleanup()` 返回的那个 identity 传播给 leader 和每个 member(新增 `TeammateService.applyWorktreeCleanup`,挂到 `TeammateOps` 上)。它们共享同一个 worktree,所以同一个 cleaned identity 适用于全部——一致性是结构性的,不是去猜某个状态值。

## 验证

- 新增真实 git 回归测试:dissolve 后断言 leader 和一个 member 的 `cleanup_state === 'deleted'`(而非 managed-active)。**已确认该测试在修复前的代码上 FAIL**(`expected 'managed-active' to be 'deleted'`)。
- `rush build` / `rush lint` / 全量 491 测试全绿。
- 纯状态一致性修复,worktree 实际删除行为本就正确(#236 已修)。
- 附 patch 级 Rush change file。