### PR TITLE
fix(ci): promote-next — explicitly dispatch release.yml after GITHUB_TOKEN push

### DIFF
--- a/.github/workflows/promote-next.yml
+++ b/.github/workflows/promote-next.yml
@@ -20,13 +20,19 @@
 #      main and would drop the link between a beta.<run_number> publish
 #      and the exact commit that shipped as stable.
 #   4. Push the fast-forwarded main back to origin.
-#   5. release.yml (`on.push.branches: [main, next]`) catches the push
-#      and runs the stable version + publish pipeline. The two
-#      workflows are therefore coupled purely by git topology, not by
-#      workflow_dispatch cross-calls — simpler and auditable.
+#   5. Dispatch release.yml against the freshly pushed main via
+#      `gh workflow run release.yml --ref main`. The explicit dispatch is
+#      required because step (4) uses the built-in GITHUB_TOKEN, and
+#      GitHub's documented anti-infinite-loop guard prevents a
+#      GITHUB_TOKEN-originated `git push` from re-triggering other
+#      workflows. `on.push.main` in release.yml therefore does NOT fire
+#      automatically; coupling is still git-topology-based (the ref to be
+#      released is `main` at its newly fast-forwarded SHA), we just nudge
+#      the other workflow ourselves.
 #
 # Permissions:
 #   contents:write  — push the fast-forwarded main back.
+#   actions:write   — dispatch the release.yml workflow after the push.
 #   Using the workflow GITHUB_TOKEN (not a PAT) keeps this workflow
 #   self-contained. The main branch protection must allow the
 #   `github-actions[bot]` identity to bypass or satisfy push rules,
@@ -34,8 +40,9 @@
 #
 # Operator usage:
 #   Actions → promote-next → Run workflow → Run (no inputs).
-#   The workflow is safe to re-run: if next has not moved since the
-#   last promote, step 3 is a no-op (already up to date → 0 exit).
+#   A single click drives the whole stable-release path:
+#     topo guard → ff merge → push main → dispatch release.yml →
+#     release.yml version job → release.yml publish → npm `latest`.
 
 name: promote-next
 
@@ -48,6 +55,7 @@ concurrency:
 
 permissions:
   contents: write
+  actions: write
 
 jobs:
   promote:
@@ -134,4 +142,32 @@ jobs:
           git remote set-url origin \
             "https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
           git push origin main
-          echo "Pushed main → origin. release.yml (on.push.main) will run the stable publish next."
+          echo "Pushed main → origin."
+          echo "Next step dispatches release.yml on the new main explicitly."
+
+      - name: dispatch release.yml on main (stable publish)
+        if: steps.ff.outputs.noop != 'true'
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          # Required because GitHub deliberately prevents a `git push` made
+          # with the default GITHUB_TOKEN from triggering new workflow runs
+          # (anti-infinite-loop guard). Without this explicit dispatch, the
+          # on.push.main trigger in release.yml would silently not fire.
+          # `gh` is preinstalled on ubuntu-latest.
+          gh workflow run release.yml --ref main
+          sleep 5
+          # Print the newest release.yml run URL for convenience (best-effort)
+          run_url=$(gh run list \
+            --workflow release.yml \
+            --branch main \
+            --limit 1 \
+            --json url \
+            --jq '.[0].url' \
+            || true)
+          if [ -n "$run_url" ]; then
+            echo "release.yml run: $run_url"
+          else
+            echo "release.yml was dispatched; check Actions tab for the latest main run."
+          fi

--- a/common/changes/@excitedjs/dreamux/promote-next-dispatch-release-fix_2026-06-27-12-15.json
+++ b/common/changes/@excitedjs/dreamux/promote-next-dispatch-release-fix_2026-06-27-12-15.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Bugfix for the promote-next workflow: the `git push origin main` in promote-next.yml uses the default GITHUB_TOKEN, and GitHub's documented anti-infinite-loop guard deliberately prevents a GITHUB_TOKEN-originated push from re-triggering other workflows. As a result, the `on.push.main` trigger in release.yml silently did not fire after a successful promote, requiring a manual dispatch workaround. Fix: (1) grant `permissions.actions:write`, (2) add a final `gh workflow run release.yml --ref main` step that dispatches the stable release pipeline explicitly after each non-noop promote, (3) update the workflow header comments to document the real coupling. No published package surface changes; this is a release-process workflow robustness fix.",
+      "type": "none",
+      "packageName": "@excitedjs/dreamux"
+    }
+  ],
+  "packageName": "@excitedjs/dreamux",
+  "email": "053700@gmail.com"
+}


### PR DESCRIPTION
### 背景漏洞
promote-next workflow 用默认 GITHUB_TOKEN push main 回 origin 后，release.yml 的 `on.push.main` **不会自动触发**。这是 GitHub 文档明确规定的反死循环机制：内建 GITHUB_TOKEN 发起的 git push 不能再触发新 workflow。

导致的实际问题：今天 promote-next（Run 28288636775）成功 fast-forward 了 main 后，release.yml 没有自动启动，必须手动 `gh workflow run release.yml --ref main` 补触发（Run 28288750872）。operator 一次点击不能完成全链路。

### 修复内容
1. **加 `permissions.actions:write`**：promote-next 有 dispatch 其他 workflow 的权限
2. **新增 Step 6 `dispatch release.yml on main (stable publish)`**：push main 成功后立即 `gh workflow run release.yml --ref main`，并打印最新 release run 的 URL 给 operator
3. **修改 header comments**：说明真实的耦合方式（git 拓扑 + 显式 dispatch，不是靠 push event）

### 效果
修复后 operator 的稳定发布流程简化为 **一次点击**：
Actions → promote-next → Run workflow
  ↓
topo guard → ff merge → push main → **自动 dispatch release.yml** → version (消费 change files + bump) → publish (npm latest)
无需任何第二次手动操作。

### 验证
- Step 数量：6（checkout / refs 检查 / topo 守卫 / ff 合并 / push / dispatch release）
- permissions：contents:write + actions:write ✅
- 5/5 嵌入 shell 块 bash -n + shellcheck 全部 OK（warning 级 0 warning）
- rush change verify against origin/next：0 exit ✅
- 红线 grep：0 bytedance / 0 Feishu id / 0 internal mirror ✅