### PR TITLE
refactor(scheduler): own the cron scheduler in the conversational agent (#233)

### DIFF
--- a/.agents/reference/scheduled-tasks.md
+++ b/.agents/reference/scheduled-tasks.md
@@ -50,9 +50,16 @@ Key source:
 
 ## Execution
 
-`SchedulerService` is owned by `DispatcherService`. It starts after the
-dispatcher agent, channel sessions, and restart-notice injection have completed,
-and it stops before channel sessions and the agent runtime are stopped.
+`SchedulerService` is owned by the conversational agent's `TeammateService` — the
+dispatcher agent owns the dispatcher scheduler, each non-closed TeamLeader owns
+its Team scheduler — built from a host-supplied config (cron-jobs store path,
+owner id, absent-runtime strategy) and wired to that agent's own runtime. The
+containers (`DispatcherService` / `TeamService`) construct no scheduler; they only
+orchestrate lifecycle and expose it for admin cron routing. The dispatcher
+scheduler starts after the dispatcher agent, channel sessions, and restart-notice
+injection have completed, and stops before channel sessions and the agent runtime
+are stopped; Team schedulers are armed at dispatcher boot (without starting the
+TeamLeader runtime) and stopped/deleted with their team.
 
 For `prompt-agent` jobs the scheduler:
 
@@ -72,7 +79,8 @@ The conversational management surface wraps the same `SchedulerService`:
 `admin/methods.ts` exposes the `scheduler.cron.*` admin methods, the `dreamux
 cron` CLI (`cli/commands/cron-mcp.ts`) drives them, and the Cron MCP
 (`mcp/cron-mcp.ts`) mirrors the native scheduling tool surface; the Cron MCP is
-injected into the dispatcher agent only (not team_leader/teammate).
+injected into each conversational agent — the dispatcher agent and every
+TeamLeader — but not regular teammates/team members.
 
 Key source:
 

--- a/common/changes/@excitedjs/dreamux/teamservice-scheduler-capability_2026-06-25-00-00.json
+++ b/common/changes/@excitedjs/dreamux/teamservice-scheduler-capability_2026-06-25-00-00.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "type": "none",
+      "packageName": "@excitedjs/dreamux"
+    }
+  ],
+  "packageName": "@excitedjs/dreamux",
+  "email": "053700@gmail.com"
+}

--- a/packages/dreamux/src/service/dispatcher-service/agent.ts
+++ b/packages/dreamux/src/service/dispatcher-service/agent.ts
@@ -12,6 +12,7 @@ import {
   type AgentRuntimeProviderCatalog,
 } from '../../agent-runtime/index.js';
 import type { DispatcherConfig, DreamuxConfig } from '../../config/config.js';
+import { dispatcherCronJobsPath } from '../../platform/paths.js';
 import type { DispatcherStore } from '../../state/dispatcher-store.js';
 import {
   completionKey,
@@ -25,6 +26,7 @@ import {
 } from '../teammate-service/index.js';
 import type { TeamMateTurnsStore } from '../teammate-collection/turns-store.js';
 import type { TeamMateIdentity } from '../teammate-collection/types.js';
+import { CronJobStore } from '../scheduler/store.js';
 import {
   DREAMUX_DISPATCHER_APPEND_INSTRUCTIONS,
   DREAMUX_DISPATCHER_BASE_INSTRUCTIONS,
@@ -123,7 +125,16 @@ export function createDispatcherAgent(deps: DispatcherAgentDeps): TeammateServic
       routeSettled(deps.router, producerName, turnId, completion),
   };
 
-  const agent = new TeammateService(serviceDeps, deps.id, identity);
+  const agent = new TeammateService(serviceDeps, deps.id, identity, {
+    scheduler: {
+      ownerId: deps.id,
+      store: new CronJobStore({
+        cronJobsPath: dispatcherCronJobsPath(deps.id),
+        dispatcherId: deps.id,
+      }),
+      absentRuntimeStrategy: 'miss',
+    },
+  });
   return agent;
 }
 

