### PR TITLE
refactor(team): own per-team construction in TeamService (#233)

### DIFF
--- a/.agents/reference/current-architecture.md
+++ b/.agents/reference/current-architecture.md
@@ -131,10 +131,19 @@ required only when the dispatcher has more than one configured channel.
 `meta` is provider-owned selector input, for example `{ "chat_id": "..." }` for
 a Feishu group chat.
 
+Each `TeamService` directly builds and holds its TeamLeader `TeammateService`
+through `/packages/dreamux/src/service/team-service/leader-agent.ts`, using the
+same dispatcher-owned identity store, turns store, worktree manager, and
+completion router that its owning `TeamCollection` injects. The per-team
+`TeammateCollection` is members-only: it spawns and caches team members under
+`team/<team>/teammate/<name>/`, while the TeamLeader lives at the team root and
+is never cached in the collection's entity map.
+
 Key source:
 
 - `/packages/dreamux/src/service/teammate-collection/`
 - `/packages/dreamux/src/service/team-collection/`
+- `/packages/dreamux/src/service/team-service/`
 - `/packages/dreamux/src/service/channel-binding/`
 - `/packages/dreamux/src/mcp/team-mcp.ts`
 

--- a/.agents/reference/scheduled-tasks.md
+++ b/.agents/reference/scheduled-tasks.md
@@ -50,9 +50,16 @@ Key source:
 
 ## Execution
 
-`SchedulerService` is owned by `DispatcherService`. It starts after the
-dispatcher agent, channel sessions, and restart-notice injection have completed,
-and it stops before channel sessions and the agent runtime are stopped.
+`SchedulerService` is owned by the conversational agent's `TeammateService` — the
+dispatcher agent owns the dispatcher scheduler, each non-closed TeamLeader owns
+its Team scheduler — built from a host-supplied config (cron-jobs store path,
+owner id, absent-runtime strategy) and wired to that agent's own runtime. The
+containers (`DispatcherService` / `TeamService`) construct no scheduler; they only
+orchestrate lifecycle and expose it for admin cron routing. The dispatcher
+scheduler starts after the dispatcher agent, channel sessions, and restart-notice
+injection have completed, and stops before channel sessions and the agent runtime
+are stopped; Team schedulers are armed at dispatcher boot (without starting the
+TeamLeader runtime) and stopped/deleted with their team.
 
 For `prompt-agent` jobs the scheduler:
 
@@ -72,7 +79,8 @@ The conversational management surface wraps the same `SchedulerService`:
 `admin/methods.ts` exposes the `scheduler.cron.*` admin methods, the `dreamux
 cron` CLI (`cli/commands/cron-mcp.ts`) drives them, and the Cron MCP
 (`mcp/cron-mcp.ts`) mirrors the native scheduling tool surface; the Cron MCP is
-injected into the dispatcher agent only (not team_leader/teammate).
+injected into each conversational agent — the dispatcher agent and every
+TeamLeader — but not regular teammates/team members.
 
 Key source:
 

--- a/common/changes/@excitedjs/dreamux/leader-out-of-collection_2026-06-25-00-00.json
+++ b/common/changes/@excitedjs/dreamux/leader-out-of-collection_2026-06-25-00-00.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "type": "none",
+      "packageName": "@excitedjs/dreamux"
+    }
+  ],
+  "packageName": "@excitedjs/dreamux",
+  "email": "053700@gmail.com"
+}

--- a/common/changes/@excitedjs/dreamux/scheduler-to-container_2026-06-25-00-00.json
+++ b/common/changes/@excitedjs/dreamux/scheduler-to-container_2026-06-25-00-00.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "type": "none",
+      "packageName": "@excitedjs/dreamux"
+    }
+  ],
+  "packageName": "@excitedjs/dreamux",
+  "email": "053700@gmail.com"
+}

--- a/common/changes/@excitedjs/dreamux/teammate-service-factory-step1_2026-06-25-00-00.json
+++ b/common/changes/@excitedjs/dreamux/teammate-service-factory-step1_2026-06-25-00-00.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "type": "none",
+      "packageName": "@excitedjs/dreamux"
+    }
+  ],
+  "packageName": "@excitedjs/dreamux",
+  "email": "053700@gmail.com"
+}

--- a/common/changes/@excitedjs/dreamux/teamservice-launch-policy_2026-06-25-00-00.json
+++ b/common/changes/@excitedjs/dreamux/teamservice-launch-policy_2026-06-25-00-00.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "type": "none",
+      "packageName": "@excitedjs/dreamux"
+    }
+  ],
+  "packageName": "@excitedjs/dreamux",
+  "email": "053700@gmail.com"
+}

--- a/common/changes/@excitedjs/dreamux/teamservice-scheduler-capability_2026-06-25-00-00.json
+++ b/common/changes/@excitedjs/dreamux/teamservice-scheduler-capability_2026-06-25-00-00.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "type": "none",
+      "packageName": "@excitedjs/dreamux"
+    }
+  ],
+  "packageName": "@excitedjs/dreamux",
+  "email": "053700@gmail.com"
+}

--- a/packages/dreamux/src/service/dispatcher-service/agent.ts
+++ b/packages/dreamux/src/service/dispatcher-service/agent.ts
@@ -20,10 +20,10 @@ import {
 } from '../completion-router/index.js';
 import type { TeamMateIdentityStore } from '../teammate-collection/identity-store.js';
 import {
-  TeammateService,
+  createTeammateService,
   type RuntimeLaunchSpec,
-  type TeammateServiceDeps,
-} from '../teammate-service/index.js';
+} from '../teammate-service/factory.js';
+import type { TeammateService } from '../teammate-service/index.js';
 import type { TeamMateTurnsStore } from '../teammate-collection/turns-store.js';
 import type { TeamMateIdentity } from '../teammate-collection/types.js';
 import { CronJobStore } from '../scheduler/store.js';
@@ -107,7 +107,20 @@ export function createDispatcherAgent(deps: DispatcherAgentDeps): TeammateServic
       /* debug record only */
     });
 
