### PR TITLE
test(arch): core-boundary fitness functions — no parallel runtime tree + semantic neutrality (#2/#6)

### DIFF
--- a/common/changes/@excitedjs/dreamux/core-boundary-fitness_2026-06-27-00-00.json
+++ b/common/changes/@excitedjs/dreamux/core-boundary-fitness_2026-06-27-00-00.json
@@ -1,0 +1,7 @@
+{
+  "changes": [
+    { "comment": "", "type": "none", "packageName": "@excitedjs/dreamux" }
+  ],
+  "packageName": "@excitedjs/dreamux",
+  "email": "053700@gmail.com"
+}

--- a/packages/dreamux/src/service/dispatcher-service/channel-tool-auth.ts
+++ b/packages/dreamux/src/service/dispatcher-service/channel-tool-auth.ts
@@ -46,6 +46,9 @@ export async function authorizeTeamLeaderChannelEgress(
       'TeamLeader channel tools require a resolvable target',
     );
   }
+  // `message_id` is a neutral channel message reference for the egress gate.
+  // Follow-up: pass opaque arguments to the channel seam, like resolveTarget(),
+  // and let the provider extract message_id under a neutral seam contract.
   const messageId = input.arguments['message_id'];
   if (
     typeof messageId === 'string' &&

--- a/packages/dreamux/src/service/team-service/index.ts
+++ b/packages/dreamux/src/service/team-service/index.ts
@@ -539,10 +539,9 @@ export function activeGroupBindingFor(
     (binding) => binding.active && binding.team_name === teamId,
   );
   if (active === undefined) return null;
-  const chatId = active.meta['chat_id'];
   return {
     provider: active.provider,
-    chat_id: typeof chatId === 'string' ? chatId : active.target_key,
+    chat_id: active.target_key,
   };
 }
 

--- a/packages/dreamux/tests/architecture-boundary-gate.test.ts
+++ b/packages/dreamux/tests/architecture-boundary-gate.test.ts
@@ -22,14 +22,34 @@
 
 import { describe, it, expect } from 'vitest';
 import { ESLint } from 'eslint';
-import { dirname, join } from 'node:path';
+import { readdir, readFile } from 'node:fs/promises';
+import { dirname, join, relative } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import ts from 'typescript';
 
 // tests/ -> @excitedjs/dreamux (core) package root.
 const CORE_ROOT = dirname(dirname(fileURLToPath(import.meta.url)));
 // Sibling package roots in the monorepo layout.
 const CODEX_ROOT = join(CORE_ROOT, '..', 'agent-runtime', 'codex');
 const TYPES_ROOT = join(CORE_ROOT, '..', 'dreamux-types');
+const SERVICE_ROOT = join(CORE_ROOT, 'src', 'service');
+const SERVER_FILE = join(CORE_ROOT, 'src', 'server.ts');
+// Provider identity/routing fields that core service/server code must not read:
+// each has a neutral replacement at the core seam. Neutral channel concepts such
+// as message_id are deliberately excluded.
+const PROVIDER_FIELD_NAMES = new Set([
+  'chat_id',
+  'app_id',
+  'sender_id',
+  'union_id',
+  'open_id',
+]);
+
+interface MemberAccessHit {
+  file: string;
+  line: number;
+  text: string;
+}
 
 function lint(
   packageRoot: string,
@@ -42,6 +62,86 @@ function lint(
 
 function ruleIds(results: ESLint.LintResult[]): string[] {
   return results.flatMap((r) => r.messages.map((m) => m.ruleId ?? ''));
+}
+
+function packagePath(file: string): string {
+  return `packages/dreamux/${relative(CORE_ROOT, file).replace(/\\/g, '/')}`;
+}
+
+async function sourceFilesUnder(root: string): Promise<string[]> {
+  const entries = await readdir(root, { withFileTypes: true });
+  const files: string[] = [];
+  for (const entry of entries) {
+    const full = join(root, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...(await sourceFilesUnder(full)));
+    } else if (entry.isFile() && entry.name.endsWith('.ts')) {
+      files.push(full);
+    }
+  }
+  return files.sort();
+}
+
+function stringLiteralText(node: ts.Expression): string | null {
+  if (ts.isStringLiteral(node) || ts.isNoSubstitutionTemplateLiteral(node)) {
+    return node.text;
+  }
+  return null;
+}
+
+function providerFieldMemberAccessHits(
+  file: string,
+  source: string,
+): MemberAccessHit[] {
+  const sourceFile = ts.createSourceFile(
+    file,
+    source,
+    ts.ScriptTarget.Latest,
+    true,
+    ts.ScriptKind.TS,
+  );
+  const hits: MemberAccessHit[] = [];
+
+  function record(node: ts.Node, fieldName: string): void {
+    if (!PROVIDER_FIELD_NAMES.has(fieldName)) return;
+    const { line } = sourceFile.getLineAndCharacterOfPosition(
+      node.getStart(sourceFile),
+    );
+    hits.push({
+      file,
+      line: line + 1,
+      text: node.getText(sourceFile),
+    });
+  }
+
+  function visit(node: ts.Node): void {
+    if (ts.isPropertyAccessExpression(node)) {
+      record(node, node.name.text);
+    } else if (ts.isElementAccessExpression(node)) {
+      const fieldName = stringLiteralText(node.argumentExpression);
+      if (fieldName !== null) record(node, fieldName);
+    }
+    ts.forEachChild(node, visit);
+  }
+
+  visit(sourceFile);
+  return hits;
+}
+
+async function findCoreProviderFieldMemberAccessHits(): Promise<MemberAccessHit[]> {
+  const hits: MemberAccessHit[] = [];
+  for (const file of [...(await sourceFilesUnder(SERVICE_ROOT)), SERVER_FILE]) {
+    hits.push(
+      ...providerFieldMemberAccessHits(file, await readFile(file, 'utf8')),
+    );
+  }
+  return hits;
+}
+
+function formatMemberAccessHits(hits: MemberAccessHit[]): string {
+  return hits
+    .map((hit) => `${packagePath(hit.file)}:${hit.line}: ${hit.text}`)
+    .join('\n');
 }
 
 describe('architecture neutrality lint gate (issue #209)', () => {
@@ -177,5 +277,15 @@ describe('architecture neutrality lint gate (issue #209)', () => {
       ].join('\n'),
     );
     expect(ruleIds(results)).toContain('no-restricted-syntax');
+  });
+
+  it('keeps core service/server code from reading provider-specific fields', async () => {
+    const hits = await findCoreProviderFieldMemberAccessHits();
+    if (hits.length > 0) {
+      throw new Error(
+        'Semantic-neutrality invariant violated: core service/** and server.ts must not read provider identity/routing fields via member access. Use the neutral provider/channel seams and opaque target_key/meta pass-through instead.\n' +
+          `Offending member access:\n${formatMemberAccessHits(hits)}`,
+      );
+    }
   });
 });

