### PR TITLE
test(arch): external-runtime production-parity smoke harness (#228)

### DIFF
--- a/common/changes/@excitedjs/dreamux/external-runtime-parity_2026-06-27-03-00.json
+++ b/common/changes/@excitedjs/dreamux/external-runtime-parity_2026-06-27-03-00.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "type": "none",
+      "packageName": "@excitedjs/dreamux"
+    }
+  ],
+  "packageName": "@excitedjs/dreamux",
+  "email": "053700@gmail.com"
+}

--- a/packages/dreamux/tests/external-runtime-parity.test.ts
+++ b/packages/dreamux/tests/external-runtime-parity.test.ts
@@ -1,0 +1,284 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { chmod, mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import type {
+  ChannelProvider,
+  ChannelSession,
+  DreamuxLogger,
+} from '@excitedjs/dreamux-types';
+
+import { AgentRuntimeProviderCatalog } from '../src/agent-runtime/catalog.js';
+import { loadConfig } from '../src/config/config.js';
+import { createTeammateService } from '../src/service/teammate-service/factory.js';
+import { TeamMateIdentityStore } from '../src/service/teammate-collection/identity-store.js';
+import { TeamMateTurnsStore } from '../src/service/teammate-collection/turns-store.js';
+import type {
+  TeamMateWorktreeIdentity,
+} from '../src/service/teammate-collection/types.js';
+import { WorktreeManager } from '../src/service/worktree/manager.js';
+import type { ExternalChannelProviderFactory } from '../src/channel/external-channel-provider.js';
+import { testConfigFileObject } from './helpers/config.js';
+import { asChannelDescriptor } from './helpers/provider.js';
+import * as externalRuntimeModule from './fixtures/external-runtime-provider.js';
+
+const EXTERNAL_RUNTIME_REF = 'npm:@example/dreamux-runtime#provider';
+const EXTERNAL_CHANNEL_REF = 'npm:@example/dreamux-channel#provider';
+
+function noopLog(): DreamuxLogger {
+  const log = {
+    error: () => undefined,
+    warn: () => undefined,
+    info: () => undefined,
+    debug: () => undefined,
+    trace: () => undefined,
+    child: () => log,
+  };
+  return log as DreamuxLogger;
+}
+
+function reuseCwd(path: string): TeamMateWorktreeIdentity {
+  return {
+    mode: 'reuse-cwd',
+    slug: null,
+    path,
+    branch: null,
+    base_ref: null,
+    cleanup: 'keep',
+    cleanup_state: 'not-managed',
+    cleanup_error: null,
+  };
+}
+
+function externalChannelFactory(): ExternalChannelProviderFactory {
+  return ({ ref, descriptor }) => {
+    const provider: ChannelProvider = {
+      ref,
+      descriptor: asChannelDescriptor(descriptor),
+      readConfig(rawConfig) {
+        return rawConfig;
+      },
+      getIdentity(config) {
+        if (typeof config !== 'object' || config === null) return '';
+        return String((config as Record<string, unknown>)['app_id'] ?? '');
+      },
+      createSession(context) {
+        const session: ChannelSession = {
+          provider: ref,
+          channel_id: context.channel_id,
+          async start() {
+            /* config parse only */
+          },
+          async close() {
+            /* config parse only */
+          },
+          async resolveTarget() {
+            return { target_type: 'group', target_key: 'fixture', bindable: true };
+          },
+        };
+        return session;
+      },
+    };
+    return provider;
+  };
+}
+
+async function writeConfigFile(input: {
+  configDir: string;
+  workspace: string;
+}): Promise<void> {
+  await mkdir(input.configDir, { recursive: true });
+  const configFile = join(input.configDir, 'config.json');
+  await writeFile(
+    configFile,
+    JSON.stringify(
+      testConfigFileObject({
+        agents: [
+          {
+            id: 'external-agent',
+            provider: EXTERNAL_RUNTIME_REF,
+            config: {
+              finalTextPrefix: 'settled-by-generic-loader',
+              model: 'fixture-model',
+            },
+          },
+        ],
+        dispatchers: [
+          {
+            id: 'flow',
+            cwd: input.workspace,
+            agentRuntime: 'external-agent',
+            channelProvider: EXTERNAL_CHANNEL_REF,
+            feishu: { app_id: 'fixture-app', app_secret: 'fixture-secret' },
+          },
+        ],
+      }),
+      null,
+      2,
+    ),
+    { mode: 0o600 },
+  );
+  await chmod(configFile, 0o600);
+}
+
+async function waitFor(predicate: () => boolean, timeoutMs = 2000): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (predicate()) return;
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+  throw new Error('waitFor timed out');
+}
+
+describe('external runtime production parity', () => {
+  let root: string;
+
+  beforeEach(async () => {
+    root = await mkdtemp(join(tmpdir(), 'dreamux-external-runtime-parity-'));
+    externalRuntimeModule.resetExternalRuntimeFixture();
+  });
+
+  afterEach(async () => {
+    await rm(root, { recursive: true, force: true });
+    externalRuntimeModule.resetExternalRuntimeFixture();
+  });
+
+  it('drives a generic-loader provider through the real TeammateService runtime path', async () => {
+    const configDir = join(root, 'config');
+    const workspace = join(root, 'workspace');
+    await mkdir(workspace, { recursive: true });
+    await writeConfigFile({ configDir, workspace });
+
+    const importedRuntimePackages: string[] = [];
+    const importedChannelPackages: string[] = [];
+    const { config, providerRegistry } = await loadConfig({
+      configDir,
+      externalAgentRuntimeModuleImporter: async (packageName) => {
+        importedRuntimePackages.push(packageName);
+        return externalRuntimeModule;
+      },
+      externalChannelModuleImporter: async (packageName) => {
+        importedChannelPackages.push(packageName);
+        return { provider: externalChannelFactory() };
+      },
+    });
+
+    expect(importedRuntimePackages).toEqual(['@example/dreamux-runtime']);
+    expect(importedChannelPackages).toEqual(['@example/dreamux-channel']);
+
+    const agentRuntimeProviders = new AgentRuntimeProviderCatalog({
+      registry: providerRegistry,
+    });
+    expect(agentRuntimeProviders.resolve(EXTERNAL_RUNTIME_REF).ref).toBe(
+      EXTERNAL_RUNTIME_REF,
+    );
+
+    const log = noopLog();
+    const identities = new TeamMateIdentityStore({ warn: log.warn.bind(log) });
+    const turnsStore = new TeamMateTurnsStore({ warn: log.warn.bind(log) });
+    const identity = await identities.create({
+      dispatcherId: 'flow',
+      name: 'external-peer',
+      role: 'teammate',
+      agentRuntime: 'external-agent',
+      sourceCwd: workspace,
+      sourceRepo: null,
+      cwd: workspace,
+      runtimeCwd: workspace,
+      worktree: reuseCwd(workspace),
+      intent: 'prove external runtime parity',
+      status: 'starting',
+    });
+    const settleCaptures: Promise<void>[] = [];
+    const routedCompletions: Array<{
+      producerName: string;
+      turnId: string;
+      result: string;
+    }> = [];
+    let submissionSeq = 0;
+    const teammate = createTeammateService({
+      dispatcherId: 'flow',
+      identity,
+      launch: { kind: 'agent-ref' },
+      config,
+      agentRuntimeProviders,
+      identities,
+      turnsStore,
+      worktrees: new WorktreeManager(),
+      log,
+      nextSubmissionSeq: () => {
+        submissionSeq += 1;
+        return submissionSeq;
+      },
+      trackSettleCapture: (capture) => settleCaptures.push(capture),
+      routeSettledCompletion: async (producerName, turnId, completion) => {
+        routedCompletions.push({
+          producerName,
+          turnId,
+          result: completion.result,
+        });
+      },
+    });
+
+    const sent = await teammate.send({ prompt: 'exercise neutral runtime seam' });
+    expect(sent.turn).toEqual({
+      status: 'submitted',
+      turn_id: 'teammate:external-peer:1',
+    });
+
+    await waitFor(() => settleCaptures.length === 1);
+    await Promise.all(settleCaptures);
+
+    expect(routedCompletions).toEqual([
+      {
+        producerName: 'external-peer',
+        turnId: 'teammate:external-peer:1',
+        result: 'settled-by-generic-loader: exercise neutral runtime seam',
+      },
+    ]);
+
+    const last = await teammate.last(1);
+    expect(last.turns).toMatchObject([
+      {
+        turn_id: 'teammate:external-peer:1',
+        settle_status: 'completed',
+        assistant: 'settled-by-generic-loader: exercise neutral runtime seam',
+      },
+    ]);
+
+    expect(externalRuntimeModule.externalRuntimeObservations).toEqual([
+      expect.objectContaining({
+        providerRef: EXTERNAL_RUNTIME_REF,
+        role: 'teammate',
+        cwd: workspace,
+        config: {
+          finalTextPrefix: 'settled-by-generic-loader',
+          model: 'fixture-model',
+        },
+        mcpServerNames: [],
+        hasTurnSettledHook: true,
+        starts: 1,
+        submittedTexts: ['exercise neutral runtime seam'],
+      }),
+    ]);
+    expect(
+      externalRuntimeModule.externalRuntimeObservations[0]?.disableFeatures,
+    ).toContain('userInterrupt');
+    expect(
+      externalRuntimeModule.externalRuntimeObservations[0]?.skillSourceNames,
+    ).not.toContain('codex');
+
+    await teammate.stop();
+    expect(externalRuntimeModule.externalRuntimeObservations[0]?.stops).toBe(1);
+
+    const fixtureSource = await readFile(
+      join(import.meta.dirname, 'fixtures', 'external-runtime-provider.ts'),
+      'utf8',
+    );
+    expect(fixtureSource.match(/^import\s+(?!type\b)/gm) ?? []).toEqual([]);
+    expect(fixtureSource.match(/^import\s+type\s+[\s\S]*?from\s+['"][^'"]+['"];?/gm)).toEqual([
+      expect.stringContaining("from '@excitedjs/dreamux-types'"),
+    ]);
+  });
+});

