### PR TITLE
ci: run the workflow on every PR regardless of base branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,17 +23,19 @@
 
 name: ci
 
-# Trigger scope: these gates must cover the epic integration branches too, not
-# only `main`. Implementation PRs target a `feature/**` integration branch first
-# (issue #182), so a `main`-only filter left those PRs unchecked and forced
-# manual `workflow_dispatch` runs. Run on PRs into `main` or any `feature/**`
-# branch, on pushes to those branches (validating the integrated state after a
-# merge), and on manual dispatch.
+# Trigger scope: every PR in this repo must run these gates, whatever its base
+# branch. A base-branch allowlist (`main` + `feature/**`) silently left PRs into
+# other long-lived integration branches — notably `next` — unchecked and forced
+# manual `workflow_dispatch` runs. GitHub evaluates a `pull_request` workflow
+# from the file on the PR's BASE branch, so an allowlist there is exactly what
+# skips those PRs; drop it so `pull_request` fires for ALL bases. `push` stays
+# scoped to the long-lived branches we want to re-validate post-merge (the
+# integrated state), so feature-branch dev pushes still trigger but throwaway
+# topic branches don't double-run alongside their PR.
 on:
   push:
-    branches: [main, 'feature/**']
+    branches: [main, next, 'feature/**']
   pull_request:
-    branches: [main, 'feature/**']
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
## Why

PRs into `next` were getting **no CI**. Root cause: the `pull_request` trigger
had a base-branch allowlist (`branches: [main, 'feature/**']`). GitHub evaluates
a `pull_request` workflow from the file on the PR's **base** branch, so that
allowlist is precisely what skipped any PR whose base isn't `main`/`feature/**`
— including every PR targeting `next` — and forced manual `workflow_dispatch`
runs. Every PR in this repo should run these gates.

## What

- **`pull_request`**: drop the `branches` filter entirely → fires for **all**
  bases. This is the fix.
- **`push`**: add `next` alongside `main` / `feature/**` (the long-lived
  branches we re-validate post-merge). A throwaway topic branch is still checked
  once via its PR, not double-run on push.

No job logic changes; only the trigger scope. `pull_request` jobs (`rush-change-status`
etc.) already gate on `github.event_name == 'pull_request'`, so widening the
trigger is safe.

Note: because GitHub reads `pull_request` workflows from the base branch, this
only takes effect for PRs opened **after** it merges into `next` (and likewise
needs to reach `main`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)