-  const serviceDeps: TeammateServiceDeps = {
+  const agent = createTeammateService({
+    dispatcherId: deps.id,
+    identity,
+    launch: { kind: 'inline', build: () => buildDispatcherLaunch(deps) },
+    options: {
+      scheduler: {
+        ownerId: deps.id,
+        store: new CronJobStore({
+          cronJobsPath: dispatcherCronJobsPath(deps.id),
+          dispatcherId: deps.id,
+        }),
+        absentRuntimeStrategy: 'miss',
+      },
+    },
     config: deps.config,
     agentRuntimeProviders: deps.agentRuntimeProviders,
     identities: deps.identities,
@@ -115,7 +128,6 @@ export function createDispatcherAgent(deps: DispatcherAgentDeps): TeammateServic
     // The dispatcher agent has no worktree — it neither spawns nor closes, so it
     // never reaches the worktree manager (issue #233 Phase 5).
     log: deps.log,
-    buildLaunch: () => buildDispatcherLaunch(deps),
     nextSubmissionSeq: () => 0,
     trackSettleCapture: () => {
       /* no-op: the dispatcher agent is never a send-registered producer, so it
@@ -123,17 +135,6 @@ export function createDispatcherAgent(deps: DispatcherAgentDeps): TeammateServic
     },
     routeSettledCompletion: (producerName, turnId, completion) =>
       routeSettled(deps.router, producerName, turnId, completion),
-  };
-
-  const agent = new TeammateService(serviceDeps, deps.id, identity, {
-    scheduler: {
-      ownerId: deps.id,
-      store: new CronJobStore({
-        cronJobsPath: dispatcherCronJobsPath(deps.id),
-        dispatcherId: deps.id,
-      }),
-      absentRuntimeStrategy: 'miss',
-    },
   });
   return agent;
 }

--- a/packages/dreamux/src/service/dispatcher-service/agent.ts
+++ b/packages/dreamux/src/service/dispatcher-service/agent.ts
@@ -12,6 +12,7 @@ import {
   type AgentRuntimeProviderCatalog,
 } from '../../agent-runtime/index.js';
 import type { DispatcherConfig, DreamuxConfig } from '../../config/config.js';
+import { dispatcherCronJobsPath } from '../../platform/paths.js';
 import type { DispatcherStore } from '../../state/dispatcher-store.js';
 import {
   completionKey,
@@ -25,6 +26,7 @@ import {
 } from '../teammate-service/index.js';
 import type { TeamMateTurnsStore } from '../teammate-collection/turns-store.js';
 import type { TeamMateIdentity } from '../teammate-collection/types.js';
+import { CronJobStore } from '../scheduler/store.js';
 import {
   DREAMUX_DISPATCHER_APPEND_INSTRUCTIONS,
   DREAMUX_DISPATCHER_BASE_INSTRUCTIONS,
@@ -123,7 +125,16 @@ export function createDispatcherAgent(deps: DispatcherAgentDeps): TeammateServic
       routeSettled(deps.router, producerName, turnId, completion),
   };
 
-  const agent = new TeammateService(serviceDeps, deps.id, identity);
+  const agent = new TeammateService(serviceDeps, deps.id, identity, {
+    scheduler: {
+      ownerId: deps.id,
+      store: new CronJobStore({
+        cronJobsPath: dispatcherCronJobsPath(deps.id),
+        dispatcherId: deps.id,
+      }),
+      absentRuntimeStrategy: 'miss',
+    },
+  });
   return agent;
 }
 

--- a/packages/dreamux/src/service/dispatcher-service/agent.ts
+++ b/packages/dreamux/src/service/dispatcher-service/agent.ts
@@ -12,7 +12,6 @@ import {
   type AgentRuntimeProviderCatalog,
 } from '../../agent-runtime/index.js';
 import type { DispatcherConfig, DreamuxConfig } from '../../config/config.js';
-import { dispatcherCronJobsPath } from '../../platform/paths.js';
 import type { DispatcherStore } from '../../state/dispatcher-store.js';
 import {
   completionKey,
@@ -26,7 +25,6 @@ import {
 import type { TeammateService } from '../teammate-service/index.js';
 import type { TeamMateTurnsStore } from '../teammate-collection/turns-store.js';
 import type { TeamMateIdentity } from '../teammate-collection/types.js';
-import { CronJobStore } from '../scheduler/store.js';
 import {
   DREAMUX_DISPATCHER_APPEND_INSTRUCTIONS,
   DREAMUX_DISPATCHER_BASE_INSTRUCTIONS,
@@ -111,16 +109,6 @@ export function createDispatcherAgent(deps: DispatcherAgentDeps): TeammateServic
     dispatcherId: deps.id,
     identity,
     launch: { kind: 'inline', build: () => buildDispatcherLaunch(deps) },
-    options: {
-      scheduler: {
-        ownerId: deps.id,
-        store: new CronJobStore({
-          cronJobsPath: dispatcherCronJobsPath(deps.id),
-          dispatcherId: deps.id,
-        }),
-        absentRuntimeStrategy: 'miss',
-      },
-    },
     config: deps.config,
     agentRuntimeProviders: deps.agentRuntimeProviders,
     identities: deps.identities,

--- a/packages/dreamux/src/service/dispatcher-service/index.ts
+++ b/packages/dreamux/src/service/dispatcher-service/index.ts
@@ -15,7 +15,10 @@ import type { AgentRuntimeProviderCatalog } from '../../agent-runtime/index.js';
 import type { ChannelProviderCatalog } from '../../channel/catalog.js';
 import type { DreamuxConfig } from '../../config/config.js';
 import type { RestartIntentConsumer } from '../../daemon/restart-intent.js';
-import { adminSocketPath as defaultAdminSocketPath } from '../../platform/paths.js';
+import {
+  adminSocketPath as defaultAdminSocketPath,
+  dispatcherCronJobsPath,
+} from '../../platform/paths.js';
 import type {
   DispatcherRow,
   DispatcherStatus,
@@ -38,7 +41,8 @@ import { ChannelBindingStore } from '../channel-binding/store.js';
 import { type TeamMateIdentity } from '../teammate-collection/types.js';
 import { type TeamChannelContext } from '../team-service/index.js';
 import { TeamCollection } from '../team-collection/index.js';
-import type { SchedulerService } from '../scheduler/service.js';
+import { SchedulerService } from '../scheduler/service.js';
+import { CronJobStore } from '../scheduler/store.js';
 import type {
   TeamCreateInput,
   TeamDissolveInput,
@@ -92,6 +96,7 @@ export class DispatcherService implements TeamChannelContext {
   private readonly teams: TeamCollection;
   private readonly channels: ChannelSessions;
   private readonly agent: TeammateService;
+  private readonly scheduler_: SchedulerService;
   private restartIntent: RestartIntentConsumer | null = null;
   private starting: Promise<void> | null = null;
   private workspaceCwd: string | null = null;
@@ -149,6 +154,18 @@ export class DispatcherService implements TeamChannelContext {
       liveChannels: () => this.channels.live(),
     });
 
+    this.scheduler_ = new SchedulerService({
+      ownerId: opts.id,
+      store: new CronJobStore({
+        cronJobsPath: dispatcherCronJobsPath(opts.id),
+        dispatcherId: opts.id,
+      }),
+      absentRuntimeStrategy: 'miss',
+      getRuntime: () => this.agent.getRuntime(),
+      submitScheduled: (input) => this.agent.scheduledInput(input),
+      log: opts.log,
+    });
+
     // A dispatcher-owned teammate is never a team_leader, so it carries no
     // launch policy (the team_leader policy is owned by the team layer).
     this._teammates = new TeammateCollection({
@@ -191,13 +208,7 @@ export class DispatcherService implements TeamChannelContext {
   }
 
   get scheduler(): SchedulerService {
-    const scheduler = this.agent.scheduler;
-    if (scheduler === null) {
-      throw new Error(
-        `dispatcher ${JSON.stringify(this.id)} agent has no scheduler capability`,
-      );
-    }
-    return scheduler;
+    return this.scheduler_;
   }
 
   /**
@@ -270,10 +281,10 @@ export class DispatcherService implements TeamChannelContext {
         });
       }
       await this.injectRestartNoticeIfNeeded(id, runtime);
-      await this.agent.startScheduler();
+      await this.scheduler.start();
       await this.teams.startSchedulers();
     } catch (err) {
-      this.agent.stopScheduler();
+      this.scheduler.stop();
       this.teams.stopSchedulers();
       // Undo the slot adoption so a failed start never leaves a half-built slot.
       this.channels.clear();
@@ -297,7 +308,7 @@ export class DispatcherService implements TeamChannelContext {
   }
 
   async stop(): Promise<void> {
-    this.agent.stopScheduler();
+    this.scheduler.stop();
     this.teams.stopSchedulers();
     await this.channels.closeAll(this.log);
     try {

--- a/packages/dreamux/src/service/dispatcher-service/index.ts
+++ b/packages/dreamux/src/service/dispatcher-service/index.ts
@@ -15,7 +15,7 @@ import type { AgentRuntimeProviderCatalog } from '../../agent-runtime/index.js';
 import type { ChannelProviderCatalog } from '../../channel/catalog.js';
 import type { DreamuxConfig } from '../../config/config.js';
 import type { RestartIntentConsumer } from '../../daemon/restart-intent.js';
-import { adminSocketPath as defaultAdminSocketPath, dispatcherCronJobsPath } from '../../platform/paths.js';
+import { adminSocketPath as defaultAdminSocketPath } from '../../platform/paths.js';
 import type {
   DispatcherRow,
   DispatcherStatus,
@@ -38,8 +38,7 @@ import { ChannelBindingStore } from '../channel-binding/store.js';
 import { type TeamMateIdentity } from '../teammate-collection/types.js';
 import { type TeamChannelContext } from '../team-service/index.js';
 import { TeamCollection } from '../team-collection/index.js';
-import { SchedulerService } from '../scheduler/service.js';
-import { CronJobStore } from '../scheduler/store.js';
+import type { SchedulerService } from '../scheduler/service.js';
 import type {
   TeamCreateInput,
   TeamDissolveInput,
@@ -93,7 +92,6 @@ export class DispatcherService implements TeamChannelContext {
   private readonly teams: TeamCollection;
   private readonly channels: ChannelSessions;
   private readonly agent: TeammateService;
-  readonly scheduler: SchedulerService;
   private restartIntent: RestartIntentConsumer | null = null;
   private starting: Promise<void> | null = null;
   private workspaceCwd: string | null = null;
@@ -151,14 +149,6 @@ export class DispatcherService implements TeamChannelContext {
       liveChannels: () => this.channels.live(),
     });
 
-    this.scheduler = new SchedulerService({
-      ownerId: opts.id,
-      store: new CronJobStore({ cronJobsPath: dispatcherCronJobsPath(opts.id), dispatcherId: opts.id }),
-      absentRuntimeStrategy: 'miss',
-      getRuntime: () => this.agent.getRuntime(),
-      submitScheduled: (input) => this.agent.scheduledInput(input),
-      log: opts.log,
-    });
     // A dispatcher-owned teammate is never a team_leader, so it carries no
     // launch policy (the team_leader policy is owned by the team layer).
     this._teammates = new TeammateCollection({
@@ -198,6 +188,16 @@ export class DispatcherService implements TeamChannelContext {
         }),
       log: opts.log,
     });
+  }
+
+  get scheduler(): SchedulerService {
+    const scheduler = this.agent.scheduler;
+    if (scheduler === null) {
+      throw new Error(
+        `dispatcher ${JSON.stringify(this.id)} agent has no scheduler capability`,
+      );
+    }
+    return scheduler;
   }
 
   /**
@@ -270,10 +270,10 @@ export class DispatcherService implements TeamChannelContext {
         });
       }
       await this.injectRestartNoticeIfNeeded(id, runtime);
-      await this.scheduler.start();
+      await this.agent.startScheduler();
       await this.teams.startSchedulers();
     } catch (err) {
-      this.scheduler.stop();
+      this.agent.stopScheduler();
       this.teams.stopSchedulers();
       // Undo the slot adoption so a failed start never leaves a half-built slot.
       this.channels.clear();
@@ -297,7 +297,7 @@ export class DispatcherService implements TeamChannelContext {
   }
 
   async stop(): Promise<void> {
-    this.scheduler.stop();
+    this.agent.stopScheduler();
     this.teams.stopSchedulers();
     await this.channels.closeAll(this.log);
     try {

--- a/packages/dreamux/src/service/team-collection/index.ts
+++ b/packages/dreamux/src/service/team-collection/index.ts
@@ -5,33 +5,21 @@ import type {
   DreamuxLogger,
 } from '@excitedjs/dreamux-types';
 
-import {
-  DISABLE_FEATURE_CRON,
-  type AgentRuntimeProviderCatalog,
-} from '../../agent-runtime/index.js';
-import { cronMcpServerDescriptor } from '../scheduler/mcp-config.js';
-import { teammateMcpServerDescriptor } from '../teammate-collection/mcp-config.js';
+import type { AgentRuntimeProviderCatalog } from '../../agent-runtime/index.js';
 import type { DreamuxConfig } from '../../config/config.js';
 import type { WorktreeManager } from '../worktree/manager.js';
 import { dispatcherWorkspace } from '../worktree/workspaces.js';
-import { TeammateCollection } from '../teammate-collection/index.js';
 import type { TeamMateIdentityStore } from '../teammate-collection/identity-store.js';
 import type { TeamMateTurnsStore } from '../teammate-collection/turns-store.js';
 import type {
   CompletionInitiator,
   CompletionRouter,
 } from '../completion-router/index.js';
-import type { TeammateService } from '../teammate-service/index.js';
 import { requireLifecycleText } from '../teammate-collection/types.js';
-import type {
-  TeamMateIdentity,
-  TeamMateLaunchPolicy,
-} from '../teammate-collection/types.js';
+import type { TeamMateIdentity } from '../teammate-collection/types.js';
 import type { ChannelBindingStore } from '../channel-binding/store.js';
 import type { ChannelBinding } from '../channel-binding/store.js';
-import { SchedulerService } from '../scheduler/service.js';
-import { CronJobStore } from '../scheduler/store.js';
-import { dispatcherTeamCronJobsPath } from '../../platform/paths.js';
+import type { SchedulerService } from '../scheduler/service.js';
 import { TeamStore } from './store.js';
 import type {
   TeamChannelBindingSummary,
@@ -48,9 +36,8 @@ import { validateTeamId } from './types.js';
 import type { TeamMateIdentityStatus } from '../teammate-collection/types.js';
 import {
   activeGroupBindingFor,
-  teamView,
   TeamService,
-  type TeamServiceOptions,
+  type TeamServiceDeps,
 } from '../team-service/index.js';
 
 export interface TeamCollectionOptions {
@@ -151,58 +138,27 @@ export class TeamCollection {
               cleanup: 'keep',
             },
           });
-    // The team's own collection allocates the (dispatcher-global) leader name
-    // and creates the leader (issue #233).
-    const teammates = this.buildTeammates(teamId);
-    const leaderName = await teammates.allocateLeaderName();
-    let team =
-      existing ??
-      (await this.store.create({
-        dispatcher_id: this.dispatcherId,
-        team_id: teamId,
+    const { service, leaderResult } = await TeamService.createNew(
+      { ...this.depsBase(), evict: () => this.cache.delete(teamId) },
+      {
+        teamId,
         name: input.name,
-        repo_cwd: workspace.sourceCwd,
-        source_repo: workspace.sourceRepo,
-        leader_name: leaderName,
-        leader_agent_runtime: input.leaderAgentRuntime,
-        runtime_cwd: workspace.runtimeCwd,
-        worktree: workspace.worktree,
-        status: 'starting',
+        ...(input.prompt !== undefined ? { prompt: input.prompt } : {}),
+        leaderAgentRuntime: input.leaderAgentRuntime,
         intent: input.intent,
-        closed_at: null,
-        close_note: null,
-      }));
-    team = await this.store.update(team, {
-      status: 'starting',
-      closedAt: null,
-      closeNote: null,
-      worktree: workspace.worktree,
-      intent: input.intent,
-      leaderName,
-    });
-    const { leader, result } = await teammates.createTeamLeader({
-      name: leaderName,
-      ...(input.prompt !== undefined ? { prompt: input.prompt } : {}),
-      agentRuntime: input.leaderAgentRuntime,
-      sourceCwd: workspace.sourceCwd,
-      sourceRepo: workspace.sourceRepo,
-      runtimeCwd: workspace.runtimeCwd,
-      worktree: workspace.worktree,
-      intent: input.intent,
-    });
-    team = await this.store.update(team, { status: 'running' });
+        workspace,
+        existing,
+      },
+    );
     // Cache the live service so later `get`s reuse this leader + collection and
     // record mutations route through it (issue #233).
-    const service = new TeamService(
-      await this.teamServiceOptions(team, teammates, leader),
-    );
     this.cache.set(teamId, service);
     return {
-      team: teamView(team),
-      leader: result.teammate,
+      team: service.view(),
+      leader: leaderResult.teammate,
       member_count: await service.memberCount(),
       binding: null,
-      turn: result.turn,
+      turn: leaderResult.turn,
     };
   }
 
@@ -273,55 +229,17 @@ export class TeamCollection {
 
   /** Rebuild a team's live service from its record and cache it (issue #233). */
   private async serviceFor(record: TeamRecord): Promise<TeamService> {
-    const teammates = this.buildTeammates(record.team_id);
-    const leader = await teammates.leader(record.leader_name);
-    const service = new TeamService(
-      await this.teamServiceOptions(record, teammates, leader),
+    const service = await TeamService.rebuild(
+      { ...this.depsBase(), evict: () => this.cache.delete(record.team_id) },
+      record,
     );
     this.cache.set(record.team_id, service);
     return service;
   }
 
-  /** The team_leader role policy, owned here because team_leader is a team
-   * concept: a leader's MCP servers (its team's teammate MCP + cron MCP + its
-   * channel-egress descriptors) plus the native features its runtime disables
-   * (cron — it drives Dreamux's cron MCP instead). A team_member gets neither.
-   * The dispatcher only injects the primitives (admin socket, channel
-   * descriptors); it does not decide what a team_leader gets. */
-  private teamMateLaunchPolicy(identity: TeamMateIdentity): TeamMateLaunchPolicy {
-    if (identity.role !== 'team_leader') {
-      return { mcpServers: [], disableFeatures: [] };
-    }
-    const teamId = identity.team_id ?? '';
+  private depsBase(): Omit<TeamServiceDeps, 'evict'> {
     return {
-      mcpServers: [
-        teammateMcpServerDescriptor({
-          dispatcherId: this.dispatcherId,
-          callerKind: 'team_leader',
-          teamId,
-          adminSocketPath: this.opts.adminSocketPath,
-        }),
-        cronMcpServerDescriptor({
-          dispatcherId: this.dispatcherId,
-          teamId: identity.team_id ?? undefined,
-          adminSocketPath: this.opts.adminSocketPath,
-        }),
-        ...this.opts.leaderChannelDescriptors({
-          teamId,
-          leaderName: identity.name,
-        }),
-      ],
-      disableFeatures: [DISABLE_FEATURE_CRON],
-    };
-  }
-
-  /** Build the team-scoped {@link TeammateCollection} the team OWNS (issue #233).
-   * Shares the dispatcher's identity + turns store pair (R4) — the stores are
-   * stateless path-derivers, so no team news its own. */
-  private buildTeammates(teamId: string): TeammateCollection {
-    return new TeammateCollection({
       dispatcherId: this.dispatcherId,
-      teamScope: teamId,
       config: this.opts.config,
       agentRuntimeProviders: this.opts.agentRuntimeProviders,
       worktrees: this.worktrees,
@@ -330,49 +248,12 @@ export class TeamCollection {
       router: this.opts.router,
       initiatorFor: this.opts.initiatorFor,
       isShuttingDown: this.opts.isShuttingDown,
-      launchPolicyForTeamMate: (input) => this.teamMateLaunchPolicy(input.identity),
-      log: this.opts.log,
-    });
-  }
-
-  private async teamServiceOptions(
-    record: TeamRecord,
-    teammates: TeammateCollection,
-    leader: TeammateService,
-  ): Promise<TeamServiceOptions> {
-    // The scheduler is owned by the TeamService it is built with: its closures
-    // fire against that service's own leader, so it is created and evicted with
-    // the service (no separate registry). A closed team gets an unstarted one
-    // only to satisfy the field; dissolve()/stopSchedulers() stop it.
-    const scheduler = this.buildScheduler(record.team_id, leader);
-    if (record.status !== 'closed') await scheduler.start();
-    return {
-      record,
-      leader,
-      scheduler,
       store: this.store,
       bindings: this.bindings,
-      worktrees: this.worktrees,
-      teammates,
-      evict: () => this.cache.delete(record.team_id),
-    };
-  }
-
-  private buildScheduler(
-    teamId: string,
-    leader: TeammateService,
-  ): SchedulerService {
-    return new SchedulerService({
-      ownerId: `${this.dispatcherId}/team/${teamId}`,
-      store: new CronJobStore({
-        cronJobsPath: dispatcherTeamCronJobsPath(this.dispatcherId, teamId),
-        dispatcherId: this.dispatcherId,
-      }),
-      absentRuntimeStrategy: 'submit',
-      getRuntime: () => leader.getRuntime() ?? null,
-      submitScheduled: (input) => leader.scheduledInput(input),
+      adminSocketPath: this.opts.adminSocketPath,
+      leaderChannelDescriptors: this.opts.leaderChannelDescriptors,
       log: this.opts.log,
-    });
+    };
   }
 
   private async listRow(team: TeamRecord): Promise<TeamListRow> {

--- a/packages/dreamux/src/service/team-service/index.ts
+++ b/packages/dreamux/src/service/team-service/index.ts
@@ -1,4 +1,5 @@
 import type {
+  CompletionEnvelope,
   AgentRuntimeMcpServer,
   ChannelTarget,
   DreamuxLogger,
@@ -15,6 +16,7 @@ import type {
   CompletionInitiator,
   CompletionRouter,
 } from '../completion-router/index.js';
+import { completionKey } from '../completion-router/index.js';
 import type { ChannelBindingStore } from '../channel-binding/store.js';
 import type { ChannelBinding } from '../channel-binding/store.js';
 import { cronMcpServerDescriptor } from '../scheduler/mcp-config.js';
@@ -36,6 +38,7 @@ import {
   type TeamMateRuntimeStatus,
   type TeamMateTurnResult,
 } from '../teammate-collection/types.js';
+import { allocateConcreteName } from '../teammate-collection/name-allocator.js';
 import type { TeammateService } from '../teammate-service/index.js';
 import type { TeamStore } from '../team-collection/store.js';
 import type {
@@ -46,6 +49,7 @@ import type {
   TeamView,
 } from '../team-collection/types.js';
 import type { WorktreeManager } from '../worktree/manager.js';
+import { createTeamLeaderAgent } from './leader-agent.js';
 
 /**
  * The narrow dispatcher seam a {@link TeamService} needs for channel-bound
@@ -112,13 +116,14 @@ export interface TeamServiceCreateOutput {
 export class TeamService {
   private record: TeamRecord | null = null;
   private leader_: TeammateService | null = null;
+  private leaderSubmissionSeq = 0;
+  private readonly leaderSettleCaptures = new Set<Promise<void>>();
   readonly id: string;
   /** The team's OWN members collection (`teamScope: team_id`, issue #233). Held
-   * as the concrete class internally because the lifecycle/factory methods the
-   * team drives (`allocateLeaderName` / `createTeamLeader` / `leader` /
-   * `stopAll` / `applyWorktreeCleanup` / workspace-injecting `spawn`) live off
-   * `TeammateOps`. The PUBLIC surface stays the narrow admin op set via the
-   * `teammates` getter — never re-expose those internal verbs to callers. */
+   * as the concrete class internally because the lifecycle methods the team
+   * drives (`stopAll` / `applyWorktreeCleanup` / workspace-injecting `spawn`)
+   * live off `TeammateOps`. The PUBLIC surface stays the narrow admin op set via
+   * the `teammates` getter — never re-expose those internal verbs to callers. */
   private readonly teammateCollection: TeammateCollection;
   readonly scheduler: SchedulerService;
 
@@ -155,7 +160,7 @@ export class TeamService {
     input: TeamServiceCreateInput,
   ): Promise<TeamServiceCreateOutput> {
     const service = new TeamService(deps, input.teamId);
-    const leaderName = await service.teammateCollection.allocateLeaderName();
+    const leaderName = await service.allocateLeaderName();
     let team =
       input.existing ??
       (await deps.store.create({
@@ -181,26 +186,43 @@ export class TeamService {
       intent: input.intent,
       leaderName,
     });
-    const { leader, result } = await service.teammateCollection.createTeamLeader(
-      {
-        name: leaderName,
-        ...(input.prompt !== undefined ? { prompt: input.prompt } : {}),
-        agentRuntime: input.leaderAgentRuntime,
-        sourceCwd: input.workspace.sourceCwd,
-        sourceRepo: input.workspace.sourceRepo,
-        runtimeCwd: input.workspace.runtimeCwd,
-        worktree: input.workspace.worktree,
-        intent: input.intent,
-      },
-      {
-        launchPolicy: service.leaderLaunchPolicy(leaderName),
-      },
+    const existingLeader = await deps.identities.get(
+      deps.dispatcherId,
+      leaderName,
+      input.teamId,
     );
+    if (existingLeader !== null) {
+      throw new Error(`TeamLeader ${JSON.stringify(leaderName)} already exists`);
+    }
+    const identity = await deps.identities.create({
+      dispatcherId: deps.dispatcherId,
+      name: leaderName,
+      role: 'team_leader',
+      teamId: input.teamId,
+      agentRuntime: input.leaderAgentRuntime,
+      sourceCwd: input.workspace.sourceCwd,
+      sourceRepo: input.workspace.sourceRepo,
+      cwd: input.workspace.runtimeCwd,
+      runtimeCwd: input.workspace.runtimeCwd,
+      worktree: input.workspace.worktree,
+      intent: input.intent,
+      status: 'starting',
+    });
+    const leader = service.buildLeader(identity);
+    await leader.ensureStarted({ teamId: input.teamId });
+    let turn: TeamMateTurnResult | null = null;
+    if (input.prompt !== undefined) {
+      turn = await leader.submitInitialPrompt(input.prompt, {
+        teamId: input.teamId,
+        turnOrigin: 'dispatcher',
+      });
+      await service.registerLeaderCompletion(leader, turn.turn_id ?? null);
+    }
     service.leader_ = leader;
     team = await deps.store.update(team, { status: 'running' });
     service.record = team;
     await service.scheduler.start();
-    return { service, leaderResult: result };
+    return { service, leaderResult: { teammate: leader.status(), turn } };
   }
 
   static async rebuild(
@@ -209,12 +231,17 @@ export class TeamService {
   ): Promise<TeamService> {
     const service = new TeamService(deps, record.team_id);
     service.record = record;
-    service.leader_ = await service.teammateCollection.leader(
+    const identity = await deps.identities.get(
+      deps.dispatcherId,
       record.leader_name,
-      {
-        launchPolicy: service.leaderLaunchPolicy(record.leader_name),
-      },
+      record.team_id,
     );
+    if (identity === null || identity.role !== 'team_leader') {
+      throw new Error(
+        `TeamLeader ${JSON.stringify(record.leader_name)} does not exist`,
+      );
+    }
+    service.leader_ = service.buildLeader(identity);
     if (record.status !== 'closed') await service.scheduler.start();
     return service;
   }
@@ -272,7 +299,7 @@ export class TeamService {
         note: input.note,
       });
     }
-    await this.leader.close({ note: input.note });
+    await this.stopLeader({ note: input.note });
     // `dissolve` is the single authoritative cleanup site for the Team's shared
     // worktree (issue #236): members and the leader borrow it and skip cleanup on
     // their own `close`, so only this call removes it.
@@ -305,7 +332,7 @@ export class TeamService {
    * the owned collection, then the leader. Persisted records stay intact. */
   async stopAll(): Promise<void> {
     await this.teammateCollection.stopAll();
-    await this.leader.stop();
+    await this.stopLeader();
   }
 
   async bindChannel(
@@ -388,15 +415,24 @@ export class TeamService {
     );
   }
 
+  private async allocateLeaderName(): Promise<string> {
+    const taken = await this.deps.identities.listAllNames(this.deps.dispatcherId);
+    return allocateConcreteName({
+      role: 'team_leader',
+      base: this.id,
+      teamSlug: this.id,
+      exists: (candidate) => taken.has(candidate),
+    });
+  }
+
   /** The team leader's launch policy, owned here because team_leader is a team
    * concept: the leader's MCP servers (its team's teammate MCP + cron MCP + its
    * channel-egress descriptors) plus the native features its runtime disables
    * (cron — it drives Dreamux's cron MCP instead). The team supplies this only
-   * where it structurally builds the leader (`createNew` → `createTeamLeader`,
-   * `rebuild` → `leader`); team members are built with no policy and get none,
-   * so nothing branches on `identity.role` to decide capability. The dispatcher
-   * only injects the primitives (admin socket, channel descriptors); it does not
-   * decide what a team_leader gets. */
+   * where it structurally builds the leader; team members are built with no
+   * policy and get none, so nothing branches on `identity.role` to decide
+   * capability. The dispatcher only injects the primitives (admin socket,
+   * channel descriptors); it does not decide what a team_leader gets. */
   private leaderLaunchPolicy(leaderName: string): TeamMateLaunchPolicy {
     return {
       mcpServers: [
@@ -418,6 +454,64 @@ export class TeamService {
       ],
       disableFeatures: [DISABLE_FEATURE_CRON],
     };
+  }
+
+  private buildLeader(identity: TeamMateIdentity): TeammateService {
+    return createTeamLeaderAgent({
+      dispatcherId: this.deps.dispatcherId,
+      identity,
+      launchPolicy: this.leaderLaunchPolicy(identity.name),
+      config: this.deps.config,
+      agentRuntimeProviders: this.deps.agentRuntimeProviders,
+      identities: this.deps.identities,
+      turnsStore: this.deps.turnsStore,
+      worktrees: this.deps.worktrees,
+      log: this.deps.log,
+      nextSubmissionSeq: () => ++this.leaderSubmissionSeq,
+      trackSettleCapture: (capture) => this.trackLeaderSettleCapture(capture),
+      routeSettledCompletion: (producerName, turnId, completion) =>
+        this.routeLeaderSettledCompletion(producerName, turnId, completion),
+    });
+  }
+
+  private trackLeaderSettleCapture(capture: Promise<void>): void {
+    this.leaderSettleCaptures.add(capture);
+    void capture.finally(() => {
+      this.leaderSettleCaptures.delete(capture);
+    });
+  }
+
+  private async drainLeaderSettleCaptures(): Promise<void> {
+    while (this.leaderSettleCaptures.size > 0) {
+      await Promise.allSettled([...this.leaderSettleCaptures]);
+    }
+  }
+
+  private async stopLeader(input: { note?: string } = {}): Promise<void> {
+    try {
+      if (input.note !== undefined) await this.leader.close({ note: input.note });
+      else await this.leader.stop();
+    } finally {
+      await this.drainLeaderSettleCaptures();
+    }
+  }
+
+  private async registerLeaderCompletion(
+    leader: TeammateService,
+    turnId: string | null,
+  ): Promise<void> {
+    if (turnId === null) return;
+    const initiator = await this.deps.initiatorFor(leader.current());
+    if (initiator === null) return;
+    this.deps.router.register(completionKey(leader.name, turnId), initiator);
+  }
+
+  private async routeLeaderSettledCompletion(
+    producerName: string,
+    turnId: string,
+    completion: CompletionEnvelope,
+  ): Promise<void> {
+    await this.deps.router.settle(completionKey(producerName, turnId), completion);
   }
 
   private mustRecord(): TeamRecord {

--- a/packages/dreamux/src/service/team-service/index.ts
+++ b/packages/dreamux/src/service/team-service/index.ts
@@ -135,8 +135,6 @@ export class TeamService {
       router: deps.router,
       initiatorFor: deps.initiatorFor,
       isShuttingDown: deps.isShuttingDown,
-      launchPolicyForTeamMate: (input) =>
-        this.teamMateLaunchPolicy(input.identity),
       log: deps.log,
     });
     this.scheduler = new SchedulerService({
@@ -183,16 +181,19 @@ export class TeamService {
       intent: input.intent,
       leaderName,
     });
-    const { leader, result } = await service.teammateCollection.createTeamLeader({
-      name: leaderName,
-      ...(input.prompt !== undefined ? { prompt: input.prompt } : {}),
-      agentRuntime: input.leaderAgentRuntime,
-      sourceCwd: input.workspace.sourceCwd,
-      sourceRepo: input.workspace.sourceRepo,
-      runtimeCwd: input.workspace.runtimeCwd,
-      worktree: input.workspace.worktree,
-      intent: input.intent,
-    });
+    const { leader, result } = await service.teammateCollection.createTeamLeader(
+      {
+        name: leaderName,
+        ...(input.prompt !== undefined ? { prompt: input.prompt } : {}),
+        agentRuntime: input.leaderAgentRuntime,
+        sourceCwd: input.workspace.sourceCwd,
+        sourceRepo: input.workspace.sourceRepo,
+        runtimeCwd: input.workspace.runtimeCwd,
+        worktree: input.workspace.worktree,
+        intent: input.intent,
+      },
+      service.leaderLaunchPolicy(leaderName),
+    );
     service.leader_ = leader;
     team = await deps.store.update(team, { status: 'running' });
     service.record = team;
@@ -206,7 +207,10 @@ export class TeamService {
   ): Promise<TeamService> {
     const service = new TeamService(deps, record.team_id);
     service.record = record;
-    service.leader_ = await service.teammateCollection.leader(record.leader_name);
+    service.leader_ = await service.teammateCollection.leader(
+      record.leader_name,
+      service.leaderLaunchPolicy(record.leader_name),
+    );
     if (record.status !== 'closed') await service.scheduler.start();
     return service;
   }
@@ -380,33 +384,32 @@ export class TeamService {
     );
   }
 
-  /** The team_leader role policy, owned here because team_leader is a team
-   * concept: a leader's MCP servers (its team's teammate MCP + cron MCP + its
+  /** The team leader's launch policy, owned here because team_leader is a team
+   * concept: the leader's MCP servers (its team's teammate MCP + cron MCP + its
    * channel-egress descriptors) plus the native features its runtime disables
-   * (cron — it drives Dreamux's cron MCP instead). A team_member gets neither.
-   * The dispatcher only injects the primitives (admin socket, channel
-   * descriptors); it does not decide what a team_leader gets. */
-  private teamMateLaunchPolicy(identity: TeamMateIdentity): TeamMateLaunchPolicy {
-    if (identity.role !== 'team_leader') {
-      return { mcpServers: [], disableFeatures: [] };
-    }
-    const teamId = identity.team_id ?? '';
+   * (cron — it drives Dreamux's cron MCP instead). The team supplies this only
+   * where it structurally builds the leader (`createNew` → `createTeamLeader`,
+   * `rebuild` → `leader`); team members are built with no policy and get none,
+   * so nothing branches on `identity.role` to decide capability. The dispatcher
+   * only injects the primitives (admin socket, channel descriptors); it does not
+   * decide what a team_leader gets. */
+  private leaderLaunchPolicy(leaderName: string): TeamMateLaunchPolicy {
     return {
       mcpServers: [
         teammateMcpServerDescriptor({
           dispatcherId: this.deps.dispatcherId,
           callerKind: 'team_leader',
-          teamId,
+          teamId: this.id,
           adminSocketPath: this.deps.adminSocketPath,
         }),
         cronMcpServerDescriptor({
           dispatcherId: this.deps.dispatcherId,
-          teamId: identity.team_id ?? undefined,
+          teamId: this.id,
           adminSocketPath: this.deps.adminSocketPath,
         }),
         ...this.deps.leaderChannelDescriptors({
-          teamId,
-          leaderName: identity.name,
+          teamId: this.id,
+          leaderName,
         }),
       ],
       disableFeatures: [DISABLE_FEATURE_CRON],

--- a/packages/dreamux/src/service/team-service/index.ts
+++ b/packages/dreamux/src/service/team-service/index.ts
@@ -18,7 +18,7 @@ import type {
 import type { ChannelBindingStore } from '../channel-binding/store.js';
 import type { ChannelBinding } from '../channel-binding/store.js';
 import { cronMcpServerDescriptor } from '../scheduler/mcp-config.js';
-import { SchedulerService } from '../scheduler/service.js';
+import type { SchedulerService } from '../scheduler/service.js';
 import { CronJobStore } from '../scheduler/store.js';
 import {
   TeammateCollection,
@@ -36,7 +36,10 @@ import {
   type TeamMateRuntimeStatus,
   type TeamMateTurnResult,
 } from '../teammate-collection/types.js';
-import type { TeammateService } from '../teammate-service/index.js';
+import type {
+  TeammateService,
+  TeamMateSchedulerConfig,
+} from '../teammate-service/index.js';
 import type { TeamStore } from '../team-collection/store.js';
 import type {
   TeamChannelBindingSummary,
@@ -120,7 +123,6 @@ export class TeamService {
    * `TeammateOps`. The PUBLIC surface stays the narrow admin op set via the
    * `teammates` getter — never re-expose those internal verbs to callers. */
   private readonly teammateCollection: TeammateCollection;
-  readonly scheduler: SchedulerService;
 
   private constructor(private readonly deps: TeamServiceDeps, teamId: string) {
     this.id = teamId;
@@ -135,17 +137,6 @@ export class TeamService {
       router: deps.router,
       initiatorFor: deps.initiatorFor,
       isShuttingDown: deps.isShuttingDown,
-      log: deps.log,
-    });
-    this.scheduler = new SchedulerService({
-      ownerId: `${deps.dispatcherId}/team/${teamId}`,
-      store: new CronJobStore({
-        cronJobsPath: dispatcherTeamCronJobsPath(deps.dispatcherId, teamId),
-        dispatcherId: deps.dispatcherId,
-      }),
-      absentRuntimeStrategy: 'submit',
-      getRuntime: () => this.leader_?.getRuntime() ?? null,
-      submitScheduled: (input) => this.mustLeader().scheduledInput(input),
       log: deps.log,
     });
   }
@@ -192,12 +183,15 @@ export class TeamService {
         worktree: input.workspace.worktree,
         intent: input.intent,
       },
-      service.leaderLaunchPolicy(leaderName),
+      {
+        launchPolicy: service.leaderLaunchPolicy(leaderName),
+        scheduler: service.leaderSchedulerConfig(),
+      },
     );
     service.leader_ = leader;
     team = await deps.store.update(team, { status: 'running' });
     service.record = team;
-    await service.scheduler.start();
+    await leader.startScheduler();
     return { service, leaderResult: result };
   }
 
@@ -209,14 +203,27 @@ export class TeamService {
     service.record = record;
     service.leader_ = await service.teammateCollection.leader(
       record.leader_name,
-      service.leaderLaunchPolicy(record.leader_name),
+      {
+        launchPolicy: service.leaderLaunchPolicy(record.leader_name),
+        scheduler: service.leaderSchedulerConfig(),
+      },
     );
-    if (record.status !== 'closed') await service.scheduler.start();
+    if (record.status !== 'closed') await service.leader_.startScheduler();
     return service;
   }
 
   get leader(): TeammateService {
     return this.mustLeader();
+  }
+
+  get scheduler(): SchedulerService {
+    const scheduler = this.mustLeader().scheduler;
+    if (scheduler === null) {
+      throw new Error(
+        `Team ${JSON.stringify(this.id)} leader has no scheduler capability`,
+      );
+    }
+    return scheduler;
   }
 
   /** This team's members, as the narrow admin-facing op surface (issue #233):
@@ -250,7 +257,7 @@ export class TeamService {
 
   async dissolve(input: TeamDissolveInput): Promise<TeamSummary> {
     requireLifecycleText(input.note, 'Team dissolve note');
-    this.scheduler.stop();
+    this.mustLeader().stopScheduler();
     const record = this.mustRecord();
     for (const binding of await this.deps.bindings.list(this.dispatcherId)) {
       if (binding.active && binding.team_name === this.id) {
@@ -290,7 +297,7 @@ export class TeamService {
     for (const member of members) {
       await this.teammateCollection.applyWorktreeCleanup(member.name, cleaned);
     }
-    await this.scheduler.deleteStoreFile();
+    await this.mustLeader().deleteSchedulerStore();
     const summary = await this.status();
     // Evict so a later `get` rebuilds from disk and reads `status: closed`.
     this.deps.evict();
@@ -413,6 +420,17 @@ export class TeamService {
         }),
       ],
       disableFeatures: [DISABLE_FEATURE_CRON],
+    };
+  }
+
+  private leaderSchedulerConfig(): TeamMateSchedulerConfig {
+    return {
+      ownerId: `${this.deps.dispatcherId}/team/${this.id}`,
+      store: new CronJobStore({
+        cronJobsPath: dispatcherTeamCronJobsPath(this.deps.dispatcherId, this.id),
+        dispatcherId: this.deps.dispatcherId,
+      }),
+      absentRuntimeStrategy: 'submit',
     };
   }
 

--- a/packages/dreamux/src/service/team-service/index.ts
+++ b/packages/dreamux/src/service/team-service/index.ts
@@ -1,22 +1,43 @@
 import type {
+  AgentRuntimeMcpServer,
   ChannelTarget,
+  DreamuxLogger,
   InboundTurnInput,
 } from '@excitedjs/dreamux-types';
 
-import type {
-  TeammateCollection,
-  TeammateOps,
-} from '../teammate-collection/index.js';
 import {
-  type SpawnTeamMateRequest,
-  type TeamMateSharedWorkspace,
-} from '../teammate-collection/index.js';
-import type { TeammateService } from '../teammate-service/index.js';
-import { requireLifecycleText } from '../teammate-collection/types.js';
+  DISABLE_FEATURE_CRON,
+  type AgentRuntimeProviderCatalog,
+} from '../../agent-runtime/index.js';
+import type { DreamuxConfig } from '../../config/config.js';
+import { dispatcherTeamCronJobsPath } from '../../platform/paths.js';
+import type {
+  CompletionInitiator,
+  CompletionRouter,
+} from '../completion-router/index.js';
 import type { ChannelBindingStore } from '../channel-binding/store.js';
 import type { ChannelBinding } from '../channel-binding/store.js';
-import { TeamStore } from '../team-collection/store.js';
-import type { SchedulerService } from '../scheduler/service.js';
+import { cronMcpServerDescriptor } from '../scheduler/mcp-config.js';
+import { SchedulerService } from '../scheduler/service.js';
+import { CronJobStore } from '../scheduler/store.js';
+import {
+  TeammateCollection,
+  type SpawnTeamMateRequest,
+  type TeamMateSharedWorkspace,
+  type TeammateOps,
+} from '../teammate-collection/index.js';
+import type { TeamMateIdentityStore } from '../teammate-collection/identity-store.js';
+import { teammateMcpServerDescriptor } from '../teammate-collection/mcp-config.js';
+import type { TeamMateTurnsStore } from '../teammate-collection/turns-store.js';
+import {
+  requireLifecycleText,
+  type TeamMateIdentity,
+  type TeamMateLaunchPolicy,
+  type TeamMateRuntimeStatus,
+  type TeamMateTurnResult,
+} from '../teammate-collection/types.js';
+import type { TeammateService } from '../teammate-service/index.js';
+import type { TeamStore } from '../team-collection/store.js';
 import type {
   TeamChannelBindingSummary,
   TeamDissolveInput,
@@ -24,7 +45,6 @@ import type {
   TeamSummary,
   TeamView,
 } from '../team-collection/types.js';
-import type { TeamMateRuntimeStatus } from '../teammate-collection/types.js';
 import type { WorktreeManager } from '../worktree/manager.js';
 
 /**
@@ -39,53 +59,185 @@ export interface TeamChannelContext {
   resolveChannelTarget(meta: unknown, channelId?: string): Promise<ChannelTarget>;
 }
 
-export interface TeamServiceOptions {
-  record: TeamRecord;
-  /** The team's leader, a contained {@link TeammateService} (issue #233 Phase 4). */
-  leader: TeammateService;
-  scheduler: SchedulerService;
+export interface TeamServiceDeps {
+  dispatcherId: string;
+  config: DreamuxConfig;
+  agentRuntimeProviders: AgentRuntimeProviderCatalog;
+  worktrees: WorktreeManager;
+  identities: TeamMateIdentityStore;
+  turnsStore: TeamMateTurnsStore;
+  router: CompletionRouter;
+  initiatorFor: (
+    producer: TeamMateIdentity,
+  ) => Promise<CompletionInitiator | null>;
+  isShuttingDown: () => boolean;
+  adminSocketPath: string;
+  leaderChannelDescriptors: (input: {
+    teamId: string;
+    leaderName: string;
+  }) => readonly AgentRuntimeMcpServer[];
   store: TeamStore;
   bindings: ChannelBindingStore;
-  worktrees: WorktreeManager;
-  /** The team's OWN members collection (`teamScope: team_id`, issue #233). */
-  teammates: TeammateCollection;
-  /** Evict from the live cache on dissolve (issue #233). */
   evict: () => void;
+  log: DreamuxLogger;
+}
+
+export interface TeamServiceCreateInput {
+  teamId: string;
+  name: string;
+  prompt?: string;
+  leaderAgentRuntime: string;
+  intent: string;
+  workspace: TeamMateSharedWorkspace;
+  existing: TeamRecord | null;
+}
+
+export interface TeamServiceCreateOutput {
+  service: TeamService;
+  leaderResult: {
+    teammate: TeamMateRuntimeStatus;
+    turn: TeamMateTurnResult | null;
+  };
 }
 
 /**
  * A single team entity (issue #233): holds its own {@link TeamRecord}, *has a*
  * leader {@link TeammateService} (Phase 4, at the team root), and OWNS its
- * members' team-scoped {@link TeammateCollection}. It exposes the per-team domain
- * ops (`status` / `dissolve` / `bindChannel` / `deliverToLeader` /
+ * members' team-scoped {@link TeammateCollection}. It exposes the per-team
+ * domain ops (`status` / `dissolve` / `bindChannel` / `deliverToLeader` /
  * `sharedWorkspace`) and forwards admin `team_leader` target calls to its own
  * collection (no team id — scope is baked in); the leader is never a member row.
  * Channel-bound ops run through an injected {@link TeamChannelContext}.
  */
 export class TeamService {
-  private record: TeamRecord;
+  private record: TeamRecord | null = null;
+  private leader_: TeammateService | null = null;
   readonly id: string;
-  readonly leader: TeammateService;
+  /** The team's OWN members collection (`teamScope: team_id`, issue #233). Held
+   * as the concrete class internally because the lifecycle/factory methods the
+   * team drives (`allocateLeaderName` / `createTeamLeader` / `leader` /
+   * `stopAll` / `applyWorktreeCleanup` / workspace-injecting `spawn`) live off
+   * `TeammateOps`. The PUBLIC surface stays the narrow admin op set via the
+   * `teammates` getter — never re-expose those internal verbs to callers. */
+  private readonly teammateCollection: TeammateCollection;
   readonly scheduler: SchedulerService;
 
-  constructor(private readonly opts: TeamServiceOptions) {
-    this.record = opts.record;
-    this.id = opts.record.team_id;
-    this.leader = opts.leader;
-    this.scheduler = opts.scheduler;
+  private constructor(private readonly deps: TeamServiceDeps, teamId: string) {
+    this.id = teamId;
+    this.teammateCollection = new TeammateCollection({
+      dispatcherId: deps.dispatcherId,
+      teamScope: teamId,
+      config: deps.config,
+      agentRuntimeProviders: deps.agentRuntimeProviders,
+      worktrees: deps.worktrees,
+      identities: deps.identities,
+      turnsStore: deps.turnsStore,
+      router: deps.router,
+      initiatorFor: deps.initiatorFor,
+      isShuttingDown: deps.isShuttingDown,
+      launchPolicyForTeamMate: (input) =>
+        this.teamMateLaunchPolicy(input.identity),
+      log: deps.log,
+    });
+    this.scheduler = new SchedulerService({
+      ownerId: `${deps.dispatcherId}/team/${teamId}`,
+      store: new CronJobStore({
+        cronJobsPath: dispatcherTeamCronJobsPath(deps.dispatcherId, teamId),
+        dispatcherId: deps.dispatcherId,
+      }),
+      absentRuntimeStrategy: 'submit',
+      getRuntime: () => this.leader_?.getRuntime() ?? null,
+      submitScheduled: (input) => this.mustLeader().scheduledInput(input),
+      log: deps.log,
+    });
+  }
+
+  static async createNew(
+    deps: TeamServiceDeps,
+    input: TeamServiceCreateInput,
+  ): Promise<TeamServiceCreateOutput> {
+    const service = new TeamService(deps, input.teamId);
+    const leaderName = await service.teammateCollection.allocateLeaderName();
+    let team =
+      input.existing ??
+      (await deps.store.create({
+        dispatcher_id: deps.dispatcherId,
+        team_id: input.teamId,
+        name: input.name,
+        repo_cwd: input.workspace.sourceCwd,
+        source_repo: input.workspace.sourceRepo,
+        leader_name: leaderName,
+        leader_agent_runtime: input.leaderAgentRuntime,
+        runtime_cwd: input.workspace.runtimeCwd,
+        worktree: input.workspace.worktree,
+        status: 'starting',
+        intent: input.intent,
+        closed_at: null,
+        close_note: null,
+      }));
+    team = await deps.store.update(team, {
+      status: 'starting',
+      closedAt: null,
+      closeNote: null,
+      worktree: input.workspace.worktree,
+      intent: input.intent,
+      leaderName,
+    });
+    const { leader, result } = await service.teammateCollection.createTeamLeader({
+      name: leaderName,
+      ...(input.prompt !== undefined ? { prompt: input.prompt } : {}),
+      agentRuntime: input.leaderAgentRuntime,
+      sourceCwd: input.workspace.sourceCwd,
+      sourceRepo: input.workspace.sourceRepo,
+      runtimeCwd: input.workspace.runtimeCwd,
+      worktree: input.workspace.worktree,
+      intent: input.intent,
+    });
+    service.leader_ = leader;
+    team = await deps.store.update(team, { status: 'running' });
+    service.record = team;
+    await service.scheduler.start();
+    return { service, leaderResult: result };
+  }
+
+  static async rebuild(
+    deps: TeamServiceDeps,
+    record: TeamRecord,
+  ): Promise<TeamService> {
+    const service = new TeamService(deps, record.team_id);
+    service.record = record;
+    service.leader_ = await service.teammateCollection.leader(record.leader_name);
+    if (record.status !== 'closed') await service.scheduler.start();
+    return service;
+  }
+
+  get leader(): TeammateService {
+    return this.mustLeader();
+  }
+
+  /** This team's members, as the narrow admin-facing op surface (issue #233):
+   * the verbs the admin `team_leader` target needs run directly through this
+   * collection. `spawnTeamMate` stays a separate method because it injects the
+   * shared workspace — the raw `spawn` is deliberately not on `TeammateOps`. */
+  get teammates(): TeammateOps {
+    return this.teammateCollection;
   }
 
   get dispatcherId(): string {
-    return this.record.dispatcher_id;
+    return this.mustRecord().dispatcher_id;
   }
 
   get leaderName(): string {
-    return this.record.leader_name;
+    return this.mustRecord().leader_name;
+  }
+
+  view(): TeamView {
+    return teamView(this.mustRecord());
   }
 
   async status(): Promise<TeamSummary> {
     return {
-      team: teamView(this.record),
+      team: this.view(),
       leader: this.leader.status(),
       member_count: await this.memberCount(),
       binding: await this.activeGroupBinding(),
@@ -95,9 +247,10 @@ export class TeamService {
   async dissolve(input: TeamDissolveInput): Promise<TeamSummary> {
     requireLifecycleText(input.note, 'Team dissolve note');
     this.scheduler.stop();
-    for (const binding of await this.opts.bindings.list(this.dispatcherId)) {
+    const record = this.mustRecord();
+    for (const binding of await this.deps.bindings.list(this.dispatcherId)) {
       if (binding.active && binding.team_name === this.id) {
-        await this.opts.bindings.transferBack({
+        await this.deps.bindings.transferBack({
           dispatcherId: this.dispatcherId,
           channelId: binding.channel_id,
           targetKey: binding.target_key,
@@ -106,7 +259,7 @@ export class TeamService {
     }
     const members = await this.members();
     for (const member of members) {
-      await this.opts.teammates.close({
+      await this.teammateCollection.close({
         name: member.name,
         note: input.note,
       });
@@ -115,12 +268,12 @@ export class TeamService {
     // `dissolve` is the single authoritative cleanup site for the Team's shared
     // worktree (issue #236): members and the leader borrow it and skip cleanup on
     // their own `close`, so only this call removes it.
-    const cleaned = await this.opts.worktrees.cleanup({
-      source_cwd: this.record.repo_cwd,
-      source_repo: this.record.source_repo,
-      worktree: this.record.worktree,
+    const cleaned = await this.deps.worktrees.cleanup({
+      source_cwd: record.repo_cwd,
+      source_repo: record.source_repo,
+      worktree: record.worktree,
     });
-    this.record = await this.opts.store.update(this.record, {
+    this.record = await this.deps.store.update(record, {
       status: 'closed',
       closedAt: Date.now(),
       closeNote: input.note,
@@ -131,19 +284,19 @@ export class TeamService {
     // (issue #237). They share the one worktree, so the same identity applies.
     await this.leader.applyWorktreeCleanup(cleaned);
     for (const member of members) {
-      await this.opts.teammates.applyWorktreeCleanup(member.name, cleaned);
+      await this.teammateCollection.applyWorktreeCleanup(member.name, cleaned);
     }
     await this.scheduler.deleteStoreFile();
     const summary = await this.status();
     // Evict so a later `get` rebuilds from disk and reads `status: closed`.
-    this.opts.evict();
+    this.deps.evict();
     return summary;
   }
 
   /** Stop this team's live runtimes on server shutdown (issue #233): members in
    * the owned collection, then the leader. Persisted records stay intact. */
   async stopAll(): Promise<void> {
-    await this.opts.teammates.stopAll();
+    await this.teammateCollection.stopAll();
     await this.leader.stop();
   }
 
@@ -151,18 +304,19 @@ export class TeamService {
     context: TeamChannelContext,
     input: { channelId?: string; meta: Record<string, unknown> },
   ): Promise<ChannelBinding> {
-    if (this.record.status === 'closed') {
+    const record = this.mustRecord();
+    if (record.status === 'closed') {
       throw new Error(`Team ${JSON.stringify(this.id)} is closed`);
     }
     const channelId = context.resolveChannelId(input.channelId);
     const target = await context.resolveChannelTarget(input.meta, channelId);
-    return this.opts.bindings.bind({
+    return this.deps.bindings.bind({
       dispatcherId: this.dispatcherId,
       channelId,
       provider: context.channelProviderRef(channelId),
       target,
       teamName: this.id,
-      leaderName: this.record.leader_name,
+      leaderName: record.leader_name,
     });
   }
 
@@ -170,7 +324,7 @@ export class TeamService {
     leaderName: string;
     targetKey: string;
   }): Promise<string | null> {
-    const bindings = await this.opts.bindings.list(this.dispatcherId);
+    const bindings = await this.deps.bindings.list(this.dispatcherId);
     const match = bindings.find(
       (binding) =>
         binding.active &&
@@ -179,23 +333,24 @@ export class TeamService {
         binding.leader_name === input.leaderName,
     );
     if (match === undefined) return null;
-    if (this.record.status === 'closed') return null;
+    if (this.mustRecord().status === 'closed') return null;
     return match.channel_id;
   }
 
   async deliverToLeader(
     turn: InboundTurnInput,
   ): Promise<import('@excitedjs/dreamux-types').AgentRuntimeTurnResult> {
-    if (this.record.status === 'closed') return { status: 'stopped' };
+    if (this.mustRecord().status === 'closed') return { status: 'stopped' };
     return this.leader.channelInput(turn);
   }
 
   sharedWorkspace(): TeamMateSharedWorkspace {
+    const record = this.mustRecord();
     return {
-      sourceCwd: this.record.repo_cwd,
-      sourceRepo: this.record.source_repo,
-      runtimeCwd: this.record.runtime_cwd,
-      worktree: this.record.worktree,
+      sourceCwd: record.repo_cwd,
+      sourceRepo: record.source_repo,
+      runtimeCwd: record.runtime_cwd,
+      worktree: record.worktree,
     };
   }
 
@@ -204,18 +359,10 @@ export class TeamService {
     // the shared workspace (issue #233). This stays a real method — injecting
     // the shared workspace is the team's job — unlike the pure teammate forwards
     // that now go through `.teammates`.
-    return this.opts.teammates.spawn({
+    return this.teammateCollection.spawn({
       ...input,
       sharedWorkspace: this.sharedWorkspace(),
     });
-  }
-
-  /** This team's members, as the narrow admin-facing op surface (issue #233).
-   * `spawnTeamMate` stays separate because it injects the shared workspace; the
-   * remaining teammate verbs the admin `team_leader` target needs run directly
-   * through this collection. */
-  get teammates(): TeammateOps {
-    return this.opts.teammates;
   }
 
   async memberCount(): Promise<number> {
@@ -223,14 +370,61 @@ export class TeamService {
   }
 
   private async members(): Promise<TeamMateRuntimeStatus[]> {
-    return this.opts.teammates.list(); // members-only; leader is `this.leader`
+    return this.teammateCollection.list(); // members-only; leader is `this.leader`
   }
 
   private async activeGroupBinding(): Promise<TeamChannelBindingSummary | null> {
     return activeGroupBindingFor(
-      await this.opts.bindings.list(this.dispatcherId),
+      await this.deps.bindings.list(this.dispatcherId),
       this.id,
     );
+  }
+
+  /** The team_leader role policy, owned here because team_leader is a team
+   * concept: a leader's MCP servers (its team's teammate MCP + cron MCP + its
+   * channel-egress descriptors) plus the native features its runtime disables
+   * (cron — it drives Dreamux's cron MCP instead). A team_member gets neither.
+   * The dispatcher only injects the primitives (admin socket, channel
+   * descriptors); it does not decide what a team_leader gets. */
+  private teamMateLaunchPolicy(identity: TeamMateIdentity): TeamMateLaunchPolicy {
+    if (identity.role !== 'team_leader') {
+      return { mcpServers: [], disableFeatures: [] };
+    }
+    const teamId = identity.team_id ?? '';
+    return {
+      mcpServers: [
+        teammateMcpServerDescriptor({
+          dispatcherId: this.deps.dispatcherId,
+          callerKind: 'team_leader',
+          teamId,
+          adminSocketPath: this.deps.adminSocketPath,
+        }),
+        cronMcpServerDescriptor({
+          dispatcherId: this.deps.dispatcherId,
+          teamId: identity.team_id ?? undefined,
+          adminSocketPath: this.deps.adminSocketPath,
+        }),
+        ...this.deps.leaderChannelDescriptors({
+          teamId,
+          leaderName: identity.name,
+        }),
+      ],
+      disableFeatures: [DISABLE_FEATURE_CRON],
+    };
+  }
+
+  private mustRecord(): TeamRecord {
+    if (this.record === null) {
+      throw new Error(`Team ${JSON.stringify(this.id)} is not booted`);
+    }
+    return this.record;
+  }
+
+  private mustLeader(): TeammateService {
+    if (this.leader_ === null) {
+      throw new Error(`Team ${JSON.stringify(this.id)} leader is not booted`);
+    }
+    return this.leader_;
   }
 }
 

--- a/packages/dreamux/src/service/team-service/index.ts
+++ b/packages/dreamux/src/service/team-service/index.ts
@@ -18,7 +18,7 @@ import type {
 import type { ChannelBindingStore } from '../channel-binding/store.js';
 import type { ChannelBinding } from '../channel-binding/store.js';
 import { cronMcpServerDescriptor } from '../scheduler/mcp-config.js';
-import type { SchedulerService } from '../scheduler/service.js';
+import { SchedulerService } from '../scheduler/service.js';
 import { CronJobStore } from '../scheduler/store.js';
 import {
   TeammateCollection,
@@ -36,10 +36,7 @@ import {
   type TeamMateRuntimeStatus,
   type TeamMateTurnResult,
 } from '../teammate-collection/types.js';
-import type {
-  TeammateService,
-  TeamMateSchedulerConfig,
-} from '../teammate-service/index.js';
+import type { TeammateService } from '../teammate-service/index.js';
 import type { TeamStore } from '../team-collection/store.js';
 import type {
   TeamChannelBindingSummary,
@@ -123,6 +120,7 @@ export class TeamService {
    * `TeammateOps`. The PUBLIC surface stays the narrow admin op set via the
    * `teammates` getter — never re-expose those internal verbs to callers. */
   private readonly teammateCollection: TeammateCollection;
+  readonly scheduler: SchedulerService;
 
   private constructor(private readonly deps: TeamServiceDeps, teamId: string) {
     this.id = teamId;
@@ -137,6 +135,17 @@ export class TeamService {
       router: deps.router,
       initiatorFor: deps.initiatorFor,
       isShuttingDown: deps.isShuttingDown,
+      log: deps.log,
+    });
+    this.scheduler = new SchedulerService({
+      ownerId: `${deps.dispatcherId}/team/${teamId}`,
+      store: new CronJobStore({
+        cronJobsPath: dispatcherTeamCronJobsPath(deps.dispatcherId, teamId),
+        dispatcherId: deps.dispatcherId,
+      }),
+      absentRuntimeStrategy: 'submit',
+      getRuntime: () => this.leader_?.getRuntime() ?? null,
+      submitScheduled: (input) => this.mustLeader().scheduledInput(input),
       log: deps.log,
     });
   }
@@ -185,13 +194,12 @@ export class TeamService {
       },
       {
         launchPolicy: service.leaderLaunchPolicy(leaderName),
-        scheduler: service.leaderSchedulerConfig(),
       },
     );
     service.leader_ = leader;
     team = await deps.store.update(team, { status: 'running' });
     service.record = team;
-    await leader.startScheduler();
+    await service.scheduler.start();
     return { service, leaderResult: result };
   }
 
@@ -205,25 +213,14 @@ export class TeamService {
       record.leader_name,
       {
         launchPolicy: service.leaderLaunchPolicy(record.leader_name),
-        scheduler: service.leaderSchedulerConfig(),
       },
     );
-    if (record.status !== 'closed') await service.leader_.startScheduler();
+    if (record.status !== 'closed') await service.scheduler.start();
     return service;
   }
 
   get leader(): TeammateService {
     return this.mustLeader();
-  }
-
-  get scheduler(): SchedulerService {
-    const scheduler = this.mustLeader().scheduler;
-    if (scheduler === null) {
-      throw new Error(
-        `Team ${JSON.stringify(this.id)} leader has no scheduler capability`,
-      );
-    }
-    return scheduler;
   }
 
   /** This team's members, as the narrow admin-facing op surface (issue #233):
@@ -257,7 +254,7 @@ export class TeamService {
 
   async dissolve(input: TeamDissolveInput): Promise<TeamSummary> {
     requireLifecycleText(input.note, 'Team dissolve note');
-    this.mustLeader().stopScheduler();
+    this.scheduler.stop();
     const record = this.mustRecord();
     for (const binding of await this.deps.bindings.list(this.dispatcherId)) {
       if (binding.active && binding.team_name === this.id) {
@@ -297,7 +294,7 @@ export class TeamService {
     for (const member of members) {
       await this.teammateCollection.applyWorktreeCleanup(member.name, cleaned);
     }
-    await this.mustLeader().deleteSchedulerStore();
+    await this.scheduler.deleteStoreFile();
     const summary = await this.status();
     // Evict so a later `get` rebuilds from disk and reads `status: closed`.
     this.deps.evict();
@@ -420,17 +417,6 @@ export class TeamService {
         }),
       ],
       disableFeatures: [DISABLE_FEATURE_CRON],
-    };
-  }
-
-  private leaderSchedulerConfig(): TeamMateSchedulerConfig {
-    return {
-      ownerId: `${this.deps.dispatcherId}/team/${this.id}`,
-      store: new CronJobStore({
-        cronJobsPath: dispatcherTeamCronJobsPath(this.deps.dispatcherId, this.id),
-        dispatcherId: this.deps.dispatcherId,
-      }),
-      absentRuntimeStrategy: 'submit',
     };
   }
 

--- a/packages/dreamux/src/service/team-service/leader-agent.ts
+++ b/packages/dreamux/src/service/team-service/leader-agent.ts
@@ -1,0 +1,54 @@
+import type { CompletionEnvelope, DreamuxLogger } from '@excitedjs/dreamux-types';
+
+import type { AgentRuntimeProviderCatalog } from '../../agent-runtime/index.js';
+import type { DreamuxConfig } from '../../config/config.js';
+import type { TeamMateIdentityStore } from '../teammate-collection/identity-store.js';
+import type { TeamMateTurnsStore } from '../teammate-collection/turns-store.js';
+import type {
+  TeamMateIdentity,
+  TeamMateLaunchPolicy,
+} from '../teammate-collection/types.js';
+import {
+  createTeammateService,
+} from '../teammate-service/factory.js';
+import type { TeammateService } from '../teammate-service/index.js';
+import type { WorktreeManager } from '../worktree/manager.js';
+
+export interface TeamLeaderAgentDeps {
+  dispatcherId: string;
+  identity: TeamMateIdentity;
+  launchPolicy: TeamMateLaunchPolicy;
+  config: DreamuxConfig;
+  agentRuntimeProviders: AgentRuntimeProviderCatalog;
+  identities: TeamMateIdentityStore;
+  turnsStore: TeamMateTurnsStore;
+  worktrees: WorktreeManager;
+  log: DreamuxLogger;
+  nextSubmissionSeq: () => number;
+  trackSettleCapture: (capture: Promise<void>) => void;
+  routeSettledCompletion: (
+    producerName: string,
+    turnId: string,
+    completion: CompletionEnvelope,
+  ) => Promise<void>;
+}
+
+export function createTeamLeaderAgent(
+  deps: TeamLeaderAgentDeps,
+): TeammateService {
+  return createTeammateService({
+    dispatcherId: deps.dispatcherId,
+    identity: deps.identity,
+    launch: { kind: 'agent-ref' },
+    options: { launchPolicy: deps.launchPolicy },
+    config: deps.config,
+    agentRuntimeProviders: deps.agentRuntimeProviders,
+    identities: deps.identities,
+    turnsStore: deps.turnsStore,
+    worktrees: deps.worktrees,
+    log: deps.log,
+    nextSubmissionSeq: deps.nextSubmissionSeq,
+    trackSettleCapture: deps.trackSettleCapture,
+    routeSettledCompletion: deps.routeSettledCompletion,
+  });
+}

--- a/packages/dreamux/src/service/teammate-collection/index.ts
+++ b/packages/dreamux/src/service/teammate-collection/index.ts
@@ -17,7 +17,6 @@ import {
 import { createTeammateService } from '../teammate-service/factory.js';
 import { TeamMateIdentityStore } from './identity-store.js';
 import {
-  assertInRoster,
   clampHistoryLimit,
   decodeCursor,
   encodeCursor,
@@ -27,10 +26,7 @@ import {
   toStatus,
   validateLastTurns,
 } from './read-helpers.js';
-import type {
-  TeammateService,
-  TeammateServiceOptions,
-} from '../teammate-service/index.js';
+import type { TeammateService } from '../teammate-service/index.js';
 import { TeamMateTurnsStore } from './turns-store.js';
 import { allocateConcreteName, type SuffixGenerator } from './name-allocator.js';
 import {
@@ -47,7 +43,6 @@ import {
   type SpawnTeamMateInput,
   type TeamMateCapabilities,
   type TeamMateCloseResult,
-  type CreateTeamLeaderInput,
   type TeamMateHistoryQuery,
   type TeamMateHistoryResult,
   type TeamMateIdentity,
@@ -57,7 +52,6 @@ import {
   type TeamMateRuntimeStatus,
   type TeamMateSendResult,
   type TeamMateSpawnResult,
-  type TeamMateTurnResult,
   type TeamMateWorktreeIdentity,
 } from './types.js';
 
@@ -67,11 +61,11 @@ export interface TeammateCollectionOptions {
   /**
    * The fixed scope this collection serves (issue #233): `null` = the
    * dispatcher's own teammates (`teammate/<name>/`); a `team_id` = that team's
-   * leader + members (`team/<team>/…`). One `TeammateCollection` per scope; the
-   * scope is baked in, not threaded per call — `spawn` / `send` / `list` /
-   * `status` / `history` / `last` / `close` supply this scope to the (unchanged)
-   * stores and read model. Leader operations (`allocateLeaderName` /
-   * `createTeamLeader` / `leader`) require a non-null scope.
+   * members (`team/<team>/teammate/<name>/`). One `TeammateCollection` per
+   * scope; the scope is baked in, not threaded per call — `spawn` / `send` /
+   * `list` / `status` / `history` / `last` / `close` supply this scope to the
+   * (unchanged) stores and read model. The team leader is owned directly by
+   * `TeamService`.
    */
   teamScope: string | null;
   config: DreamuxConfig;
@@ -130,8 +124,8 @@ export type SpawnTeamMateRequest = SpawnTeamMateInput & {
  * collection without the service re-forwarding each verb. `Omit` hides the
  * scope-internal inputs — `sharedWorkspace` (injected by `TeamService.spawnTeamMate`)
  * and the history `teamId` (the scope is baked into the collection) — and the
- * leader/lifecycle methods (`createTeamLeader` / `allocateLeaderName` / `leader`
- * / `turns` / `stopAll` / `dispatcherWorkspace`) stay off the interface entirely.
+ * lifecycle methods (`turns` / `stopAll` / `dispatcherWorkspace`) stay off the
+ * interface entirely.
  */
 export interface TeammateOps {
   spawn(input: Omit<SpawnTeamMateRequest, 'sharedWorkspace'>): Promise<TeamMateSpawnResult>;
@@ -150,11 +144,11 @@ export interface TeammateOps {
  * (`teamScope: team_id`). The dispatcher-scope collection is owned by
  * `DispatcherService`; each team-scope collection is owned by its `TeamService`.
  * It owns the identity/turns stores, holds the per-dispatcher worktree manager,
- * and caches the per-name `TeammateService` entity, and exposes `spawn` / `get` /
- * `list` / `history` / `close` plus the factory paths (`createTeamLeader`,
- * `allocateLeaderName`). Per-entity domain operations (`send` / `status` / `last`
- * / completion delivery) live on `TeammateService`. Both the dispatcher id and
- * the scope are baked into the collection, not threaded per call.
+ * and caches the per-name member `TeammateService` entity, and exposes `spawn` /
+ * `list` / `history` / `close`. Per-entity domain operations (`send` /
+ * `status` / `last` / completion delivery) live on `TeammateService`. Both the
+ * dispatcher id and the scope are baked into the collection, not threaded per
+ * call.
  */
 export class TeammateCollection implements TeammateOps {
   private readonly dispatcherId: string;
@@ -185,22 +179,6 @@ export class TeammateCollection implements TeammateOps {
 
   turns(): TeamMateTurnsStore {
     return this.turnsStore;
-  }
-
-  async allocateLeaderName(): Promise<string> {
-    const teamId = this.mustTeamScope('allocateLeaderName');
-    return this.allocateName('team_leader', teamId, teamId);
-  }
-
-  /** The team id this collection is scoped to, or throw for a dispatcher-scope
-   * collection (leader ops only exist within a team scope, issue #233). */
-  private mustTeamScope(op: string): string {
-    if (this.teamScope === null) {
-      throw new Error(
-        `${op} requires a team-scoped collection (this collection is dispatcher-scoped)`,
-      );
-    }
-    return this.teamScope;
   }
 
   /**
@@ -377,7 +355,7 @@ export class TeammateCollection implements TeammateOps {
     if (identity === null) {
       throw new Error(`TeamMate ${JSON.stringify(name)} does not exist`);
     }
-    assertInRoster(identity, this.dispatcherId, teamId);
+    this.assertInCollection(identity);
     return identity;
   }
 
@@ -390,86 +368,6 @@ export class TeammateCollection implements TeammateOps {
    */
   private async rosterList(): Promise<TeamMateIdentity[]> {
     return this.identities.list(this.dispatcherId, this.teamScope ?? undefined);
-  }
-
-  /**
-   * Create a team leader as a contained {@link TeammateService} (issue #233
-   * Phase 4): same entity, store, runtime, and turn recording as a regular
-   * teammate, only with `role: 'team_leader'` so it lands at the team root. The
-   * created entity is returned so the {@link TeamService} can hold it directly
-   * (has-a), rather than re-resolving the leader by name on every call.
-   */
-  async createTeamLeader(
-    input: CreateTeamLeaderInput,
-    options: TeammateServiceOptions,
-  ): Promise<{
-    leader: TeammateService;
-    result: Omit<TeamMateSpawnResult, 'turn'> & { turn: TeamMateTurnResult | null };
-  }> {
-    const teamId = this.mustTeamScope('createTeamLeader');
-    const name = validateTeamMateName(input.name);
-    // The leader lives at the team scope root (`team/<team>/identity.json`), so
-    // the existence probe must be team-scoped — a dispatcher-scope `get` would
-    // miss it and re-create a name that #188 forbids reusing (issue #233).
-    const existing = await this.identities.get(this.dispatcherId, name, teamId);
-    if (existing !== null) {
-      throw new Error(`TeamLeader ${JSON.stringify(name)} already exists`);
-    }
-    const identity = await this.identities.create({
-      dispatcherId: this.dispatcherId,
-      name,
-      role: 'team_leader',
-      teamId,
-      agentRuntime: input.agentRuntime,
-      sourceCwd: input.sourceCwd,
-      sourceRepo: input.sourceRepo,
-      cwd: input.runtimeCwd,
-      runtimeCwd: input.runtimeCwd,
-      worktree: input.worktree,
-      intent: input.intent ?? null,
-      status: 'starting',
-    });
-    const entity = this.entityFor(identity, options);
-    await entity.ensureStarted({ teamId });
-    // Only fire a first turn when the dispatcher explicitly supplied a prompt.
-    // A team created without a prompt starts its leader idle — the leader entity
-    // is persisted and recoverable from its record, and its runtime-native
-    // session materializes on start (eager runtimes, e.g. Codex `thread/start`)
-    // or on the first turn (lazy runtimes, e.g. Claude Code) — and waits for a
-    // bound channel or a dispatcher `send` to drive its first real turn. We no
-    // longer fabricate a synthetic default prompt and auto-run a turn at create.
-    let turn: TeamMateTurnResult | null = null;
-    if (input.prompt !== undefined) {
-      // The dispatcher created this leader, so its first turn is `dispatcher`
-      // origin — not the `team_leader` origin a team_id alone would imply.
-      turn = await entity.submitInitialPrompt(input.prompt, {
-        teamId,
-        turnOrigin: 'dispatcher',
-      });
-      // A dispatcher->leader create registers `leaderName:turnId -> dispatcher`.
-      await this.registerCompletion(entity, turn.turn_id ?? null);
-    }
-    return { leader: entity, result: { teammate: entity.status(), turn } };
-  }
-
-  /**
-   * Materialize a team's leader {@link TeammateService} entity by its known name
-   * (issue #233 Phase 4). The leader lives at the team root, so the lookup is
-   * team-scoped; the entity is created from the persisted record on first access
-   * after a restart and cached thereafter. The `TeamService` holds the returned
-   * entity for the team's lifetime.
-   *
-   * The leader's construction options are supplied by the team layer at both
-   * construction sites (here on rebuild, `createTeamLeader` on create), so the
-   * leader's role capabilities travel with its construction and no entity is
-   * ever built by re-inspecting `identity.role` (issue #233).
-   */
-  async leader(
-    leaderName: string,
-    options: TeammateServiceOptions,
-  ): Promise<TeammateService> {
-    this.mustTeamScope('leader');
-    return this.mustEntity(leaderName, options);
   }
 
   getCapabilities(): TeamMateCapabilities {
@@ -528,37 +426,36 @@ export class TeammateCollection implements TeammateOps {
     router.register(completionKey(entity.name, turnId), initiator);
   }
 
-  private async mustEntity(
-    name: string,
-    options: TeammateServiceOptions = {},
-  ): Promise<TeammateService> {
-    const teamId = this.teamScope ?? undefined;
+  private async mustEntity(name: string): Promise<TeammateService> {
     const teammateName = validateTeamMateName(name);
     const existing = this.entities.get(teammateName);
     if (existing !== undefined) {
-      assertInRoster(existing.current(), this.dispatcherId, teamId);
+      this.assertInCollection(existing.current());
       return existing;
     }
     const identity = await this.mustIdentity(teammateName);
-    return this.entityFor(identity, options);
+    return this.entityFor(identity);
+  }
+
+  private assertInCollection(identity: TeamMateIdentity): void {
+    const inCollection =
+      identity.dispatcher_id === this.dispatcherId &&
+      (this.teamScope === null
+        ? identity.team_id === null && identity.role === 'teammate'
+        : identity.team_id === this.teamScope && identity.role === 'team_member');
+    if (inCollection) return;
+    throw new Error(`TeamMate ${JSON.stringify(identity.name)} does not exist`);
   }
 
   /** Build (and cache) the entity for an identity. Options default to empty:
-   * only a team's leader is built with role-granted capabilities, passed in at
-   * its two construction sites (`createTeamLeader` / `leader`). Members and
-   * dispatcher-owned teammates take the empty default — capability is decided by
-   * the construction path, never by re-inspecting `identity.role` (issue #233). */
-  private entityFor(
-    identity: TeamMateIdentity,
-    options: TeammateServiceOptions = {},
-  ): TeammateService {
+   * members and dispatcher-owned teammates get no role policy here. */
+  private entityFor(identity: TeamMateIdentity): TeammateService {
     const existing = this.entities.get(identity.name);
     if (existing !== undefined) return existing;
     const entity = createTeammateService({
       dispatcherId: this.dispatcherId,
       identity,
       launch: { kind: 'agent-ref' },
-      options,
       config: this.opts.config,
       agentRuntimeProviders: this.opts.agentRuntimeProviders,
       identities: this.identities,

--- a/packages/dreamux/src/service/teammate-collection/index.ts
+++ b/packages/dreamux/src/service/teammate-collection/index.ts
@@ -26,7 +26,11 @@ import {
   toStatus,
   validateLastTurns,
 } from './read-helpers.js';
-import { TeammateService, type TeammateServiceDeps } from '../teammate-service/index.js';
+import {
+  TeammateService,
+  type TeammateServiceDeps,
+  type TeammateServiceOptions,
+} from '../teammate-service/index.js';
 import { TeamMateTurnsStore } from './turns-store.js';
 import { allocateConcreteName, type SuffixGenerator } from './name-allocator.js';
 import {
@@ -48,7 +52,6 @@ import {
   type TeamMateHistoryResult,
   type TeamMateIdentity,
   type TeamMateLastResult,
-  type TeamMateLaunchPolicy,
   type TeamMateRecordRow,
   type TeamMateRole,
   type TeamMateRuntimeStatus,
@@ -57,14 +60,6 @@ import {
   type TeamMateTurnResult,
   type TeamMateWorktreeIdentity,
 } from './types.js';
-
-/** A teammate with no role-granted launch additions. The default for every
- * entity; only a team's leader is built with a non-empty policy, supplied by
- * the team layer at the leader's construction sites (issue #233). */
-const EMPTY_LAUNCH_POLICY: TeamMateLaunchPolicy = {
-  mcpServers: [],
-  disableFeatures: [],
-};
 
 export interface TeammateCollectionOptions {
   /** The dispatcher this collection belongs to (issue #233 ownership sinking). */
@@ -406,7 +401,7 @@ export class TeammateCollection implements TeammateOps {
    */
   async createTeamLeader(
     input: CreateTeamLeaderInput,
-    launchPolicy: TeamMateLaunchPolicy,
+    options: TeammateServiceOptions,
   ): Promise<{
     leader: TeammateService;
     result: Omit<TeamMateSpawnResult, 'turn'> & { turn: TeamMateTurnResult | null };
@@ -434,7 +429,7 @@ export class TeammateCollection implements TeammateOps {
       intent: input.intent ?? null,
       status: 'starting',
     });
-    const entity = this.entityFor(identity, launchPolicy);
+    const entity = this.entityFor(identity, options);
     await entity.ensureStarted({ teamId });
     // Only fire a first turn when the dispatcher explicitly supplied a prompt.
     // A team created without a prompt starts its leader idle — the leader entity
@@ -464,17 +459,17 @@ export class TeammateCollection implements TeammateOps {
    * after a restart and cached thereafter. The `TeamService` holds the returned
    * entity for the team's lifetime.
    *
-   * The leader's `launchPolicy` is supplied by the team layer at both leader
+   * The leader's construction options are supplied by the team layer at both
    * construction sites (here on rebuild, `createTeamLeader` on create), so the
    * leader's role capabilities travel with its construction and no entity is
    * ever built by re-inspecting `identity.role` (issue #233).
    */
   async leader(
     leaderName: string,
-    launchPolicy: TeamMateLaunchPolicy,
+    options: TeammateServiceOptions,
   ): Promise<TeammateService> {
     this.mustTeamScope('leader');
-    return this.mustEntity(leaderName, launchPolicy);
+    return this.mustEntity(leaderName, options);
   }
 
   getCapabilities(): TeamMateCapabilities {
@@ -535,7 +530,7 @@ export class TeammateCollection implements TeammateOps {
 
   private async mustEntity(
     name: string,
-    launchPolicy: TeamMateLaunchPolicy = EMPTY_LAUNCH_POLICY,
+    options: TeammateServiceOptions = {},
   ): Promise<TeammateService> {
     const teamId = this.teamScope ?? undefined;
     const teammateName = validateTeamMateName(name);
@@ -545,17 +540,17 @@ export class TeammateCollection implements TeammateOps {
       return existing;
     }
     const identity = await this.mustIdentity(teammateName);
-    return this.entityFor(identity, launchPolicy);
+    return this.entityFor(identity, options);
   }
 
-  /** Build (and cache) the entity for an identity. `launchPolicy` defaults to
-   * empty: only a team's leader is built with a non-empty policy, passed in at
+  /** Build (and cache) the entity for an identity. Options default to empty:
+   * only a team's leader is built with role-granted capabilities, passed in at
    * its two construction sites (`createTeamLeader` / `leader`). Members and
    * dispatcher-owned teammates take the empty default — capability is decided by
    * the construction path, never by re-inspecting `identity.role` (issue #233). */
   private entityFor(
     identity: TeamMateIdentity,
-    launchPolicy: TeamMateLaunchPolicy = EMPTY_LAUNCH_POLICY,
+    options: TeammateServiceOptions = {},
   ): TeammateService {
     const existing = this.entities.get(identity.name);
     if (existing !== undefined) return existing;
@@ -563,7 +558,7 @@ export class TeammateCollection implements TeammateOps {
       this.entityDeps(),
       this.dispatcherId,
       identity,
-      launchPolicy,
+      options,
     );
     this.entities.set(identity.name, entity);
     return entity;

--- a/packages/dreamux/src/service/teammate-collection/index.ts
+++ b/packages/dreamux/src/service/teammate-collection/index.ts
@@ -14,6 +14,7 @@ import {
   type CompletionInitiator,
   type CompletionRouter,
 } from '../completion-router/index.js';
+import { createTeammateService } from '../teammate-service/factory.js';
 import { TeamMateIdentityStore } from './identity-store.js';
 import {
   assertInRoster,
@@ -26,10 +27,9 @@ import {
   toStatus,
   validateLastTurns,
 } from './read-helpers.js';
-import {
+import type {
   TeammateService,
-  type TeammateServiceDeps,
-  type TeammateServiceOptions,
+  TeammateServiceOptions,
 } from '../teammate-service/index.js';
 import { TeamMateTurnsStore } from './turns-store.js';
 import { allocateConcreteName, type SuffixGenerator } from './name-allocator.js';
@@ -554,18 +554,11 @@ export class TeammateCollection implements TeammateOps {
   ): TeammateService {
     const existing = this.entities.get(identity.name);
     if (existing !== undefined) return existing;
-    const entity = new TeammateService(
-      this.entityDeps(),
-      this.dispatcherId,
+    const entity = createTeammateService({
+      dispatcherId: this.dispatcherId,
       identity,
+      launch: { kind: 'agent-ref' },
       options,
-    );
-    this.entities.set(identity.name, entity);
-    return entity;
-  }
-
-  private entityDeps(): TeammateServiceDeps {
-    return {
       config: this.opts.config,
       agentRuntimeProviders: this.opts.agentRuntimeProviders,
       identities: this.identities,
@@ -581,7 +574,9 @@ export class TeammateCollection implements TeammateOps {
       },
       routeSettledCompletion: (producerName, turnId, completion) =>
         this.routeSettledCompletion(producerName, turnId, completion),
-    };
+    });
+    this.entities.set(identity.name, entity);
+    return entity;
   }
 
   private async routeSettledCompletion(

--- a/packages/dreamux/src/service/teammate-collection/index.ts
+++ b/packages/dreamux/src/service/teammate-collection/index.ts
@@ -58,6 +58,14 @@ import {
   type TeamMateWorktreeIdentity,
 } from './types.js';
 
+/** A teammate with no role-granted launch additions. The default for every
+ * entity; only a team's leader is built with a non-empty policy, supplied by
+ * the team layer at the leader's construction sites (issue #233). */
+const EMPTY_LAUNCH_POLICY: TeamMateLaunchPolicy = {
+  mcpServers: [],
+  disableFeatures: [],
+};
+
 export interface TeammateCollectionOptions {
   /** The dispatcher this collection belongs to (issue #233 ownership sinking). */
   dispatcherId: string;
@@ -83,11 +91,6 @@ export interface TeammateCollectionOptions {
    */
   identities?: TeamMateIdentityStore;
   turnsStore?: TeamMateTurnsStore;
-  launchPolicyForTeamMate?: (input: {
-    dispatcherId: string;
-    name: string;
-    identity: TeamMateIdentity;
-  }) => TeamMateLaunchPolicy;
   /**
    * The dispatcher's delivery router (issue #233). Omitted in storage-only
    * contexts (no settle delivery is then routed).
@@ -403,6 +406,7 @@ export class TeammateCollection implements TeammateOps {
    */
   async createTeamLeader(
     input: CreateTeamLeaderInput,
+    launchPolicy: TeamMateLaunchPolicy,
   ): Promise<{
     leader: TeammateService;
     result: Omit<TeamMateSpawnResult, 'turn'> & { turn: TeamMateTurnResult | null };
@@ -430,7 +434,7 @@ export class TeammateCollection implements TeammateOps {
       intent: input.intent ?? null,
       status: 'starting',
     });
-    const entity = this.entityFor(identity);
+    const entity = this.entityFor(identity, launchPolicy);
     await entity.ensureStarted({ teamId });
     // Only fire a first turn when the dispatcher explicitly supplied a prompt.
     // A team created without a prompt starts its leader idle — the leader entity
@@ -459,10 +463,18 @@ export class TeammateCollection implements TeammateOps {
    * team-scoped; the entity is created from the persisted record on first access
    * after a restart and cached thereafter. The `TeamService` holds the returned
    * entity for the team's lifetime.
+   *
+   * The leader's `launchPolicy` is supplied by the team layer at both leader
+   * construction sites (here on rebuild, `createTeamLeader` on create), so the
+   * leader's role capabilities travel with its construction and no entity is
+   * ever built by re-inspecting `identity.role` (issue #233).
    */
-  async leader(leaderName: string): Promise<TeammateService> {
+  async leader(
+    leaderName: string,
+    launchPolicy: TeamMateLaunchPolicy,
+  ): Promise<TeammateService> {
     this.mustTeamScope('leader');
-    return this.mustEntity(leaderName);
+    return this.mustEntity(leaderName, launchPolicy);
   }
 
   getCapabilities(): TeamMateCapabilities {
@@ -521,7 +533,10 @@ export class TeammateCollection implements TeammateOps {
     router.register(completionKey(entity.name, turnId), initiator);
   }
 
-  private async mustEntity(name: string): Promise<TeammateService> {
+  private async mustEntity(
+    name: string,
+    launchPolicy: TeamMateLaunchPolicy = EMPTY_LAUNCH_POLICY,
+  ): Promise<TeammateService> {
     const teamId = this.teamScope ?? undefined;
     const teammateName = validateTeamMateName(name);
     const existing = this.entities.get(teammateName);
@@ -530,16 +545,25 @@ export class TeammateCollection implements TeammateOps {
       return existing;
     }
     const identity = await this.mustIdentity(teammateName);
-    return this.entityFor(identity);
+    return this.entityFor(identity, launchPolicy);
   }
 
-  private entityFor(identity: TeamMateIdentity): TeammateService {
+  /** Build (and cache) the entity for an identity. `launchPolicy` defaults to
+   * empty: only a team's leader is built with a non-empty policy, passed in at
+   * its two construction sites (`createTeamLeader` / `leader`). Members and
+   * dispatcher-owned teammates take the empty default — capability is decided by
+   * the construction path, never by re-inspecting `identity.role` (issue #233). */
+  private entityFor(
+    identity: TeamMateIdentity,
+    launchPolicy: TeamMateLaunchPolicy = EMPTY_LAUNCH_POLICY,
+  ): TeammateService {
     const existing = this.entities.get(identity.name);
     if (existing !== undefined) return existing;
     const entity = new TeammateService(
       this.entityDeps(),
       this.dispatcherId,
       identity,
+      launchPolicy,
     );
     this.entities.set(identity.name, entity);
     return entity;
@@ -553,9 +577,6 @@ export class TeammateCollection implements TeammateOps {
       turnsStore: this.turnsStore,
       worktrees: this.worktrees,
       log: this.opts.log,
-      ...(this.opts.launchPolicyForTeamMate !== undefined
-        ? { launchPolicyForTeamMate: this.opts.launchPolicyForTeamMate }
-        : {}),
       nextSubmissionSeq: () => ++this.submissionSeq,
       trackSettleCapture: (capture) => {
         this.inFlightSettleCaptures.add(capture);

--- a/packages/dreamux/src/service/teammate-service/factory.ts
+++ b/packages/dreamux/src/service/teammate-service/factory.ts
@@ -1,0 +1,71 @@
+import type { CompletionEnvelope, DreamuxLogger } from '@excitedjs/dreamux-types';
+
+import type { AgentRuntimeProviderCatalog } from '../../agent-runtime/index.js';
+import type { DreamuxConfig } from '../../config/config.js';
+import type { TeamMateIdentityStore } from '../teammate-collection/identity-store.js';
+import type { TeamMateTurnsStore } from '../teammate-collection/turns-store.js';
+import type { TeamMateIdentity } from '../teammate-collection/types.js';
+import type { WorktreeManager } from '../worktree/manager.js';
+import {
+  TeammateService,
+  type RuntimeLaunchSpec,
+  type TeammateServiceDeps,
+  type TeammateServiceOptions,
+} from './index.js';
+
+type TeammateServiceBuildLaunch = NonNullable<TeammateServiceDeps['buildLaunch']>;
+
+export type TeammateServiceLaunch =
+  | {
+      kind: 'agent-ref';
+    }
+  | {
+      kind: 'inline';
+      build: TeammateServiceBuildLaunch;
+    };
+
+export interface CreateTeammateServiceInput {
+  dispatcherId: string;
+  identity: TeamMateIdentity;
+  launch: TeammateServiceLaunch;
+  options?: TeammateServiceOptions;
+  config: DreamuxConfig;
+  agentRuntimeProviders: AgentRuntimeProviderCatalog;
+  identities: TeamMateIdentityStore;
+  turnsStore: TeamMateTurnsStore;
+  worktrees?: WorktreeManager;
+  log: DreamuxLogger;
+  nextSubmissionSeq: () => number;
+  trackSettleCapture: (capture: Promise<void>) => void;
+  routeSettledCompletion: (
+    producerName: string,
+    turnId: string,
+    completion: CompletionEnvelope,
+  ) => Promise<void>;
+}
+
+export function createTeammateService(
+  input: CreateTeammateServiceInput,
+): TeammateService {
+  const deps: TeammateServiceDeps = {
+    config: input.config,
+    agentRuntimeProviders: input.agentRuntimeProviders,
+    identities: input.identities,
+    turnsStore: input.turnsStore,
+    ...(input.worktrees !== undefined ? { worktrees: input.worktrees } : {}),
+    log: input.log,
+    ...(input.launch.kind === 'inline' ? { buildLaunch: input.launch.build } : {}),
+    nextSubmissionSeq: input.nextSubmissionSeq,
+    trackSettleCapture: input.trackSettleCapture,
+    routeSettledCompletion: input.routeSettledCompletion,
+  };
+
+  return new TeammateService(
+    deps,
+    input.dispatcherId,
+    input.identity,
+    input.options,
+  );
+}
+
+export type { RuntimeLaunchSpec };

--- a/packages/dreamux/src/service/teammate-service/index.ts
+++ b/packages/dreamux/src/service/teammate-service/index.ts
@@ -82,11 +82,6 @@ export interface TeammateServiceDeps {
    */
   worktrees?: WorktreeManager;
   log: DreamuxLogger;
-  launchPolicyForTeamMate?: (input: {
-    dispatcherId: string;
-    name: string;
-    identity: TeamMateIdentity;
-  }) => TeamMateLaunchPolicy;
   /**
    * Build the provider + create context for this entity's runtime (issue #233
    * Phase 5). Omitted for an ordinary teammate, which derives its launch from its
@@ -132,6 +127,17 @@ export class TeammateService {
     private readonly deps: TeammateServiceDeps,
     private readonly dispatcherId: string,
     private identity: TeamMateIdentity,
+    /**
+     * The role-granted launch additions (MCP servers + neutral disabled
+     * features) for THIS entity, fixed at construction (issue #233). Defaults to
+     * empty: only a team leader is built with a non-empty policy, supplied by the
+     * team layer at its construction sites. The entity never re-derives this from
+     * its `identity.role`.
+     */
+    private readonly launchPolicy: TeamMateLaunchPolicy = {
+      mcpServers: [],
+      disableFeatures: [],
+    },
   ) {
     this.state = new TeamMateRuntimeStateStore(deps.identities, identity);
   }
@@ -410,11 +416,7 @@ export class TeammateService {
     );
     const provider = this.deps.agentRuntimeProviders.resolve(agent.provider);
     const runtimeName = runtimeIdentityName(identity);
-    const launchPolicy = this.deps.launchPolicyForTeamMate?.({
-      dispatcherId: this.dispatcherId,
-      name: identity.name,
-      identity,
-    }) ?? { mcpServers: [], disableFeatures: [] };
+    const launchPolicy = this.launchPolicy;
     return {
       provider,
       checkpointId: identity.session_id,

--- a/packages/dreamux/src/service/teammate-service/index.ts
+++ b/packages/dreamux/src/service/teammate-service/index.ts
@@ -31,6 +31,8 @@ import {
 } from '../teammate-collection/read-helpers.js';
 import { TeamMateRuntimeStateStore } from '../teammate-collection/runtime-state.js';
 import { recordSettledTurn, recordSubmittedTurn, toTurnResult } from './turn-recording.js';
+import { SchedulerService } from '../scheduler/service.js';
+import type { CronJobStore } from '../scheduler/store.js';
 import type { TeamMateTurnsStore } from '../teammate-collection/turns-store.js';
 import {
   reprepareDeletedManagedWorktree,
@@ -108,6 +110,25 @@ export interface TeammateServiceDeps {
   ) => Promise<void>;
 }
 
+export interface TeamMateSchedulerConfig {
+  store: CronJobStore;
+  ownerId: string;
+  absentRuntimeStrategy: 'miss' | 'submit';
+}
+
+export interface TeammateServiceOptions {
+  /**
+   * Role-granted launch additions for THIS entity, fixed at construction. The
+   * entity never re-derives this from `identity.role`.
+   */
+  launchPolicy?: TeamMateLaunchPolicy;
+  /**
+   * Optional scheduler capability for conversational agents only. The caller
+   * owns host paths and strategy; this entity only wires the scheduler to itself.
+   */
+  scheduler?: TeamMateSchedulerConfig;
+}
+
 /**
  * A single named teammate entity (issue #233): it holds its own identity, its
  * (lazily started) runtime, a per-turn origin cache, and the domain operations
@@ -122,24 +143,29 @@ export class TeammateService {
   private runtime: AgentRuntime | null = null;
   private starting: Promise<void> | null = null;
   private state: TeamMateRuntimeStateStore;
+  private readonly launchPolicy: TeamMateLaunchPolicy;
+  private readonly scheduler_: SchedulerService | null;
 
   constructor(
     private readonly deps: TeammateServiceDeps,
     private readonly dispatcherId: string,
     private identity: TeamMateIdentity,
-    /**
-     * The role-granted launch additions (MCP servers + neutral disabled
-     * features) for THIS entity, fixed at construction (issue #233). Defaults to
-     * empty: only a team leader is built with a non-empty policy, supplied by the
-     * team layer at its construction sites. The entity never re-derives this from
-     * its `identity.role`.
-     */
-    private readonly launchPolicy: TeamMateLaunchPolicy = {
+    options: TeammateServiceOptions = {},
+  ) {
+    this.launchPolicy = options.launchPolicy ?? {
       mcpServers: [],
       disableFeatures: [],
-    },
-  ) {
+    };
     this.state = new TeamMateRuntimeStateStore(deps.identities, identity);
+    this.scheduler_ =
+      options.scheduler === undefined
+        ? null
+        : new SchedulerService({
+            ...options.scheduler,
+            getRuntime: () => this.getRuntime(),
+            submitScheduled: (input) => this.scheduledInput(input),
+            log: deps.log,
+          });
   }
 
   get name(): string {
@@ -152,6 +178,22 @@ export class TeammateService {
 
   getRuntime(): AgentRuntime | null {
     return this.runtime;
+  }
+
+  get scheduler(): SchedulerService | null {
+    return this.scheduler_;
+  }
+
+  async startScheduler(): Promise<void> {
+    await this.scheduler_?.start();
+  }
+
+  stopScheduler(): void {
+    this.scheduler_?.stop();
+  }
+
+  async deleteSchedulerStore(): Promise<void> {
+    await this.scheduler_?.deleteStoreFile();
   }
 
   /**

--- a/packages/dreamux/src/service/teammate-service/index.ts
+++ b/packages/dreamux/src/service/teammate-service/index.ts
@@ -31,8 +31,6 @@ import {
 } from '../teammate-collection/read-helpers.js';
 import { TeamMateRuntimeStateStore } from '../teammate-collection/runtime-state.js';
 import { recordSettledTurn, recordSubmittedTurn, toTurnResult } from './turn-recording.js';
-import { SchedulerService } from '../scheduler/service.js';
-import type { CronJobStore } from '../scheduler/store.js';
 import type { TeamMateTurnsStore } from '../teammate-collection/turns-store.js';
 import {
   reprepareDeletedManagedWorktree,
@@ -110,23 +108,12 @@ export interface TeammateServiceDeps {
   ) => Promise<void>;
 }
 
-export interface TeamMateSchedulerConfig {
-  store: CronJobStore;
-  ownerId: string;
-  absentRuntimeStrategy: 'miss' | 'submit';
-}
-
 export interface TeammateServiceOptions {
   /**
    * Role-granted launch additions for THIS entity, fixed at construction. The
    * entity never re-derives this from `identity.role`.
    */
   launchPolicy?: TeamMateLaunchPolicy;
-  /**
-   * Optional scheduler capability for conversational agents only. The caller
-   * owns host paths and strategy; this entity only wires the scheduler to itself.
-   */
-  scheduler?: TeamMateSchedulerConfig;
 }
 
 /**
@@ -144,7 +131,6 @@ export class TeammateService {
   private starting: Promise<void> | null = null;
   private state: TeamMateRuntimeStateStore;
   private readonly launchPolicy: TeamMateLaunchPolicy;
-  private readonly scheduler_: SchedulerService | null;
 
   constructor(
     private readonly deps: TeammateServiceDeps,
@@ -157,15 +143,6 @@ export class TeammateService {
       disableFeatures: [],
     };
     this.state = new TeamMateRuntimeStateStore(deps.identities, identity);
-    this.scheduler_ =
-      options.scheduler === undefined
-        ? null
-        : new SchedulerService({
-            ...options.scheduler,
-            getRuntime: () => this.getRuntime(),
-            submitScheduled: (input) => this.scheduledInput(input),
-            log: deps.log,
-          });
   }
 
   get name(): string {
@@ -178,22 +155,6 @@ export class TeammateService {
 
   getRuntime(): AgentRuntime | null {
     return this.runtime;
-  }
-
-  get scheduler(): SchedulerService | null {
-    return this.scheduler_;
-  }
-
-  async startScheduler(): Promise<void> {
-    await this.scheduler_?.start();
-  }
-
-  stopScheduler(): void {
-    this.scheduler_?.stop();
-  }
-
-  async deleteSchedulerStore(): Promise<void> {
-    await this.scheduler_?.deleteStoreFile();
   }
 
   /**

--- a/packages/dreamux/tests/teammate-service.test.ts
+++ b/packages/dreamux/tests/teammate-service.test.ts
@@ -17,8 +17,11 @@ import type {
 } from '@excitedjs/dreamux-types';
 
 import type { AgentRuntimeProviderCatalog } from '../src/agent-runtime/index.js';
-import { TeammateCollection } from '../src/service/teammate-collection/index.js';
+import { TeamMateIdentityStore } from '../src/service/teammate-collection/identity-store.js';
+import { TeamMateTurnsStore } from '../src/service/teammate-collection/turns-store.js';
 import type { TeamMateWorktreeIdentity } from '../src/service/teammate-collection/types.js';
+import { createTeamLeaderAgent } from '../src/service/team-service/leader-agent.js';
+import type { TeammateService } from '../src/service/teammate-service/index.js';
 import { WorktreeManager } from '../src/service/worktree/manager.js';
 import { testDispatcherConfig, testDreamuxConfig } from './helpers/config.js';
 
@@ -138,6 +141,61 @@ function reuseCwd(path: string): TeamMateWorktreeIdentity {
   };
 }
 
+async function createTestTeamLeader(input: {
+  dispatcherId: string;
+  teamId: string;
+  name: string;
+  prompt?: string;
+  agentRuntime: string;
+  workspace: string;
+  config: ReturnType<typeof testDreamuxConfig>;
+  agentRuntimeProviders: AgentRuntimeProviderCatalog;
+}): Promise<TeammateService> {
+  const log = noopLog();
+  const identities = new TeamMateIdentityStore({ warn: log.warn.bind(log) });
+  const turnsStore = new TeamMateTurnsStore({ warn: log.warn.bind(log) });
+  const identity = await identities.create({
+    dispatcherId: input.dispatcherId,
+    name: input.name,
+    role: 'team_leader',
+    teamId: input.teamId,
+    agentRuntime: input.agentRuntime,
+    sourceCwd: input.workspace,
+    sourceRepo: null,
+    cwd: input.workspace,
+    runtimeCwd: input.workspace,
+    worktree: reuseCwd(input.workspace),
+    intent: 'lead alpha',
+    status: 'starting',
+  });
+  const leader = createTeamLeaderAgent({
+    dispatcherId: input.dispatcherId,
+    identity,
+    launchPolicy: { mcpServers: [], disableFeatures: [] },
+    config: input.config,
+    agentRuntimeProviders: input.agentRuntimeProviders,
+    identities,
+    turnsStore,
+    worktrees: new WorktreeManager(),
+    log,
+    nextSubmissionSeq: () => 0,
+    trackSettleCapture: () => {
+      /* tests do not emit settle signals */
+    },
+    routeSettledCompletion: async () => {
+      /* no router in this unit helper */
+    },
+  });
+  await leader.ensureStarted({ teamId: input.teamId });
+  if (input.prompt !== undefined) {
+    await leader.submitInitialPrompt(input.prompt, {
+      teamId: input.teamId,
+      turnOrigin: 'dispatcher',
+    });
+  }
+  return leader;
+}
+
 describe('TeammateService channel input routing', () => {
   let root: string;
   let previousHome: string | undefined;
@@ -167,28 +225,16 @@ describe('TeammateService channel input routing', () => {
         runtimeProvider: FAKE_RUNTIME_REF,
       }),
     ]);
-    const collection = new TeammateCollection({
+    const leader = await createTestTeamLeader({
       dispatcherId: 'dispatcher-a',
-      teamScope: 'alpha',
+      teamId: 'alpha',
+      name: 'tl-alpha-0001',
+      prompt: 'initial leader prompt',
+      agentRuntime: 'agent-a',
+      workspace,
       config,
       agentRuntimeProviders: fakeRuntimeCatalog(runtimes),
-      worktrees: new WorktreeManager(),
-      log: noopLog(),
     });
-
-    const { leader } = await collection.createTeamLeader(
-      {
-        name: 'tl-alpha-0001',
-        prompt: 'initial leader prompt',
-        agentRuntime: 'agent-a',
-        sourceCwd: workspace,
-        sourceRepo: null,
-        runtimeCwd: workspace,
-        worktree: reuseCwd(workspace),
-        intent: 'lead alpha',
-      },
-      { launchPolicy: { mcpServers: [], disableFeatures: [] } },
-    );
 
     await expect(
       leader.channelInput({ sourceId: 'message-1', text: 'from bound group' }),
@@ -212,27 +258,15 @@ describe('TeammateService channel input routing', () => {
         runtimeProvider: FAKE_RUNTIME_REF,
       }),
     ]);
-    const collection = new TeammateCollection({
+    const leader = await createTestTeamLeader({
       dispatcherId: 'dispatcher-a',
-      teamScope: 'alpha',
+      teamId: 'alpha',
+      name: 'tl-alpha-0001',
+      agentRuntime: 'agent-a',
+      workspace,
       config,
       agentRuntimeProviders: fakeRuntimeCatalog(runtimes),
-      worktrees: new WorktreeManager(),
-      log: noopLog(),
     });
-
-    const { leader } = await collection.createTeamLeader(
-      {
-        name: 'tl-alpha-0001',
-        agentRuntime: 'agent-a',
-        sourceCwd: workspace,
-        sourceRepo: null,
-        runtimeCwd: workspace,
-        worktree: reuseCwd(workspace),
-        intent: 'lead alpha',
-      },
-      { launchPolicy: { mcpServers: [], disableFeatures: [] } },
-    );
 
     await expect(
       leader.scheduledInput({ jobId: 'job-1', prompt: 'scheduled report' }),
@@ -255,28 +289,16 @@ describe('TeammateService channel input routing', () => {
         runtimeProvider: FAKE_RUNTIME_REF,
       }),
     ]);
-    const collection = new TeammateCollection({
+    const leader = await createTestTeamLeader({
       dispatcherId: 'dispatcher-a',
-      teamScope: 'alpha',
+      teamId: 'alpha',
+      name: 'tl-alpha-0001',
+      prompt: 'initial leader prompt',
+      agentRuntime: 'agent-a',
+      workspace,
       config,
       agentRuntimeProviders: fakeRuntimeCatalog(runtimes),
-      worktrees: new WorktreeManager(),
-      log: noopLog(),
     });
-
-    const { leader } = await collection.createTeamLeader(
-      {
-        name: 'tl-alpha-0001',
-        prompt: 'initial leader prompt',
-        agentRuntime: 'agent-a',
-        sourceCwd: workspace,
-        sourceRepo: null,
-        runtimeCwd: workspace,
-        worktree: reuseCwd(workspace),
-        intent: 'lead alpha',
-      },
-      { launchPolicy: { mcpServers: [], disableFeatures: [] } },
-    );
 
     await expect(
       leader.scheduledInput({ jobId: 'job-1', prompt: 'scheduled report' }),

--- a/packages/dreamux/tests/teammate-service.test.ts
+++ b/packages/dreamux/tests/teammate-service.test.ts
@@ -185,7 +185,7 @@ describe('TeammateService channel input routing', () => {
       runtimeCwd: workspace,
       worktree: reuseCwd(workspace),
       intent: 'lead alpha',
-    });
+    }, { mcpServers: [], disableFeatures: [] });
 
     await expect(
       leader.channelInput({ sourceId: 'message-1', text: 'from bound group' }),
@@ -226,7 +226,7 @@ describe('TeammateService channel input routing', () => {
       runtimeCwd: workspace,
       worktree: reuseCwd(workspace),
       intent: 'lead alpha',
-    });
+    }, { mcpServers: [], disableFeatures: [] });
 
     await expect(
       leader.scheduledInput({ jobId: 'job-1', prompt: 'scheduled report' }),
@@ -267,7 +267,7 @@ describe('TeammateService channel input routing', () => {
       runtimeCwd: workspace,
       worktree: reuseCwd(workspace),
       intent: 'lead alpha',
-    });
+    }, { mcpServers: [], disableFeatures: [] });
 
     await expect(
       leader.scheduledInput({ jobId: 'job-1', prompt: 'scheduled report' }),

--- a/packages/dreamux/tests/teammate-service.test.ts
+++ b/packages/dreamux/tests/teammate-service.test.ts
@@ -176,16 +176,19 @@ describe('TeammateService channel input routing', () => {
       log: noopLog(),
     });
 
-    const { leader } = await collection.createTeamLeader({
-      name: 'tl-alpha-0001',
-      prompt: 'initial leader prompt',
-      agentRuntime: 'agent-a',
-      sourceCwd: workspace,
-      sourceRepo: null,
-      runtimeCwd: workspace,
-      worktree: reuseCwd(workspace),
-      intent: 'lead alpha',
-    }, { mcpServers: [], disableFeatures: [] });
+    const { leader } = await collection.createTeamLeader(
+      {
+        name: 'tl-alpha-0001',
+        prompt: 'initial leader prompt',
+        agentRuntime: 'agent-a',
+        sourceCwd: workspace,
+        sourceRepo: null,
+        runtimeCwd: workspace,
+        worktree: reuseCwd(workspace),
+        intent: 'lead alpha',
+      },
+      { launchPolicy: { mcpServers: [], disableFeatures: [] } },
+    );
 
     await expect(
       leader.channelInput({ sourceId: 'message-1', text: 'from bound group' }),
@@ -218,15 +221,18 @@ describe('TeammateService channel input routing', () => {
       log: noopLog(),
     });
 
-    const { leader } = await collection.createTeamLeader({
-      name: 'tl-alpha-0001',
-      agentRuntime: 'agent-a',
-      sourceCwd: workspace,
-      sourceRepo: null,
-      runtimeCwd: workspace,
-      worktree: reuseCwd(workspace),
-      intent: 'lead alpha',
-    }, { mcpServers: [], disableFeatures: [] });
+    const { leader } = await collection.createTeamLeader(
+      {
+        name: 'tl-alpha-0001',
+        agentRuntime: 'agent-a',
+        sourceCwd: workspace,
+        sourceRepo: null,
+        runtimeCwd: workspace,
+        worktree: reuseCwd(workspace),
+        intent: 'lead alpha',
+      },
+      { launchPolicy: { mcpServers: [], disableFeatures: [] } },
+    );
 
     await expect(
       leader.scheduledInput({ jobId: 'job-1', prompt: 'scheduled report' }),
@@ -258,16 +264,19 @@ describe('TeammateService channel input routing', () => {
       log: noopLog(),
     });
 
-    const { leader } = await collection.createTeamLeader({
-      name: 'tl-alpha-0001',
-      prompt: 'initial leader prompt',
-      agentRuntime: 'agent-a',
-      sourceCwd: workspace,
-      sourceRepo: null,
-      runtimeCwd: workspace,
-      worktree: reuseCwd(workspace),
-      intent: 'lead alpha',
-    }, { mcpServers: [], disableFeatures: [] });
+    const { leader } = await collection.createTeamLeader(
+      {
+        name: 'tl-alpha-0001',
+        prompt: 'initial leader prompt',
+        agentRuntime: 'agent-a',
+        sourceCwd: workspace,
+        sourceRepo: null,
+        runtimeCwd: workspace,
+        worktree: reuseCwd(workspace),
+        intent: 'lead alpha',
+      },
+      { launchPolicy: { mcpServers: [], disableFeatures: [] } },
+    );
 
     await expect(
       leader.scheduledInput({ jobId: 'job-1', prompt: 'scheduled report' }),


### PR DESCRIPTION
## Why

The `team_leader` launch policy belongs to the layer that owns the
`team_leader` role. Previously `TeamCollection` built each team's members
`TeammateCollection`, leader, and scheduler, and held `teamMateLaunchPolicy`;
`TeamService` merely received them via `TeamServiceOptions`. That left a
team-layer policy living a level too high and forced an awkward indirection
(`launchPolicyForTeamMate` threaded down from the collection).

## What

Move per-team construction **into** `TeamService`:

- `TeamService` gains a private **sync constructor** that builds its own
  team-scoped `TeammateCollection` + `SchedulerService`, plus two static
  **async factories** `createNew()` / `rebuild()`. This breaks the
  construction cycle (the leader is a `TeammateService` whose launch policy
  is a dep, so the policy owner must exist before the leader starts): the
  closure `(input) => this.teamMateLaunchPolicy(input.identity)` is captured
  at construction and only invoked at leader/teammate launch (by which time
  `deps` is set); the scheduler is created unstarted and started only after
  `leader_` is assigned.
- `teamMateLaunchPolicy` is now a true **private instance method** of
  `TeamService`.
- `TeamCollection` collapses to a thin factory/registry: `depsBase()`
  forwards the shared deps; each call site injects the per-team `evict`
  closure.
- `record` / `leader_` become nullable with `mustRecord()` / `mustLeader()`
  guards + a `view()` helper. Behavior is unchanged (store create/update
  sequence, create-with-prompt vs idle leader, scheduler start gating,
  dissolve cleanup).
- The public `teammates` surface stays **narrow**: the collection is held as
  a private concrete field, exposed via `get teammates(): TeammateOps`, so
  internal lifecycle/factory verbs (`createTeamLeader`, `allocateLeaderName`,
  `stopAll`, `applyWorktreeCleanup`, the workspace-injecting raw `spawn`) are
  not re-exposed to admin callers — `spawnTeamMate` remains the only spawn
  path.

## Review

Reviewed by two independent heterogeneous reviewers (codex + claude). Both
converged on one finding — the `teammates` getter had been widened to the
concrete `TeammateCollection` (a deviation from the design intent of keeping
the narrow `TeammateOps` seam); that is fixed in this PR (private field +
narrowed getter).

## Verification

- `tsc --noEmit` (src + tests) — clean
- `eslint` on both changed files — clean
- `vitest run` (`DREAMUX_SKIP_LIVE_CODEX=1`) — **525 passed | 4 skipped**

🤖 Generated with [Claude Code](https://claude.com/claude-code)