### PR TITLE
refactor(scheduler): own the cron scheduler in the container, not the agent (#233)

### DIFF
--- a/common/changes/@excitedjs/dreamux/scheduler-to-container_2026-06-25-00-00.json
+++ b/common/changes/@excitedjs/dreamux/scheduler-to-container_2026-06-25-00-00.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "type": "none",
+      "packageName": "@excitedjs/dreamux"
+    }
+  ],
+  "packageName": "@excitedjs/dreamux",
+  "email": "053700@gmail.com"
+}

--- a/packages/dreamux/src/service/dispatcher-service/agent.ts
+++ b/packages/dreamux/src/service/dispatcher-service/agent.ts
@@ -12,7 +12,6 @@ import {
   type AgentRuntimeProviderCatalog,
 } from '../../agent-runtime/index.js';
 import type { DispatcherConfig, DreamuxConfig } from '../../config/config.js';
-import { dispatcherCronJobsPath } from '../../platform/paths.js';
 import type { DispatcherStore } from '../../state/dispatcher-store.js';
 import {
   completionKey,
@@ -26,7 +25,6 @@ import {
 import type { TeammateService } from '../teammate-service/index.js';
 import type { TeamMateTurnsStore } from '../teammate-collection/turns-store.js';
 import type { TeamMateIdentity } from '../teammate-collection/types.js';
-import { CronJobStore } from '../scheduler/store.js';
 import {
   DREAMUX_DISPATCHER_APPEND_INSTRUCTIONS,
   DREAMUX_DISPATCHER_BASE_INSTRUCTIONS,
@@ -111,16 +109,6 @@ export function createDispatcherAgent(deps: DispatcherAgentDeps): TeammateServic
     dispatcherId: deps.id,
     identity,
     launch: { kind: 'inline', build: () => buildDispatcherLaunch(deps) },
-    options: {
-      scheduler: {
-        ownerId: deps.id,
-        store: new CronJobStore({
-          cronJobsPath: dispatcherCronJobsPath(deps.id),
-          dispatcherId: deps.id,
-        }),
-        absentRuntimeStrategy: 'miss',
-      },
-    },
     config: deps.config,
     agentRuntimeProviders: deps.agentRuntimeProviders,
     identities: deps.identities,

--- a/packages/dreamux/src/service/dispatcher-service/index.ts
+++ b/packages/dreamux/src/service/dispatcher-service/index.ts
@@ -15,7 +15,10 @@ import type { AgentRuntimeProviderCatalog } from '../../agent-runtime/index.js';
 import type { ChannelProviderCatalog } from '../../channel/catalog.js';
 import type { DreamuxConfig } from '../../config/config.js';
 import type { RestartIntentConsumer } from '../../daemon/restart-intent.js';
-import { adminSocketPath as defaultAdminSocketPath } from '../../platform/paths.js';
+import {
+  adminSocketPath as defaultAdminSocketPath,
+  dispatcherCronJobsPath,
+} from '../../platform/paths.js';
 import type {
   DispatcherRow,
   DispatcherStatus,
@@ -38,7 +41,8 @@ import { ChannelBindingStore } from '../channel-binding/store.js';
 import { type TeamMateIdentity } from '../teammate-collection/types.js';
 import { type TeamChannelContext } from '../team-service/index.js';
 import { TeamCollection } from '../team-collection/index.js';
-import type { SchedulerService } from '../scheduler/service.js';
+import { SchedulerService } from '../scheduler/service.js';
+import { CronJobStore } from '../scheduler/store.js';
 import type {
   TeamCreateInput,
   TeamDissolveInput,
@@ -92,6 +96,7 @@ export class DispatcherService implements TeamChannelContext {
   private readonly teams: TeamCollection;
   private readonly channels: ChannelSessions;
   private readonly agent: TeammateService;
+  private readonly scheduler_: SchedulerService;
   private restartIntent: RestartIntentConsumer | null = null;
   private starting: Promise<void> | null = null;
   private workspaceCwd: string | null = null;
@@ -149,6 +154,18 @@ export class DispatcherService implements TeamChannelContext {
       liveChannels: () => this.channels.live(),
     });
 
+    this.scheduler_ = new SchedulerService({
+      ownerId: opts.id,
+      store: new CronJobStore({
+        cronJobsPath: dispatcherCronJobsPath(opts.id),
+        dispatcherId: opts.id,
+      }),
+      absentRuntimeStrategy: 'miss',
+      getRuntime: () => this.agent.getRuntime(),
+      submitScheduled: (input) => this.agent.scheduledInput(input),
+      log: opts.log,
+    });
+
     // A dispatcher-owned teammate is never a team_leader, so it carries no
     // launch policy (the team_leader policy is owned by the team layer).
     this._teammates = new TeammateCollection({
@@ -191,13 +208,7 @@ export class DispatcherService implements TeamChannelContext {
   }
 
   get scheduler(): SchedulerService {
-    const scheduler = this.agent.scheduler;
-    if (scheduler === null) {
-      throw new Error(
-        `dispatcher ${JSON.stringify(this.id)} agent has no scheduler capability`,
-      );
-    }
-    return scheduler;
+    return this.scheduler_;
   }
 
   /**
@@ -270,10 +281,10 @@ export class DispatcherService implements TeamChannelContext {
         });
       }
       await this.injectRestartNoticeIfNeeded(id, runtime);
-      await this.agent.startScheduler();
+      await this.scheduler.start();
       await this.teams.startSchedulers();
     } catch (err) {
-      this.agent.stopScheduler();
+      this.scheduler.stop();
       this.teams.stopSchedulers();
       // Undo the slot adoption so a failed start never leaves a half-built slot.
       this.channels.clear();
@@ -297,7 +308,7 @@ export class DispatcherService implements TeamChannelContext {
   }
 
   async stop(): Promise<void> {
-    this.agent.stopScheduler();
+    this.scheduler.stop();
     this.teams.stopSchedulers();
     await this.channels.closeAll(this.log);
     try {

--- a/packages/dreamux/src/service/team-service/index.ts
+++ b/packages/dreamux/src/service/team-service/index.ts
@@ -18,7 +18,7 @@ import type {
 import type { ChannelBindingStore } from '../channel-binding/store.js';
 import type { ChannelBinding } from '../channel-binding/store.js';
 import { cronMcpServerDescriptor } from '../scheduler/mcp-config.js';
-import type { SchedulerService } from '../scheduler/service.js';
+import { SchedulerService } from '../scheduler/service.js';
 import { CronJobStore } from '../scheduler/store.js';
 import {
   TeammateCollection,
@@ -36,10 +36,7 @@ import {
   type TeamMateRuntimeStatus,
   type TeamMateTurnResult,
 } from '../teammate-collection/types.js';
-import type {
-  TeammateService,
-  TeamMateSchedulerConfig,
-} from '../teammate-service/index.js';
+import type { TeammateService } from '../teammate-service/index.js';
 import type { TeamStore } from '../team-collection/store.js';
 import type {
   TeamChannelBindingSummary,
@@ -123,6 +120,7 @@ export class TeamService {
    * `TeammateOps`. The PUBLIC surface stays the narrow admin op set via the
    * `teammates` getter — never re-expose those internal verbs to callers. */
   private readonly teammateCollection: TeammateCollection;
+  readonly scheduler: SchedulerService;
 
   private constructor(private readonly deps: TeamServiceDeps, teamId: string) {
     this.id = teamId;
@@ -137,6 +135,17 @@ export class TeamService {
       router: deps.router,
       initiatorFor: deps.initiatorFor,
       isShuttingDown: deps.isShuttingDown,
+      log: deps.log,
+    });
+    this.scheduler = new SchedulerService({
+      ownerId: `${deps.dispatcherId}/team/${teamId}`,
+      store: new CronJobStore({
+        cronJobsPath: dispatcherTeamCronJobsPath(deps.dispatcherId, teamId),
+        dispatcherId: deps.dispatcherId,
+      }),
+      absentRuntimeStrategy: 'submit',
+      getRuntime: () => this.leader_?.getRuntime() ?? null,
+      submitScheduled: (input) => this.mustLeader().scheduledInput(input),
       log: deps.log,
     });
   }
@@ -185,13 +194,12 @@ export class TeamService {
       },
       {
         launchPolicy: service.leaderLaunchPolicy(leaderName),
-        scheduler: service.leaderSchedulerConfig(),
       },
     );
     service.leader_ = leader;
     team = await deps.store.update(team, { status: 'running' });
     service.record = team;
-    await leader.startScheduler();
+    await service.scheduler.start();
     return { service, leaderResult: result };
   }
 
@@ -205,25 +213,14 @@ export class TeamService {
       record.leader_name,
       {
         launchPolicy: service.leaderLaunchPolicy(record.leader_name),
-        scheduler: service.leaderSchedulerConfig(),
       },
     );
-    if (record.status !== 'closed') await service.leader_.startScheduler();
+    if (record.status !== 'closed') await service.scheduler.start();
     return service;
   }
 
   get leader(): TeammateService {
     return this.mustLeader();
-  }
-
-  get scheduler(): SchedulerService {
-    const scheduler = this.mustLeader().scheduler;
-    if (scheduler === null) {
-      throw new Error(
-        `Team ${JSON.stringify(this.id)} leader has no scheduler capability`,
-      );
-    }
-    return scheduler;
   }
 
   /** This team's members, as the narrow admin-facing op surface (issue #233):
@@ -257,7 +254,7 @@ export class TeamService {
 
   async dissolve(input: TeamDissolveInput): Promise<TeamSummary> {
     requireLifecycleText(input.note, 'Team dissolve note');
-    this.mustLeader().stopScheduler();
+    this.scheduler.stop();
     const record = this.mustRecord();
     for (const binding of await this.deps.bindings.list(this.dispatcherId)) {
       if (binding.active && binding.team_name === this.id) {
@@ -297,7 +294,7 @@ export class TeamService {
     for (const member of members) {
       await this.teammateCollection.applyWorktreeCleanup(member.name, cleaned);
     }
-    await this.mustLeader().deleteSchedulerStore();
+    await this.scheduler.deleteStoreFile();
     const summary = await this.status();
     // Evict so a later `get` rebuilds from disk and reads `status: closed`.
     this.deps.evict();
@@ -420,17 +417,6 @@ export class TeamService {
         }),
       ],
       disableFeatures: [DISABLE_FEATURE_CRON],
-    };
-  }
-
-  private leaderSchedulerConfig(): TeamMateSchedulerConfig {
-    return {
-      ownerId: `${this.deps.dispatcherId}/team/${this.id}`,
-      store: new CronJobStore({
-        cronJobsPath: dispatcherTeamCronJobsPath(this.deps.dispatcherId, this.id),
-        dispatcherId: this.deps.dispatcherId,
-      }),
-      absentRuntimeStrategy: 'submit',
     };
   }
 

--- a/packages/dreamux/src/service/teammate-service/index.ts
+++ b/packages/dreamux/src/service/teammate-service/index.ts
@@ -31,8 +31,6 @@ import {
 } from '../teammate-collection/read-helpers.js';
 import { TeamMateRuntimeStateStore } from '../teammate-collection/runtime-state.js';
 import { recordSettledTurn, recordSubmittedTurn, toTurnResult } from './turn-recording.js';
-import { SchedulerService } from '../scheduler/service.js';
-import type { CronJobStore } from '../scheduler/store.js';
 import type { TeamMateTurnsStore } from '../teammate-collection/turns-store.js';
 import {
   reprepareDeletedManagedWorktree,
@@ -110,23 +108,12 @@ export interface TeammateServiceDeps {
   ) => Promise<void>;
 }
 
-export interface TeamMateSchedulerConfig {
-  store: CronJobStore;
-  ownerId: string;
-  absentRuntimeStrategy: 'miss' | 'submit';
-}
-
 export interface TeammateServiceOptions {
   /**
    * Role-granted launch additions for THIS entity, fixed at construction. The
    * entity never re-derives this from `identity.role`.
    */
   launchPolicy?: TeamMateLaunchPolicy;
-  /**
-   * Optional scheduler capability for conversational agents only. The caller
-   * owns host paths and strategy; this entity only wires the scheduler to itself.
-   */
-  scheduler?: TeamMateSchedulerConfig;
 }
 
 /**
@@ -144,7 +131,6 @@ export class TeammateService {
   private starting: Promise<void> | null = null;
   private state: TeamMateRuntimeStateStore;
   private readonly launchPolicy: TeamMateLaunchPolicy;
-  private readonly scheduler_: SchedulerService | null;
 
   constructor(
     private readonly deps: TeammateServiceDeps,
@@ -157,15 +143,6 @@ export class TeammateService {
       disableFeatures: [],
     };
     this.state = new TeamMateRuntimeStateStore(deps.identities, identity);
-    this.scheduler_ =
-      options.scheduler === undefined
-        ? null
-        : new SchedulerService({
-            ...options.scheduler,
-            getRuntime: () => this.getRuntime(),
-            submitScheduled: (input) => this.scheduledInput(input),
-            log: deps.log,
-          });
   }
 
   get name(): string {
@@ -178,22 +155,6 @@ export class TeammateService {
 
   getRuntime(): AgentRuntime | null {
     return this.runtime;
-  }
-
-  get scheduler(): SchedulerService | null {
-    return this.scheduler_;
-  }
-
-  async startScheduler(): Promise<void> {
-    await this.scheduler_?.start();
-  }
-
-  stopScheduler(): void {
-    this.scheduler_?.stop();
-  }
-
-  async deleteSchedulerStore(): Promise<void> {
-    await this.scheduler_?.deleteStoreFile();
   }
 
   /**


### PR DESCRIPTION
Targets the integration branch `teamservice-launch-policy` (#240); merges to `next`
once, via #240.

## Why

The earlier scheduler-capability work put the cron `SchedulerService` on
`TeammateService`. That was the wrong owner. `TeammateService` is a generic runtime
entity — team members and dispatcher-owned teammates are `TeammateService` too and
must never have cron. Putting the scheduler there turned "does this entity have
cron?" into a per-instance capability the construction sites had to answer.

Cron is a **conversational-context concern owned by the container**: the cron store
path is container-scoped, the lifecycle (boot eager-arm, dissolve-delete) is
container-driven, and the absent-runtime strategy (`'miss'` vs `'submit'`) is
container-specific.

## What

Move the `SchedulerService` back onto the containers, wired into the conversational
agent via the agent's generic `getRuntime()` / `scheduledInput()` seam:

- `TeammateService` loses its scheduler entirely (field, `scheduler` option,
  `TeamMateSchedulerConfig`, getter, `start`/`stop`/`deleteSchedulerStore`). It keeps
  only the neutral `getRuntime()` / `scheduledInput()` seam.
- `DispatcherService` constructs + owns its scheduler (`'miss'`, dispatcher cron
  path) wired to `this.agent`. `TeamService` constructs + owns its scheduler
  (`'submit'`, team cron path) wired to its `leader_`. `leaderSchedulerConfig` is
  removed; `createTeamLeader`/`leader` now take only `launchPolicy`.

Now **"only the dispatcher and each team leader have cron" is structural** — only
those two container types hold a scheduler — with no per-instance capability policy.
Keeps #244's independent factory and #240's other refactors. (The composition-based
`AgentHost` from the closed #245 is dropped — the Dispatcher/Team symmetry comes
from the shared primitives, not an aggregate wrapper.)

## Byte-identical behavior

- Store paths / ownerIds / strategies unchanged. Boot eager-arms each non-closed
  team scheduler without starting the leader runtime; dissolve stops + deletes the
  team cron store; dispatcher start ordering preserved; `cronTargetFor` unchanged.

## Review

Two independent heterogeneous reviewers (codex + claude) — both **PASS**, no
findings (TeammateService confirmed fully scheduler-free; eager-arm / mustLeader
timing / store-path equivalence traced clean).

## Verification

- `tsc --noEmit` (src + tests), `eslint` — clean
- `vitest run` (`DREAMUX_SKIP_LIVE_CODEX=1`) — **525 passed | 4 skipped**
- `none`-type Rush change file (pure refactor)

🤖 Generated with [Claude Code](https://claude.com/claude-code)