--- a/packages/dreamux/src/service/dispatcher-service/index.ts
+++ b/packages/dreamux/src/service/dispatcher-service/index.ts
@@ -15,7 +15,7 @@ import type { AgentRuntimeProviderCatalog } from '../../agent-runtime/index.js';
 import type { ChannelProviderCatalog } from '../../channel/catalog.js';
 import type { DreamuxConfig } from '../../config/config.js';
 import type { RestartIntentConsumer } from '../../daemon/restart-intent.js';
-import { adminSocketPath as defaultAdminSocketPath, dispatcherCronJobsPath } from '../../platform/paths.js';
+import { adminSocketPath as defaultAdminSocketPath } from '../../platform/paths.js';
 import type {
   DispatcherRow,
   DispatcherStatus,
@@ -38,8 +38,7 @@ import { ChannelBindingStore } from '../channel-binding/store.js';
 import { type TeamMateIdentity } from '../teammate-collection/types.js';
 import { type TeamChannelContext } from '../team-service/index.js';
 import { TeamCollection } from '../team-collection/index.js';
-import { SchedulerService } from '../scheduler/service.js';
-import { CronJobStore } from '../scheduler/store.js';
+import type { SchedulerService } from '../scheduler/service.js';
 import type {
   TeamCreateInput,
   TeamDissolveInput,
@@ -93,7 +92,6 @@ export class DispatcherService implements TeamChannelContext {
   private readonly teams: TeamCollection;
   private readonly channels: ChannelSessions;
   private readonly agent: TeammateService;
-  readonly scheduler: SchedulerService;
   private restartIntent: RestartIntentConsumer | null = null;
   private starting: Promise<void> | null = null;
   private workspaceCwd: string | null = null;
@@ -151,14 +149,6 @@ export class DispatcherService implements TeamChannelContext {
       liveChannels: () => this.channels.live(),
     });
 
-    this.scheduler = new SchedulerService({
-      ownerId: opts.id,
-      store: new CronJobStore({ cronJobsPath: dispatcherCronJobsPath(opts.id), dispatcherId: opts.id }),
-      absentRuntimeStrategy: 'miss',
-      getRuntime: () => this.agent.getRuntime(),
-      submitScheduled: (input) => this.agent.scheduledInput(input),
-      log: opts.log,
-    });
     // A dispatcher-owned teammate is never a team_leader, so it carries no
     // launch policy (the team_leader policy is owned by the team layer).
     this._teammates = new TeammateCollection({
@@ -198,6 +188,16 @@ export class DispatcherService implements TeamChannelContext {
         }),
       log: opts.log,
     });
+  }
+
+  get scheduler(): SchedulerService {
+    const scheduler = this.agent.scheduler;
+    if (scheduler === null) {
+      throw new Error(
+        `dispatcher ${JSON.stringify(this.id)} agent has no scheduler capability`,
+      );
+    }
+    return scheduler;
   }
 
   /**
@@ -270,10 +270,10 @@ export class DispatcherService implements TeamChannelContext {
         });
       }
       await this.injectRestartNoticeIfNeeded(id, runtime);
-      await this.scheduler.start();
+      await this.agent.startScheduler();
       await this.teams.startSchedulers();
     } catch (err) {
-      this.scheduler.stop();
+      this.agent.stopScheduler();
       this.teams.stopSchedulers();
       // Undo the slot adoption so a failed start never leaves a half-built slot.
       this.channels.clear();
@@ -297,7 +297,7 @@ export class DispatcherService implements TeamChannelContext {
   }
 
   async stop(): Promise<void> {
-    this.scheduler.stop();
+    this.agent.stopScheduler();
     this.teams.stopSchedulers();
     await this.channels.closeAll(this.log);
     try {

--- a/packages/dreamux/src/service/team-service/index.ts
+++ b/packages/dreamux/src/service/team-service/index.ts
@@ -18,7 +18,7 @@ import type {
 import type { ChannelBindingStore } from '../channel-binding/store.js';
 import type { ChannelBinding } from '../channel-binding/store.js';
 import { cronMcpServerDescriptor } from '../scheduler/mcp-config.js';
-import { SchedulerService } from '../scheduler/service.js';
+import type { SchedulerService } from '../scheduler/service.js';
 import { CronJobStore } from '../scheduler/store.js';
 import {
   TeammateCollection,
@@ -36,7 +36,10 @@ import {
   type TeamMateRuntimeStatus,
   type TeamMateTurnResult,
 } from '../teammate-collection/types.js';
-import type { TeammateService } from '../teammate-service/index.js';
+import type {
+  TeammateService,
+  TeamMateSchedulerConfig,
+} from '../teammate-service/index.js';
 import type { TeamStore } from '../team-collection/store.js';
 import type {
   TeamChannelBindingSummary,
@@ -120,7 +123,6 @@ export class TeamService {
    * `TeammateOps`. The PUBLIC surface stays the narrow admin op set via the
    * `teammates` getter — never re-expose those internal verbs to callers. */
   private readonly teammateCollection: TeammateCollection;
