### PR TITLE
feat(ci): add promote-next.yml — fast-forward promote next → main with topo guard

### DIFF
--- a/.github/workflows/promote-next.yml
+++ b/.github/workflows/promote-next.yml
@@ -1,0 +1,137 @@
+# Promote `next` into `main` with a strict fast-forward-only merge.
+#
+# This workflow is the operator-controlled gate between the prerelease
+# (beta) channel and the stable (latest) channel. It is deliberately
+# manual-only: the operator decides when a beta that has lived on `next`
+# for long enough is stable enough to ship as the default `latest` npm
+# dist-tag. No automatic trigger, no schedule, no PR merge button can
+# invoke it.
+#
+# Behavior:
+#   1. Fetch both main and next at full depth.
+#   2. Fail hard if `main` is NOT a direct ancestor of `next`. A
+#      non-linear topology (e.g. a hotfix landed directly on main)
+#      means the operator must first reconcile it before promoting;
+#      silently producing a merge commit here would break the
+#      invariant that main is a strict prefix of next.
+#   3. `git checkout main && git merge --ff-only origin/next`.
+#      Fast-forward-only is the ONLY allowed merge shape. Squash,
+#      rebase, and true merge commits all rewrite commit metadata on
+#      main and would drop the link between a beta.<run_number> publish
+#      and the exact commit that shipped as stable.
+#   4. Push the fast-forwarded main back to origin.
+#   5. release.yml (`on.push.branches: [main, next]`) catches the push
+#      and runs the stable version + publish pipeline. The two
+#      workflows are therefore coupled purely by git topology, not by
+#      workflow_dispatch cross-calls — simpler and auditable.
+#
+# Permissions:
+#   contents:write  — push the fast-forwarded main back.
+#   Using the workflow GITHUB_TOKEN (not a PAT) keeps this workflow
+#   self-contained. The main branch protection must allow the
+#   `github-actions[bot]` identity to bypass or satisfy push rules,
+#   exactly as the release.yml version job already requires.
+#
+# Operator usage:
+#   Actions → promote-next → Run workflow → Run (no inputs).
+#   The workflow is safe to re-run: if next has not moved since the
+#   last promote, step 3 is a no-op (already up to date → 0 exit).
+
+name: promote-next
+
+on:
+  workflow_dispatch:
+
+concurrency:
+  group: promote-next
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+
+jobs:
+  promote:
+    name: fast-forward main to next
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0   # topology check + ff merge need the full graph
+          ref: main
+
+      - name: ensure local refs exist for both branches
+        run: |
+          set -euo pipefail
+          git show-ref --verify --quiet refs/remotes/origin/main || {
+            echo "::error::origin/main ref missing; aborting."
+            exit 1
+          }
+          git show-ref --verify --quiet refs/remotes/origin/next || {
+            echo "::error::origin/next ref missing; aborting."
+            exit 1
+          }
+
+      - name: topology guard — main MUST be a direct ancestor of next
+        id: topo
+        run: |
+          set -euo pipefail
+          main_sha=$(git rev-parse origin/main)
+          next_sha=$(git rev-parse origin/next)
+          echo "main_sha=$main_sha"
+          echo "next_sha=$next_sha"
+          echo "main_sha=$main_sha" >> "$GITHUB_OUTPUT"
+          echo "next_sha=$next_sha" >> "$GITHUB_OUTPUT"
+          if git merge-base --is-ancestor "$main_sha" "$next_sha"; then
+            echo "Topology OK: main is an ancestor of next — fast-forward is valid."
+            echo "linear=true" >> "$GITHUB_OUTPUT"
+          else
+            base=$(git merge-base "$main_sha" "$next_sha")
+            echo "::error::Topology violation: origin/main is NOT a direct ancestor of origin/next."
+            echo "::error::merge-base (divergence point) = $base"
+            echo "::error::This means a commit landed on main without going through next."
+            echo "::error::Resolve the divergence (cherry-pick / re-anchor next) before running promote-next."
+            # Human-readable debug for the operator
+            echo ""
+            echo "--- Commits on main but NOT on next ---"
+            git --no-pager log --oneline "${base}..origin/main" || true
+            echo ""
+            echo "--- Commits on next but NOT on main ---"
+            git --no-pager log --oneline "${base}..origin/next" || true
+            exit 1
+          fi
+
+      - name: fast-forward main to next
+        id: ff
+        run: |
+          set -euo pipefail
+          before=$(git rev-parse HEAD)
+          # checkout main explicitly; we already started on main but guard anyway
+          git checkout main
+          # --ff-only: produce a merge commit is never acceptable.
+          git merge --ff-only origin/next
+          after=$(git rev-parse HEAD)
+          echo "before=$before"
+          echo "after =$after"
+          echo "before=$before" >> "$GITHUB_OUTPUT"
+          echo "after=$after"   >> "$GITHUB_OUTPUT"
+          if [ "$before" = "$after" ]; then
+            echo "Note: main was already equal to next (nothing to promote)."
+            echo "noop=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "noop=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: push main to origin
+        if: steps.ff.outputs.noop != 'true'
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          git config user.name  'github-actions[bot]'
+          git config user.email 'github-actions[bot]@users.noreply.github.com'
+          git remote set-url origin \
+            "https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+          git push origin main
+          echo "Pushed main → origin. release.yml (on.push.main) will run the stable publish next."

