### PR TITLE
chore(rush-change): #255 漏项补齐 — dreamux-utils change file + email cleanup

### DIFF
--- a/common/changes/@excitedjs/dreamux-utils/fs-write-atomic-primitive_2026-06-27-06-00.json
+++ b/common/changes/@excitedjs/dreamux-utils/fs-write-atomic-primitive_2026-06-27-06-00.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Add `packages/dreamux-utils/src/fs.ts` with a shared `writeAtomic(dir, filename, data, mode?)` helper (tmpfile + O_CREAT|O_EXCL + rename, default mode 0o600) and re-export it from the package barrel index. Previously this helper lived inside `@excitedjs/feishu-channel` (v3 pairing-code access gate); hoisting it lets downstream packages share the same atomic-write primitive without copying. Future filesystem primitives (safe tmpdir, safe unlink) belong in this module rather than the sibling `os.ts` module (process/signal/directory-enforcement primitives).",
+      "type": "patch",
+      "packageName": "@excitedjs/dreamux-utils"
+    }
+  ],
+  "packageName": "@excitedjs/dreamux-utils",
+  "email": "053700@gmail.com"
+}

--- a/common/changes/@excitedjs/feishu-channel/v3-pairing-code-gate_2026-06-27-05-00.json
+++ b/common/changes/@excitedjs/feishu-channel/v3-pairing-code-gate_2026-06-27-05-00.json
@@ -7,5 +7,5 @@
     }
   ],
   "packageName": "@excitedjs/feishu-channel",
-  "email": "dyzhu@bytedance.com"
+  "email": "053700@gmail.com"
 }

--- a/common/changes/@excitedjs/feishu-transport/transport-boundary-cleanup_2026-06-27-05-00.json
+++ b/common/changes/@excitedjs/feishu-transport/transport-boundary-cleanup_2026-06-27-05-00.json
@@ -7,5 +7,5 @@
     }
   ],
   "packageName": "@excitedjs/feishu-transport",
-  "email": "dyzhu@bytedance.com"
+  "email": "053700@gmail.com"
 }


### PR DESCRIPTION
## 背景

#255 CI head check 挂了两项：

1. **rush change verify** — `@excitedjs/dreamux-utils` 缺 change 文件
   （C1 把 `writeAtomic` 移到了 `packages/dreamux-utils/src/fs.ts` 并从 `index.ts` re-export，
   但我忘记加对应的 rush change）

2. **commit email denylist** — PR head 3 个 commit 用了本地 bytedance 邮箱，
   还把这个邮箱写进了两个 change 文件的 `email:` 字段。

## 本次修复

| 文件 | 改动 |
|---|---|
| `common/changes/@excitedjs/dreamux-utils/fs-write-atomic-primitive_2026-06-27-06-00.json` | **新增**，patch 级别 bump，comment 说明 fs.ts + re-export |
| `common/changes/@excitedjs/feishu-channel/v3-pairing-code-gate_2026-06-27-05-00.json` | `email:` 从 bytedance 邮箱 → `053700@gmail.com` |
| `common/changes/@excitedjs/feishu-transport/transport-boundary-cleanup_2026-06-27-05-00.json` | `email:` 同上 |

## 验证

- `grep -r "bytedance\|byted\.org" common/changes/@excitedjs/` = 0 命中
- 三个 change 文件 JSON parse 全部通过
- 本 commit author email = `YourWildDad@users.noreply.github.com`（CI denylist 干净）
- gitleaks pre-commit hook = 0 leak

## 对 next 分支质量的影响回顾（#255 合并后确认）

- squash merge 后 GitHub 把最终 commit 重写成 `YourWildDad` 的公开邮箱，next 分支实际 clean
- beta.86 prerelease publish 已成功，unpkg 验证 `@excitedjs/dreamux-utils@0.2.0-beta.86` 包含 `dist/fs.js` 和 index 第三行 `export * from './fs.js'`
- rush build 两个平台 / rush test / gitleaks / KB check.sh 全绿

## 合并要求

**请等 CI 全绿再合**。上次 #255 就是跳过了这步导致挂点未被提前发现，这次不重犯。
