### PR TITLE
fix(ci): release.yml — sync next onto bumped main to preserve promote-next topology invariant

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -137,6 +137,47 @@ jobs:
           git remote set-url origin "https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
           git push origin HEAD:"${GITHUB_REF_NAME}"
 
+      - name: sync next onto the freshly bumped main (topology invariant)
+        # The long-lived fast-forward contract between next and main is:
+        #   "main is always a strict ancestor of next".
+        # The version job above pushed a new `chore(release)` commit directly
+        # to main without going through next, which would otherwise break that
+        # contract and force the next promote-next run into Topology Violation
+        # (see promote-next.yml). Keep the invariant alive by syncing `next`
+        # to the newly bumped SHA of `main` immediately.
+        #
+        # This is ONLY safe because (1) the promote-next path guarantees that,
+        # at the moment version job starts, `next == main` (it produced main
+        # via `git merge --ff-only origin/next`), so any delta on main is the
+        # single version-bump commit we just wrote, and (2) any new commits
+        # added to next after this push land on top of the version bump,
+        # preserving the ancestor relationship required by promote-next.
+        #
+        # If next has already moved (someone pushed a new commit to next
+        # between the promote push and this point), the sync is skipped:
+        # next must already have absorbed the prior version bump, so the
+        # ancestor invariant still holds (otherwise promote-next would have
+        # refused to run earlier).
+        if: github.ref == 'refs/heads/main' && steps.version.outputs.changed == 'true'
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          git fetch origin next
+          new_main_sha=$(git rev-parse HEAD)
+          old_next_sha=$(git rev-parse origin/next || true)
+          # Only move next if it points at the exact pre-bump SHA. If next
+          # already moved on (new commits landed between promote and here),
+          # skip — the next promote-next run will fold the bump in via the
+          # normal fast-forward path.
+          pre_bump_sha=$(git rev-parse HEAD^)
+          if [ "$old_next_sha" = "$pre_bump_sha" ]; then
+            git push origin "refs/heads/main:refs/heads/next"
+            echo "Sync next ${old_next_sha} → ${new_main_sha} (release bump only)."
+          else
+            echo "Skipping next sync: next already moved (${old_next_sha}) past pre-bump (${pre_bump_sha})."
+          fi
+
   publish:
     name: rush publish changed packages to npm (OIDC)
     needs: version

--- a/common/changes/@excitedjs/dreamux/release-sync-next-invariant_2026-06-27-12-20.json
+++ b/common/changes/@excitedjs/dreamux/release-sync-next-invariant_2026-06-27-12-20.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Add a new 'sync next onto the freshly bumped main' step at the end of the release.yml version job. The long-lived topology invariant between the two long-lived branches is: 'main must always be a strict ancestor of next' (promote-next.yml enforces this with a hard fail). Without this step, every successful stable release breaks the invariant: the version job writes a 'chore(release): version packages [skip ci]' commit directly to main without going through next, which forces the next promote-next run into Topology Violation and requires a manual rebuild of the next branch (cherry-pick + force push). The new step fast-forwards next onto the freshly bumped main SHA immediately after the version bump, keeping the invariant alive. Skip logic: sync only if next still points at the exact pre-bump SHA; otherwise next already moved on and will absorb the bump via a future promote-next. No published package surface changes.",
+      "type": "none",
+      "packageName": "@excitedjs/dreamux"
+    }
+  ],
+  "packageName": "@excitedjs/dreamux",
+  "email": "053700@gmail.com"
+}


### PR DESCRIPTION
### 漏洞根因
今天 promote-next 第二次运行（Run 28288915057）失败在 Topology Violation：
- origin/main = 58f5f1c `chore(release): version packages [skip ci]`
- origin/next = d50ef4d `fix(ci): promote-next — dispatch release.yml... (PR #263)`
- 分叉点 = 0079466

原因：release.yml 的 version job 把版本 bump commit **只 push 到 main**，不经过 next。这直接破坏了 promote-next 的拓扑前提（main 必须是 next 的祖先），导致每次稳定发布后下次 promote-next 必挂，必须手动 cherry-pick + force push 重写 next 才能恢复。

今天修复 PR #263 合并后已经手动重建了 next（cherry-pick d50ef4d onto 58f5f1c → ca9630a）。这是紧急修复。本 PR 做永久修复，让 release.yml 每次发布后自动同步 next，再也不用手动修。

### 修复内容
在 release.yml version job 末尾（Push version bump 之后）新增 **Step：sync next onto the freshly bumped main (topology invariant)**：
- 触发条件：`github.ref == refs/heads/main` 且 `steps.version.outputs.changed == true`
- 逻辑：
  1. `git fetch origin next`
  2. 取 pre_bump_sha = HEAD^（push 前 main 的 SHA）
  3. 比较 `origin/next == pre_bump_sha` 吗？
     - 相等 → next 在 promote 后没动过，直接 `git push origin refs/heads/main:refs/heads/next` 快进同步
     - 不相等 → next 已经有新 commits，跳过（下次 promote-next 走正常 fast-forward）
- 这种设计保证：**只要 release 期间没人往 next push，next 和 main 自动对齐；否则下次 promote-next 走正常 ff 也没问题**。

### 4 步发布流程的完整闭环（本 PR 落地后）
Operator 单次点击 Actions → promote-next → Run workflow：
1. promote-next：topo 检查 → ff 合 main → push main → **显式 dispatch release.yml**（PR #263）
2. release.yml：version 消费 change files → bump → push chore(release) 到 main → **自动同步 next**（本 PR）
3. release.yml：publish → OIDC trusted publishing → npm latest 更新
4. 最终不变量：next == main，拓扑保持，下次任意 PR 合 next 后拓扑仍正确

### 验证清单
- 红线 grep（workflow 文件）：0 bytedance / 0 Feishu id ✅
- Python 状态机抽取 11/11 嵌入 shell 块：bash -n 全部 OK ✅
- rush change verify (target origin/next)：0 exit ✅
- commit author email：YourWildDad@users.noreply.github.com（非 DENYLIST）✅
- gitleaks pre-commit：由本地钩子在 commit 时强制扫描 ✅