### PR TITLE
refactor(team): build + hold the leader in TeamService, out of the collection (#233)

### DIFF
--- a/.agents/reference/current-architecture.md
+++ b/.agents/reference/current-architecture.md
@@ -131,10 +131,19 @@ required only when the dispatcher has more than one configured channel.
 `meta` is provider-owned selector input, for example `{ "chat_id": "..." }` for
 a Feishu group chat.
 
+Each `TeamService` directly builds and holds its TeamLeader `TeammateService`
+through `/packages/dreamux/src/service/team-service/leader-agent.ts`, using the
+same dispatcher-owned identity store, turns store, worktree manager, and
+completion router that its owning `TeamCollection` injects. The per-team
+`TeammateCollection` is members-only: it spawns and caches team members under
+`team/<team>/teammate/<name>/`, while the TeamLeader lives at the team root and
+is never cached in the collection's entity map.
+
 Key source:
 
 - `/packages/dreamux/src/service/teammate-collection/`
 - `/packages/dreamux/src/service/team-collection/`
+- `/packages/dreamux/src/service/team-service/`
 - `/packages/dreamux/src/service/channel-binding/`
 - `/packages/dreamux/src/mcp/team-mcp.ts`
 

--- a/common/changes/@excitedjs/dreamux/leader-out-of-collection_2026-06-25-00-00.json
+++ b/common/changes/@excitedjs/dreamux/leader-out-of-collection_2026-06-25-00-00.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "type": "none",
+      "packageName": "@excitedjs/dreamux"
+    }
+  ],
+  "packageName": "@excitedjs/dreamux",
+  "email": "053700@gmail.com"
+}