--- a/common/changes/@excitedjs/dreamux/promote-next-ff-workflow_2026-06-27-11-40.json
+++ b/common/changes/@excitedjs/dreamux/promote-next-ff-workflow_2026-06-27-11-40.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Add `.github/workflows/promote-next.yml`, the operator-only manual gate for promoting the beta `next` branch into the stable `main` branch. The workflow enforces a strict fast-forward-only merge shape (topology guard + `git merge --ff-only`), pushes the fast-forwarded `main` back to origin using the built-in GITHUB_TOKEN, and relies on `release.yml` (`on.push.branches: [main, next]`) to then run the stable version+publish pipeline. No published package API changes; this is a release-process infrastructure change.",
+      "type": "none",
+      "packageName": "@excitedjs/dreamux"
+    }
+  ],
+  "packageName": "@excitedjs/dreamux",
+  "email": "053700@gmail.com"
+}


### PR DESCRIPTION
### 需求背景
今天用户确定发布流水线为 4 步：feature→next→beta→next 体验稳定→ff 到 main→stable。基建中唯一缺口是第 4 步（next→main fast-forward 合入 + 触发正式发布）。

### 变更内容
新增 `.github/workflows/promote-next.yml`（仅手动触发），完整实现了 next→main fast-forward 推进的 operator gate。

关键设计：
1. **仅 `workflow_dispatch` 触发**，无人能意外推进
2. **拓扑硬门禁**：`git merge-base --is-ancestor origin/main origin/next` 失败直接 exit 1，输出分叉点 + 两边 diff 让 operator 决策，**绝不允许生成 merge commit / squash / rebase**
3. **fast-forward-only 锁死**：`git merge --ff-only origin/next` — 保留 next 上的 commit SHA 原样进入 main，保证 beta → stable 审计链完整
4. **并发锁**：`concurrency: promote-next` 独占
5. **幂等安全**：main == next 时 noop exit 0（不触发误推送）
6. **权限最小化**：仅 `contents: write`，用内建 GITHUB_TOKEN 推送，不需 PAT
7. **与 release.yml 松耦合**：push main 后自动触发 `release.yml (on.push.main)` 的 version + publish → stable 发布

### 验证
- **YAML 结构验证**：`name: promote-next` / only `workflow_dispatch` / `contents: write` / 独占 concurrency 全部符合预期
- **4 个嵌入 shell 块**：`bash -n syntax OK` + `shellcheck (warning-level) OK`（0 warnings/errors）
- **3 个功能场景**（临时 git repo 端到端模拟）：
  - TEST 1 正常路径（main 是 next 祖先）→ ff 成功 ✓
  - TEST 2 拓扑破坏（main 有 hotfix 未进 next）→ topo guard 正确拒绝 ✓
  - TEST 3 幂等（main 已等于 next，再次执行）→ noop 退出 0 ✓
- **红线 grep**：workflow 文件 + rush change 文件 0 bytedance/0 Feishu id/0 internal mirror ✓
- **rush change verify (against origin/next)**：0 exit PASS

### 不涉及
- 无 published npm package surface 变更 → rush change `type=none`，不触发 version bump
- 不修改 ci.yml / release.yml — 两个 workflow 通过 git push 事件自然耦合

### Operator 用法
Actions → **promote-next** → Run workflow → Run（无 inputs，纯人工 gate）

成功后：
1. main 被 fast-forward 到 next HEAD
2. `on.push.main` 触发 release.yml → version job（消费 change files + bump 版本 + 写回 main）→ publish job（OIDC + NPM_CONFIG_PROVENANCE 发正式版）
3. npm `latest` dist-tag 更新