-  readonly scheduler: SchedulerService;
 
   private constructor(private readonly deps: TeamServiceDeps, teamId: string) {
     this.id = teamId;
@@ -135,17 +137,6 @@ export class TeamService {
       router: deps.router,
       initiatorFor: deps.initiatorFor,
       isShuttingDown: deps.isShuttingDown,
-      log: deps.log,
-    });
-    this.scheduler = new SchedulerService({
-      ownerId: `${deps.dispatcherId}/team/${teamId}`,
-      store: new CronJobStore({
-        cronJobsPath: dispatcherTeamCronJobsPath(deps.dispatcherId, teamId),
-        dispatcherId: deps.dispatcherId,
-      }),
-      absentRuntimeStrategy: 'submit',
-      getRuntime: () => this.leader_?.getRuntime() ?? null,
-      submitScheduled: (input) => this.mustLeader().scheduledInput(input),
       log: deps.log,
     });
   }
@@ -192,12 +183,15 @@ export class TeamService {
         worktree: input.workspace.worktree,
         intent: input.intent,
       },
-      service.leaderLaunchPolicy(leaderName),
+      {
+        launchPolicy: service.leaderLaunchPolicy(leaderName),
+        scheduler: service.leaderSchedulerConfig(),
+      },
     );
     service.leader_ = leader;
     team = await deps.store.update(team, { status: 'running' });
     service.record = team;
-    await service.scheduler.start();
+    await leader.startScheduler();
     return { service, leaderResult: result };
   }
 