--- a/packages/dreamux/src/service/team-service/index.ts
+++ b/packages/dreamux/src/service/team-service/index.ts
@@ -1,4 +1,5 @@
 import type {
+  CompletionEnvelope,
   AgentRuntimeMcpServer,
   ChannelTarget,
   DreamuxLogger,
@@ -15,6 +16,7 @@ import type {
   CompletionInitiator,
   CompletionRouter,
 } from '../completion-router/index.js';
+import { completionKey } from '../completion-router/index.js';
 import type { ChannelBindingStore } from '../channel-binding/store.js';
 import type { ChannelBinding } from '../channel-binding/store.js';
 import { cronMcpServerDescriptor } from '../scheduler/mcp-config.js';
@@ -36,6 +38,7 @@ import {
   type TeamMateRuntimeStatus,
   type TeamMateTurnResult,
 } from '../teammate-collection/types.js';
+import { allocateConcreteName } from '../teammate-collection/name-allocator.js';
 import type { TeammateService } from '../teammate-service/index.js';
 import type { TeamStore } from '../team-collection/store.js';
 import type {
@@ -46,6 +49,7 @@ import type {
   TeamView,
 } from '../team-collection/types.js';
 import type { WorktreeManager } from '../worktree/manager.js';
+import { createTeamLeaderAgent } from './leader-agent.js';
 
 /**
  * The narrow dispatcher seam a {@link TeamService} needs for channel-bound
@@ -112,13 +116,14 @@ export interface TeamServiceCreateOutput {
 export class TeamService {
   private record: TeamRecord | null = null;
   private leader_: TeammateService | null = null;
+  private leaderSubmissionSeq = 0;
+  private readonly leaderSettleCaptures = new Set<Promise<void>>();
   readonly id: string;
   /** The team's OWN members collection (`teamScope: team_id`, issue #233). Held
-   * as the concrete class internally because the lifecycle/factory methods the
-   * team drives (`allocateLeaderName` / `createTeamLeader` / `leader` /
-   * `stopAll` / `applyWorktreeCleanup` / workspace-injecting `spawn`) live off
-   * `TeammateOps`. The PUBLIC surface stays the narrow admin op set via the
-   * `teammates` getter — never re-expose those internal verbs to callers. */
+   * as the concrete class internally because the lifecycle methods the team
+   * drives (`stopAll` / `applyWorktreeCleanup` / workspace-injecting `spawn`)
+   * live off `TeammateOps`. The PUBLIC surface stays the narrow admin op set via
+   * the `teammates` getter — never re-expose those internal verbs to callers. */
   private readonly teammateCollection: TeammateCollection;
   readonly scheduler: SchedulerService;
 
@@ -155,7 +160,7 @@ export class TeamService {
     input: TeamServiceCreateInput,
   ): Promise<TeamServiceCreateOutput> {
     const service = new TeamService(deps, input.teamId);
-    const leaderName = await service.teammateCollection.allocateLeaderName();
+    const leaderName = await service.allocateLeaderName();
     let team =
       input.existing ??
       (await deps.store.create({
@@ -181,26 +186,43 @@ export class TeamService {
       intent: input.intent,
       leaderName,
     });
-    const { leader, result } = await service.teammateCollection.createTeamLeader(
-      {
-        name: leaderName,
-        ...(input.prompt !== undefined ? { prompt: input.prompt } : {}),
-        agentRuntime: input.leaderAgentRuntime,
-        sourceCwd: input.workspace.sourceCwd,
-        sourceRepo: input.workspace.sourceRepo,
-        runtimeCwd: input.workspace.runtimeCwd,
-        worktree: input.workspace.worktree,
-        intent: input.intent,
-      },
-      {
-        launchPolicy: service.leaderLaunchPolicy(leaderName),
-      },
+    const existingLeader = await deps.identities.get(
+      deps.dispatcherId,
+      leaderName,
+      input.teamId,
     );
+    if (existingLeader !== null) {
+      throw new Error(`TeamLeader ${JSON.stringify(leaderName)} already exists`);
+    }
+    const identity = await deps.identities.create({
+      dispatcherId: deps.dispatcherId,
+      name: leaderName,
+      role: 'team_leader',
+      teamId: input.teamId,
+      agentRuntime: input.leaderAgentRuntime,
+      sourceCwd: input.workspace.sourceCwd,
+      sourceRepo: input.workspace.sourceRepo,
+      cwd: input.workspace.runtimeCwd,
+      runtimeCwd: input.workspace.runtimeCwd,
+      worktree: input.workspace.worktree,
+      intent: input.intent,
+      status: 'starting',
+    });
+    const leader = service.buildLeader(identity);
+    await leader.ensureStarted({ teamId: input.teamId });
+    let turn: TeamMateTurnResult | null = null;
+    if (input.prompt !== undefined) {
+      turn = await leader.submitInitialPrompt(input.prompt, {
+        teamId: input.teamId,
+        turnOrigin: 'dispatcher',
+      });
+      await service.registerLeaderCompletion(leader, turn.turn_id ?? null);
+    }
     service.leader_ = leader;
     team = await deps.store.update(team, { status: 'running' });
     service.record = team;
     await service.scheduler.start();
-    return { service, leaderResult: result };
+    return { service, leaderResult: { teammate: leader.status(), turn } };
   }
 
   static async rebuild(
@@ -209,12 +231,17 @@ export class TeamService {
   ): Promise<TeamService> {
     const service = new TeamService(deps, record.team_id);
     service.record = record;
-    service.leader_ = await service.teammateCollection.leader(
+    const identity = await deps.identities.get(
+      deps.dispatcherId,
       record.leader_name,
-      {
-        launchPolicy: service.leaderLaunchPolicy(record.leader_name),
-      },
+      record.team_id,
     );
+    if (identity === null || identity.role !== 'team_leader') {
+      throw new Error(
+        `TeamLeader ${JSON.stringify(record.leader_name)} does not exist`,
+      );
+    }
+    service.leader_ = service.buildLeader(identity);
     if (record.status !== 'closed') await service.scheduler.start();
     return service;
   }
@@ -272,7 +299,7 @@ export class TeamService {
         note: input.note,
       });
     }
-    await this.leader.close({ note: input.note });
+    await this.stopLeader({ note: input.note });
     // `dissolve` is the single authoritative cleanup site for the Team's shared
     // worktree (issue #236): members and the leader borrow it and skip cleanup on
     // their own `close`, so only this call removes it.
@@ -305,7 +332,7 @@ export class TeamService {
    * the owned collection, then the leader. Persisted records stay intact. */
   async stopAll(): Promise<void> {
     await this.teammateCollection.stopAll();
-    await this.leader.stop();
+    await this.stopLeader();
   }
 
   async bindChannel(
@@ -388,15 +415,24 @@ export class TeamService {
     );
   }
 
+  private async allocateLeaderName(): Promise<string> {
+    const taken = await this.deps.identities.listAllNames(this.deps.dispatcherId);
+    return allocateConcreteName({
+      role: 'team_leader',
+      base: this.id,
+      teamSlug: this.id,
+      exists: (candidate) => taken.has(candidate),
+    });
+  }
+
   /** The team leader's launch policy, owned here because team_leader is a team
    * concept: the leader's MCP servers (its team's teammate MCP + cron MCP + its
    * channel-egress descriptors) plus the native features its runtime disables
    * (cron — it drives Dreamux's cron MCP instead). The team supplies this only
-   * where it structurally builds the leader (`createNew` → `createTeamLeader`,
-   * `rebuild` → `leader`); team members are built with no policy and get none,
-   * so nothing branches on `identity.role` to decide capability. The dispatcher
-   * only injects the primitives (admin socket, channel descriptors); it does not
-   * decide what a team_leader gets. */
+   * where it structurally builds the leader; team members are built with no
+   * policy and get none, so nothing branches on `identity.role` to decide
+   * capability. The dispatcher only injects the primitives (admin socket,
+   * channel descriptors); it does not decide what a team_leader gets. */
   private leaderLaunchPolicy(leaderName: string): TeamMateLaunchPolicy {
     return {
       mcpServers: [
@@ -418,6 +454,64 @@ export class TeamService {
       ],
       disableFeatures: [DISABLE_FEATURE_CRON],
     };
+  }
+
+  private buildLeader(identity: TeamMateIdentity): TeammateService {
+    return createTeamLeaderAgent({
+      dispatcherId: this.deps.dispatcherId,
+      identity,
+      launchPolicy: this.leaderLaunchPolicy(identity.name),
+      config: this.deps.config,
+      agentRuntimeProviders: this.deps.agentRuntimeProviders,
+      identities: this.deps.identities,
+      turnsStore: this.deps.turnsStore,
+      worktrees: this.deps.worktrees,
+      log: this.deps.log,
+      nextSubmissionSeq: () => ++this.leaderSubmissionSeq,
+      trackSettleCapture: (capture) => this.trackLeaderSettleCapture(capture),
+      routeSettledCompletion: (producerName, turnId, completion) =>
+        this.routeLeaderSettledCompletion(producerName, turnId, completion),
+    });
+  }
+
+  private trackLeaderSettleCapture(capture: Promise<void>): void {
+    this.leaderSettleCaptures.add(capture);
+    void capture.finally(() => {
+      this.leaderSettleCaptures.delete(capture);
+    });
+  }
+
+  private async drainLeaderSettleCaptures(): Promise<void> {
+    while (this.leaderSettleCaptures.size > 0) {
+      await Promise.allSettled([...this.leaderSettleCaptures]);
+    }
+  }
+
+  private async stopLeader(input: { note?: string } = {}): Promise<void> {
+    try {
+      if (input.note !== undefined) await this.leader.close({ note: input.note });
+      else await this.leader.stop();
+    } finally {
+      await this.drainLeaderSettleCaptures();
+    }
+  }
+
+  private async registerLeaderCompletion(
+    leader: TeammateService,
+    turnId: string | null,
+  ): Promise<void> {
+    if (turnId === null) return;
+    const initiator = await this.deps.initiatorFor(leader.current());
+    if (initiator === null) return;
+    this.deps.router.register(completionKey(leader.name, turnId), initiator);
+  }
+
+  private async routeLeaderSettledCompletion(
+    producerName: string,
+    turnId: string,
+    completion: CompletionEnvelope,
+  ): Promise<void> {
+    await this.deps.router.settle(completionKey(producerName, turnId), completion);
   }
 
   private mustRecord(): TeamRecord {

--- a/packages/dreamux/src/service/team-service/leader-agent.ts
+++ b/packages/dreamux/src/service/team-service/leader-agent.ts
@@ -1,0 +1,54 @@
+import type { CompletionEnvelope, DreamuxLogger } from '@excitedjs/dreamux-types';
+
+import type { AgentRuntimeProviderCatalog } from '../../agent-runtime/index.js';
+import type { DreamuxConfig } from '../../config/config.js';
+import type { TeamMateIdentityStore } from '../teammate-collection/identity-store.js';
+import type { TeamMateTurnsStore } from '../teammate-collection/turns-store.js';
+import type {
+  TeamMateIdentity,
+  TeamMateLaunchPolicy,
+} from '../teammate-collection/types.js';
+import {
+  createTeammateService,
+} from '../teammate-service/factory.js';
+import type { TeammateService } from '../teammate-service/index.js';
+import type { WorktreeManager } from '../worktree/manager.js';
+
+export interface TeamLeaderAgentDeps {
+  dispatcherId: string;
+  identity: TeamMateIdentity;
+  launchPolicy: TeamMateLaunchPolicy;
+  config: DreamuxConfig;
+  agentRuntimeProviders: AgentRuntimeProviderCatalog;
+  identities: TeamMateIdentityStore;
+  turnsStore: TeamMateTurnsStore;
+  worktrees: WorktreeManager;
+  log: DreamuxLogger;
+  nextSubmissionSeq: () => number;
+  trackSettleCapture: (capture: Promise<void>) => void;
+  routeSettledCompletion: (
+    producerName: string,
+    turnId: string,
+    completion: CompletionEnvelope,
+  ) => Promise<void>;
+}
+
+export function createTeamLeaderAgent(
+  deps: TeamLeaderAgentDeps,
+): TeammateService {
+  return createTeammateService({
+    dispatcherId: deps.dispatcherId,
+    identity: deps.identity,
+    launch: { kind: 'agent-ref' },
+    options: { launchPolicy: deps.launchPolicy },
+    config: deps.config,
+    agentRuntimeProviders: deps.agentRuntimeProviders,
+    identities: deps.identities,
+    turnsStore: deps.turnsStore,
+    worktrees: deps.worktrees,
+    log: deps.log,
+    nextSubmissionSeq: deps.nextSubmissionSeq,
+    trackSettleCapture: deps.trackSettleCapture,
+    routeSettledCompletion: deps.routeSettledCompletion,
+  });
+}

--- a/packages/dreamux/src/service/teammate-collection/index.ts
+++ b/packages/dreamux/src/service/teammate-collection/index.ts
@@ -17,7 +17,6 @@ import {
 import { createTeammateService } from '../teammate-service/factory.js';
 import { TeamMateIdentityStore } from './identity-store.js';
 import {
-  assertInRoster,
   clampHistoryLimit,
   decodeCursor,
   encodeCursor,
@@ -27,10 +26,7 @@ import {
   toStatus,
   validateLastTurns,
 } from './read-helpers.js';
-import type {
-  TeammateService,
-  TeammateServiceOptions,
-} from '../teammate-service/index.js';
+import type { TeammateService } from '../teammate-service/index.js';
 import { TeamMateTurnsStore } from './turns-store.js';
 import { allocateConcreteName, type SuffixGenerator } from './name-allocator.js';
 import {
@@ -47,7 +43,6 @@ import {
   type SpawnTeamMateInput,
   type TeamMateCapabilities,
   type TeamMateCloseResult,
-  type CreateTeamLeaderInput,
   type TeamMateHistoryQuery,
   type TeamMateHistoryResult,
   type TeamMateIdentity,
@@ -57,7 +52,6 @@ import {
   type TeamMateRuntimeStatus,
   type TeamMateSendResult,
   type TeamMateSpawnResult,
-  type TeamMateTurnResult,
   type TeamMateWorktreeIdentity,
 } from './types.js';
 
@@ -67,11 +61,11 @@ export interface TeammateCollectionOptions {
   /**
    * The fixed scope this collection serves (issue #233): `null` = the
    * dispatcher's own teammates (`teammate/<name>/`); a `team_id` = that team's
-   * leader + members (`team/<team>/…`). One `TeammateCollection` per scope; the
-   * scope is baked in, not threaded per call — `spawn` / `send` / `list` /
-   * `status` / `history` / `last` / `close` supply this scope to the (unchanged)
-   * stores and read model. Leader operations (`allocateLeaderName` /
-   * `createTeamLeader` / `leader`) require a non-null scope.
+   * members (`team/<team>/teammate/<name>/`). One `TeammateCollection` per
+   * scope; the scope is baked in, not threaded per call — `spawn` / `send` /
+   * `list` / `status` / `history` / `last` / `close` supply this scope to the
+   * (unchanged) stores and read model. The team leader is owned directly by
+   * `TeamService`.
    */
   teamScope: string | null;
   config: DreamuxConfig;
@@ -130,8 +124,8 @@ export type SpawnTeamMateRequest = SpawnTeamMateInput & {
  * collection without the service re-forwarding each verb. `Omit` hides the
  * scope-internal inputs — `sharedWorkspace` (injected by `TeamService.spawnTeamMate`)
  * and the history `teamId` (the scope is baked into the collection) — and the
- * leader/lifecycle methods (`createTeamLeader` / `allocateLeaderName` / `leader`
- * / `turns` / `stopAll` / `dispatcherWorkspace`) stay off the interface entirely.
+ * lifecycle methods (`turns` / `stopAll` / `dispatcherWorkspace`) stay off the
+ * interface entirely.
  */
 export interface TeammateOps {
   spawn(input: Omit<SpawnTeamMateRequest, 'sharedWorkspace'>): Promise<TeamMateSpawnResult>;
@@ -150,11 +144,11 @@ export interface TeammateOps {
  * (`teamScope: team_id`). The dispatcher-scope collection is owned by
  * `DispatcherService`; each team-scope collection is owned by its `TeamService`.
  * It owns the identity/turns stores, holds the per-dispatcher worktree manager,
- * and caches the per-name `TeammateService` entity, and exposes `spawn` / `get` /
- * `list` / `history` / `close` plus the factory paths (`createTeamLeader`,
- * `allocateLeaderName`). Per-entity domain operations (`send` / `status` / `last`
- * / completion delivery) live on `TeammateService`. Both the dispatcher id and
- * the scope are baked into the collection, not threaded per call.
+ * and caches the per-name member `TeammateService` entity, and exposes `spawn` /
+ * `list` / `history` / `close`. Per-entity domain operations (`send` /
+ * `status` / `last` / completion delivery) live on `TeammateService`. Both the
+ * dispatcher id and the scope are baked into the collection, not threaded per
+ * call.
  */
 export class TeammateCollection implements TeammateOps {
   private readonly dispatcherId: string;
@@ -185,22 +179,6 @@ export class TeammateCollection implements TeammateOps {
 
   turns(): TeamMateTurnsStore {
     return this.turnsStore;
-  }
-
-  async allocateLeaderName(): Promise<string> {
-    const teamId = this.mustTeamScope('allocateLeaderName');
-    return this.allocateName('team_leader', teamId, teamId);
-  }
-
-  /** The team id this collection is scoped to, or throw for a dispatcher-scope
-   * collection (leader ops only exist within a team scope, issue #233). */
-  private mustTeamScope(op: string): string {
-    if (this.teamScope === null) {
-      throw new Error(
-        `${op} requires a team-scoped collection (this collection is dispatcher-scoped)`,
-      );
-    }
-    return this.teamScope;
   }
 
   /**
@@ -377,7 +355,7 @@ export class TeammateCollection implements TeammateOps {
     if (identity === null) {
       throw new Error(`TeamMate ${JSON.stringify(name)} does not exist`);
     }
-    assertInRoster(identity, this.dispatcherId, teamId);
+    this.assertInCollection(identity);
     return identity;
   }
 
@@ -390,86 +368,6 @@ export class TeammateCollection implements TeammateOps {
    */
   private async rosterList(): Promise<TeamMateIdentity[]> {
     return this.identities.list(this.dispatcherId, this.teamScope ?? undefined);
-  }
-
-  /**
-   * Create a team leader as a contained {@link TeammateService} (issue #233
-   * Phase 4): same entity, store, runtime, and turn recording as a regular
-   * teammate, only with `role: 'team_leader'` so it lands at the team root. The
-   * created entity is returned so the {@link TeamService} can hold it directly
-   * (has-a), rather than re-resolving the leader by name on every call.
-   */
-  async createTeamLeader(
-    input: CreateTeamLeaderInput,
-    options: TeammateServiceOptions,
-  ): Promise<{
-    leader: TeammateService;
-    result: Omit<TeamMateSpawnResult, 'turn'> & { turn: TeamMateTurnResult | null };
-  }> {
-    const teamId = this.mustTeamScope('createTeamLeader');
-    const name = validateTeamMateName(input.name);
-    // The leader lives at the team scope root (`team/<team>/identity.json`), so
-    // the existence probe must be team-scoped — a dispatcher-scope `get` would
-    // miss it and re-create a name that #188 forbids reusing (issue #233).
-    const existing = await this.identities.get(this.dispatcherId, name, teamId);
-    if (existing !== null) {
-      throw new Error(`TeamLeader ${JSON.stringify(name)} already exists`);
-    }
-    const identity = await this.identities.create({
-      dispatcherId: this.dispatcherId,
-      name,
-      role: 'team_leader',
-      teamId,
-      agentRuntime: input.agentRuntime,
-      sourceCwd: input.sourceCwd,
-      sourceRepo: input.sourceRepo,
-      cwd: input.runtimeCwd,
-      runtimeCwd: input.runtimeCwd,
-      worktree: input.worktree,
-      intent: input.intent ?? null,
-      status: 'starting',
-    });
-    const entity = this.entityFor(identity, options);
-    await entity.ensureStarted({ teamId });
-    // Only fire a first turn when the dispatcher explicitly supplied a prompt.
-    // A team created without a prompt starts its leader idle — the leader entity
-    // is persisted and recoverable from its record, and its runtime-native
-    // session materializes on start (eager runtimes, e.g. Codex `thread/start`)
-    // or on the first turn (lazy runtimes, e.g. Claude Code) — and waits for a
-    // bound channel or a dispatcher `send` to drive its first real turn. We no
-    // longer fabricate a synthetic default prompt and auto-run a turn at create.
-    let turn: TeamMateTurnResult | null = null;
-    if (input.prompt !== undefined) {
-      // The dispatcher created this leader, so its first turn is `dispatcher`
-      // origin — not the `team_leader` origin a team_id alone would imply.
-      turn = await entity.submitInitialPrompt(input.prompt, {
-        teamId,
-        turnOrigin: 'dispatcher',
-      });
-      // A dispatcher->leader create registers `leaderName:turnId -> dispatcher`.
-      await this.registerCompletion(entity, turn.turn_id ?? null);
-    }
-    return { leader: entity, result: { teammate: entity.status(), turn } };
-  }
-
-  /**
-   * Materialize a team's leader {@link TeammateService} entity by its known name
-   * (issue #233 Phase 4). The leader lives at the team root, so the lookup is
-   * team-scoped; the entity is created from the persisted record on first access
-   * after a restart and cached thereafter. The `TeamService` holds the returned
-   * entity for the team's lifetime.
-   *
-   * The leader's construction options are supplied by the team layer at both
-   * construction sites (here on rebuild, `createTeamLeader` on create), so the
-   * leader's role capabilities travel with its construction and no entity is
-   * ever built by re-inspecting `identity.role` (issue #233).
-   */
-  async leader(
-    leaderName: string,
-    options: TeammateServiceOptions,
-  ): Promise<TeammateService> {
-    this.mustTeamScope('leader');
-    return this.mustEntity(leaderName, options);
   }
 
   getCapabilities(): TeamMateCapabilities {
@@ -528,37 +426,36 @@ export class TeammateCollection implements TeammateOps {
     router.register(completionKey(entity.name, turnId), initiator);
   }
 
-  private async mustEntity(
-    name: string,
-    options: TeammateServiceOptions = {},
-  ): Promise<TeammateService> {
-    const teamId = this.teamScope ?? undefined;
+  private async mustEntity(name: string): Promise<TeammateService> {
     const teammateName = validateTeamMateName(name);
     const existing = this.entities.get(teammateName);
     if (existing !== undefined) {
-      assertInRoster(existing.current(), this.dispatcherId, teamId);
+      this.assertInCollection(existing.current());
       return existing;
     }
     const identity = await this.mustIdentity(teammateName);
-    return this.entityFor(identity, options);
+    return this.entityFor(identity);
+  }
+
+  private assertInCollection(identity: TeamMateIdentity): void {
+    const inCollection =
+      identity.dispatcher_id === this.dispatcherId &&
+      (this.teamScope === null
+        ? identity.team_id === null && identity.role === 'teammate'
+        : identity.team_id === this.teamScope && identity.role === 'team_member');
+    if (inCollection) return;
+    throw new Error(`TeamMate ${JSON.stringify(identity.name)} does not exist`);
   }
 
   /** Build (and cache) the entity for an identity. Options default to empty:
-   * only a team's leader is built with role-granted capabilities, passed in at
-   * its two construction sites (`createTeamLeader` / `leader`). Members and
-   * dispatcher-owned teammates take the empty default — capability is decided by
-   * the construction path, never by re-inspecting `identity.role` (issue #233). */
-  private entityFor(
-    identity: TeamMateIdentity,
-    options: TeammateServiceOptions = {},
-  ): TeammateService {
+   * members and dispatcher-owned teammates get no role policy here. */
+  private entityFor(identity: TeamMateIdentity): TeammateService {
     const existing = this.entities.get(identity.name);
     if (existing !== undefined) return existing;
     const entity = createTeammateService({
       dispatcherId: this.dispatcherId,
       identity,
       launch: { kind: 'agent-ref' },
-      options,
       config: this.opts.config,
       agentRuntimeProviders: this.opts.agentRuntimeProviders,
       identities: this.identities,

--- a/packages/dreamux/tests/teammate-service.test.ts
+++ b/packages/dreamux/tests/teammate-service.test.ts
@@ -17,8 +17,11 @@ import type {
 } from '@excitedjs/dreamux-types';
 
 import type { AgentRuntimeProviderCatalog } from '../src/agent-runtime/index.js';
-import { TeammateCollection } from '../src/service/teammate-collection/index.js';
+import { TeamMateIdentityStore } from '../src/service/teammate-collection/identity-store.js';
+import { TeamMateTurnsStore } from '../src/service/teammate-collection/turns-store.js';
 import type { TeamMateWorktreeIdentity } from '../src/service/teammate-collection/types.js';
+import { createTeamLeaderAgent } from '../src/service/team-service/leader-agent.js';
+import type { TeammateService } from '../src/service/teammate-service/index.js';
 import { WorktreeManager } from '../src/service/worktree/manager.js';
 import { testDispatcherConfig, testDreamuxConfig } from './helpers/config.js';
 
@@ -138,6 +141,61 @@ function reuseCwd(path: string): TeamMateWorktreeIdentity {
   };
 }
 
+async function createTestTeamLeader(input: {
+  dispatcherId: string;
+  teamId: string;
+  name: string;
+  prompt?: string;
+  agentRuntime: string;
+  workspace: string;
+  config: ReturnType<typeof testDreamuxConfig>;
+  agentRuntimeProviders: AgentRuntimeProviderCatalog;
+}): Promise<TeammateService> {
+  const log = noopLog();
+  const identities = new TeamMateIdentityStore({ warn: log.warn.bind(log) });
+  const turnsStore = new TeamMateTurnsStore({ warn: log.warn.bind(log) });
+  const identity = await identities.create({
+    dispatcherId: input.dispatcherId,
+    name: input.name,
+    role: 'team_leader',
+    teamId: input.teamId,
+    agentRuntime: input.agentRuntime,
+    sourceCwd: input.workspace,
+    sourceRepo: null,
+    cwd: input.workspace,
+    runtimeCwd: input.workspace,
+    worktree: reuseCwd(input.workspace),
+    intent: 'lead alpha',
+    status: 'starting',
+  });
+  const leader = createTeamLeaderAgent({
+    dispatcherId: input.dispatcherId,
+    identity,
+    launchPolicy: { mcpServers: [], disableFeatures: [] },
+    config: input.config,
+    agentRuntimeProviders: input.agentRuntimeProviders,
+    identities,
+    turnsStore,
+    worktrees: new WorktreeManager(),
+    log,
+    nextSubmissionSeq: () => 0,
+    trackSettleCapture: () => {
+      /* tests do not emit settle signals */
+    },
+    routeSettledCompletion: async () => {
+      /* no router in this unit helper */
+    },
+  });
+  await leader.ensureStarted({ teamId: input.teamId });
+  if (input.prompt !== undefined) {
+    await leader.submitInitialPrompt(input.prompt, {
+      teamId: input.teamId,
+      turnOrigin: 'dispatcher',
+    });
+  }
+  return leader;
+}
+
 describe('TeammateService channel input routing', () => {
   let root: string;
   let previousHome: string | undefined;
@@ -167,28 +225,16 @@ describe('TeammateService channel input routing', () => {
         runtimeProvider: FAKE_RUNTIME_REF,
       }),
     ]);
-    const collection = new TeammateCollection({
+    const leader = await createTestTeamLeader({
       dispatcherId: 'dispatcher-a',
-      teamScope: 'alpha',
+      teamId: 'alpha',
+      name: 'tl-alpha-0001',
+      prompt: 'initial leader prompt',
+      agentRuntime: 'agent-a',
+      workspace,
       config,
       agentRuntimeProviders: fakeRuntimeCatalog(runtimes),
-      worktrees: new WorktreeManager(),
-      log: noopLog(),
     });
-
-    const { leader } = await collection.createTeamLeader(
-      {
-        name: 'tl-alpha-0001',
-        prompt: 'initial leader prompt',
-        agentRuntime: 'agent-a',
-        sourceCwd: workspace,
-        sourceRepo: null,
-        runtimeCwd: workspace,
-        worktree: reuseCwd(workspace),
-        intent: 'lead alpha',
-      },
-      { launchPolicy: { mcpServers: [], disableFeatures: [] } },
-    );
 
     await expect(
       leader.channelInput({ sourceId: 'message-1', text: 'from bound group' }),
@@ -212,27 +258,15 @@ describe('TeammateService channel input routing', () => {
         runtimeProvider: FAKE_RUNTIME_REF,
       }),
     ]);
-    const collection = new TeammateCollection({
+    const leader = await createTestTeamLeader({
       dispatcherId: 'dispatcher-a',
-      teamScope: 'alpha',
+      teamId: 'alpha',
+      name: 'tl-alpha-0001',
+      agentRuntime: 'agent-a',
+      workspace,
       config,
       agentRuntimeProviders: fakeRuntimeCatalog(runtimes),
-      worktrees: new WorktreeManager(),
-      log: noopLog(),
     });
-
-    const { leader } = await collection.createTeamLeader(
-      {
-        name: 'tl-alpha-0001',
-        agentRuntime: 'agent-a',
-        sourceCwd: workspace,
-        sourceRepo: null,
-        runtimeCwd: workspace,
-        worktree: reuseCwd(workspace),
-        intent: 'lead alpha',
-      },
-      { launchPolicy: { mcpServers: [], disableFeatures: [] } },
-    );
 
     await expect(
       leader.scheduledInput({ jobId: 'job-1', prompt: 'scheduled report' }),
@@ -255,28 +289,16 @@ describe('TeammateService channel input routing', () => {
         runtimeProvider: FAKE_RUNTIME_REF,
       }),
     ]);
-    const collection = new TeammateCollection({
+    const leader = await createTestTeamLeader({
       dispatcherId: 'dispatcher-a',
-      teamScope: 'alpha',
+      teamId: 'alpha',
+      name: 'tl-alpha-0001',
+      prompt: 'initial leader prompt',
+      agentRuntime: 'agent-a',
+      workspace,
       config,
       agentRuntimeProviders: fakeRuntimeCatalog(runtimes),
-      worktrees: new WorktreeManager(),
-      log: noopLog(),
     });
-
-    const { leader } = await collection.createTeamLeader(
-      {
-        name: 'tl-alpha-0001',
-        prompt: 'initial leader prompt',
-        agentRuntime: 'agent-a',
-        sourceCwd: workspace,
-        sourceRepo: null,
-        runtimeCwd: workspace,
-        worktree: reuseCwd(workspace),
-        intent: 'lead alpha',
-      },
-      { launchPolicy: { mcpServers: [], disableFeatures: [] } },
-    );
 
     await expect(
       leader.scheduledInput({ jobId: 'job-1', prompt: 'scheduled report' }),


### PR DESCRIPTION
**Final symmetry step.** Targets the integration branch `teamservice-launch-policy`
(#240); the whole series merges to `next` once, via #240.

## Why

The team leader was still manufactured by, and cached in, the members
`TeammateCollection` (`createTeamLeader`/`leader`), while the dispatcher agent is
built directly by its container (`createDispatcherAgent`). That asymmetry — and the
leader living in a collection cache — is the remaining wart from the #240 review.

## What

`TeamService` now builds + holds its leader DIRECTLY via the independent factory,
exactly as `DispatcherService` builds its agent:

- New `team-service/leader-agent.ts` `createTeamLeaderAgent` (symmetric to
  `createDispatcherAgent`) → `createTeammateService` with an `agent-ref` launch.
- `TeamService.createNew`/`rebuild` build the leader themselves (name via shared
  `allocateConcreteName` + `identities.listAllNames`; `identities.create` role
  `team_leader`; `ensureStarted` on create only — rebuild materializes WITHOUT
  starting the runtime; first-turn `turnOrigin:'dispatcher'` + completion
  registration). Held in `leader_`, never in the collection.
- `TeammateCollection` is members-only: `createTeamLeader`/`leader`/
  `allocateLeaderName` removed; `assertInCollection` excludes `team_leader`.

## The settle-capture drain

The leader is a real settle producer (unlike the dispatcher agent's no-op), so
`TeamService` owns the leader's `nextSubmissionSeq` + `inFlightSettleCaptures` and
DRAINS them on teardown: `stopLeader` stops/closes the leader then drains in a
`finally`; both `stopAll` and `dissolve` go through it, so no in-flight reverse
delivery is abandoned. Shared per-dispatcher router/identity/turns/worktree reused
(no parallel instances); `sourceId` stays name-scoped so the separate leader counter
cannot collide.

## Symmetry, no base class

Dispatcher and Team are now strictly parallel: each container builds its
conversational agent via the factory + holds a members collection + holds a
scheduler. This is symmetry by **parallel structure** — a shared base class was
evaluated by deep research and rejected (it doesn't relieve DispatcherService's size,
is never used polymorphically, can't own the construction, and would re-couple the
`TeamChannelContext` construction-cycle seam).

## Review & verification

Two independent heterogeneous reviewers (codex + claude) — both **PASS**, no findings
(settle-drain + build equivalence + name-allocation + leader-out-of-collection all
traced). `tsc` (src + tests), `eslint`, `vitest` (**525 passed | 4 skipped**).
Updates `.agents/reference/current-architecture.md`; `none`-type Rush change file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)