### PR TITLE
fix(arch): chat_id is a neutral channel-layer field, not Feishu-specific (correct #251 overreach)

### DIFF
--- a/.agents/decisions/npm-package-split-and-channel-targets.md
+++ b/.agents/decisions/npm-package-split-and-channel-targets.md
@@ -416,34 +416,35 @@ keeps one-way event feeds from inheriting Feishu/Slack chat assumptions.
 
 ## Channel Targets and Binding
 
-`bind_channel` is a core-owned **Team MCP** capability. It writes core binding
-state, but it relies on the selected channel to normalize provider-specific
-selectors:
+`bind_channel` is a core-owned **Team MCP** capability for conversational
+(bindable) channels. It writes core binding state, but it relies on the selected
+channel to normalize its selector into a target:
 
 ```ts
 bind_channel({
   team_name: 'dreamux',
   channel_id: 'feishu',
-  meta: { chat_id: '<provider-local-chat-id>' }
-});
-
-bind_channel({
-  team_name: 'dreamux',
-  channel_id: 'github',
-  meta: { url: 'https://github.com/excitedjs/dreamux/issues/209' }
+  meta: { chat_id: '<group-chat-id>' }
 });
 ```
 
 Core resolves the configured channel by `channel_id`, calls
 `session.resolveTarget(meta)`, rejects `bindable: false`, derives
 `leader_name` from the active Team record, and stores the resolved target. Core
-does not trust a caller-supplied leader identity.
+does not trust a caller-supplied leader identity. Binding is a CAPABILITY, not a
+channel class (a one-way/two-way enum was rejected): a target is bindable when
+its channel's `resolveTarget` yields a stable `target_key`. (Whether one-way
+subscription channels — GitHub/Jira feeds — should ALSO bind through
+`bind_channel`, vs a separate publish/route path, is an OPEN design question;
+either way their replies are out of band, e.g. `gh` CLI, not a channel reply
+tool. See "Bidirectional vs subscription channels".)
 
-The selector `meta` is human/model-facing input. The durable routing key is
-`target_key`, which is provider-owned and opaque to core. A GitHub-style channel
-should normalize selectors such as URLs or `repo + number` into a
-platform-stable key, preferably an immutable platform id. If the channel cannot
-resolve a stable key, it fails loudly rather than storing an ambiguous selector.
+The selector `meta` is human/model-facing input (a chat channel's is
+`{ chat_id }` — a neutral IM-family selector shared by Feishu/Slack/Telegram,
+not a Feishu-specific field). The durable routing key is `target_key`, which is
+provider-owned and opaque to core. A conversational channel normalizes its
+selector into a platform-stable `target_key`, preferably an immutable platform
+id; if it cannot, it fails loudly rather than storing an ambiguous selector.
 
 The binding store remains flat:
 
@@ -459,7 +460,7 @@ The binding store remains flat:
       "display": "optional display name",
       "canonical_url": null,
       "meta": {
-        "chat_id": "provider-local-chat-id",
+        "chat_id": "group-chat-id",
         "chat_type": "group"
       },
       "team_name": "dreamux",