@@ -209,14 +203,27 @@ export class TeamService {
     service.record = record;
     service.leader_ = await service.teammateCollection.leader(
       record.leader_name,
-      service.leaderLaunchPolicy(record.leader_name),
+      {
+        launchPolicy: service.leaderLaunchPolicy(record.leader_name),
+        scheduler: service.leaderSchedulerConfig(),
+      },
     );
-    if (record.status !== 'closed') await service.scheduler.start();
+    if (record.status !== 'closed') await service.leader_.startScheduler();
     return service;
   }
 
   get leader(): TeammateService {
     return this.mustLeader();
+  }
+
+  get scheduler(): SchedulerService {
+    const scheduler = this.mustLeader().scheduler;
+    if (scheduler === null) {
+      throw new Error(
+        `Team ${JSON.stringify(this.id)} leader has no scheduler capability`,
+      );
+    }
+    return scheduler;
   }
 
   /** This team's members, as the narrow admin-facing op surface (issue #233):
@@ -250,7 +257,7 @@ export class TeamService {
 
   async dissolve(input: TeamDissolveInput): Promise<TeamSummary> {
     requireLifecycleText(input.note, 'Team dissolve note');
-    this.scheduler.stop();
+    this.mustLeader().stopScheduler();
     const record = this.mustRecord();
     for (const binding of await this.deps.bindings.list(this.dispatcherId)) {
       if (binding.active && binding.team_name === this.id) {
@@ -290,7 +297,7 @@ export class TeamService {
     for (const member of members) {
       await this.teammateCollection.applyWorktreeCleanup(member.name, cleaned);
     }
-    await this.scheduler.deleteStoreFile();
+    await this.mustLeader().deleteSchedulerStore();
     const summary = await this.status();
     // Evict so a later `get` rebuilds from disk and reads `status: closed`.
     this.deps.evict();
@@ -413,6 +420,17 @@ export class TeamService {
         }),
       ],
       disableFeatures: [DISABLE_FEATURE_CRON],
+    };
+  }
+
+  private leaderSchedulerConfig(): TeamMateSchedulerConfig {
+    return {
+      ownerId: `${this.deps.dispatcherId}/team/${this.id}`,
+      store: new CronJobStore({
+        cronJobsPath: dispatcherTeamCronJobsPath(this.deps.dispatcherId, this.id),
+        dispatcherId: this.deps.dispatcherId,
+      }),
+      absentRuntimeStrategy: 'submit',
     };
   }
 

--- a/packages/dreamux/src/service/teammate-collection/index.ts
+++ b/packages/dreamux/src/service/teammate-collection/index.ts
@@ -26,7 +26,11 @@ import {
   toStatus,
   validateLastTurns,
 } from './read-helpers.js';
-import { TeammateService, type TeammateServiceDeps } from '../teammate-service/index.js';
+import {
+  TeammateService,
+  type TeammateServiceDeps,
+  type TeammateServiceOptions,
+} from '../teammate-service/index.js';
 import { TeamMateTurnsStore } from './turns-store.js';
 import { allocateConcreteName, type SuffixGenerator } from './name-allocator.js';
 import {
@@ -48,7 +52,6 @@ import {
   type TeamMateHistoryResult,
   type TeamMateIdentity,
   type TeamMateLastResult,
-  type TeamMateLaunchPolicy,
   type TeamMateRecordRow,
   type TeamMateRole,
   type TeamMateRuntimeStatus,
@@ -57,14 +60,6 @@ import {
   type TeamMateTurnResult,
   type TeamMateWorktreeIdentity,
 } from './types.js';
-
-/** A teammate with no role-granted launch additions. The default for every
- * entity; only a team's leader is built with a non-empty policy, supplied by
- * the team layer at the leader's construction sites (issue #233). */
-const EMPTY_LAUNCH_POLICY: TeamMateLaunchPolicy = {
-  mcpServers: [],
-  disableFeatures: [],
-};
 
 export interface TeammateCollectionOptions {
   /** The dispatcher this collection belongs to (issue #233 ownership sinking). */
@@ -406,7 +401,7 @@ export class TeammateCollection implements TeammateOps {
    */
   async createTeamLeader(
     input: CreateTeamLeaderInput,
-    launchPolicy: TeamMateLaunchPolicy,
+    options: TeammateServiceOptions,
   ): Promise<{
     leader: TeammateService;
     result: Omit<TeamMateSpawnResult, 'turn'> & { turn: TeamMateTurnResult | null };
@@ -434,7 +429,7 @@ export class TeammateCollection implements TeammateOps {
       intent: input.intent ?? null,
       status: 'starting',
     });
-    const entity = this.entityFor(identity, launchPolicy);
+    const entity = this.entityFor(identity, options);
     await entity.ensureStarted({ teamId });
     // Only fire a first turn when the dispatcher explicitly supplied a prompt.
     // A team created without a prompt starts its leader idle — the leader entity
@@ -464,17 +459,17 @@ export class TeammateCollection implements TeammateOps {
    * after a restart and cached thereafter. The `TeamService` holds the returned
    * entity for the team's lifetime.
    *
-   * The leader's `launchPolicy` is supplied by the team layer at both leader
+   * The leader's construction options are supplied by the team layer at both
    * construction sites (here on rebuild, `createTeamLeader` on create), so the
    * leader's role capabilities travel with its construction and no entity is
    * ever built by re-inspecting `identity.role` (issue #233).
    */
   async leader(
     leaderName: string,
-    launchPolicy: TeamMateLaunchPolicy,
+    options: TeammateServiceOptions,
   ): Promise<TeammateService> {
     this.mustTeamScope('leader');
-    return this.mustEntity(leaderName, launchPolicy);
+    return this.mustEntity(leaderName, options);
   }
 
   getCapabilities(): TeamMateCapabilities {
@@ -535,7 +530,7 @@ export class TeammateCollection implements TeammateOps {
 
   private async mustEntity(
     name: string,
-    launchPolicy: TeamMateLaunchPolicy = EMPTY_LAUNCH_POLICY,
+    options: TeammateServiceOptions = {},
   ): Promise<TeammateService> {
     const teamId = this.teamScope ?? undefined;
     const teammateName = validateTeamMateName(name);
@@ -545,17 +540,17 @@ export class TeammateCollection implements TeammateOps {
       return existing;
     }
     const identity = await this.mustIdentity(teammateName);
-    return this.entityFor(identity, launchPolicy);
+    return this.entityFor(identity, options);
   }
 
-  /** Build (and cache) the entity for an identity. `launchPolicy` defaults to
-   * empty: only a team's leader is built with a non-empty policy, passed in at
+  /** Build (and cache) the entity for an identity. Options default to empty:
+   * only a team's leader is built with role-granted capabilities, passed in at
    * its two construction sites (`createTeamLeader` / `leader`). Members and
    * dispatcher-owned teammates take the empty default — capability is decided by
    * the construction path, never by re-inspecting `identity.role` (issue #233). */
   private entityFor(
     identity: TeamMateIdentity,
-    launchPolicy: TeamMateLaunchPolicy = EMPTY_LAUNCH_POLICY,
+    options: TeammateServiceOptions = {},
   ): TeammateService {
     const existing = this.entities.get(identity.name);
     if (existing !== undefined) return existing;
@@ -563,7 +558,7 @@ export class TeammateCollection implements TeammateOps {
       this.entityDeps(),
       this.dispatcherId,
       identity,
-      launchPolicy,
+      options,
     );
     this.entities.set(identity.name, entity);
     return entity;

--- a/packages/dreamux/src/service/teammate-service/index.ts
+++ b/packages/dreamux/src/service/teammate-service/index.ts
@@ -31,6 +31,8 @@ import {
 } from '../teammate-collection/read-helpers.js';
 import { TeamMateRuntimeStateStore } from '../teammate-collection/runtime-state.js';
 import { recordSettledTurn, recordSubmittedTurn, toTurnResult } from './turn-recording.js';
+import { SchedulerService } from '../scheduler/service.js';
+import type { CronJobStore } from '../scheduler/store.js';
 import type { TeamMateTurnsStore } from '../teammate-collection/turns-store.js';
 import {
   reprepareDeletedManagedWorktree,
@@ -108,6 +110,25 @@ export interface TeammateServiceDeps {
   ) => Promise<void>;
 }
 
+export interface TeamMateSchedulerConfig {
+  store: CronJobStore;
+  ownerId: string;
+  absentRuntimeStrategy: 'miss' | 'submit';
+}
+
+export interface TeammateServiceOptions {
+  /**
+   * Role-granted launch additions for THIS entity, fixed at construction. The
+   * entity never re-derives this from `identity.role`.
+   */
+  launchPolicy?: TeamMateLaunchPolicy;
+  /**
+   * Optional scheduler capability for conversational agents only. The caller
+   * owns host paths and strategy; this entity only wires the scheduler to itself.
+   */
+  scheduler?: TeamMateSchedulerConfig;
+}
+
 /**
  * A single named teammate entity (issue #233): it holds its own identity, its
  * (lazily started) runtime, a per-turn origin cache, and the domain operations
@@ -122,24 +143,29 @@ export class TeammateService {
   private runtime: AgentRuntime | null = null;
   private starting: Promise<void> | null = null;
   private state: TeamMateRuntimeStateStore;
+  private readonly launchPolicy: TeamMateLaunchPolicy;
+  private readonly scheduler_: SchedulerService | null;
 
   constructor(
     private readonly deps: TeammateServiceDeps,
     private readonly dispatcherId: string,
     private identity: TeamMateIdentity,
-    /**
-     * The role-granted launch additions (MCP servers + neutral disabled
-     * features) for THIS entity, fixed at construction (issue #233). Defaults to
-     * empty: only a team leader is built with a non-empty policy, supplied by the
-     * team layer at its construction sites. The entity never re-derives this from
-     * its `identity.role`.
-     */
-    private readonly launchPolicy: TeamMateLaunchPolicy = {
+    options: TeammateServiceOptions = {},
+  ) {
+    this.launchPolicy = options.launchPolicy ?? {
       mcpServers: [],
       disableFeatures: [],
-    },
-  ) {
+    };
     this.state = new TeamMateRuntimeStateStore(deps.identities, identity);
+    this.scheduler_ =
+      options.scheduler === undefined
+        ? null
+        : new SchedulerService({
+            ...options.scheduler,
+            getRuntime: () => this.getRuntime(),
+            submitScheduled: (input) => this.scheduledInput(input),
+            log: deps.log,
+          });
   }
 
   get name(): string {
@@ -152,6 +178,22 @@ export class TeammateService {
 
   getRuntime(): AgentRuntime | null {
     return this.runtime;
+  }
+
+  get scheduler(): SchedulerService | null {
+    return this.scheduler_;
+  }
+
+  async startScheduler(): Promise<void> {
+    await this.scheduler_?.start();
+  }
+
+  stopScheduler(): void {
+    this.scheduler_?.stop();
+  }
+
+  async deleteSchedulerStore(): Promise<void> {
+    await this.scheduler_?.deleteStoreFile();
   }
 
   /**

--- a/packages/dreamux/tests/teammate-service.test.ts
+++ b/packages/dreamux/tests/teammate-service.test.ts
@@ -176,16 +176,19 @@ describe('TeammateService channel input routing', () => {
       log: noopLog(),
     });
 
-    const { leader } = await collection.createTeamLeader({
-      name: 'tl-alpha-0001',
-      prompt: 'initial leader prompt',
-      agentRuntime: 'agent-a',
-      sourceCwd: workspace,
-      sourceRepo: null,
-      runtimeCwd: workspace,
-      worktree: reuseCwd(workspace),
-      intent: 'lead alpha',
-    }, { mcpServers: [], disableFeatures: [] });
+    const { leader } = await collection.createTeamLeader(
+      {
+        name: 'tl-alpha-0001',
+        prompt: 'initial leader prompt',
+        agentRuntime: 'agent-a',
+        sourceCwd: workspace,
+        sourceRepo: null,
+        runtimeCwd: workspace,
+        worktree: reuseCwd(workspace),
+        intent: 'lead alpha',
+      },
+      { launchPolicy: { mcpServers: [], disableFeatures: [] } },
+    );
 
     await expect(
       leader.channelInput({ sourceId: 'message-1', text: 'from bound group' }),
@@ -218,15 +221,18 @@ describe('TeammateService channel input routing', () => {
       log: noopLog(),
     });
 
-    const { leader } = await collection.createTeamLeader({
-      name: 'tl-alpha-0001',
-      agentRuntime: 'agent-a',
-      sourceCwd: workspace,
-      sourceRepo: null,
-      runtimeCwd: workspace,
-      worktree: reuseCwd(workspace),
-      intent: 'lead alpha',
-    }, { mcpServers: [], disableFeatures: [] });
+    const { leader } = await collection.createTeamLeader(
+      {
+        name: 'tl-alpha-0001',
+        agentRuntime: 'agent-a',
+        sourceCwd: workspace,
+        sourceRepo: null,
+        runtimeCwd: workspace,
+        worktree: reuseCwd(workspace),
+        intent: 'lead alpha',
+      },
+      { launchPolicy: { mcpServers: [], disableFeatures: [] } },
+    );
 
     await expect(
       leader.scheduledInput({ jobId: 'job-1', prompt: 'scheduled report' }),
@@ -258,16 +264,19 @@ describe('TeammateService channel input routing', () => {
       log: noopLog(),
     });
 
-    const { leader } = await collection.createTeamLeader({
-      name: 'tl-alpha-0001',
-      prompt: 'initial leader prompt',
-      agentRuntime: 'agent-a',
-      sourceCwd: workspace,
-      sourceRepo: null,
-      runtimeCwd: workspace,
-      worktree: reuseCwd(workspace),
-      intent: 'lead alpha',
-    }, { mcpServers: [], disableFeatures: [] });
+    const { leader } = await collection.createTeamLeader(
+      {
+        name: 'tl-alpha-0001',
+        prompt: 'initial leader prompt',
+        agentRuntime: 'agent-a',
+        sourceCwd: workspace,
+        sourceRepo: null,
+        runtimeCwd: workspace,
+        worktree: reuseCwd(workspace),
+        intent: 'lead alpha',
+      },
+      { launchPolicy: { mcpServers: [], disableFeatures: [] } },
+    );
 
     await expect(
       leader.scheduledInput({ jobId: 'job-1', prompt: 'scheduled report' }),


### PR DESCRIPTION
**Stacked on #240** (base = `teamservice-launch-policy`). Merge order:
#242 → #240 → this. After #240 merges, retarget this to `next`.

## Why

`cron-per-conversational-agent.md` (accepted) says cron is a per-conversational-
agent capability, and the conversational agents — the dispatcher agent and each
TeamLeader — are both `TeammateService` instances. But the `SchedulerService` was
constructed and OWNED by the CONTAINER in two near-identical special cases
(`DispatcherService` wired to its agent, `TeamService` wired to its leader). The
scheduler is really a satellite of one conversational agent. Per CLAUDE.md
"prefer a capability over a special case", the owner should be the
`TeammateService`.

This is the natural continuation of the launch-policy change in #240 (capability
follows construction, not `identity.role`).

## What

- `TeammateService` gains `TeammateServiceOptions { launchPolicy?, scheduler? }`
  (4th ctor arg, folds #240's `launchPolicy` positional into the object). When a
  `scheduler` config is supplied it news a `SchedulerService` wired to its OWN
  `getRuntime()` / `scheduledInput()`, and exposes `scheduler` +
  `startScheduler` / `stopScheduler` / `deleteSchedulerStore`.
- The dispatcher agent (`agent.ts`) injects its config (`dispatcherCronJobsPath`,
  owner = id, `'miss'`). `TeamService.leaderSchedulerConfig()` injects the team
  config (`dispatcherTeamCronJobsPath`, owner `<id>/team/<teamId>`, `'submit'`) at
  both leader construction sites (`createTeamLeader`, `leader`).
- `DispatcherService` / `TeamService` drop their `scheduler` field + construction;
  `get scheduler()` delegates to the agent/leader. Admin `cronTargetFor`
  unchanged.

## Invariants preserved (byte-identical paths/owners/strategies)

- Boot eager-arms each Team scheduler **without** starting the TeamLeader runtime
  (lazy-start on fire via `'submit'`).
- Dispatcher keeps `'miss'` (no cron resurrection outside `doStart`).
- `dissolve` stops + deletes the team `cron-jobs.json`.
- Dispatcher start ordering unchanged.

## Review

Two independent heterogeneous reviewers (codex + claude) — both **PASS**, no
blocking findings. Each traced the boot-eager-arm and dissolve invariants against
the live source.

## Verification

- `tsc --noEmit` (src + tests), `eslint` — clean
- `vitest run` (`DREAMUX_SKIP_LIVE_CODEX=1`) — **525 passed | 4 skipped**
- `rush test` / `typecheck` / `typecheck:tests` / `lint` — pass

Updates `.agents/reference/scheduled-tasks.md` (scheduler ownership + cron-MCP
injection scope). `none`-type Rush change file (pure refactor).

🤖 Generated with [Claude Code](https://claude.com/claude-code)