### PR TITLE
feat(git-hooks): pre-commit 新增 author-identity gate（对齐 CI DENYLIST，本地 100ms 拒绝红线邮箱）

### DIFF
--- a/common/changes/@excitedjs/dreamux/precommit-author-email-gate_2026-06-27-09-00.json
+++ b/common/changes/@excitedjs/dreamux/precommit-author-email-gate_2026-06-27-09-00.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Add a third gate (author-identity) to the Rush-managed pre-commit hook at common/git-hooks/pre-commit. The new gate mirrors the `commit-metadata` CI job semantics: it requires a well-formed non-local author email, allows *@users.noreply.github.com, and (optionally) rejects any email matching the operator-owned AUTHOR_EMAIL_DENYLIST_REGEX env var. Shortens the feedback loop for author-email misconfigurations from ~5 minutes (CI) to ~100 ms (pre-commit). Semantics deliberately match .github/workflows/ci.yml so local and CI agree on what a valid author identity is. No published package surface changes.",
+      "type": "none",
+      "packageName": "@excitedjs/dreamux"
+    }
+  ],
+  "packageName": "@excitedjs/dreamux",
+  "email": "053700@gmail.com"
+}

--- a/common/git-hooks/pre-commit
+++ b/common/git-hooks/pre-commit
@@ -1,11 +1,15 @@
 #!/bin/sh
-# Local pre-commit pre-flight. Two fast gates that shorten the feedback loop
+# Local pre-commit pre-flight. Three fast gates that shorten the feedback loop
 # before CI:
 #
 #   1. staged-eslint — lint staged package TypeScript against each package's
 #      ESLint flat config. This enforces the source max-lines cap, the issue #85
 #      n/no-sync ban, import / syntax backstops, and package-specific guards.
-#   2. anti-leak — scan the *staged* changes with gitleaks. dreamux is a PUBLIC
+#   2. author-identity — verify the commit author email is well-formed, is not
+#      a machine-local identity, and (optionally) is not on a private denylist.
+#      Mirrors the `commit-metadata` job in `.github/workflows/ci.yml` so a bad
+#      author email fails in <100 ms locally instead of minutes later in CI.
+#   3. anti-leak — scan the *staged* changes with gitleaks. dreamux is a PUBLIC
 #      repo: company-internal content (Feishu ids, tokens, private-mirror
 #      registry URLs, secrets) must never be committed.
 #
@@ -18,6 +22,14 @@
 # Rush installs this script into .git/hooks on `rush install` / `rush update`.
 # If your hooks aren't wired up yet, point git at this directory manually:
 #   git config core.hooksPath common/git-hooks
+#
+# The optional denylist in gate (2) mirrors the CI-side repository variable:
+#   AUTHOR_EMAIL_DENYLIST_REGEX
+# Set it as an (extended, case-insensitive) regex — matching author emails are
+# rejected. Example (bash):
+#   export AUTHOR_EMAIL_DENYLIST_REGEX='@([a-z0-9-]+\.)*(example\.com|example\.org)$'
+# Keep the regex out of committed files: this is a public repo and the denylist
+# is operator-owned configuration.
 
 repo_root=$(git rev-parse --show-toplevel)
 
@@ -78,7 +90,54 @@ if [ -n "$staged_ts" ]; then
   fi
 fi
 
-# --- 2. anti-leak gate -------------------------------------------------------
+# --- 2. author-identity gate ------------------------------------------------
+# Rejects malformed and machine-local author emails, plus any email matching
+# the optional AUTHOR_EMAIL_DENYLIST_REGEX. Semantics are intentionally
+# identical to the `commit-metadata` / "Check commit author emails" step in
+# .github/workflows/ci.yml so a local commit aborts with the same reason CI
+# would have failed 5+ minutes later.
+#
+# Prefer the GIT_AUTHOR_EMAIL env var set by `git commit -c --author` etc.,
+# then fall back to the resolved git config value (covers the common path of
+# `user.email` in repo / global / system config order).
+author_email="${GIT_AUTHOR_EMAIL:-$(git config user.email || true)}"
+
+if [ -z "$author_email" ]; then
+  echo "[author-identity] author email is not set." >&2
+  echo "[author-identity] Run: git config user.email <your-github-email>" >&2
+  exit 1
+fi
+
+case "$author_email" in
+  *@users.noreply.github.com)
+    # Always allow GitHub privacy emails — guaranteed public-repo-safe.
+    ;;
+  *@localhost|*@*.local|*@local)
+    echo "[author-identity] author email is a machine-local identity: $author_email" >&2
+    echo "[author-identity] Set a real email via: git config user.email <your-github-email>" >&2
+    exit 1
+    ;;
+  *@*)
+    # Well-formed address with a domain — fall through to optional denylist.
+    ;;
+  *)
+    echo "[author-identity] author email is invalid (no @-domain): $author_email" >&2
+    echo "[author-identity] Set a real email via: git config user.email <your-github-email>" >&2
+    exit 1
+    ;;
+esac
+
+# Optional private denylist (env var, never committed). Matches the CI-side
+# repository variable name so operators can set-and-forget across both.
+if [ -n "${AUTHOR_EMAIL_DENYLIST_REGEX:-}" ]; then
+  if printf '%s' "$author_email" | grep -qiE "$AUTHOR_EMAIL_DENYLIST_REGEX"; then
+    echo "[author-identity] author email matches AUTHOR_EMAIL_DENYLIST_REGEX: $author_email" >&2
+    echo "[author-identity] Fix with: git config user.email <allowed-github-email>" >&2
+    exit 1
+  fi
+fi
+
+# --- 3. anti-leak gate -------------------------------------------------------
 if ! command -v gitleaks >/dev/null 2>&1; then
   echo "[anti-leak] gitleaks not installed — skipping local scan; CI will enforce." >&2
   echo "[anti-leak] install: https://github.com/gitleaks/gitleaks#installing" >&2


