### PR TITLE
refactor(teammate): extract an independent TeammateService factory (#233, step 1/3)

### DIFF
--- a/common/changes/@excitedjs/dreamux/teammate-service-factory-step1_2026-06-25-00-00.json
+++ b/common/changes/@excitedjs/dreamux/teammate-service-factory-step1_2026-06-25-00-00.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "type": "none",
+      "packageName": "@excitedjs/dreamux"
+    }
+  ],
+  "packageName": "@excitedjs/dreamux",
+  "email": "053700@gmail.com"
+}

--- a/packages/dreamux/src/service/dispatcher-service/agent.ts
+++ b/packages/dreamux/src/service/dispatcher-service/agent.ts
@@ -20,10 +20,10 @@ import {
 } from '../completion-router/index.js';
 import type { TeamMateIdentityStore } from '../teammate-collection/identity-store.js';
 import {
-  TeammateService,
+  createTeammateService,
   type RuntimeLaunchSpec,
-  type TeammateServiceDeps,
-} from '../teammate-service/index.js';
+} from '../teammate-service/factory.js';
+import type { TeammateService } from '../teammate-service/index.js';
 import type { TeamMateTurnsStore } from '../teammate-collection/turns-store.js';
 import type { TeamMateIdentity } from '../teammate-collection/types.js';
 import { CronJobStore } from '../scheduler/store.js';
@@ -107,7 +107,20 @@ export function createDispatcherAgent(deps: DispatcherAgentDeps): TeammateServic
       /* debug record only */
     });
 