--- a/packages/dreamux/tests/architecture-ownership-gate.test.ts
+++ b/packages/dreamux/tests/architecture-ownership-gate.test.ts
@@ -202,6 +202,16 @@ describe('architecture ownership gate (#233)', () => {
     });
   });
 
+  it('keeps core free of a parallel worker/runtime provider tree', async () => {
+    assertNoHits(
+      'T2 runtime-tree invariant violated: dreamux core has one AgentRuntime seam, backed by AgentRuntimeProviderCatalog and ProviderRegistry; do not reintroduce a parallel worker/runtime/provider tree.',
+      await findSourceHits(
+        SRC_ROOT,
+        /\b(?:class|interface|type)\s+(?!(?:AgentRuntimeProvider|AgentRuntimeProviderCatalog)\b)[A-Za-z_$][\w$]*(?:Worker(?:Provider|Runtime|Service|Catalog)|RuntimeProvider(?:Catalog)?|RuntimeService|RuntimeCatalog)\b/,
+      ),
+    );
+  });
+
   it('keeps the team leader out of the members collection', async () => {
     const file = 'teammate-collection/index.ts';
     const source = await readServiceSource(file);


### PR DESCRIPTION
Batch 3a of the post-#110 sustainability backlog (diagnostic **#2 + #6**), into the
`architecture-sustainability` integration branch. Two of the operator's
most-recurrent corrections become gates that go red on violation.

## T2 — no parallel runtime tree
`tests/architecture-ownership-gate.test.ts`: forbids a reintroduced
`*Worker(Provider|Runtime|Service|Catalog)` or a second
`*RuntimeProvider(Catalog)?`/`*RuntimeService`/`*RuntimeCatalog` in `src/**`, exempting
the canonical `AgentRuntimeProvider`/`AgentRuntimeProviderCatalog` seam. The #135/#233
red line: one AgentRuntime seam, no forked worker/runtime tree.

## T6 → T4 — semantic neutrality inside core
`tests/architecture-boundary-gate.test.ts`: a **TypeScript-AST** scan of
`src/service/**` + `src/server.ts` flags member access (`x.chat_id` / `y['chat_id']`)
to provider identity/routing fields `chat_id|app_id|sender_id|union_id|open_id`. AST
(not regex) ⇒ object-literal keys / type fields / imports are not false-flagged.
`message_id` is **deliberately excluded** — it is a neutral cross-provider channel
concept named by the `ChannelSession.messageBelongsToTarget({ target, message_id })`
seam itself, used by channel-layer egress code, with no neutral alternative.

## The gate immediately caught a real leak
`team-service/index.ts` `activeGroupBindingFor` read `active.meta['chat_id']` (the
provider-specific bag) where the neutral `active.target_key` is the right source.
Fixed to `target_key` directly — **behavior-preserving** (same value for a bound group
chat; the old code already fell back to `target_key`); the external `chat_id` result
field name is kept (#209 conversational-neutral selector, used across the
bind/transfer tool surface). This validates the whole exercise: prose had rationalized
the inconsistency away; the executable gate caught it.

## Follow-up (own PR — neutral-seam contract change)
`channel-tool-auth.ts` extracts `message_id` from the raw channel-tool `arguments`
directly; ideally it passes the opaque arguments to the channel seam like
`resolveTarget()` and lets the provider extract it. Noted in-code; not done here (it
touches the neutral ChannelSession contract). An earlier attempt to dodge the gate by
obfuscating `arguments['message_id']` via an `Object.entries` loop was **rejected** as
lexical-bypass glue; the egress logic is unchanged (comment-only).

## Verification
- `tsc --noEmit -p tsconfig.tests.json`, `eslint` — clean
- `vitest run` — **533 passed | 4 skipped** (prior 531 + the 2 new gates)
- two independent heterogeneous reviewers (codex + claude), both PASS, 0 blocking;
  both gates confirmed to bite with no false positives

🤖 Generated with [Claude Code](https://claude.com/claude-code)