### PR TITLE
Use Codex developerInstructions for append prompts

### DIFF
--- a/.agents/decisions/agents-config-normalization.md
+++ b/.agents/decisions/agents-config-normalization.md
@@ -156,11 +156,12 @@ stops branching on `BUILTIN_CODEX_PROVIDER_REF`:
 
 The codex diagnostic enforces `MIN_CODEX_VERSION = '0.137.0'`: it runs
 `codex --version`, parses the `major.minor.patch` triple, and compares
-component-wise (numeric, not string). Below 0.137 it fails loud. Reason: the
-teammate-completion reverse leg appends the completion to the dispatcher thread
-via `thread/inject_items`, an RPC that exists only on codex >= 0.137 — doctor
-surfaces the requirement up front rather than letting a teammate completion
-silently RPC-fail at runtime.
+component-wise (numeric, not string). Below 0.137 it fails loud. The floor now
+guards the app-server protocol surface used by the built-in runtime, including
+thread start/resume, turn start, and thread-level instruction overrides such as
+`baseInstructions` and `developerInstructions`. Doctor surfaces the requirement
+up front rather than letting prompt customization or turn delivery degrade
+silently at runtime.
 
 ### #98 fail-loud (no migration shim)
 

--- a/.agents/proposals/agent-runtime-lifecycle-contracts.md
+++ b/.agents/proposals/agent-runtime-lifecycle-contracts.md
@@ -325,10 +325,11 @@ Rules:
 - Provider adapters decide whether to pass `replace`, `append`, a combination,
   nothing, or fail loudly when prompt injection is required but impossible.
 - Built-in Codex maps `replace` to Codex `baseInstructions`; when append is
-  selected, it wraps each append fragment in `<developer-reminder>` before
-  injecting one developer item. Built-in Claude Code wraps each append fragment in
-  `<system-reminder>` and maps the joined result to `--append-system-prompt`.
-  Future runtimes choose their own mapping without Dreamux core changes.
+  selected, it wraps each append fragment in `<developer-reminder>` and passes
+  the joined result as Codex `developerInstructions` on thread start/resume.
+  Built-in Claude Code wraps each append fragment in `<system-reminder>` and maps
+  the joined result to `--append-system-prompt`. Future runtimes choose their own
+  mapping without Dreamux core changes.
 - `systemPrompt.mode` should no longer be a core-routing capability. If kept for
   diagnostics/docs, it is provider-authored metadata only.
 