--- a/packages/dreamux/tests/fixtures/external-runtime-provider.ts
+++ b/packages/dreamux/tests/fixtures/external-runtime-provider.ts
@@ -1,0 +1,165 @@
+import type {
+  AgentRuntime,
+  AgentRuntimeCapabilities,
+  AgentRuntimeContextSnapshot,
+  AgentRuntimeCreateContext,
+  AgentRuntimeLastResult,
+  AgentRuntimeProviderFactory,
+  AgentRuntimeStatus,
+  AgentRuntimeSystemInput,
+  AgentRuntimeTurnResult,
+  InboundTurnInput,
+} from '@excitedjs/dreamux-types';
+
+interface ExternalParityRuntimeConfig {
+  finalTextPrefix: string;
+  model: string;
+}
+
+export interface ExternalRuntimeObservation {
+  providerRef: string;
+  runtimeId: string;
+  role: string;
+  cwd: string;
+  config: ExternalParityRuntimeConfig;
+  mcpServerNames: string[];
+  disableFeatures: readonly string[];
+  skillSourceNames: string[];
+  injectEnvKeys: string[];
+  hasTurnSettledHook: boolean;
+  starts: number;
+  stops: number;
+  submittedTexts: string[];
+  lastText: string | null;
+}
+
+export const EXTERNAL_PARITY_RUNTIME_CAPABILITIES: AgentRuntimeCapabilities = {
+  resume: { supported: false },
+  steer: { supported: false },
+  events: { kind: 'synthesized' },
+  last: { supported: true },
+  context: { supported: false },
+  systemPrompt: { mode: 'append' },
+  teammateCompletion: [],
+};
+
+export const externalRuntimeObservations: ExternalRuntimeObservation[] = [];
+
+export function resetExternalRuntimeFixture(): void {
+  externalRuntimeObservations.splice(0);
+}
+
+class ExternalParityRuntime implements AgentRuntime {
+  private status: AgentRuntimeStatus = 'declared';
+  private threadId: string | null;
+
+  constructor(
+    readonly providerRef: string,
+    private readonly context: AgentRuntimeCreateContext<ExternalParityRuntimeConfig>,
+    private readonly observation: ExternalRuntimeObservation,
+  ) {
+    this.threadId = context.identity.checkpoint_id ?? null;
+  }
+
+  async start(): Promise<void> {
+    this.status = 'ready';
+    this.observation.starts += 1;
+    this.threadId = `external-thread:${this.context.identity.runtime_id}`;
+    await this.context.state?.setStatus(this.context.identity.runtime_id, 'ready');
+    await this.context.state?.setThreadId(
+      this.context.identity.runtime_id,
+      this.threadId,
+    );
+  }
+
+  async resume(): Promise<void> {
+    await this.start();
+  }
+
+  async stop(): Promise<void> {
+    this.status = 'stopped';
+    this.observation.stops += 1;
+    await this.context.state?.setStatus(this.context.identity.runtime_id, 'stopped');
+  }
+
+  async channelInput(input: InboundTurnInput): Promise<AgentRuntimeTurnResult> {
+    if (this.status !== 'ready') {
+      return { status: 'failed', error: new Error('external runtime is not ready') };
+    }
+    this.observation.submittedTexts.push(input.text);
+    const turnId = input.sourceId;
+    this.observation.lastText =
+      `${this.context.config.finalTextPrefix}: ${input.text}`;
+    await Promise.resolve();
+    this.context.onTurnSettled?.({ turnId, status: 'completed' });
+    return { status: 'submitted', turnId };
+  }
+
+  async systemInput(_notice: AgentRuntimeSystemInput): Promise<AgentRuntimeTurnResult> {
+    return { status: 'skipped' };
+  }
+
+  getStatus(): AgentRuntimeStatus {
+    return this.status;
+  }
+
+  getThreadId(): string | null {
+    return this.threadId;
+  }
+
+  wasThreadResumed(): boolean {
+    return false;
+  }
+
+  async getLast(): Promise<AgentRuntimeLastResult | null> {
+    return { text: this.observation.lastText };
+  }
+
+  async getContext(): Promise<AgentRuntimeContextSnapshot | null> {
+    return null;
+  }
+
+  getCapabilities(): AgentRuntimeCapabilities {
+    return EXTERNAL_PARITY_RUNTIME_CAPABILITIES;
+  }
+}
+
+export const provider: AgentRuntimeProviderFactory<ExternalParityRuntimeConfig> =
+  ({ ref, descriptor }) => ({
+    ref,
+    descriptor,
+    getCapabilities() {
+      return EXTERNAL_PARITY_RUNTIME_CAPABILITIES;
+    },
+    readConfig(rawConfig) {
+      return {
+        finalTextPrefix:
+          typeof rawConfig['finalTextPrefix'] === 'string'
+            ? rawConfig['finalTextPrefix']
+            : 'external-runtime-completed',
+        model: typeof rawConfig['model'] === 'string' ? rawConfig['model'] : 'fake',
+      };
+    },
+    createRuntime(context) {
+      const observation: ExternalRuntimeObservation = {
+        providerRef: ref,
+        runtimeId: context.identity.runtime_id,
+        role: context.role,
+        cwd: context.cwd,
+        config: context.config,
+        mcpServerNames: context.mcpServers.map((server) => server.name),
+        disableFeatures: context.disableFeatures ?? [],
+        skillSourceNames: context.skillSources?.map((source) => source.name) ?? [],
+        injectEnvKeys: Object.keys(context.injectEnv ?? {}).sort(),
+        hasTurnSettledHook: context.onTurnSettled !== undefined,
+        starts: 0,
+        stops: 0,
+        submittedTexts: [],
+        lastText: null,
+      };
+      externalRuntimeObservations.push(observation);
+      return new ExternalParityRuntime(ref, context, observation);
+    },
+  });
+
+export default provider;


