### PR TITLE
test(arch): prompt ↔ MCP-registry parity gate for the dispatcher (T5a)

### DIFF
--- a/common/changes/@excitedjs/dreamux/prompt-registry-parity_2026-06-27-02-00.json
+++ b/common/changes/@excitedjs/dreamux/prompt-registry-parity_2026-06-27-02-00.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "type": "none",
+      "packageName": "@excitedjs/dreamux"
+    }
+  ],
+  "packageName": "@excitedjs/dreamux",
+  "email": "053700@gmail.com"
+}

--- a/packages/dreamux/src/mcp/cron-mcp.ts
+++ b/packages/dreamux/src/mcp/cron-mcp.ts
@@ -104,7 +104,7 @@ async function handleRequest(
   }
 }
 
-function cronTools(): Array<Record<string, unknown>> {
+export function cronTools(): Array<Record<string, unknown>> {
   return [
     tool('cron_create', 'Create a durable Dreamux cron job for this agent. cron is a standard 5-field local-time expression (M H DoM Mon DoW); prefer off-:00/:30 minutes for approximate schedules. prompt is the text injected into this dispatcher or TeamLeader agent. recurring defaults to true; use recurring:false for one-shot reminders. dreamux jobs are always persisted and do not auto-expire. tz is resolved and stored. This milestone supports only internal prompt-agent jobs, with no deliver or spawn target.', {
       cron: { type: 'string', minLength: 1, maxLength: 200 },

--- a/packages/dreamux/src/mcp/team-mcp.ts
+++ b/packages/dreamux/src/mcp/team-mcp.ts
@@ -98,7 +98,7 @@ async function handleRequest(
   }
 }
 
-function teamTools(): Array<Record<string, unknown>> {
+export function teamTools(): Array<Record<string, unknown>> {
   return [
     tool('create', 'Create a Team and start its TeamLeader. team_name is the concrete Team key used by all later status/history/dissolve calls. intent is required: it is the durable recovery subject for the Team. repo is optional: omit it to run the TeamLeader and members in a plain shared work directory under the dispatcher workspace (.workspace/work/<team_name>/ — the dispatcher cwd need not be a git repo), or pass { mode: reuse-cwd | managed, path?, base_ref?, branch?, slug?, cleanup? } — managed creates a git worktree. prompt is optional: when supplied it is delivered as the TeamLeader\'s first turn; when omitted the leader starts idle and fires no turn, waiting for a bound channel inbound or a later send to drive its first turn (creation does NOT fabricate a default prompt). To hand a group chat to the Team, bind it after create with the team bind_channel tool.', {
       team_name: { type: 'string', minLength: 1, maxLength: 64 },

--- a/packages/dreamux/src/mcp/teammate-mcp.ts
+++ b/packages/dreamux/src/mcp/teammate-mcp.ts
@@ -132,7 +132,7 @@ function initializeResult(params: unknown): Record<string, unknown> {
   };
 }
 
-function teammateTools(callerKind: TeamMateMcpCallerKind): Array<Record<string, unknown>> {
+export function teammateTools(callerKind: TeamMateMcpCallerKind): Array<Record<string, unknown>> {
   const readTools = [
     tool('history', 'Search this TeamMate set for recovery (closed included). A compact recovery list keyed by concrete name, not a raw event timeline. Returns { items, next_cursor }.', {
       name: { type: 'string', minLength: 1, maxLength: 64 },

--- a/packages/dreamux/tests/prompt-registry-parity.test.ts
+++ b/packages/dreamux/tests/prompt-registry-parity.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it } from 'vitest';
+
+import { cronTools } from '../src/mcp/cron-mcp.js';
+import { teamTools } from '../src/mcp/team-mcp.js';
+import { teammateTools } from '../src/mcp/teammate-mcp.js';
+import {
+  DREAMUX_DISPATCHER_APPEND_INSTRUCTIONS,
+  DREAMUX_DISPATCHER_BASE_INSTRUCTIONS,
+} from '../src/service/dispatcher-service/base-prompt.js';
+import { dispatcherMcpServerDescriptors } from '../src/service/dispatcher-service/mcp-descriptors.js';
+
+interface RegisteredTool {
+  server: string;
+  name: string;
+}
+
+const CRON_KNOWN_DRIFT_EXEMPTION_REASON =
+  'KNOWN DRIFT (T5a), grandfathered: the dispatcher is injected the cron MCP (service/dispatcher-service/mcp-descriptors.ts) but neither the base/append prompt nor the bundled `dispatcher` skill describes scheduling. Documenting the dispatcher scheduling model is a model-facing change tracked as a follow-up; these are exempted so the gate still enforces parity for the teammate/team verbs and bites future drift. REMOVE this exemption once the dispatcher prompt/skill describes cron_*.';
+
+const PROMPT_EXEMPT_TOOLS = new Map<string, string>([
+  // KNOWN DRIFT (T5a), grandfathered: cron is injected into the dispatcher but
+  // scheduling is not yet model-facing in the prompt/skill. Remove when cron_*
+  // is documented.
+  ['cron.cron_create', CRON_KNOWN_DRIFT_EXEMPTION_REASON],
+  ['cron.cron_list', CRON_KNOWN_DRIFT_EXEMPTION_REASON],
+  ['cron.cron_delete', CRON_KNOWN_DRIFT_EXEMPTION_REASON],
+  ['cron.cron_update', CRON_KNOWN_DRIFT_EXEMPTION_REASON],
+  ['cron.cron_run_now', CRON_KNOWN_DRIFT_EXEMPTION_REASON],
+]);
+
+const PROMPT_DECLARED_REMOVED_VERBS = [
+  'resume',
+  'ctx',
+  'history_events',
+] as const;
+
+function registeredDreamuxMcpTools(): RegisteredTool[] {
+  return [
+    ...toolNames('teammate', teammateTools('dispatcher')),
+    ...toolNames('team', teamTools()),
+    ...toolNames('cron', cronTools()),
+  ];
+}
+
+function toolNames(
+  server: string,
+  tools: Array<Record<string, unknown>>,
+): RegisteredTool[] {
+  return tools.map((tool) => {
+    const name = tool['name'];
+    if (typeof name !== 'string' || name === '') {
+      throw new Error(`${server} MCP tool has an invalid name: ${JSON.stringify(name)}`);
+    }
+    return { server, name };
+  });
+}
+
+function promptMentionsTool(name: string): boolean {
+  const pattern = new RegExp(`\\b${escapeRegExp(name)}\\b`);
+  return (
+    pattern.test(DREAMUX_DISPATCHER_BASE_INSTRUCTIONS) ||
+    pattern.test(DREAMUX_DISPATCHER_APPEND_INSTRUCTIONS)
+  );
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function formatTools(tools: RegisteredTool[]): string {
+  return tools.map((tool) => `${tool.server}.${tool.name}`).join('\n');
+}
+
+describe('dispatcher prompt matches registered Dreamux MCP tools', () => {
+  it('keeps dispatcher Dreamux MCP server registration aligned with this gate', () => {
+    const servers = dispatcherMcpServerDescriptors({
+      dispatcherId: 'dispatcher-a',
+      channels: new Map(),
+      adminSocketPath: '/tmp/dreamux-admin.sock',
+    }).map((server) => server.name);
+
+    expect(servers).toEqual(['team', 'teammate', 'cron']);
+  });
+
+  it('names every registered dispatcher Dreamux MCP tool in the model-facing prompt', () => {
+    const missing = registeredDreamuxMcpTools().filter(
+      (tool) => !promptMentionsTool(tool.name) && !PROMPT_EXEMPT_TOOLS.has(`${tool.server}.${tool.name}`),
+    );
+
+    expect(
+      missing,
+      [
+        'Dispatcher prompt/registry parity drift: registered Dreamux MCP tools must be named as whole words in DREAMUX_DISPATCHER_BASE_INSTRUCTIONS or DREAMUX_DISPATCHER_APPEND_INSTRUCTIONS, unless explicitly exempted in PROMPT_EXEMPT_TOOLS with a model-facing documentation reason.',
+        `Missing tool(s):\n${formatTools(missing)}`,
+        `Prompt exemption(s):\n${[...PROMPT_EXEMPT_TOOLS.entries()]
+          .map(([tool, reason]) => `${tool}: ${reason}`)
+          .join('\n')}`,
+      ].join('\n'),
+    ).toEqual([]);
+  });
+
+  it('keeps prompt-declared removed verbs out of the registered dispatcher tools', () => {
+    const registered = new Set(registeredDreamuxMcpTools().map((tool) => tool.name));
+    const reintroduced = PROMPT_DECLARED_REMOVED_VERBS.filter((name) =>
+      registered.has(name),
+    );
+
+    expect(
+      reintroduced,
+      [
+        'Dispatcher prompt removed-verb honesty drift: the prompt declares these verbs removed, so they must not be registered dispatcher Dreamux MCP tools.',
+        `Reintroduced verb(s): ${reintroduced.join(', ')}`,
+      ].join('\n'),
+    ).toEqual([]);
+  });
+});


### PR DESCRIPTION
Batch 3b of the post-#110 sustainability backlog (#4), into the
`architecture-sustainability` integration branch. Turns the dispatcher's model-facing
prompt vs its registered MCP tools into a gate that goes red on drift (theme **T5a** —
self-reinforcing prompt/skill drift).

## The gate (`tests/prompt-registry-parity.test.ts`)
Reads the **authoritative** tool-name registry by importing the shim `*Tools()`
builders (the only non-test change is adding `export` to
`teammate-mcp`/`team-mcp`/`cron-mcp` — behaviour-neutral). Three checks:
1. the dispatcher's dreamux-MCP server set is exactly `team/teammate/cron` (a new
   server forces this gate to be extended);
2. every registered teammate/team/cron tool name appears as a whole word in the
   dispatcher base/append prompt, or is in an explicit `PROMPT_EXEMPT_TOOLS` with a
   reason;
3. the prompt's declared-removed verbs (`resume`/`ctx`/`history_events`) are not
   registered.

## It immediately caught a real drift
The dispatcher is injected the cron MCP, but neither the prompt nor the bundled
`dispatcher` skill describes scheduling. The 5 `cron_*` verbs are **grandfathered**
into `PROMPT_EXEMPT_TOOLS` with a loud KNOWN-DRIFT reason — documenting the dispatcher
scheduling model is a model-facing change tracked as a follow-up. The teammate/team
verbs are enforced with no exemption.

## Review & verification
- Two independent heterogeneous reviewers (codex + claude), both PASS; both gates
  confirmed to bite (fake `tool('frobnicate')` → red; reintroduced removed verb →
  red) with no false positives, and the MCP shims have no import-time side effects.
- `tsc --noEmit -p tsconfig.tests.json`, `vitest run` — **536 passed | 4 skipped**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)