--- a/.agents/proposals/codex-system-prompt-append-instructions.md
+++ b/.agents/proposals/codex-system-prompt-append-instructions.md
@@ -1,0 +1,154 @@
+# Codex system prompt append instructions
+
+- **Status:** Draft for review
+- **Date:** 2026-07-02
+- **Related PR:** [#271](https://github.com/excitedjs/dreamux/pull/271)
+- **Depends on:** [TeamMate identity system prompt](teammate-identity-system-prompt.md)
+- **Affects:** `@excitedjs/agent-runtime-codex`, Codex runtime protocol mapping, system-prompt tests
+- **Source snapshot:** Dreamux branch `team/agentruntime-opt-0630-1901` after [#274](https://github.com/excitedjs/dreamux/pull/274); Codex source `main@129ea2aaf5fb426d8ba683ee53f290742f41dd31`
+
+## Context
+
+Dreamux now exposes system prompt customization to runtime providers as a
+neutral representation:
+
+```ts
+interface AgentRuntimeSystemPrompt {
+  replace?: string;
+  append?: readonly string[];
+}
+```
+
+`replace` and `append` are not the same operation. Dispatcher launch may supply
+both as alternate representations of the same dispatcher guidance. TeamLeader
+and TeamMate identity guidance supplies append-only fragments that must survive
+runtime recreation and resume because they describe the agent's durable working
+identity, not a single turn.
+
+The Codex runtime currently maps `replace` to Codex `baseInstructions`, renders
+append fragments as `<developer-reminder>` blocks, then injects one developer
+message into the thread with `thread/inject_items` after `thread/start` or
+`thread/resume`.
+
+That is the wrong layer for append-only system guidance:
+
+- `thread/inject_items` mutates model-visible thread history. It is suitable for
+  historical item delivery, not for the runtime creation contract.
+- Codex app-server already accepts `developerInstructions` on both
+  `thread/start` and `thread/resume`.
+- Codex persists `base_instructions` in thread metadata, but the current Codex
+  source does not persist `developer_instructions` in `SessionMeta` or
+  `CreateThreadParams`.
+- Codex `developerInstructions` becomes developer-role input text, but Codex
+  does not wrap the text in XML or preserve Dreamux append-array boundaries by
+  itself.
+
+Therefore Dreamux must keep the durable source of append guidance in Dreamux
+state, and the Codex adapter must re-supply the rendered developer instructions
+whenever it creates or resumes the Codex thread.
+
+## Intent
+
+Move Codex append-only system prompt delivery from history injection to Codex's
+native thread configuration surface.
+
+The runtime should treat `AgentRuntimeCreateContext.systemPrompt` as the only
+provider-facing prompt source:
+
+- `replace` maps to Codex `baseInstructions`;
+- append-only fragments map to Codex `developerInstructions`;
+- append fragments are rendered before the first model turn and supplied on
+  both fresh start and resume.
+
+Dreamux core remains responsible for persisting the source data that produces
+append fragments. The Codex adapter remains stateless with respect to that
+source and only renders the create-context value it receives.
+
+## Contract
+
+Dreamux persists structured prompt sources, not provider-rendered prompt blobs.
+For the current Team and TeamMate identity feature, the sources are:
+
+- the deterministic one-line TeamLeader default derived from the Team name;
+- the optional TeamLeader identity prompt persisted on the TeamLeader identity
+  record;
+- the optional TeamMate or team-member identity prompt persisted on that
+  agent's identity record;
+- dispatcher prompt constants supplied by dispatcher launch.
+
+If a future feature introduces another append prompt source that cannot be
+reconstructed from existing durable Dreamux state, that source must be persisted
+in Dreamux-owned state before it is handed to a runtime adapter. Runtime
+adapters must not become hidden prompt-state stores.
+
+The Codex adapter selection rules are:
+
+- when `replace` is present, pass it as `baseInstructions` and do not also apply
+  `append`;
+- when `replace` is absent and non-empty `append` fragments exist, render the
+  ordered fragments and pass the result as `developerInstructions`;
+- when neither selected prompt form is present, omit both Codex instruction
+  fields.
+
+The same selected instructions are supplied to:
+
+- `thread/start` for a fresh Codex thread;
+- `thread/resume` for an existing Codex thread;
+- fallback `thread/start` when `thread/resume` fails and the runtime starts a
+  replacement thread.
+
+Because current Codex does not persist `developer_instructions`, Dreamux cannot
+assume a cold resume will keep append-only guidance from the original start
+request. Re-supplying `developerInstructions` on resume is load-bearing.
+
+Codex `developerInstructions` does not add XML wrappers. It only provides
+developer-role separation. To keep Dreamux's append array boundary stable, the
+Codex adapter renders every append element as its own XML block:
+
+```xml
+<developer-reminder>
+...
+</developer-reminder>
+```
+
+The adapter escapes XML text content inside each block. It then joins the blocks
+with blank lines and sends the joined string as `developerInstructions`. The
+adapter must not send append guidance through `thread/inject_items`, first-turn
+input, `channelInput`, `completionInput`, or `baseInstructions`.
+
+If Codex later persists `developer_instructions` natively, Dreamux may still
+re-supply the same developer instructions on resume unless a future verified
+Codex contract proves duplicate application would occur. That future change
+requires a new proposal or decision update with source evidence.
+
+## Acceptance
+
+- `ThreadStartParams` and `ThreadResumeParams` in
+  `/packages/agent-runtime/codex/src/types.ts` include `developerInstructions`.
+- The Codex runtime passes rendered append-only guidance as
+  `developerInstructions` on fresh `thread/start`, `thread/resume`, and fallback
+  fresh `thread/start` after resume failure.
+- The Codex runtime no longer calls `thread/inject_items` for
+  `systemPrompt.append`.
+- Existing completion delivery behavior remains unchanged. This change must not
+  remove or weaken the reverse-completion delivery path that relies on Codex
+  item injection.
+- `replace` continues to map to `baseInstructions`, and Codex still suppresses
+  `append` when `replace` is present so dispatcher guidance is not duplicated.
+- Append-only prompts never become `baseInstructions` and never appear in the
+  first user/channel/completion turn text.
+- Tests cover fresh start, resume, resume-fallback start, replace precedence,
+  XML escaping, and the absence of append prompt delivery through
+  `thread/inject_items`.
+- Focused verification runs for the Codex runtime package tests touched by this
+  change, plus repository KB validation when proposal links change.
+
+## Out of scope
+
+- Persisting provider-rendered system prompt blobs in Dreamux state.
+- Changing TeamLeader or TeamMate identity storage beyond the existing durable
+  identity prompt source.
+- Changing Claude Code append behavior; it already maps append fragments to
+  native `--append-system-prompt` arguments.
+- Adding channel-level system prompt injection.
+- Adding a runtime capability flag for replace or append support.

--- a/.agents/proposals/codex-system-prompt-append-instructions.md
+++ b/.agents/proposals/codex-system-prompt-append-instructions.md
@@ -25,10 +25,10 @@ and TeamMate identity guidance supplies append-only fragments that must survive
 runtime recreation and resume because they describe the agent's durable working
 identity, not a single turn.
 
-The Codex runtime currently maps `replace` to Codex `baseInstructions`, renders
-append fragments as `<developer-reminder>` blocks, then injects one developer
-message into the thread with `thread/inject_items` after `thread/start` or
-`thread/resume`.
+Before this proposal, the Codex runtime mapped `replace` to Codex
+`baseInstructions`, rendered append fragments as `<developer-reminder>` blocks,
+then injected one developer message into the thread with `thread/inject_items`
+after `thread/start` or `thread/resume`.
 
 That is the wrong layer for append-only system guidance:
 

--- a/.agents/proposals/codex-system-prompt-append-instructions.md
+++ b/.agents/proposals/codex-system-prompt-append-instructions.md
@@ -5,7 +5,7 @@
 - **Related PR:** [#271](https://github.com/excitedjs/dreamux/pull/271)
 - **Depends on:** [TeamMate identity system prompt](teammate-identity-system-prompt.md)
 - **Affects:** `@excitedjs/agent-runtime-codex`, Codex runtime protocol mapping, system-prompt tests
-- **Source snapshot:** Dreamux branch `team/agentruntime-opt-0630-1901` after [#274](https://github.com/excitedjs/dreamux/pull/274); Codex source `main@129ea2aaf5fb426d8ba683ee53f290742f41dd31`
+- **Source snapshot:** Dreamux branch `team/agentruntime-opt-0630-1901` after [#274](https://github.com/excitedjs/dreamux/pull/274); Codex source `main@129ea2aaf5fb426d8ba683ee53f290742f41dd31`; refreshed Codex tags show `developerInstructions` present in `rust-v0.135.0` and `rust-v0.137.0`
 
 ## Context
 
@@ -35,7 +35,8 @@ That is the wrong layer for append-only system guidance:
 - `thread/inject_items` mutates model-visible thread history. It is suitable for
   historical item delivery, not for the runtime creation contract.
 - Codex app-server already accepts `developerInstructions` on both
-  `thread/start` and `thread/resume`.
+  `thread/start` and `thread/resume`; this was verified in Codex `rust-v0.135.0`
+  and `rust-v0.137.0`.
 - Codex persists `base_instructions` in thread metadata, but the current Codex
   source does not persist `developer_instructions` in `SessionMeta` or
   `CreateThreadParams`.
@@ -111,10 +112,29 @@ Codex adapter renders every append element as its own XML block:
 </developer-reminder>
 ```
 
-The adapter escapes XML text content inside each block. It then joins the blocks
-with blank lines and sends the joined string as `developerInstructions`. The
-adapter must not send append guidance through `thread/inject_items`, first-turn
-input, `channelInput`, `completionInput`, or `baseInstructions`.
+The adapter escapes XML text content inside each block. It should reuse the
+existing Codex append renderer rather than introducing a second renderer for the
+same XML boundary contract. After empty fragments are filtered, an empty result
+omits `developerInstructions`; it must not send an empty string. For non-empty
+append input, the adapter joins the rendered blocks with blank lines and sends
+the joined string as `developerInstructions`.
+
+The adapter must not send append guidance through `thread/inject_items`,
+first-turn input, `channelInput`, `completionInput`, or `baseInstructions`.
+
+Dreamux must continue to fail loudly when the installed Codex version cannot
+support the selected runtime prompt protocol. The existing Dreamux minimum
+Codex version (`0.137.0`) is already high enough for `developerInstructions`,
+because that field is present in Codex `rust-v0.137.0`. This change should keep
+or raise the version gate only if later code facts require it, but the gate and
+diagnostic text must no longer claim that teammate completion delivery depends
+on `thread/inject_items`.
+
+Reverse completion delivery is separate from append prompt delivery. Current
+Codex completion delivery uses `completionInput` -> `turn/start`, not
+`thread/inject_items`. This change must not remove or weaken that `turn/start`
+completion path, but it should remove the stale prompt-append item-injection
+helpers when no callers remain.
 
 If Codex later persists `developer_instructions` natively, Dreamux may still
 re-supply the same developer instructions on resume unless a future verified
@@ -131,14 +151,22 @@ requires a new proposal or decision update with source evidence.
 - The Codex runtime no longer calls `thread/inject_items` for
   `systemPrompt.append`.
 - Existing completion delivery behavior remains unchanged. This change must not
-  remove or weaken the reverse-completion delivery path that relies on Codex
-  item injection.
+  remove or weaken the reverse-completion delivery path
+  (`completionInput` -> `turn/start`).
+- Stale `thread/inject_items` append-prompt plumbing is cleaned up when no
+  callers remain: the `buildCodexSystemPromptAppendItem` helper is removed, and
+  the internal `injectThreadItems` helper is either removed or retained only with
+  a real remaining caller or a clearly documented near-term use.
+- Codex version gate comments and diagnostics are updated so they describe the
+  current runtime requirements and fail-loud behavior instead of the stale
+  "teammate completion delivery via `thread/inject_items`" rationale.
 - `replace` continues to map to `baseInstructions`, and Codex still suppresses
   `append` when `replace` is present so dispatcher guidance is not duplicated.
 - Append-only prompts never become `baseInstructions` and never appear in the
   first user/channel/completion turn text.
 - Tests cover fresh start, resume, resume-fallback start, replace precedence,
-  XML escaping, and the absence of append prompt delivery through
+  XML escaping, omission of empty `developerInstructions`, completion delivery
+  through `turn/start`, and the absence of append prompt delivery through
   `thread/inject_items`.
 - Focused verification runs for the Codex runtime package tests touched by this
   change, plus repository KB validation when proposal links change.

--- a/.agents/proposals/teammate-identity-system-prompt.md
+++ b/.agents/proposals/teammate-identity-system-prompt.md
@@ -156,10 +156,12 @@ spawns a resident session, while a model-history runtime may skip a duplicate
 injection when the same guidance already survives in the resumed native history.
 When a built-in runtime folds multiple append fragments into one native prompt
 string, it wraps each fragment in its own XML block. The Claude Code runtime uses
-`<system-reminder>` for each fragment; the Codex runtime uses
-`<developer-reminder>` for each fragment. Built-in adapters escape XML text
-content inside each wrapper so one fragment cannot create or modify sibling
-blocks.
+`<system-reminder>` for each fragment. The Codex runtime uses
+`<developer-reminder>` for each fragment and supplies the rendered string through
+Codex `developerInstructions`; see
+[Codex system prompt append instructions](codex-system-prompt-append-instructions.md).
+Built-in adapters escape XML text content inside each wrapper so one fragment
+cannot create or modify sibling blocks.
 
 The injection must not be routed through `channelInput`, first-turn `prompt`,
 `intent`, `name_prefix`, or `team_name`.

--- a/.agents/reference/current-architecture.md
+++ b/.agents/reference/current-architecture.md
@@ -241,9 +241,10 @@ Runtime adapters must implement selected `systemPrompt.append` semantics. Claude
 Code folds append prompt fragments into `--append-system-prompt` before the
 resident session is created, wrapping each fragment in its own
 `<system-reminder>` block. Codex maps selected `systemPrompt.replace` to
-`baseInstructions`; when append is selected, it applies one developer-role
-history item with `thread/inject_items` before the first user/channel turn,
-wrapping each append fragment in its own `<developer-reminder>` block.
+`baseInstructions`; when append is selected, it renders each append fragment
+inside its own `<developer-reminder>` block and supplies the joined prompt as
+Codex `developerInstructions` on `thread/start`, `thread/resume`, and resume
+fallback start.
 Both built-in adapters escape XML text content inside each wrapper so one append
 fragment cannot create or modify sibling blocks.
 

--- a/common/changes/@excitedjs/agent-runtime-codex/team-codex-developer-instructions-0702_2026-07-02-12-58.json
+++ b/common/changes/@excitedjs/agent-runtime-codex/team-codex-developer-instructions-0702_2026-07-02-12-58.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@excitedjs/agent-runtime-codex",
+      "comment": "Apply append-only systemPrompt guidance through Codex developerInstructions on thread start and resume.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@excitedjs/agent-runtime-codex"
+}

--- a/packages/agent-runtime/codex/src/diagnostic.ts
+++ b/packages/agent-runtime/codex/src/diagnostic.ts
@@ -47,7 +47,7 @@ async function checkCodexVersion(
   if (codexVersionSatisfies(raw)) return null;
   return (
     `Codex at ${bin} reported ${raw.trim() || '<empty>'}; requires codex >= ` +
-    `${MIN_CODEX_VERSION} for teammate completion delivery (thread/inject_items)`
+    `${MIN_CODEX_VERSION} for the app-server runtime protocol`
   );
 }
 

--- a/packages/agent-runtime/codex/src/events.ts
+++ b/packages/agent-runtime/codex/src/events.ts
@@ -241,23 +241,6 @@ function traceItemType(params: Record<string, unknown>): string | null {
 }
 
 /**
- * Append raw Responses API items to a thread's model-visible history without
- * starting a turn (`thread/inject_items`, codex 0.137+). codex folds the items
- * onto the active turn when one is running and otherwise records them against a
- * default turn context (codex_thread.rs `inject_response_items` →
- * `inject_no_new_turn`); either way it never rejects on a busy thread, so a
- * rejection here is a genuine RPC error. Persisted to the rollout, so injected
- * items survive resume.
- */
-export async function injectThreadItems(
-  client: CodexWsClient,
-  threadId: string,
-  items: ReadonlyArray<Record<string, unknown>>,
-): Promise<void> {
-  await client.request('thread/inject_items', { threadId, items });
-}
-
-/**
  * Send a `turn/start` request and resolve once Codex accepts the submission.
  * This is the production Feishu inbound primitive: it intentionally does not
  * wait for `turn/completed`.

--- a/packages/agent-runtime/codex/src/runtime-support.ts
+++ b/packages/agent-runtime/codex/src/runtime-support.ts
@@ -16,21 +16,6 @@ export function codexProcessEnv(
   return { ...globalThis.process.env, ...injectEnv, ...extraEnv };
 }
 
-export function buildCodexSystemPromptAppendItem(
-  systemPromptAppend: readonly string[],
-): Record<string, unknown> {
-  return {
-    type: 'message',
-    role: 'developer',
-    content: [
-      {
-        type: 'input_text',
-        text: renderCodexSystemPromptAppend(systemPromptAppend),
-      },
-    ],
-  };
-}
-
 export function renderCodexSystemPromptAppend(
   append: readonly string[],
 ): string {

--- a/packages/agent-runtime/codex/src/runtime.ts
+++ b/packages/agent-runtime/codex/src/runtime.ts
@@ -19,7 +19,6 @@ import {
 } from './turn-manager.js';
 import {
   extractAssistantText,
-  injectThreadItems,
   type CollectedTurn,
 } from './events.js';
 import { renderChannelInput } from '@excitedjs/dreamux-utils';
@@ -43,8 +42,8 @@ import type {
 import { BUILTIN_CODEX_PROVIDER_REF } from './provider-ref.js';
 import { CODEX_AGENT_RUNTIME_CAPABILITIES } from './provider.js';
 import {
-  buildCodexSystemPromptAppendItem,
   codexProcessEnv,
+  renderCodexSystemPromptAppend,
 } from './runtime-support.js';
 import { applyCodexSkillExtraRoots } from './skill-roots.js';
 
@@ -229,7 +228,6 @@ export class CodexRuntime implements AgentRuntime {
     await this.applySkillExtraRoots();
 
     await this.resolveThread();
-    await this.injectSystemPromptAppend();
 
     this.turnManager = new TurnManager({
       dispatcherId: this.dispatcherId,
@@ -253,10 +251,11 @@ export class CodexRuntime implements AgentRuntime {
   private async resolveThread(): Promise<void> {
     if (this.client === null) throw new Error('client not initialized');
     this.threadResumed = false;
+    const threadInstructions = this.threadInstructionParams();
     const existing = this.threadId ?? this.identity.checkpoint_id ?? null;
     if (existing === null) {
       const params: ThreadStartParams = {
-        baseInstructions: this.deps.systemPromptReplace,
+        ...threadInstructions,
       };
       const res = await this.client.request<ThreadStartResponse>(
         'thread/start',
@@ -270,7 +269,7 @@ export class CodexRuntime implements AgentRuntime {
     try {
       const params: ThreadResumeParams = {
         threadId: existing,
-        baseInstructions: this.deps.systemPromptReplace,
+        ...threadInstructions,
       };
       await this.client.request<ThreadResumeResponse>('thread/resume', params);
       this.threadId = existing;
@@ -284,7 +283,7 @@ export class CodexRuntime implements AgentRuntime {
       );
       const res = await this.client.request<ThreadStartResponse>(
         'thread/start',
-        { baseInstructions: this.deps.systemPromptReplace },
+        { ...threadInstructions },
       );
       this.threadId = res.thread.id;
       if (this.state.recordLostCheckpoint !== undefined) {
@@ -302,25 +301,23 @@ export class CodexRuntime implements AgentRuntime {
     }
   }
 
-  private async injectSystemPromptAppend(): Promise<void> {
-    const systemPromptAppend = (this.deps.systemPromptAppend ?? []).filter(
-      (prompt) => prompt !== '',
-    );
-    if (systemPromptAppend.length === 0) return;
-    if (this.client === null) throw new Error('client not initialized');
-    if (this.threadId === null) {
-      throw new Error('codex systemPrompt.append injection has no thread id');
+  private threadInstructionParams(): Pick<
+    ThreadStartParams,
+    'baseInstructions' | 'developerInstructions'
+  > {
+    const params: Pick<
+      ThreadStartParams,
+      'baseInstructions' | 'developerInstructions'
+    > = {};
+    if (this.deps.systemPromptReplace !== undefined) {
+      params.baseInstructions = this.deps.systemPromptReplace;
+      return params;
     }
-    try {
-      await injectThreadItems(this.client, this.threadId, [
-        buildCodexSystemPromptAppendItem(systemPromptAppend),
-      ]);
-    } catch (err) {
-      const cause = err instanceof Error ? err.message : String(err);
-      throw new Error(
-        `codex systemPrompt.append thread/inject_items failed (requires codex 0.137+): ${cause}`,
-      );
+    if (this.deps.systemPromptAppend !== undefined) {
+      const rendered = renderCodexSystemPromptAppend(this.deps.systemPromptAppend);
+      if (rendered !== '') params.developerInstructions = rendered;
     }
+    return params;
   }
 
   async channelInput(

--- a/packages/agent-runtime/codex/src/types.ts
+++ b/packages/agent-runtime/codex/src/types.ts
@@ -50,6 +50,7 @@ export interface ThreadStartParams {
   cwd?: string | null;
   approvalPolicy?: string | null;
   baseInstructions?: string | null;
+  developerInstructions?: string | null;
 }
 
 export interface ThreadStartResponse {
@@ -62,6 +63,7 @@ export interface ThreadResumeParams {
   cwd?: string | null;
   approvalPolicy?: string | null;
   baseInstructions?: string | null;
+  developerInstructions?: string | null;
 }
 
 export interface ThreadResumeResponse {

--- a/packages/agent-runtime/codex/src/version.ts
+++ b/packages/agent-runtime/codex/src/version.ts
@@ -1,8 +1,9 @@
 /**
- * Codex version gate. The teammate-completion reverse leg (#147) appends the
- * completion to the dispatcher thread via `thread/inject_items`, an RPC that
- * exists only on codex >= 0.137. Doctor surfaces this loudly rather than letting
- * a teammate completion silently RPC-fail at runtime.
+ * Codex version gate. Dreamux depends on the app-server protocol surface used
+ * by the built-in runtime: `thread/start`, `thread/resume`, `turn/start`, and
+ * thread-level instruction overrides (`baseInstructions` / `developerInstructions`).
+ * Doctor surfaces unsupported Codex builds loudly rather than letting prompt
+ * customization or turn delivery degrade silently at runtime.
  *
  * Pure version logic lives here in the package; the host-coupled diagnostic surface
  * (codex home + path validation) lives in Dreamux core and imports these.

--- a/packages/agent-runtime/codex/tests/skill-extra-roots.test.ts
+++ b/packages/agent-runtime/codex/tests/skill-extra-roots.test.ts
@@ -360,6 +360,65 @@ describe('codex skills/extraRoots/set injection', () => {
     expect(client.methods).not.toContain('thread/inject_items');
   });
 
+  it('passes replacement baseInstructions on resume without duplicate append injection', async () => {
+    const client = new FakeClient();
+    const runtime = buildRuntime(
+      client,
+      [],
+      undefined,
+      undefined,
+      {
+        replace: 'complete dispatcher base instructions',
+        append: ['dispatcher append guidance'],
+      },
+      'thread-existing',
+    );
+
+    await runtime.start();
+    await runtime.stop();
+
+    expect(client.threadStartCalls).toEqual([]);
+    expect(client.threadResumeCalls).toEqual([
+      {
+        threadId: 'thread-existing',
+        baseInstructions: 'complete dispatcher base instructions',
+      },
+    ]);
+    expect(client.methods).not.toContain('thread/inject_items');
+  });
+
+  it('passes replacement baseInstructions on resume fallback start', async () => {
+    const client = new FakeClient();
+    client.threadResumeError = new Error('resume unavailable');
+    const runtime = buildRuntime(
+      client,
+      [],
+      undefined,
+      undefined,
+      {
+        replace: 'complete dispatcher base instructions',
+        append: ['dispatcher append guidance'],
+      },
+      'thread-existing',
+    );
+
+    await runtime.start();
+    await runtime.stop();
+
+    expect(client.threadResumeCalls).toEqual([
+      {
+        threadId: 'thread-existing',
+        baseInstructions: 'complete dispatcher base instructions',
+      },
+    ]);
+    expect(client.threadStartCalls).toEqual([
+      {
+        baseInstructions: 'complete dispatcher base instructions',
+      },
+    ]);
+    expect(client.methods).not.toContain('thread/inject_items');
+  });
+
   it('skips the RPC entirely when no skill sources are supplied', async () => {
     const client = new FakeClient();
     const runtime = buildRuntime(client, []);

--- a/packages/agent-runtime/codex/tests/skill-extra-roots.test.ts
+++ b/packages/agent-runtime/codex/tests/skill-extra-roots.test.ts
@@ -30,10 +30,10 @@ function skillSource(path: string): AgentRuntimeSkillSource {
 class FakeClient {
   readonly methods: string[] = [];
   readonly extraRootsCalls: string[][] = [];
-  readonly injectItemsCalls: unknown[] = [];
   readonly threadStartCalls: unknown[] = [];
+  readonly threadResumeCalls: unknown[] = [];
   readonly turnStartCalls: unknown[] = [];
-  injectItemsError: Error | null = null;
+  threadResumeError: Error | null = null;
   private readonly handlers: Array<(notification: unknown) => void> = [];
   private nextTurnId = 1;
   failExtraRoots = false;
@@ -73,10 +73,11 @@ class FakeClient {
       this.threadStartCalls.push(params);
       return { thread: { id: 'thread-fake' } } as R;
     }
-    if (method === 'thread/inject_items') {
-      if (this.injectItemsError !== null) throw this.injectItemsError;
-      this.injectItemsCalls.push(params);
-      return {} as R;
+    if (method === 'thread/resume') {
+      this.threadResumeCalls.push(params);
+      if (this.threadResumeError !== null) throw this.threadResumeError;
+      const threadId = (params as { threadId: string }).threadId;
+      return { thread: { id: threadId } } as R;
     }
     if (method === 'turn/start') {
       this.turnStartCalls.push(params);
@@ -173,8 +174,12 @@ function buildRuntime(
   logger?: DreamuxLogger,
   onTurnSettled?: (settled: TurnSettledSignal) => void,
   systemPrompt?: AgentRuntimeSystemPrompt,
+  checkpointId: string | null = null,
 ): CodexRuntime {
-  const identity: AgentRuntimeIdentity = { runtime_id: 'flow', checkpoint_id: null };
+  const identity: AgentRuntimeIdentity = {
+    runtime_id: 'flow',
+    checkpoint_id: checkpointId,
+  };
   return new CodexRuntime(identity, {
     cwd: '/fake/cwd',
     state: noopState(),
@@ -215,27 +220,7 @@ describe('codex skills/extraRoots/set injection', () => {
     expect(startIdx).toBeGreaterThan(setIdx);
   });
 
-  it('fails append-only systemPrompt loudly before first turn when injection fails', async () => {
-    const client = new FakeClient();
-    client.injectItemsError = new Error('injection unavailable');
-    const runtime = buildRuntime(
-      client,
-      [],
-      undefined,
-      undefined,
-      {
-        append: [
-          'Dreamux persistent identity guidance:\narchitecture reviewer',
-          'Keep <review> & do not close </developer-reminder>.',
-        ],
-      },
-    );
-
-    await expect(runtime.start()).rejects.toThrow(/systemPrompt\.append/);
-    expect(client.methods).not.toContain('turn/start');
-  });
-
-  it('injects append-only systemPrompt after thread start and before first turn', async () => {
+  it('passes append-only systemPrompt as developerInstructions before first turn', async () => {
     const client = new FakeClient();
     const runtime = buildRuntime(
       client,
@@ -255,33 +240,102 @@ describe('codex skills/extraRoots/set injection', () => {
     await runtime.stop();
 
     const startIdx = client.methods.indexOf('thread/start');
-    const injectIdx = client.methods.indexOf('thread/inject_items');
     const turnIdx = client.methods.indexOf('turn/start');
-    expect(injectIdx).toBeGreaterThan(startIdx);
-    expect(turnIdx).toBeGreaterThan(injectIdx);
-    expect(client.injectItemsCalls).toHaveLength(1);
-    const inject = client.injectItemsCalls[0] as {
-      threadId: string;
-      items: Array<Record<string, unknown>>;
-    };
-    expect(inject.threadId).toBe('thread-fake');
-    expect(inject.items).toHaveLength(1);
-    expect(inject.items[0]?.['role']).toBe('developer');
-    const content = inject.items[0]?.['content'] as Array<Record<string, unknown>>;
-    expect(content[0]?.['text']).toBe(
-      '<developer-reminder>\n' +
+    expect(turnIdx).toBeGreaterThan(startIdx);
+    expect(client.methods).not.toContain('thread/inject_items');
+    expect(client.threadStartCalls[0]).toEqual({
+      developerInstructions:
+        '<developer-reminder>\n' +
         'Dreamux persistent identity guidance:\narchitecture reviewer\n' +
         '</developer-reminder>\n\n' +
         '<developer-reminder>\n' +
         'Keep &lt;review&gt; &amp; do not close &lt;/developer-reminder&gt;.\n' +
         '</developer-reminder>',
-    );
-    expect(client.threadStartCalls[0]).toEqual({ baseInstructions: undefined });
+    });
     const firstTurn = client.turnStartCalls[0] as {
       input: Array<{ text: string }>;
     };
     expect(firstTurn.input[0]?.text).toBe('first task');
     expect(firstTurn.input[0]?.text).not.toContain('architecture reviewer');
+  });
+
+  it('passes append-only systemPrompt as developerInstructions on resume', async () => {
+    const client = new FakeClient();
+    const runtime = buildRuntime(
+      client,
+      [],
+      undefined,
+      undefined,
+      {
+        append: ['resume identity'],
+      },
+      'thread-existing',
+    );
+
+    await runtime.start();
+    await runtime.stop();
+
+    expect(client.threadStartCalls).toEqual([]);
+    expect(client.threadResumeCalls).toEqual([
+      {
+        threadId: 'thread-existing',
+        developerInstructions:
+          '<developer-reminder>\nresume identity\n</developer-reminder>',
+      },
+    ]);
+    expect(client.methods).not.toContain('thread/inject_items');
+  });
+
+  it('passes append-only systemPrompt as developerInstructions on resume fallback start', async () => {
+    const client = new FakeClient();
+    client.threadResumeError = new Error('resume unavailable');
+    const runtime = buildRuntime(
+      client,
+      [],
+      undefined,
+      undefined,
+      {
+        append: ['fallback identity'],
+      },
+      'thread-existing',
+    );
+
+    await runtime.start();
+    await runtime.stop();
+
+    expect(client.threadResumeCalls).toEqual([
+      {
+        threadId: 'thread-existing',
+        developerInstructions:
+          '<developer-reminder>\nfallback identity\n</developer-reminder>',
+      },
+    ]);
+    expect(client.threadStartCalls).toEqual([
+      {
+        developerInstructions:
+          '<developer-reminder>\nfallback identity\n</developer-reminder>',
+      },
+    ]);
+    expect(client.methods).not.toContain('thread/inject_items');
+  });
+
+  it('omits developerInstructions when append-only systemPrompt is empty after filtering', async () => {
+    const client = new FakeClient();
+    const runtime = buildRuntime(
+      client,
+      [],
+      undefined,
+      undefined,
+      {
+        append: ['', ''],
+      },
+    );
+
+    await runtime.start();
+    await runtime.stop();
+
+    expect(client.threadStartCalls[0]).toEqual({});
+    expect(client.methods).not.toContain('thread/inject_items');
   });
 
   it('uses replacement baseInstructions without duplicate append injection', async () => {


### PR DESCRIPTION
## Summary

- Route Codex append-only systemPrompt fragments through thread start/resume `developerInstructions` instead of `thread/inject_items`.
- Keep replacement prompts on `baseInstructions`, preserve per-fragment XML rendering, and re-supply append guidance on resume and resume fallback.
- Clean stale append item-injection helpers and update Codex version diagnostic wording.

## Verification

- `node common/scripts/install-run-rush.js test --to @excitedjs/agent-runtime-codex`
- `node common/scripts/install-run-rush.js build --to @excitedjs/agent-runtime-codex`
- `node common/scripts/install-run-rush.js lint --to @excitedjs/agent-runtime-codex`
- `.agents/scripts/check.sh`
- `node common/scripts/install-run-rush.js change --verify`
- `git diff --check`