### PR DESCRIPTION
## 背景

#255 的 PR head 有 3 个 commit 用了本地 bytedance 邮箱命中 CI DENYLIST，最终由 GitHub squash 重写为公开邮箱才干净。用户要求：把 CI 的邮箱检查下沉到 pre-commit hook，让错误在 <100ms 内就本地暴露，而不是 5 分钟后在 CI。

## 实现

在 Rush 原生的 `common/git-hooks/pre-commit`（由 `rush install` / `rush update` 安装）中新增 **第 3 个 gate: `author-identity`**。语义与 `.github/workflows/ci.yml` 的 `commit-metadata` job **严格对齐**：

### Gate 行为

| 邮箱 | 结果 |
|---|---|
| `*@users.noreply.github.com` | ✅ 放行（GitHub 隐私邮箱） |
| `*@localhost` / `*@*.local` / `*@local` | ❌ 拒绝（本地机器邮箱） |
| 无 `@`（畸形） | ❌ 拒绝 |
| 未设置（GIT_AUTHOR_EMAIL + git config user.email 均为空）| ❌ 拒绝 |
| 其他含 `@` 的正常邮箱 | 通过 → 进入可选 DENYLIST |
| 匹配 `AUTHOR_EMAIL_DENYLIST_REGEX` 环境变量 | ❌ 拒绝（可选，未设置时跳过） |

### DENYLIST 对齐 CI

DENYLIST 正则 **不在仓库内 hardcode**（遵守 public repo 红线，不泄露内部域名），而是通过环境变量 `AUTHOR_EMAIL_DENYLIST_REGEX` 注入，与 CI 的 `vars.AUTHOR_EMAIL_DENYLIST_REGEX` **同名同语义**（`grep -qiE`），operator 只需设置一次即可同时覆盖本地 + CI 两条路径。

## 测试矩阵

在临时隔离 git repo（空 TS staging area，无 gitleaks 安装）中跑整段 hook，共 10 场景全部通过：

| # | Scenario | GIT_AUTHOR_EMAIL | DENYLIST env | Expected | Actual |
|---|---|---|---|---|---|
| T1 | GitHub noreply 放行 | `foo@users.noreply.github.com` | (unset) | exit 0 | ✅ 0 |
| T2 | gmail 放行 | `053700@gmail.com` | (unset) | exit 0 | ✅ 0 |
| T3 | 完全未设 email（fallback 仍空） | (unset) | (unset) | exit 1 | ✅ 1 |
| T4 | `@localhost` 拒绝 | `me@localhost` | (unset) | exit 1 | ✅ 1 |
| T5 | 畸形无 @ 拒绝 | `bad-no-at` | (unset) | exit 1 | ✅ 1 |
| T6 | DENYLIST 根域名匹配 | `dyzhu@bytedance.com` | 设置 | exit 1 | ✅ 1 |
| T7 | DENYLIST 不匹配放行 | `053700@gmail.com` | 设置 | exit 0 | ✅ 0 |
| T8 | DENYLIST 子域名匹配 | `foo@bar.byted.org` | 设置 | exit 1 | ✅ 1 |
| T9 | `@foo.local` 拒绝 | `me@foo.local` | (unset) | exit 1 | ✅ 1 |
| T10 | `@build.local` 拒绝 | `me@build.local` | (unset) | exit 1 | ✅ 1 |

### 静态校验
- `shellcheck -s sh` → **0 errors**
- `bash -n` → syntax OK
- `gitleaks protect --staged` → **no leaks**
- change 文件 JSON parse OK
- diff grep 关键字 bytedance / byted.org → **0 命中**（DENYLIST 走 env，无 hardcoded 红线）

## 合并要求

**等 CI 8/8 全绿再合。**
