### PR TITLE
refactor(service): extract a shared AgentHost (#233, step 2/3)

### DIFF
--- a/common/changes/@excitedjs/dreamux/agent-host-step2_2026-06-25-00-00.json
+++ b/common/changes/@excitedjs/dreamux/agent-host-step2_2026-06-25-00-00.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "type": "none",
+      "packageName": "@excitedjs/dreamux"
+    }
+  ],
+  "packageName": "@excitedjs/dreamux",
+  "email": "053700@gmail.com"
+}

--- a/packages/dreamux/src/service/agent-host/index.ts
+++ b/packages/dreamux/src/service/agent-host/index.ts
@@ -1,0 +1,77 @@
+import type { SchedulerService } from '../scheduler/service.js';
+import {
+  TeammateCollection,
+  type TeammateOps,
+} from '../teammate-collection/index.js';
+import type { TeammateService } from '../teammate-service/index.js';
+
+export interface AgentHostOptions {
+  members: TeammateCollection;
+  agent?: TeammateService;
+  agentDescription: string;
+}
+
+/**
+ * Shared host for a conversational agent plus its owned member collection.
+ * DispatcherService and TeamService keep their domain-specific policy and
+ * records, while this owns the duplicated member/scheduler lifecycle surface.
+ */
+export class AgentHost {
+  private readonly members_: TeammateCollection;
+  private agent_: TeammateService | null;
+  private readonly agentDescription: string;
+
+  constructor(opts: AgentHostOptions) {
+    this.members_ = opts.members;
+    this.agent_ = opts.agent ?? null;
+    this.agentDescription = opts.agentDescription;
+  }
+
+  setAgent(agent: TeammateService): void {
+    this.agent_ = agent;
+  }
+
+  get agent(): TeammateService {
+    return this.mustAgent();
+  }
+
+  mustAgent(): TeammateService {
+    if (this.agent_ === null) {
+      throw new Error(`${this.agentDescription} is not booted`);
+    }
+    return this.agent_;
+  }
+
+  get scheduler(): SchedulerService {
+    const scheduler = this.mustAgent().scheduler;
+    if (scheduler === null) {
+      throw new Error(`${this.agentDescription} has no scheduler capability`);
+    }
+    return scheduler;
+  }
+
+  get teammates(): TeammateOps {
+    return this.members_;
+  }
+
+  get members(): TeammateCollection {
+    return this.members_;
+  }
+
+  async startScheduler(): Promise<void> {
+    await this.mustAgent().startScheduler();
+  }
+
+  stopScheduler(): void {
+    this.mustAgent().stopScheduler();
+  }
+
+  async deleteSchedulerStore(): Promise<void> {
+    await this.mustAgent().deleteSchedulerStore();
+  }
+
+  async stopAll(): Promise<void> {
+    await this.members_.stopAll();
+    await this.mustAgent().stop();
+  }
+}

--- a/packages/dreamux/src/service/dispatcher-service/index.ts
+++ b/packages/dreamux/src/service/dispatcher-service/index.ts
@@ -29,10 +29,10 @@ import { assertRunnableChannelShape } from './runnable-channel.js';
 import { ensureDispatcherWorkspace } from '../dispatcher-workspace.js';
 import { ChannelToolAuthorizationError } from './errors.js';
 import { CompletionRouter, type CompletionInitiator } from '../completion-router/index.js';
+import { AgentHost } from '../agent-host/index.js';
 import { TeammateCollection, type TeammateOps } from '../teammate-collection/index.js';
 import { TeamMateIdentityStore } from '../teammate-collection/identity-store.js';
 import { TeamMateTurnsStore } from '../teammate-collection/turns-store.js';
-import type { TeammateService } from '../teammate-service/index.js';
 import { WorktreeManager } from '../worktree/manager.js';
 import { ChannelBindingStore } from '../channel-binding/store.js';
 import { type TeamMateIdentity } from '../teammate-collection/types.js';
@@ -88,10 +88,9 @@ export class DispatcherService implements TeamChannelContext {
   private readonly channelProviders: ChannelProviderCatalog;
   private readonly log: DreamuxLogger;
   private readonly router: CompletionRouter;
-  private readonly _teammates: TeammateCollection;
+  private readonly host: AgentHost;
   private readonly teams: TeamCollection;
   private readonly channels: ChannelSessions;
-  private readonly agent: TeammateService;
   private restartIntent: RestartIntentConsumer | null = null;
   private starting: Promise<void> | null = null;
   private workspaceCwd: string | null = null;
@@ -135,7 +134,7 @@ export class DispatcherService implements TeamChannelContext {
         : {}),
     });
 