### PR DESCRIPTION
Batch 3c of the post-#110 sustainability backlog (#5, theme **T3** — advertised-but-
bypassed seam), into the `architecture-sustainability` integration branch. Closes the
behavioral gap of issue **#228**.

## The gap
`package-boundary-guards.test.ts` already proves built-ins are *constructible* through
the generic loader and that core has no per-runtime adapter tree. What was missing is
the **behavioral** proof: that the real production launcher **drives** a loader-provided
provider through the neutral seam, needing no provider-specific glue in core. (The
per-runtime core adapters are already gone; `host-context.ts` is a single neutral
create-context seam — so parity holds today; this guards it.)

## The smoke
- `tests/fixtures/external-runtime-provider.ts` — a fake external `AgentRuntimeProvider`
  importing ONLY `@excitedjs/dreamux-types` (type-only), reading ONLY neutral
  `AgentRuntimeCreateContext` fields.
- `tests/external-runtime-parity.test.ts` — registers it through the real `loadConfig`
  external-module path → `AgentRuntimeProviderCatalog.resolve` → the real
  `createTeammateService` / `TeammateService.send` runtime path
  (`createRuntime`/`start`/`onTurnSettled`/`stop`), observing a settled completion and
  the neutral context the provider saw. It also asserts the fixture **source** imports
  only `@excitedjs/dreamux-types`.

## Review & verification
- **Bite-checked**: requiring a host-private `coreAdapterOnly` field in `createRuntime`
  turns the smoke red at the real construction seam — a future runtime needing a core
  adapter cannot pass.
- Test + fixture only; no `src/**` change.
- Two independent heterogeneous reviewers (codex + claude), both PASS, 0 blocking; both
  confirmed it drives the real path (not theater), stays neutral, and bites.
- `tsc`, `eslint`, `vitest run` — **537 passed | 4 skipped**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)