@@ -473,9 +474,12 @@ The binding store remains flat:
 }
 ```
 
-`chat_id` and `chat_type` are provider-specific data and stay inside `meta`.
-They are not core top-level columns. This keeps the store aligned with the
-`bind_channel` selector model and prevents core from re-coupling itself to
+`chat_id` and `chat_type` are neutral conversational-channel target selectors
+(every conversational provider has them — `chat_id` is NOT a Feishu-specific
+field) and stay inside `meta`. They are not core top-level columns because core
+routes by the opaque, target-shape-agnostic `target_key`. This keeps the store
+aligned with the `bind_channel` selector model and prevents core from re-coupling
+itself to
 chat-shaped channels.
 
 The active uniqueness key is `(channel_id, target_key)`. One Team may have
@@ -798,8 +802,9 @@ These guards are epic-wide; they land across the issue #209 slices. Status:
   channel-binding store moved to `version: 2`. Flat rows now key on
   `(channel_id, target_key)` and carry `channel_id`, the provider-owned opaque
   `target_key`, `target_type`, `display`, `canonical_url`, and a `meta` object;
-  the Feishu `chat_id` / `chat_type` selectors moved OUT of core top-level columns
-  INTO `meta`, so the store is channel-neutral. Active uniqueness is
+  the conversational `chat_id` / `chat_type` selectors moved OUT of core top-level
+  columns INTO `meta`, so the store routes by the opaque `target_key` and is
+  channel-neutral. Active uniqueness is
   `(channel_id, target_key)` — one channel target is active for at most one Team,
   and re-binding reassigns it (one row per key, `created_at` preserved). Target
   resolution is provider-owned: the Feishu `ChannelSession.resolveTarget(meta)`
@@ -992,6 +997,6 @@ These guards are epic-wide; they land across the issue #209 slices. Status:
   Feishu with Slack or Telegram, or running several channels at once, requires
   Feishu to exercise the same Channel provider contract.
 - **Keep `chat_id` and `chat_type` as core store columns:** rejected because
-  this re-couples core to chat-shaped channels. Provider-specific chat data
-  belongs in `meta`; core routes by `channel_id`, `target_type`, and
-  `target_key`.
+  this re-couples core to chat-shaped channels. The conversational selectors
+  (`chat_id` / `chat_type` — neutral, not Feishu-specific) belong in `meta`; core
+  routes by `channel_id`, `target_type`, and the opaque `target_key`.

--- a/.agents/decisions/top-level-design.md
+++ b/.agents/decisions/top-level-design.md
@@ -911,8 +911,9 @@ Channel binding is persisted as JSON under
 `state/<dispatcher-id>/team/channel-bindings.json` (issue #209 binding store v2:
 `version: 2`). Flat rows key active bindings on `(channel_id, target_key)` and
 carry `channel_id`, the provider-owned opaque `target_key`, `target_type`,
-`display`, `canonical_url`, a `meta` object (Feishu `chat_id` / `chat_type` live
-here, not as core columns), plus `team_name` / `leader_name` / `active` /
+`display`, `canonical_url`, a `meta` object (the neutral conversational selectors
+`chat_id` / `chat_type` live here, not as core columns), plus `team_name` /
+`leader_name` / `active` /
 timestamps. Active uniqueness is `(channel_id, target_key)` — one target is active
 for at most one Team; re-binding reassigns it. Targets are resolved by the channel
 provider's `resolveTarget(meta)`, run by core at the bind/route edge; the Team

--- a/common/changes/@excitedjs/dreamux/revert-chat-id-overreach_2026-06-27-01-00.json
+++ b/common/changes/@excitedjs/dreamux/revert-chat-id-overreach_2026-06-27-01-00.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "type": "none",
+      "packageName": "@excitedjs/dreamux"
+    }
+  ],
+  "packageName": "@excitedjs/dreamux",
+  "email": "053700@gmail.com"
+}

--- a/packages/dreamux/CLAUDE.md
+++ b/packages/dreamux/CLAUDE.md
@@ -17,7 +17,7 @@ Two settled shape rules govern where code lives:
    unaware of which class implements them. `builtin:codex` / `builtin:claude-code`
    / `builtin:feishu` are providers indistinguishable from npm providers — only
    the ref→package-name resolution differs. Every provider-specific concept
-   (codex thread/home/bin, claude stream, feishu chat_id/app_id) lives in the
+   (codex thread/home/bin, claude stream, feishu app_id) lives in the
    owning **package** (`@excitedjs/agent-runtime-codex`, `-claude-code`,
    `@excitedjs/feishu-channel`), never in core. The packages depend on
    `@excitedjs/dreamux-types` only and never import core. There is no

--- a/packages/dreamux/src/mcp/team-mcp.ts
+++ b/packages/dreamux/src/mcp/team-mcp.ts
@@ -125,7 +125,7 @@ function teamTools(): Array<Record<string, unknown>> {
       team_name: { type: 'string', minLength: 1, maxLength: 64 },
       note: { type: 'string', minLength: 1, maxLength: 2000 },
     }, ['team_name', 'note']),
-    tool('bind_channel', 'Bind a configured channel target to a Team by team_name so inbound from that target routes to the Team\'s TeamLeader (a core-owned Team capability). channel_id selects the configured channel (optional; defaults to the dispatcher\'s sole channel). meta carries the channel\'s provider-specific selector — e.g. { "chat_id": "<group chat id>" } for a chat channel (group chats only; chat_type is inferred). Binding state, routing, and authorization are core-owned.', {
+    tool('bind_channel', 'Bind a configured channel target to a Team by team_name so inbound from that target routes to the Team\'s TeamLeader (a core-owned Team capability). channel_id selects the configured channel (optional; defaults to the dispatcher\'s sole channel). meta carries the channel\'s target selector — e.g. { "chat_id": "<group chat id>" } for a chat channel (group chats only; chat_type is inferred). Binding state, routing, and authorization are core-owned.', {
       team_name: { type: 'string', minLength: 1, maxLength: 64 },
       channel_id: { type: 'string', minLength: 1, maxLength: 64 },
       meta: { type: 'object' },

--- a/packages/dreamux/src/service/channel-binding/store.ts
+++ b/packages/dreamux/src/service/channel-binding/store.ts
@@ -13,9 +13,10 @@ export type ChannelProviderRef = string;
 /**
  * A flat channel-binding row (issue #209 binding store v2). The durable routing
  * key is `(channel_id, target_key)`; `target_key` is provider-owned and opaque
- * to core. Provider-specific selectors (e.g. a chat channel's `chat_id` /
- * `chat_type`) live in `meta`, never as core top-level columns, so the store
- * stays channel-neutral.
+ * to core. The conversational target selectors (e.g. a chat channel's `chat_id` /
+ * `chat_type` — neutral channel concepts, not Feishu-specific) live in `meta`,
+ * never as core top-level columns, so the store routes by the opaque `target_key`
+ * and stays channel-neutral.
  */
 export interface ChannelBinding {
   /** Dispatcher-local channel id (`dispatchers[].channels[].id`). */
@@ -27,7 +28,7 @@ export interface ChannelBinding {
   target_key: string;
   display: string | null;
   canonical_url: string | null;
-  /** Provider-specific selector data (e.g. `{ chat_id, chat_type }`). */
+  /** The channel's target selector(s) (e.g. `{ chat_id, chat_type }`). */
   meta: Record<string, unknown>;
   /** The concrete Team key the target is bound to (issue #199 Slice 4). */
   team_name: string;

--- a/packages/dreamux/src/service/team-service/index.ts
+++ b/packages/dreamux/src/service/team-service/index.ts
@@ -539,9 +539,10 @@ export function activeGroupBindingFor(
     (binding) => binding.active && binding.team_name === teamId,
   );
   if (active === undefined) return null;
+  const chatId = active.meta['chat_id'];
   return {
     provider: active.provider,
-    chat_id: active.target_key,
+    chat_id: typeof chatId === 'string' ? chatId : active.target_key,
   };
 }
 

--- a/packages/dreamux/tests/architecture-boundary-gate.test.ts
+++ b/packages/dreamux/tests/architecture-boundary-gate.test.ts
@@ -34,16 +34,15 @@ const CODEX_ROOT = join(CORE_ROOT, '..', 'agent-runtime', 'codex');
 const TYPES_ROOT = join(CORE_ROOT, '..', 'dreamux-types');
 const SERVICE_ROOT = join(CORE_ROOT, 'src', 'service');
 const SERVER_FILE = join(CORE_ROOT, 'src', 'server.ts');
-// Provider identity/routing fields that core service/server code must not read:
-// each has a neutral replacement at the core seam. Neutral channel concepts such
-// as message_id are deliberately excluded.
-const PROVIDER_FIELD_NAMES = new Set([
-  'chat_id',
-  'app_id',
-  'sender_id',
-  'union_id',
-  'open_id',
-]);
+// Provider-specific identity SCHEMES that core service/server code must not read
+// (Feishu app/user id schemes with no generic-channel meaning). Generic
+// conversational-channel concepts (chat_id, message_id, sender_id) are EXCLUDED:
+// every conversational (IM) channel has them, so naming them in core is not a
+// provider leak. chat_id in particular is a unified channel-layer attribute
+// (Feishu/Slack/Telegram/WeCom all use it), NOT a Feishu-specific field; the
+// binding store keeps it in `meta` only because core routes by the universal
+// opaque `target_key`, which also covers non-chat (subscription) channels.
+const PROVIDER_FIELD_NAMES = new Set(['app_id', 'union_id', 'open_id']);
 
 interface MemberAccessHit {
   file: string;


### PR DESCRIPTION
Corrects an overreach in batch 3a (#251): the semantic-neutrality gate wrongly
classified `chat_id` as a provider-specific field and "fixed" a non-leak in core.

**Settled by the architect:** `chat_id` is a unified **channel-layer** attribute that
every conversational (IM) channel has — Feishu/Slack/Telegram/WeCom all use it — **not
a Feishu-specific field**. It lives in a binding's `meta` only because core routes by
the universal opaque `target_key`, which also covers non-chat (subscription) channels.

## Changes (no product behavior change — the only code edit is a revert)
- **Revert** the unnecessary `team-service` change: `activeGroupBindingFor` reads
  `meta['chat_id']` again (identical to pre-#251 source).
- **Narrow the gate** to genuinely provider-specific Feishu identity SCHEMES
  (`app_id`/`union_id`/`open_id`); `chat_id`, `message_id`, `sender_id` are excluded —
  naming them in core is not a leak.
- **Fix the mischaracterization** everywhere `chat_id` was branded
  provider-specific/Feishu: `channel-binding/store.ts` comment, the `team-mcp`
  `bind_channel` tool description, `packages/dreamux/CLAUDE.md`, and the
  `npm-package-split-and-channel-targets` + `top-level-design` decision docs.
- In the #209 decision doc, drop the misleading `bind_channel({channel_id:'github'})`
  example and mark "should one-way subscription channels also bind through
  `bind_channel`?" as an **OPEN design question** (binding is a capability — a target
  with a resolvable `target_key` — not a channel class; subscription replies are out
  of band, e.g. `gh` CLI). The subscription-channel design is intentionally NOT
  settled here.

## Why this happened (captured in agent memory)
At decision time the agent read conflicting in-code comments (`store.ts`:
"provider-specific selector"; `types.ts`: "neutral selector (#209)") and picked one
without consulting the `.agents/decisions/` record. Lesson: when in-code sources
conflict on a fact, go to the decision record; don't dismiss a decision-citing comment
as a rationalization.

## Verification
- `tsc --noEmit -p tsconfig.tests.json`, `vitest run` — **533 passed | 4 skipped**
- `.agents/scripts/check.sh` — KB OK (links/orphans/topology green)

🤖 Generated with [Claude Code](https://claude.com/claude-code)