-    this.agent = createDispatcherAgent({
+    const agent = createDispatcherAgent({
       id: opts.id,
       config: opts.config,
       dispatchers: opts.dispatchers,
@@ -151,7 +150,7 @@ export class DispatcherService implements TeamChannelContext {
 
     // A dispatcher-owned teammate is never a team_leader, so it carries no
     // launch policy (the team_leader policy is owned by the team layer).
-    this._teammates = new TeammateCollection({
+    const teammates = new TeammateCollection({
       dispatcherId: opts.id,
       teamScope: null,
       config: opts.config,
@@ -163,6 +162,11 @@ export class DispatcherService implements TeamChannelContext {
       initiatorFor: (producer) => this.initiatorFor(producer),
       isShuttingDown: () => this.shuttingDown,
       log: opts.log,
+    });
+    this.host = new AgentHost({
+      members: teammates,
+      agent,
+      agentDescription: `dispatcher ${JSON.stringify(this.id)} agent`,
     });
 
     // The Team layer owns the team_leader role policy; the dispatcher only lends
@@ -191,13 +195,7 @@ export class DispatcherService implements TeamChannelContext {
   }
 
   get scheduler(): SchedulerService {
-    const scheduler = this.agent.scheduler;
-    if (scheduler === null) {
-      throw new Error(
-        `dispatcher ${JSON.stringify(this.id)} agent has no scheduler capability`,
-      );
-    }
-    return scheduler;
+    return this.host.scheduler;
   }
 
   /**
@@ -208,7 +206,7 @@ export class DispatcherService implements TeamChannelContext {
    * concurrent callers.
    */
   async start(): Promise<void> {
-    if (this.agent.getRuntime() !== null) return;
+    if (this.host.agent.getRuntime() !== null) return;
     if (this.starting !== null) return this.starting;
     const promise = this.doStart().finally(() => {
       this.starting = null;
@@ -249,7 +247,7 @@ export class DispatcherService implements TeamChannelContext {
 
     let runtime: AgentRuntime;
     try {
-      await this.agent.ensureStarted();
+      await this.host.agent.ensureStarted();
       runtime = this.mustRuntime();
     } catch (err) {
       this.channels.clear();
@@ -270,16 +268,16 @@ export class DispatcherService implements TeamChannelContext {
         });
       }
       await this.injectRestartNoticeIfNeeded(id, runtime);
-      await this.agent.startScheduler();
+      await this.host.startScheduler();
       await this.teams.startSchedulers();
     } catch (err) {
-      this.agent.stopScheduler();
+      this.host.stopScheduler();
       this.teams.stopSchedulers();
       // Undo the slot adoption so a failed start never leaves a half-built slot.
       this.channels.clear();
       await closeAllBuilt(channels);
       try {
-        await this.agent.stop();
+        await this.host.agent.stop();
       } catch {
         /* best effort */
       }
@@ -297,11 +295,11 @@ export class DispatcherService implements TeamChannelContext {
   }
 
   async stop(): Promise<void> {
-    this.agent.stopScheduler();
+    this.host.stopScheduler();
     this.teams.stopSchedulers();
     await this.channels.closeAll(this.log);
     try {
-      await this.agent.stop();
+      await this.host.agent.stop();
     } catch (err) {
       this.log.error(
         { dispatcher_id: this.id, err: errInfo(err) },
@@ -311,7 +309,7 @@ export class DispatcherService implements TeamChannelContext {
   }
 
   runtimeStatus(): { status: string | null; threadId: string | null } {
-    const runtime = this.agent.getRuntime();
+    const runtime = this.host.agent.getRuntime();
     return {
       status: runtime?.getStatus() ?? null,
       threadId: runtime?.getThreadId() ?? null,
@@ -323,7 +321,7 @@ export class DispatcherService implements TeamChannelContext {
   }
 
   summary(row: DispatcherRow): DispatcherSummary {
-    const runtime = this.agent.getRuntime();
+    const runtime = this.host.agent.getRuntime();
     return {
       dispatcher_id: row.dispatcher_id,
       channel_identity: row.channel_identity,
@@ -338,14 +336,18 @@ export class DispatcherService implements TeamChannelContext {
    * the traversal-window race: it is set first so any concurrent `spawn`/`send` /
    * team `create`/`send` is rejected before it can lazily start a runtime the
    * sweep would miss. Then every live teammate runtime is stopped, followed by
-   * the dispatcher agent (channel sessions first, then the agent runtime).
+   * the dispatcher agent (channel sessions first, then the agent runtime, via
+   * `stop()`).
    */
   async shutdown(): Promise<void> {
     this.shuttingDown = true;
     // Members now live in per-team collections, so the dispatcher-scope `stopAll`
     // alone would miss them — sweep both (issue #233). Each team's `stopAll`
-    // stops its own members + leader; only materialized teams are swept.
-    await this._teammates.stopAll();
+    // stops its own members + leader; only materialized teams are swept. The
+    // dispatcher agent itself is stopped once, by `stop()` below (after channel
+    // sessions close), so sweep MEMBERS only here — not `host.stopAll()`, which
+    // would stop the agent early and out of order.
+    await this.host.members.stopAll();
     await this.teams.stopAll();
     await this.stop();
   }
@@ -389,13 +391,13 @@ export class DispatcherService implements TeamChannelContext {
     });
   }
 
-  workspace(): Promise<string> { return this._teammates.dispatcherWorkspace(); }
+  workspace(): Promise<string> { return this.host.members.dispatcherWorkspace(); }
 
   /** The dispatcher's own teammates, as the narrow admin-facing op surface
    * (issue #233). The admin layer drives the collection directly through this
    * instead of the dispatcher re-forwarding each verb. */
   get teammates(): TeammateOps {
-    return this._teammates;
+    return this.host.teammates;
   }
 
   /** The single-entity team service for a team id (admin `team_leader` target). */
@@ -461,7 +463,7 @@ export class DispatcherService implements TeamChannelContext {
         return result;
       }
     }
-    const runtime = this.agent.getRuntime();
+    const runtime = this.host.agent.getRuntime();
     if (runtime === null) return { status: 'stopped' };
     return runtime.channelInput(input, hooks);
   }
@@ -480,12 +482,12 @@ export class DispatcherService implements TeamChannelContext {
       const team = await this.teams.get(producer.team_id).catch(() => null);
       // The team's leader is its contained `TeammateService` (issue #233 Phase
       // 4); a member's settled turn delivers to it via `completionInput`.
-      return team?.leader ?? this.agent;
+      return team?.leader ?? this.host.agent;
     }
     // The dispatcher agent itself is the contained `TeammateService` (issue #233
     // Phase 5) — a dispatcher-owned teammate or leader delivers to it via its own
     // `completionInput`, the same unified router path as any other target.
-    return this.agent;
+    return this.host.agent;
   }
 
   async teamLeaderCanUseChannel(input: {
@@ -626,7 +628,7 @@ export class DispatcherService implements TeamChannelContext {
   }
 
   private mustRuntime(): AgentRuntime {
-    const runtime = this.agent.getRuntime();
+    const runtime = this.host.agent.getRuntime();
     if (runtime === null) {
       throw new Error(`dispatcher '${this.id}' agent runtime is not running`);
     }

--- a/packages/dreamux/src/service/team-service/index.ts
+++ b/packages/dreamux/src/service/team-service/index.ts
@@ -49,6 +49,7 @@ import type {
   TeamView,
 } from '../team-collection/types.js';
 import type { WorktreeManager } from '../worktree/manager.js';
+import { AgentHost } from '../agent-host/index.js';
 
 /**
  * The narrow dispatcher seam a {@link TeamService} needs for channel-bound
@@ -114,19 +115,18 @@ export interface TeamServiceCreateOutput {
  */
 export class TeamService {
   private record: TeamRecord | null = null;
-  private leader_: TeammateService | null = null;
   readonly id: string;
   /** The team's OWN members collection (`teamScope: team_id`, issue #233). Held
-   * as the concrete class internally because the lifecycle/factory methods the
+   * by the host as the concrete class internally because the lifecycle/factory methods the
    * team drives (`allocateLeaderName` / `createTeamLeader` / `leader` /
    * `stopAll` / `applyWorktreeCleanup` / workspace-injecting `spawn`) live off
    * `TeammateOps`. The PUBLIC surface stays the narrow admin op set via the
    * `teammates` getter — never re-expose those internal verbs to callers. */
-  private readonly teammateCollection: TeammateCollection;
+  private readonly host: AgentHost;
 
   private constructor(private readonly deps: TeamServiceDeps, teamId: string) {
     this.id = teamId;
-    this.teammateCollection = new TeammateCollection({
+    const members = new TeammateCollection({
       dispatcherId: deps.dispatcherId,
       teamScope: teamId,
       config: deps.config,
@@ -139,6 +139,10 @@ export class TeamService {
       isShuttingDown: deps.isShuttingDown,
       log: deps.log,
     });
+    this.host = new AgentHost({
+      members,
+      agentDescription: `Team ${JSON.stringify(this.id)} leader`,
+    });
   }
 
   static async createNew(
@@ -146,7 +150,7 @@ export class TeamService {
     input: TeamServiceCreateInput,
   ): Promise<TeamServiceCreateOutput> {
     const service = new TeamService(deps, input.teamId);
-    const leaderName = await service.teammateCollection.allocateLeaderName();
+    const leaderName = await service.host.members.allocateLeaderName();
     let team =
       input.existing ??
       (await deps.store.create({
@@ -172,7 +176,7 @@ export class TeamService {
       intent: input.intent,
       leaderName,
     });
-    const { leader, result } = await service.teammateCollection.createTeamLeader(
+    const { leader, result } = await service.host.members.createTeamLeader(
       {
         name: leaderName,
         ...(input.prompt !== undefined ? { prompt: input.prompt } : {}),
@@ -188,10 +192,10 @@ export class TeamService {
         scheduler: service.leaderSchedulerConfig(),
       },
     );
-    service.leader_ = leader;
+    service.host.setAgent(leader);
     team = await deps.store.update(team, { status: 'running' });
     service.record = team;
-    await leader.startScheduler();
+    await service.host.startScheduler();
     return { service, leaderResult: result };
   }
 
@@ -201,29 +205,24 @@ export class TeamService {
   ): Promise<TeamService> {
     const service = new TeamService(deps, record.team_id);
     service.record = record;
-    service.leader_ = await service.teammateCollection.leader(
+    const leader = await service.host.members.leader(
       record.leader_name,
       {
         launchPolicy: service.leaderLaunchPolicy(record.leader_name),
         scheduler: service.leaderSchedulerConfig(),
       },
     );
-    if (record.status !== 'closed') await service.leader_.startScheduler();
+    service.host.setAgent(leader);
+    if (record.status !== 'closed') await service.host.startScheduler();
     return service;
   }
 
   get leader(): TeammateService {
-    return this.mustLeader();
+    return this.host.agent;
   }
 
   get scheduler(): SchedulerService {
-    const scheduler = this.mustLeader().scheduler;
-    if (scheduler === null) {
-      throw new Error(
-        `Team ${JSON.stringify(this.id)} leader has no scheduler capability`,
-      );
-    }
-    return scheduler;
+    return this.host.scheduler;
   }
 
   /** This team's members, as the narrow admin-facing op surface (issue #233):
@@ -231,7 +230,7 @@ export class TeamService {
    * collection. `spawnTeamMate` stays a separate method because it injects the
    * shared workspace — the raw `spawn` is deliberately not on `TeammateOps`. */
   get teammates(): TeammateOps {
-    return this.teammateCollection;
+    return this.host.teammates;
   }
 
   get dispatcherId(): string {
@@ -257,7 +256,7 @@ export class TeamService {
 
   async dissolve(input: TeamDissolveInput): Promise<TeamSummary> {
     requireLifecycleText(input.note, 'Team dissolve note');
-    this.mustLeader().stopScheduler();
+    this.host.stopScheduler();
     const record = this.mustRecord();
     for (const binding of await this.deps.bindings.list(this.dispatcherId)) {
       if (binding.active && binding.team_name === this.id) {
@@ -270,7 +269,7 @@ export class TeamService {
     }
     const members = await this.members();
     for (const member of members) {
-      await this.teammateCollection.close({
+      await this.host.members.close({
         name: member.name,
         note: input.note,
       });
@@ -295,9 +294,9 @@ export class TeamService {
     // (issue #237). They share the one worktree, so the same identity applies.
     await this.leader.applyWorktreeCleanup(cleaned);
     for (const member of members) {
-      await this.teammateCollection.applyWorktreeCleanup(member.name, cleaned);
+      await this.host.members.applyWorktreeCleanup(member.name, cleaned);
     }
-    await this.mustLeader().deleteSchedulerStore();
+    await this.host.deleteSchedulerStore();
     const summary = await this.status();
     // Evict so a later `get` rebuilds from disk and reads `status: closed`.
     this.deps.evict();
@@ -307,8 +306,7 @@ export class TeamService {
   /** Stop this team's live runtimes on server shutdown (issue #233): members in
    * the owned collection, then the leader. Persisted records stay intact. */
   async stopAll(): Promise<void> {
-    await this.teammateCollection.stopAll();
-    await this.leader.stop();
+    await this.host.stopAll();
   }
 
   async bindChannel(
@@ -370,7 +368,7 @@ export class TeamService {
     // the shared workspace (issue #233). This stays a real method — injecting
     // the shared workspace is the team's job — unlike the pure teammate forwards
     // that now go through `.teammates`.
-    return this.teammateCollection.spawn({
+    return this.host.members.spawn({
       ...input,
       sharedWorkspace: this.sharedWorkspace(),
     });
@@ -381,7 +379,7 @@ export class TeamService {
   }
 
   private async members(): Promise<TeamMateRuntimeStatus[]> {
-    return this.teammateCollection.list(); // members-only; leader is `this.leader`
+    return this.host.members.list(); // members-only; leader is `this.leader`
   }
 
   private async activeGroupBinding(): Promise<TeamChannelBindingSummary | null> {
@@ -441,12 +439,6 @@ export class TeamService {
     return this.record;
   }
 
-  private mustLeader(): TeammateService {
-    if (this.leader_ === null) {
-      throw new Error(`Team ${JSON.stringify(this.id)} leader is not booted`);
-    }
-    return this.leader_;
-  }
 }
 
 /** Shared team view helpers (issue #233): used by both {@link TeamService} and


### PR DESCRIPTION
**Step 2 of 3** toward Dispatcher/Team responsibility symmetry. Targets the
integration branch `teamservice-launch-policy` (#240); the series merges to `next`
once, via #240. Builds on step 1 (#244, independent factory).

## Why

`DispatcherService` and `TeamService` already share a shape — a conversational
agent (`TeammateService`) + a members `TeammateCollection` + a scheduler (on the
agent, #243) + member/scheduler lifecycle — but each held and drove it separately.
That asymmetry is what makes the two services look unalike when they shouldn't.

## What (this step)

Extract `AgentHost` (`service/agent-host/index.ts`): holds the conversational
agent + the members collection, and owns the previously-duplicated surface
(`agent`/`mustAgent`, `scheduler`, narrow `teammates: TeammateOps`, concrete
`members`, `startScheduler`/`stopScheduler`/`deleteSchedulerStore`, `stopAll`).
Both services now CONTAIN an `AgentHost`:

- `DispatcherService` = host + `TeamCollection` + `ChannelSessions` + routing
  (agent set at construction).
- `TeamService` = host + record/bindings (`leader_`/`mustLeader()` move into the
  host; the leader is set via `host.setAgent(leader)` in `createNew`/`rebuild`,
  absorbing the nullable-agent pattern).

## Byte-identical behavior

- Dispatcher `shutdown()` sweeps MEMBERS only (`host.members.stopAll()`), agent
  stopped exactly once in `stop()` AFTER channels close — not `host.stopAll()`
  (which would stop the agent early + twice). `TeamService.stopAll()` =
  `host.stopAll()` keeps the old members-then-leader order.
- Scheduler start/stop ordering, `'miss'`/`'submit'`, boot eager-arm without
  starting the leader runtime, and the `dissolve` cron-store delete are unchanged.
- `teammates` stays narrowed to `TeammateOps`; completion-routing instances
  unchanged.

## Scope

Leader construction/caching is UNCHANGED — still built via the collection and
cached there; the host holds the same instance. Removing the leader from the
collection cache is **step 3**.

## Review

Two independent heterogeneous reviewers (codex + claude) — both **PASS**, no
blocking findings (teardown order, scheduler lifecycle, and `mustAgent()` timing
traced clean against pre-change source). One reviewer-independent fix was applied
during self-review: `shutdown()` → `host.members.stopAll()` (not `host.stopAll()`).

## Verification

- `tsc --noEmit` (src + tests), `eslint` — clean
- `vitest run` (`DREAMUX_SKIP_LIVE_CODEX=1`) — **525 passed | 4 skipped**
- files ≤ 700 lines; `none`-type Rush change file (pure refactor)

🤖 Generated with [Claude Code](https://claude.com/claude-code)