-  const serviceDeps: TeammateServiceDeps = {
+  const agent = createTeammateService({
+    dispatcherId: deps.id,
+    identity,
+    launch: { kind: 'inline', build: () => buildDispatcherLaunch(deps) },
+    options: {
+      scheduler: {
+        ownerId: deps.id,
+        store: new CronJobStore({
+          cronJobsPath: dispatcherCronJobsPath(deps.id),
+          dispatcherId: deps.id,
+        }),
+        absentRuntimeStrategy: 'miss',
+      },
+    },
     config: deps.config,
     agentRuntimeProviders: deps.agentRuntimeProviders,
     identities: deps.identities,
@@ -115,7 +128,6 @@ export function createDispatcherAgent(deps: DispatcherAgentDeps): TeammateServic
     // The dispatcher agent has no worktree — it neither spawns nor closes, so it
     // never reaches the worktree manager (issue #233 Phase 5).
     log: deps.log,
-    buildLaunch: () => buildDispatcherLaunch(deps),
     nextSubmissionSeq: () => 0,
     trackSettleCapture: () => {
       /* no-op: the dispatcher agent is never a send-registered producer, so it
@@ -123,17 +135,6 @@ export function createDispatcherAgent(deps: DispatcherAgentDeps): TeammateServic
     },
     routeSettledCompletion: (producerName, turnId, completion) =>
       routeSettled(deps.router, producerName, turnId, completion),
-  };
-
-  const agent = new TeammateService(serviceDeps, deps.id, identity, {
-    scheduler: {
-      ownerId: deps.id,
-      store: new CronJobStore({
-        cronJobsPath: dispatcherCronJobsPath(deps.id),
-        dispatcherId: deps.id,
-      }),
-      absentRuntimeStrategy: 'miss',
-    },
   });
   return agent;
 }

--- a/packages/dreamux/src/service/teammate-collection/index.ts
+++ b/packages/dreamux/src/service/teammate-collection/index.ts
@@ -14,6 +14,7 @@ import {
   type CompletionInitiator,
   type CompletionRouter,
 } from '../completion-router/index.js';
+import { createTeammateService } from '../teammate-service/factory.js';
 import { TeamMateIdentityStore } from './identity-store.js';
 import {
   assertInRoster,
@@ -26,10 +27,9 @@ import {
   toStatus,
   validateLastTurns,
 } from './read-helpers.js';
-import {
+import type {
   TeammateService,
-  type TeammateServiceDeps,
-  type TeammateServiceOptions,
+  TeammateServiceOptions,
 } from '../teammate-service/index.js';
 import { TeamMateTurnsStore } from './turns-store.js';
 import { allocateConcreteName, type SuffixGenerator } from './name-allocator.js';
@@ -554,18 +554,11 @@ export class TeammateCollection implements TeammateOps {
   ): TeammateService {
     const existing = this.entities.get(identity.name);
     if (existing !== undefined) return existing;
-    const entity = new TeammateService(
-      this.entityDeps(),
-      this.dispatcherId,
+    const entity = createTeammateService({
+      dispatcherId: this.dispatcherId,
       identity,
+      launch: { kind: 'agent-ref' },
       options,
-    );
-    this.entities.set(identity.name, entity);
-    return entity;
-  }
-
-  private entityDeps(): TeammateServiceDeps {
-    return {
       config: this.opts.config,
       agentRuntimeProviders: this.opts.agentRuntimeProviders,
       identities: this.identities,
@@ -581,7 +574,9 @@ export class TeammateCollection implements TeammateOps {
       },
       routeSettledCompletion: (producerName, turnId, completion) =>
         this.routeSettledCompletion(producerName, turnId, completion),
-    };
+    });
+    this.entities.set(identity.name, entity);
+    return entity;
   }
 
   private async routeSettledCompletion(

--- a/packages/dreamux/src/service/teammate-service/factory.ts
+++ b/packages/dreamux/src/service/teammate-service/factory.ts
@@ -1,0 +1,71 @@
+import type { CompletionEnvelope, DreamuxLogger } from '@excitedjs/dreamux-types';
+
+import type { AgentRuntimeProviderCatalog } from '../../agent-runtime/index.js';
+import type { DreamuxConfig } from '../../config/config.js';
+import type { TeamMateIdentityStore } from '../teammate-collection/identity-store.js';
+import type { TeamMateTurnsStore } from '../teammate-collection/turns-store.js';
+import type { TeamMateIdentity } from '../teammate-collection/types.js';
+import type { WorktreeManager } from '../worktree/manager.js';
+import {
+  TeammateService,
+  type RuntimeLaunchSpec,
+  type TeammateServiceDeps,
+  type TeammateServiceOptions,
+} from './index.js';
+
+type TeammateServiceBuildLaunch = NonNullable<TeammateServiceDeps['buildLaunch']>;
+
+export type TeammateServiceLaunch =
+  | {
+      kind: 'agent-ref';
+    }
+  | {
+      kind: 'inline';
+      build: TeammateServiceBuildLaunch;
+    };
+
+export interface CreateTeammateServiceInput {
+  dispatcherId: string;
+  identity: TeamMateIdentity;
+  launch: TeammateServiceLaunch;
+  options?: TeammateServiceOptions;
+  config: DreamuxConfig;
+  agentRuntimeProviders: AgentRuntimeProviderCatalog;
+  identities: TeamMateIdentityStore;
+  turnsStore: TeamMateTurnsStore;
+  worktrees?: WorktreeManager;
+  log: DreamuxLogger;
+  nextSubmissionSeq: () => number;
+  trackSettleCapture: (capture: Promise<void>) => void;
+  routeSettledCompletion: (
+    producerName: string,
+    turnId: string,
+    completion: CompletionEnvelope,
+  ) => Promise<void>;
+}
+
+export function createTeammateService(
+  input: CreateTeammateServiceInput,
+): TeammateService {
+  const deps: TeammateServiceDeps = {
+    config: input.config,
+    agentRuntimeProviders: input.agentRuntimeProviders,
+    identities: input.identities,
+    turnsStore: input.turnsStore,
+    ...(input.worktrees !== undefined ? { worktrees: input.worktrees } : {}),
+    log: input.log,
+    ...(input.launch.kind === 'inline' ? { buildLaunch: input.launch.build } : {}),
+    nextSubmissionSeq: input.nextSubmissionSeq,
+    trackSettleCapture: input.trackSettleCapture,
+    routeSettledCompletion: input.routeSettledCompletion,
+  };
+
+  return new TeammateService(
+    deps,
+    input.dispatcherId,
+    input.identity,
+    input.options,
+  );
+}
+
+export type { RuntimeLaunchSpec };


### PR DESCRIPTION
**Step 1 of 3** toward Dispatcher/Team responsibility symmetry. Targets the
integration branch `teamservice-launch-policy` (#240); the whole series merges to
`next` once, via #240.

## Why

`new TeammateService(...)` was scattered across two sites that each hand-rolled
their own `TeammateServiceDeps`:
- `dispatcher-service/agent.ts` — dispatcher agent, inline `dispatchers[].runtime`
  + `status.json` (via `buildLaunch`).
- `TeammateCollection.entityFor` — members + leader, resolved from `agents[<id>]`.

Two construction paths for the same entity, and the team leader being manufactured
*by the members' collection* is the root of the asymmetry raised in the #240
review.

## What (this step)

Introduce one **independent** factory — `teammate-service/factory.ts`
`createTeammateService(input)` — that owns the only `new TeammateService(...)`.
`TeammateCollection`, `DispatcherService` (via `agent.ts`) both depend on it; it is
owned by no collection (dependency arrow points one way → factory).

The one real difference becomes an explicit, named input — not a divergent path:
`launch` is a discriminated union, `{kind:'inline', build}` (sets `buildLaunch`)
vs `{kind:'agent-ref'}` (omits it → resolve from `agents[]`). The per-caller knobs
(`nextSubmissionSeq` / `trackSettleCapture` / `routeSettledCompletion` /
`worktrees?`) and `options` (`{launchPolicy?, scheduler?}`) pass through unchanged.

**Pure de-duplication, zero behavior change.** No `identity.role` branch.
Ownership/caching untouched — the leader is still built via `createTeamLeader →
entityFor → factory` and still cached in the collection. Moving the leader out of
the collection (so a collection-clear can't touch it) is **step 3**.

## Next steps (this series)

2. Extract the shared *(conversational agent + members collection + scheduler +
   member lifecycle)* host; `TeamService` / `DispatcherService` contain it.
3. Build the leader via the factory directly from `TeamService` (held there, not
   cached in the members' `TeammateCollection`); collection → members-only.

## Review

Two independent heterogeneous reviewers (codex + claude) — both **PASS**, no
findings (field-by-field byte-identical deps; the `inline`/`agent-ref` union
faithfully replaces the old optional `buildLaunch`).

## Verification

- `tsc --noEmit` (src + tests), `eslint` — clean
- `vitest run` (`DREAMUX_SKIP_LIVE_CODEX=1`) — **525 passed | 4 skipped**
- `rush typecheck` / `typecheck:tests` / `lint` / `test` — pass

`none`-type Rush change file (pure refactor).

🤖 Generated with [Claude Code](https://claude.com/claude-code)