### PR TITLE
Add MiMo Code agent runtime provider

### DIFF
--- a/.agents/proposals/mimo-code-agent-runtime.md
+++ b/.agents/proposals/mimo-code-agent-runtime.md
@@ -1,0 +1,446 @@
+# Proposal: MiMo Code Agent Runtime Provider
+
+- **Status:** Active proposal (draft for review)
+- **Date:** 2026-06-30
+- **Affects:** Agent Runtime provider loading, external provider packaging,
+  runtime state isolation, runtime diagnostics, runtime permission handling,
+  teammate completion delivery
+- **PR / Issue:** TBD
+- **Reviewed external source:** `XiaomiMiMo/MiMo-Code@1c5217ef342518d6cfcd2d1b5c9a7b21d1c1d96d`
+
+## Intent
+
+Dreamux should be able to run agents on MiMo Code without adding MiMo-specific
+branches to Dreamux core. The integration target is an external Agent Runtime
+provider package, for example `@excitedjs/agent-runtime-mimo-code`, selected by
+an `npm:` provider ref in operator config.
+
+The provider must implement the public `AgentRuntimeProvider` contract from
+`@excitedjs/dreamux-types`. Dreamux core continues to own dispatcher, Team,
+TeamMate, channel, and MCP assembly semantics; the MiMo provider owns only the
+translation between the neutral runtime contract and MiMo Code's process,
+session, event, permission, and storage surfaces.
+
+## Source Facts
+
+Dreamux already exposes the required neutral provider seam:
+
+- `/packages/dreamux-types/src/agent-runtime.ts` defines
+  `AgentRuntimeProvider`, `AgentRuntime`, `AgentRuntimeCreateContext`, runtime
+  handle methods, checkpoint/state callbacks, path context, MCP server
+  injection, prompt injection, skill sources, and plain text completion input.
+- `/packages/dreamux/src/agent-runtime/external-provider.ts` validates external
+  `agentRuntime` provider objects, resume capability declarations, and runtime
+  handles returned by `createRuntime`.
+- `/packages/dreamux/src/registry/provider-ref.ts` defines public provider refs
+  as `builtin:<id>`, `npm:<package>`, or `npm:<package>#<export>`.
+- `/packages/dreamux/src/registry/builtins.ts` keeps built-in runtime packages
+  behind the same registry/catalog path that external providers use.
+- `/packages/agent-runtime/claude-code/src/provider.ts` and
+  `/packages/agent-runtime/claude-code/src/runtime.ts` are a useful local shape
+  reference for a runtime package that stays behind `@excitedjs/dreamux-types`.
+
+The reviewed MiMo Code source has enough non-interactive surface for a Dreamux
+runtime, but the long-lived runtime driver should be the server surface, not the
+one-shot CLI command:
+
+- `packages/opencode/package.json` exposes the npm package `@mimo-ai/cli` and
+  the `mimo` bin.
+- `packages/opencode/bin/mimo` is a Node shim that locates a platform-specific
+  binary package, with `MIMOCODE_BIN_PATH` as an override.
+- `packages/opencode/src/cli/cmd/run.ts` implements `mimo run [message]` with
+  `--format json`, `--continue`, `--session`, `--fork`, `--attach`, `--dir`,
+  `--model`, `--agent`, stdin prompt input, and
+  `--dangerously-skip-permissions`.
+- `packages/opencode/src/cli/cmd/serve.ts` starts a headless MiMo Code server,
+  refuses unauthenticated non-loopback binding unless explicitly overridden,
+  and logs the selected local URL.
+- `packages/opencode/src/server/routes/instance/session.ts` exposes session
+  list/status/read endpoints, `POST /session/:sessionID/message` with a 409
+  busy precheck and disconnect cancellation, `POST
+  /session/:sessionID/prompt_async`, and `POST
+  /session/:sessionID/command`.
+- `packages/opencode/src/server/routes/instance/event.ts` exposes `/event` as
+  server-sent events with heartbeat and bounded drop-oldest buffering.
+- `packages/opencode/src/server/routes/instance/permission.ts` exposes the
+  current permission surface: `GET /permission` for pending requests and
+  `POST /permission/:requestID/reply` for replies. The older
+  `POST /session/:sessionID/permissions/:permissionID` route is deprecated.
+- `packages/shared/src/global.ts` and
+  `packages/opencode/src/global/index.ts` resolve `MIMOCODE_HOME` into isolated
+  data, cache, config, and state directories.
+- `packages/opencode/src/flag/flag.ts` exposes integration-relevant flags such
+  as `MIMOCODE_HOME`, `MIMOCODE_MIMO_ONLY`,
+  `MIMOCODE_DISABLE_EXTERNAL_SKILLS`, `MIMOCODE_DISABLE_DEFAULT_PLUGINS`,
+  `MIMOCODE_DISABLE_MODELS_FETCH`, `MIMOCODE_ENABLE_ANALYSIS`,
+  `MIMOCODE_AUTO_SHARE`, `MIMOCODE_SERVER_PASSWORD`, and `MIMOCODE_DB`.
+  `MIMOCODE_PURE` is not a general isolation switch; the reviewed source uses
+  it to skip external plugins.
+- `packages/opencode/src/metrics/client.ts` and
+  `packages/opencode/src/metrics/subscriber.ts` show that MiMo analytics are
+  enabled by default and post session-scoped model/tool/agent metrics to an
+  external endpoint unless `MIMOCODE_ENABLE_ANALYSIS=false`.
+- `packages/opencode/src/cli/network.ts` gives `mimo serve` a default loopback
+  hostname and port `0`, while allowing explicit `--hostname` and `--port`.
+- `packages/opencode/src/acp/` contains an ACP server surface. It implements
+  session, prompt, permission, cwd, and MCP concepts, but its README records
+  important current limitations: no streaming responses, no tool progress, and
+  `session/load` does not restore actual conversation history. ACP is therefore
+  a future candidate to re-evaluate after those gaps close, not the preferred
+  first production driver.
+
+## Runtime Shape
+
+The provider should spawn and own a private `mimo serve` process per live
+Dreamux runtime instance. It should communicate with that process through the
+MiMo SDK or HTTP API and subscribe to `/event` for push telemetry.
+
+```mermaid
+flowchart LR
+  Core[Dreamux core AgentRuntime] --> Provider[MiMo Code provider]
+  Provider --> Serve[mimo serve]
+  Provider --> SessionAPI[Session HTTP API]
+  Provider --> EventSSE[/event SSE]
+  Provider --> PermissionAPI[Permission API]
+  Serve --> Store[MIMOCODE_HOME]
+```
+
+The provider should not drive normal Dreamux turns by launching `mimo run` for
+each prompt. `mimo run` is useful for provider diagnostics and smoke tests
+because it has a JSON event mode and can attach to a server, but it is a weaker
+runtime substrate: the CLI process ends after the command, per-turn process
+startup obscures lifecycle ownership, and long-running event/permission handling
+would have to be reconstructed around a transient process.
+
+The provider may use `mimo run --attach` in a diagnostic path, but the production
+runtime handle should own the server child process, server URL, password, event
+stream, session id, idle state, and shutdown.
+
+Normal Dreamux turns should use `POST /session/:sessionID/message`, or an SDK
+call with the same settlement semantics. `POST /session/:sessionID/prompt_async`
+returns before the turn settles and has no 409 busy precheck; it is acceptable
+only when the provider can reconstruct terminal state from source-backed status
+and event signals. The streaming `/message` response may include leading
+heartbeat whitespace before the final JSON body, so a direct HTTP client must
+tolerate JSON whitespace and must not assume the first response byte is `{`.
+
+The `/event` stream is push telemetry, not the sole source of truth for turn
+settlement. Its queue is bounded and drops oldest events under sustained
+backpressure. The provider may use SSE for progress, but final success/failure
+must be confirmed from `/message` completion, session status, or another durable
+source-backed signal.
+
+## Provider Configuration
+
+The provider config should be provider-owned and parsed in `readConfig`. It must
+not require Dreamux core to understand MiMo-specific keys.
+
+The minimum config surface should cover:
+
+- the `mimo` executable path or default PATH lookup;
+- optional model and agent selection;
+- optional extra environment variables;
+- optional MiMo config content or config path when the operator wants to supply
+  MiMo-native settings;
+- permission mode selection for non-interactive execution;
+- startup timeout and turn timeout values;
+- an option to keep or remove the per-runtime `MIMOCODE_HOME` after stop for
+  debugging.
+
+Provider refs should use the existing npm provider grammar, for example:
+
+```json
+{
+  "agents": [
+    {
+      "id": "mimo",
+      "provider": "npm:@excitedjs/agent-runtime-mimo-code",
+      "config": {
+        "model": "mimo/default",
+        "permissionMode": "deny"
+      }
+    }
+  ]
+}
+```
+
+The exact config schema belongs to the provider package, not Dreamux core.
+When operator-supplied MiMo-native config is allowed, the provider must still
+keep Dreamux-owned runtime inputs authoritative. In particular, Dreamux-supplied
+`mcpServers` must not be merged with native MiMo `mcp` config or inherited
+Claude Code MCP config unless an explicit non-Dreamux diagnostic/manual mode
+opts into that behavior. For ordinary Dreamux runtime launches, conflicting
+native MCP config should fail loudly or be isolated from the runtime that
+Dreamux is driving.
+
+## AgentRuntime Contract Mapping
+
+The current shared contract is intentionally small. MiMo-specific transport,
+event, permission, auth, and session semantics stay inside the provider; Dreamux
+core sees only the required `AgentRuntime` handle.
+
+- `getCapabilities()` should report only `resume: { supported: true }`.
+- `start()`, `resume()`, and `stop()` own the `mimo serve` child process and
+  provider-side session binding. `resume()` reopens from
+  `context.identity.checkpoint_id`.
+- `getCheckpoint()` returns the current MiMo session id encoded as `{ id }`, or
+  `null` before a session exists.
+- `wasCheckpointResumed()` reports whether the live runtime actually continued
+  a supplied checkpoint.
+- `channelInput()` is only for `ChannelProvider`-originated `InboundTurnInput`.
+  The provider owns rendering channel metadata into MiMo-native prompt text.
+- `completionInput()` is the required plain text input for Dreamux-owned turns:
+  teammate spawn/send prompts, scheduler prompts, restart notices, and rendered
+  reverse completion notifications. It must not render channel XML or a
+  Dreamux completion envelope.
+- `completionInput({ sourceId })` should use `sourceId` as provider-side
+  dedupe/correlation metadata. If MiMo cannot accept the turn exactly once, the
+  provider should return `duplicate`, `failed`, or `stopped` rather than
+  silently creating repeated model-visible notifications.
+- `onTurnSettled` must fire exactly once for each submitted Dreamux logical
+  turn, with the terminal `turnId`, status, and that turn's result text when
+  available. Dreamux core no longer uses `getLast()` to complete the settlement
+  path.
+- `getLast()` remains a read/recovery surface and may return `null` when no
+  result is available.
+- `getContext()` may return `null` until MiMo exposes a stable context-window
+  snapshot.
+
+MiMo does not currently expose a Codex-style mid-turn injection primitive. That
+does not make `completionInput` optional; it means the provider should treat
+Dreamux-owned completion input as a normal queued plain text turn, not as an
+in-flight native injection. It may return `submitted` only after it owns a
+deterministic settlement path for that logical turn.
+
+## Session And State Ownership
+
+Dreamux core supplies `identity.runtime_id`, optional
+`identity.checkpoint_id`, `cwd`, `mcpServers`, `systemPrompt`,
+`disableFeatures`, `paths`, and state callbacks. The MiMo provider maps those
+inputs into MiMo runtime state:
+
+- Allocate `MIMOCODE_HOME` under `paths.dispatcherDir(runtime_id)` or another
+  provider-owned subdirectory under the Dreamux runtime path context.
+- Keep MiMo data, cache, config, and state under that root so a Dreamux runtime
+  instance does not read or mutate the operator's global MiMo state by default.
+- Record the MiMo session id through `state.setCheckpoint({ id: sessionID })`.
+- Treat a recovered `identity.checkpoint_id` as the MiMo session to resume.
+- Keep the server URL, password, child process pid, and transient event stream
+  connection as runtime-owned volatile state, not Dreamux durable state.
+- Use Dreamux `cwd` as the MiMo project directory; do not rediscover or rewrite
+  the working directory inside core.
+- Treat host field names such as dispatcher `thread_id` and TeamMate
+  `session_id` as Dreamux compatibility projections. The provider-facing term is
+  checkpoint.
+
+`MIMOCODE_HOME` must be an absolute path. The provider diagnostic should fail
+loudly when the configured path cannot be made absolute, cannot be created, or
+would collide across runtime instances.
+
+## Prompt Injection
+
+Dreamux now supplies prompt guidance as
+`AgentRuntimeCreateContext.systemPrompt?: { replace?: string; append?: string[] }`.
+There is no `systemPrompt.mode` capability and no structural `role` in the
+provider-facing create context.
+
+The MiMo provider should preserve MiMo's native base behavior while applying
+Dreamux guidance through a provider-owned prompt mechanism. Acceptable shapes
+include a MiMo-native agent/config entry or per-turn `PromptInput.system`, but
+the provider must document which it uses and must keep that choice inside the
+provider. When both `replace` and `append` are present, the provider should
+treat the choice explicitly rather than relying on Dreamux core to choose a
+provider-specific mode.
+
+## MCP And Skills
+
+Dreamux core already resolves MCP server descriptors before it calls
+`createRuntime`. The MiMo provider must launch exactly the supplied
+`mcpServers`, subject only to MiMo's own config syntax and process mechanics.
+It must not infer additional Dreamux MCP servers, drop supplied servers
+silently, or mutate provider refs.
+
+Because MiMo can read native `mcp` config and can inherit Claude Code MCP
+config, the provider must make the Dreamux MCP source exclusive for normal
+Dreamux launches. It should generate or supply the MiMo MCP configuration from
+`context.mcpServers`, disable or reject inherited MCP sources that would add
+servers, and fail loudly when an operator-provided MiMo config tries to add a
+second MCP graph to the same Dreamux runtime.
+
+Dreamux bundled skill sources are neutral skill directories: each
+`skillSources[].path` points directly at a directory containing `SKILL.md`.
+Core no longer supplies runtime-specific layout markers. The first MiMo provider
+version may ignore `skillSources` if MiMo has no stable skill mount format. If
+MiMo Code gains one, the provider maps those direct skill directories into a
+runtime-owned native layout without changing Dreamux core.
+
+## Permission And Safety Model
+
+Permission handling is a provider boundary. Dreamux core should not parse MiMo
+permission request payloads.
+
+The initial provider should default to `deny` or fail-loud permission behavior.
+Current Dreamux `AgentRuntime` contracts do not expose a neutral provider-to-core
+permission request and reply channel, so an `ask` mode cannot be presented as a
+fully supported channel-driven behavior yet.
+
+The provider may expose permission modes only with explicit semantics:
+
+- `deny` or fail-loud mode: reject permission requests that cannot be handled
+  safely without a human.
+- `ask`: allowed only when the provider owns a complete response loop or a
+  future Dreamux-neutral permission contract exists. Without that loop, MiMo
+  permission or question waits can hang until the turn timeout and disconnect
+  cancellation path runs.
+- `auto-approve`: allowed only as an explicit unsafe operator opt-in mapped to
+  MiMo's own unsafe permission controls.
+
+Every non-interactive mode must have a configured turn timeout. The timeout is
+the last-resort guard that prevents an unanswered permission or question wait
+from pinning the runtime forever.
+
+The provider should set isolation-oriented defaults unless the operator opts
+out:
+
+- use `MIMOCODE_HOME` for per-runtime state;
+- use `MIMOCODE_MIMO_ONLY` and targeted MiMo flags such as
+  `MIMOCODE_DISABLE_EXTERNAL_SKILLS`, `MIMOCODE_DISABLE_DEFAULT_PLUGINS`,
+  `MIMOCODE_DISABLE_MODELS_FETCH`, and `MIMOCODE_DISABLE_CLAUDE_CODE_MCP` to
+  avoid accidental inheritance of unrelated Claude, Codex, external skill,
+  default plugin, model-fetching, MCP, or ambient provider-environment behavior
+  when that inheritance is not wanted;
+- set `MIMOCODE_ENABLE_ANALYSIS=false`;
+- keep auto-share disabled, including not setting `MIMOCODE_AUTO_SHARE` and
+  using MiMo config `share: "disabled"` when the provider writes config;
+- bind `mimo serve` to loopback only;
+- pass an explicit loopback host and port, preferring port `0` or another
+  provider-owned free-port strategy over parsing an accidental global config;
+- set a generated server password unless the selected transport makes that
+  unnecessary;
+- keep MiMo logs under the provider-owned runtime/log path.
+
+## Diagnostics
+
+The provider should expose `diagnostic.binChecks` and `diagnostic.runDiagnostic`
+instead of adding MiMo-specific checks to Dreamux core.
+
+Diagnostics should verify:
+
+- the `mimo` executable resolves, or `MIMOCODE_BIN_PATH` points to an executable;
+- the platform binary shim can find a compatible binary package;
+- `mimo serve` can start on loopback with an isolated `MIMOCODE_HOME`;
+- the server URL can be discovered and authenticated;
+- analytics and auto-share are disabled for normal Dreamux launches;
+- native or inherited MCP config cannot add servers beyond
+  `context.mcpServers`;
+- `/event` can be subscribed;
+- a session can be created or resumed;
+- a no-op or cheap prompt smoke can run only when the diagnostic scope allows
+  live model calls;
+- unsupported live scopes fail loudly when credentials or model config are
+  missing.
+
+## Testing Requirements
+
+Provider tests should use a fake MiMo server first. The fake must exercise the
+provider through the same HTTP/SSE/client interface the real provider uses, not
+through private provider internals.
+
+Focused tests should cover:
+
+- provider config parsing and fail-loud validation;
+- the minimal `resume` capability matching runtime behavior;
+- required runtime-handle methods, including `completionInput`,
+  `getCheckpoint`, and `wasCheckpointResumed`;
+- isolated `MIMOCODE_HOME` path derivation;
+- `start`, `resume`, `stop`, and child-process cleanup;
+- session id persistence through `state.setCheckpoint`;
+- one successful `channelInput` turn;
+- one successful plain text `completionInput` turn with `sourceId` dedupe;
+- busy 409 handling and idle waiting;
+- `prompt_async` is not treated as settled unless the provider has a tested
+  settlement tracker;
+- SSE event parsing, reconnect, heartbeat, and bounded/no-event behavior;
+- turn settlement remains correct when SSE drops progress events;
+- permission request and reply paths;
+- unanswered permission/question behavior is bounded by turn timeout and cleanup;
+- `getLast` from session messages;
+- unsupported `getContext` returning `null`;
+- no telemetry or auto-share side effects in the fake-server launch envelope;
+- Dreamux-owned completion text is delivered through `completionInput` without
+  channel/XML rendering or a provider-facing completion envelope;
+- diagnostics for missing binary, failed server startup, and live-scope skips.
+
+Live MiMo Code tests should be opt-in and fail loudly when enabled but the
+binary or required credentials are missing. They must not depend on a developer
+global MiMo home.
+
+## Acceptance
+
+- A MiMo Code runtime can be selected through an `npm:` Agent Runtime provider
+  ref without editing Dreamux built-in provider registries or core branching on
+  MiMo-specific strings.
+- The provider imports only `@excitedjs/dreamux-types` from Dreamux packages.
+- Dreamux core continues to supply `cwd`, MCP servers, bundled skill sources,
+  disabled features, path context, and state callbacks through the neutral
+  `AgentRuntimeCreateContext`.
+- The provider starts and stops a loopback `mimo serve` process owned by the
+  runtime instance.
+- The provider uses an isolated absolute `MIMOCODE_HOME` by default.
+- The provider disables MiMo analytics and auto-share by default.
+- The provider prevents native or inherited MiMo MCP config from adding servers
+  beyond Dreamux `context.mcpServers` in normal Dreamux launches.
+- Runtime resume maps Dreamux checkpoint ids to MiMo session ids.
+- `channelInput` is reserved for ChannelProvider-originated input.
+- Dreamux-owned non-channel turns use plain text `completionInput`, preserve
+  `sourceId` dedupe, and never receive channel/XML rendering.
+- Every submitted Dreamux logical turn emits exactly one `onTurnSettled` signal
+  with that turn's result text when available.
+- `/event` may be used for progress, but durable settlement is confirmed outside
+  the best-effort SSE queue.
+- Permission behavior is explicit, safe by default, and bounded by a turn
+  timeout.
+- `mimo run` is limited to diagnostics/smoke use unless a later source-backed
+  decision records why the one-shot CLI should become the production driver.
+- Fake-server tests cover the provider contract before any live MiMo test is
+  required.
+- No MiMo-specific code is added to Dreamux core beyond generic external
+  provider loading and existing neutral provider contracts.
+
+## Out Of Scope
+
+- Adding MiMo Code as a Dreamux built-in provider.
+- Changing the public `AgentRuntimeProvider` contract.
+- Teaching Dreamux core to parse MiMo session, permission, model, skill, or MCP
+  config shapes.
+- Changing channel provider contracts.
+- Adding a neutral Dreamux permission request/reply contract.
+- Adding a Dreamux core capability for mid-turn steering. The provider may own
+  MiMo-specific queuing or steering behavior behind `channelInput` and
+  `completionInput`, but core should not learn MiMo-native semantics.
+- Claiming native mid-turn completion injection. `completionInput` is a normal
+  Dreamux logical turn unless a later source-backed decision records a stronger
+  MiMo injection primitive.
+- Allowing native MiMo MCP config to widen Dreamux's runtime MCP surface by
+  default.
+- Replacing MiMo's base prompt or agent model rather than applying Dreamux
+  `systemPrompt` content through a provider-owned append-like mechanism.
+- Depending on the operator's global MiMo state as the default runtime state.
+
+## Review Questions
+
+- Is `mimo serve` the correct first production driver, or is there a stronger
+  source-backed reason to choose ACP or `mimo run --attach`?
+- Is `resume: { supported: true }` honest against both Dreamux checkpoint
+  semantics and MiMo Code's current session source?
+- Should MiMo map `systemPrompt.replace`, `systemPrompt.append`, or both into a
+  native append-like mechanism?
+- Does the `MIMOCODE_HOME` ownership model fit Dreamux's state/cache/run/log
+  path contracts without leaking runtime-owned details into core?
+- Should a future Dreamux-neutral permission request/reply contract exist, or
+  should MiMo remain deny/fail-loud for channel-driven agents?
+- Which MiMo-native prompt/config mechanism is the least invasive way to apply
+  Dreamux system prompt content?
+- Does strict per-runtime `MIMOCODE_HOME` isolation need a shared read-only cache
+  escape hatch to avoid repeated downloads, or should repeat cache cost remain
+  the price of isolation?

--- a/.agents/root.md
+++ b/.agents/root.md
@@ -113,6 +113,12 @@ history and rationale; when you need current behavior, pair them with
   that submits turns to an existing Team's TeamLeader, registers completion
   delivery back to the dispatcher at send time, and leaves Team peer messaging
   out of this slice.
+- [MiMo Code Agent Runtime Provider](proposals/mimo-code-agent-runtime.md)
+  — draft requirement/spec for integrating MiMo Code as an external
+  `agentRuntime` npm provider, using `mimo serve` as the production driver,
+  keeping MiMo-specific session/event/permission/state behavior inside the
+  provider package, and limiting `mimo run` to diagnostics or smoke use unless a
+  later source-backed decision changes that driver choice.
 - [TeamLeader-scoped Team MCP transfer back](proposals/team-mcp-teamleader-transfer-back.md)
   — draft requirement/spec for exposing only `transfer_back` from Team MCP to
   TeamLeaders, keeping dispatcher Team lifecycle tools private, keeping explicit

--- a/common/changes/@excitedjs/agent-runtime-mimo-code/team-mimo-code-runtime_2026-07-02-14-30.json
+++ b/common/changes/@excitedjs/agent-runtime-mimo-code/team-mimo-code-runtime_2026-07-02-14-30.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@excitedjs/agent-runtime-mimo-code",
+      "comment": "Add the external MiMo Code Agent Runtime provider package with isolated serve lifecycle and HTTP message settlement.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@excitedjs/agent-runtime-mimo-code"
+}

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -69,6 +69,31 @@ importers:
         specifier: ^2.1.0
         version: 2.1.9(@types/node@22.19.19)
 
+  ../../packages/agent-runtime/mimo-code:
+    dependencies:
+      '@excitedjs/dreamux-types':
+        specifier: workspace:*
+        version: link:../../dreamux-types
+      '@excitedjs/dreamux-utils':
+        specifier: workspace:*
+        version: link:../../dreamux-utils
+    devDependencies:
+      '@excitedjs/eslint-config':
+        specifier: workspace:*
+        version: link:../../eslint-config
+      '@types/node':
+        specifier: ^22.10.0
+        version: 22.19.19
+      eslint:
+        specifier: ^9.39.0
+        version: 9.39.4
+      typescript:
+        specifier: ^5.7.0
+        version: 5.9.3
+      vitest:
+        specifier: ^2.1.0
+        version: 2.1.9(@types/node@22.19.19)
+
   ../../packages/channel/feishu-channel:
     dependencies:
       '@excitedjs/dreamux-types':

--- a/packages/agent-runtime/mimo-code/LICENSE
+++ b/packages/agent-runtime/mimo-code/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 ExcitedJS
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/agent-runtime/mimo-code/README.md
+++ b/packages/agent-runtime/mimo-code/README.md
@@ -1,0 +1,49 @@
+# @excitedjs/agent-runtime-mimo-code
+
+External Dreamux Agent Runtime provider for MiMo Code.
+
+Use it through the existing provider reference grammar:
+
+```json
+{
+  "agents": [
+    {
+      "id": "mimo",
+      "provider": "npm:@excitedjs/agent-runtime-mimo-code",
+      "config": {
+        "permission_mode": "deny"
+      }
+    }
+  ]
+}
+```
+
+This package owns a private `mimo serve` process per Dreamux runtime instance,
+binds it to loopback, uses an isolated per-runtime `MIMOCODE_HOME`, disables
+MiMo analytics and external/default inheritance flags by default, and submits
+normal turns through `POST /session/:sessionID/message`.
+
+`completionInput()` is delivered as plain text and never receives the channel
+XML envelope. `channelInput()` remains the only path that renders channel
+metadata through Dreamux's neutral channel renderer.
+
+Supported config keys:
+
+- `bin`: MiMo CLI binary, default `mimo`.
+- `model`: optional MiMo model selector.
+- `agent`: optional MiMo agent selector.
+- `extra_env`: string environment map merged after host env. Provider-owned
+  isolation and auth variables are applied after it.
+- `config_content` or `config_path`: optional operator-provided MiMo-native
+  JSON object input. They are mutually exclusive. Dreamux-owned safety fields
+  and MCP config are applied after this input.
+- `permission_mode`: `deny` by default. `ask` and `auto-approve` are rejected
+  until the provider owns a complete MiMo permission response loop.
+- `startup_timeout_ms`: wait window for `mimo serve` startup URL discovery.
+- `turn_timeout_ms`: bound for turn settlement and busy retry.
+- `keep_home`: keep the isolated `MIMOCODE_HOME` after stop for debugging.
+
+Dreamux-supplied MCP servers are authoritative and are written into MiMo's
+native `mcp` config shape. Native MiMo MCP keys in this provider config or in
+operator-provided native config are rejected so the runtime tool graph cannot be
+widened behind Dreamux core.

--- a/packages/agent-runtime/mimo-code/eslint.config.js
+++ b/packages/agent-runtime/mimo-code/eslint.config.js
@@ -1,0 +1,8 @@
+// Lint config for @excitedjs/agent-runtime-mimo-code.
+//
+// Provider packages implement the neutral @excitedjs/dreamux-types contract and
+// must not import @excitedjs/dreamux core. The shared config also enforces the
+// no synchronous blocking IO gate for package source.
+import baseConfig, { withProviderImportBoundary } from '@excitedjs/eslint-config';
+
+export default withProviderImportBoundary(baseConfig);

--- a/packages/agent-runtime/mimo-code/package.json
+++ b/packages/agent-runtime/mimo-code/package.json
@@ -1,0 +1,55 @@
+{
+  "name": "@excitedjs/agent-runtime-mimo-code",
+  "version": "0.0.0",
+  "description": "External MiMo Code Agent Runtime provider for Dreamux. Implements the @excitedjs/dreamux-types AgentRuntimeProvider contract against a private `mimo serve` process.",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/excitedjs/dreamux.git",
+    "directory": "packages/agent-runtime/mimo-code"
+  },
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "default": "./dist/index.js"
+    },
+    "./config": {
+      "types": "./dist/config.d.ts",
+      "import": "./dist/config.js",
+      "default": "./dist/config.js"
+    }
+  },
+  "engines": {
+    "node": ">=22.7"
+  },
+  "files": [
+    "dist",
+    "README.md",
+    "LICENSE"
+  ],
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "typecheck:tests": "tsc -p tsconfig.tests.json",
+    "lint": "eslint .",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "clean": "rm -rf dist",
+    "prepublishOnly": "npm run build"
+  },
+  "dependencies": {
+    "@excitedjs/dreamux-types": "workspace:*",
+    "@excitedjs/dreamux-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "@excitedjs/eslint-config": "workspace:*",
+    "@types/node": "^22.10.0",
+    "eslint": "^9.39.0",
+    "typescript": "^5.7.0",
+    "vitest": "^2.1.0"
+  }
+}

--- a/packages/agent-runtime/mimo-code/src/client.ts
+++ b/packages/agent-runtime/mimo-code/src/client.ts
@@ -1,0 +1,174 @@
+import { Buffer } from 'node:buffer';
+import type { AgentRuntimeMcpServer } from '@excitedjs/dreamux-types';
+
+export interface MimoCreateSessionInput {
+  cwd: string;
+  model: string | null;
+  agent: string | null;
+  systemPrompt: string | null;
+  mcpServers: readonly AgentRuntimeMcpServer[];
+}
+
+export interface MimoMessageInput {
+  text: string;
+  turnId: string;
+  timeoutMs: number;
+  model: string | null;
+  agent: string | null;
+  systemPrompt: string | null;
+}
+
+export interface MimoMessageResult {
+  text: string | null;
+}
+
+export interface MimoClient {
+  createSession(input: MimoCreateSessionInput): Promise<string>;
+  sendMessage(
+    sessionId: string,
+    input: MimoMessageInput,
+  ): Promise<MimoMessageResult>;
+}
+
+export interface MimoHttpClientOptions {
+  baseUrl: string;
+  password?: string | null;
+  username?: string | null;
+}
+
+export class MimoHttpError extends Error {
+  constructor(
+    message: string,
+    readonly status: number,
+  ) {
+    super(message);
+    this.name = 'MimoHttpError';
+  }
+}
+
+export class MimoBusyError extends MimoHttpError {
+  constructor(message = 'MiMo session is busy') {
+    super(message, 409);
+    this.name = 'MimoBusyError';
+  }
+}
+
+export class MimoHttpClient implements MimoClient {
+  private readonly baseUrl: string;
+  private readonly password: string | null;
+  private readonly username: string;
+
+  constructor(options: MimoHttpClientOptions) {
+    this.baseUrl = options.baseUrl.replace(/\/+$/, '');
+    this.password = options.password ?? null;
+    this.username = options.username ?? 'mimocode';
+  }
+
+  async createSession(_input: MimoCreateSessionInput): Promise<string> {
+    const response = await this.request('/session', {
+      method: 'POST',
+      body: JSON.stringify({}),
+    });
+    const body = await readJsonObject(response);
+    const id = readString(body, ['id', 'sessionID', 'sessionId']);
+    if (id === null) {
+      throw new Error('MiMo create session response did not include a session id');
+    }
+    return id;
+  }
+
+  async sendMessage(
+    sessionId: string,
+    input: MimoMessageInput,
+  ): Promise<MimoMessageResult> {
+    const controller = new AbortController();
+    const timeout = globalThis.setTimeout(() => controller.abort(), input.timeoutMs);
+    try {
+      const response = await this.request(
+        `/session/${encodeURIComponent(sessionId)}/message`,
+        {
+          method: 'POST',
+          body: JSON.stringify({
+            ...(input.model !== null ? { modelRef: input.model } : {}),
+            ...(input.agent !== null ? { agent: input.agent } : {}),
+            ...(input.systemPrompt !== null ? { system: input.systemPrompt } : {}),
+            parts: [{ type: 'text', text: input.text }],
+          }),
+          signal: controller.signal,
+        },
+      );
+      const body = await readJsonObject(response);
+      return { text: readMessageResultText(body) };
+    } catch (err) {
+      if (err instanceof DOMException && err.name === 'AbortError') {
+        throw new Error(`MiMo turn ${input.turnId} timed out`);
+      }
+      throw err;
+    } finally {
+      globalThis.clearTimeout(timeout);
+    }
+  }
+
+  private async request(path: string, init: RequestInit): Promise<Response> {
+    const headers = new Headers(init.headers);
+    headers.set('content-type', 'application/json');
+    if (this.password !== null && this.password !== '') {
+      const encoded = Buffer.from(`${this.username}:${this.password}`).toString(
+        'base64',
+      );
+      headers.set('authorization', `Basic ${encoded}`);
+    }
+    const response = await fetch(`${this.baseUrl}${path}`, {
+      ...init,
+      headers,
+    });
+    if (response.status === 409) throw new MimoBusyError();
+    if (!response.ok) {
+      throw new MimoHttpError(
+        `MiMo HTTP ${response.status} for ${path}: ${await response.text()}`,
+        response.status,
+      );
+    }
+    return response;
+  }
+}
+
+function readMessageResultText(body: Record<string, unknown>): string | null {
+  const direct = readString(body, ['text', 'message', 'content', 'result']);
+  if (direct !== null) return direct;
+
+  const parts = body['parts'];
+  if (!Array.isArray(parts)) return null;
+  const textParts = parts.flatMap((part) => {
+    if (part === null || typeof part !== 'object' || Array.isArray(part)) {
+      return [];
+    }
+    const record = part as Record<string, unknown>;
+    return record['type'] === 'text' && typeof record['text'] === 'string'
+      ? [record['text']]
+      : [];
+  });
+  return textParts.length === 0 ? null : textParts.join('');
+}
+
+async function readJsonObject(response: Response): Promise<Record<string, unknown>> {
+  const text = await response.text();
+  const trimmed = text.trim();
+  if (trimmed === '') return {};
+  const parsed: unknown = JSON.parse(trimmed);
+  if (parsed === null || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    throw new Error('MiMo HTTP response was not a JSON object');
+  }
+  return parsed as Record<string, unknown>;
+}
+
+function readString(
+  obj: Record<string, unknown>,
+  keys: readonly string[],
+): string | null {
+  for (const key of keys) {
+    const value = obj[key];
+    if (typeof value === 'string') return value;
+  }
+  return null;
+}

--- a/packages/agent-runtime/mimo-code/src/config.ts
+++ b/packages/agent-runtime/mimo-code/src/config.ts
@@ -1,0 +1,165 @@
+import {
+  isPlainObject,
+  readOptionalBoolean,
+  readOptionalString,
+  rejectUnknownKeys,
+  requirePositiveInt,
+  requireStringRecord,
+} from '@excitedjs/dreamux-utils';
+
+export type MimoCodePermissionMode = 'deny';
+
+export interface MimoCodeConfig {
+  bin: string;
+  model: string | null;
+  agent: string | null;
+  extra_env: Record<string, string>;
+  config_content: string | null;
+  config_path: string | null;
+  permission_mode: MimoCodePermissionMode;
+  startup_timeout_ms: number;
+  turn_timeout_ms: number;
+  keep_home: boolean;
+}
+
+export const DEFAULT_MIMO_CODE_BIN = 'mimo';
+export const DEFAULT_MIMO_CODE_STARTUP_TIMEOUT_MS = 30_000;
+export const DEFAULT_MIMO_CODE_TURN_TIMEOUT_MS = 600_000;
+
+export function defaultMimoCodeConfig(): MimoCodeConfig {
+  return {
+    bin: DEFAULT_MIMO_CODE_BIN,
+    model: null,
+    agent: null,
+    extra_env: {},
+    config_content: null,
+    config_path: null,
+    permission_mode: 'deny',
+    startup_timeout_ms: DEFAULT_MIMO_CODE_STARTUP_TIMEOUT_MS,
+    turn_timeout_ms: DEFAULT_MIMO_CODE_TURN_TIMEOUT_MS,
+    keep_home: false,
+  };
+}
+
+export function readMimoCodeConfig(
+  rawConfig: Record<string, unknown>,
+  file: string,
+  prefix: string,
+): MimoCodeConfig {
+  rejectUnknownKeys(
+    rawConfig,
+    new Set([
+      'bin',
+      'model',
+      'agent',
+      'extra_env',
+      'config_content',
+      'config_path',
+      'permission_mode',
+      'startup_timeout_ms',
+      'turn_timeout_ms',
+      'keep_home',
+    ]),
+    file,
+    prefix,
+  );
+
+  const defaults = defaultMimoCodeConfig();
+  const bin = readOptionalString(rawConfig, 'bin', file, prefix) ?? defaults.bin;
+  if (bin.trim() === '') {
+    throw new Error(
+      `dreamux config error in ${file}: ${prefix}bin must be a non-empty string`,
+    );
+  }
+  const permissionMode = readPermissionMode(rawConfig, file, prefix);
+  const configContent = readOptionalString(
+    rawConfig,
+    'config_content',
+    file,
+    prefix,
+  );
+  const configPath = readOptionalString(rawConfig, 'config_path', file, prefix);
+  if (configContent !== null && configPath !== null) {
+    throw new Error(
+      `dreamux config error in ${file}: ${prefix}config_content and ${prefix}config_path are mutually exclusive`,
+    );
+  }
+
+  return {
+    bin,
+    model: readOptionalString(rawConfig, 'model', file, prefix),
+    agent: readOptionalString(rawConfig, 'agent', file, prefix),
+    extra_env: requireStringRecord(
+      rawConfig,
+      'extra_env',
+      defaults.extra_env,
+      file,
+      prefix,
+    ),
+    config_content: configContent,
+    config_path: configPath,
+    permission_mode: permissionMode,
+    startup_timeout_ms: requirePositiveInt(
+      rawConfig,
+      'startup_timeout_ms',
+      defaults.startup_timeout_ms,
+      file,
+      prefix,
+    ),
+    turn_timeout_ms: requirePositiveInt(
+      rawConfig,
+      'turn_timeout_ms',
+      defaults.turn_timeout_ms,
+      file,
+      prefix,
+    ),
+    keep_home: readOptionalBoolean(
+      rawConfig,
+      'keep_home',
+      defaults.keep_home,
+      file,
+      prefix,
+    ),
+  };
+}
+
+function readPermissionMode(
+  rawConfig: Record<string, unknown>,
+  file: string,
+  prefix: string,
+): MimoCodePermissionMode {
+  const raw = rawConfig.permission_mode;
+  if (raw === undefined || raw === null) return 'deny';
+  if (typeof raw !== 'string') {
+    throw new Error(
+      `dreamux config error in ${file}: ${prefix}permission_mode must be a string`,
+    );
+  }
+  if (raw === 'deny') return raw;
+  if (raw === 'ask') {
+    throw new Error(
+      `dreamux config error in ${file}: ${prefix}permission_mode='ask' is not supported until the provider owns a complete permission response loop`,
+    );
+  }
+  if (raw === 'auto-approve') {
+    throw new Error(
+      `dreamux config error in ${file}: ${prefix}permission_mode='auto-approve' is not supported until the provider owns a complete MiMo permission response loop`,
+    );
+  }
+  throw new Error(
+    `dreamux config error in ${file}: ${prefix}permission_mode='${raw}' is not one of deny`,
+  );
+}
+
+export function assertNoNativeMcpConfig(
+  rawConfig: unknown,
+  file: string,
+  prefix: string,
+): void {
+  if (!isPlainObject(rawConfig)) return;
+  if ('mcp' in rawConfig || 'mcpServers' in rawConfig) {
+    throw new Error(
+      `dreamux config error in ${file}: ${prefix}native MiMo MCP config is not allowed; Dreamux-supplied mcpServers are authoritative`,
+    );
+  }
+}

--- a/packages/agent-runtime/mimo-code/src/diagnostic.ts
+++ b/packages/agent-runtime/mimo-code/src/diagnostic.ts
@@ -1,0 +1,36 @@
+import { DEFAULT_MIMO_CODE_BIN, type MimoCodeConfig } from './config.js';
+import type {
+  AgentRuntimeBinCheck,
+  AgentRuntimeDiagnostic,
+  AgentRuntimeDiagnosticContext,
+  AgentRuntimeDiagnosticResult,
+} from '@excitedjs/dreamux-types';
+
+type MimoDiagnosticContext = AgentRuntimeDiagnosticContext<MimoCodeConfig>;
+
+function mimoBinCheckName(scope: MimoDiagnosticContext['scope']): string {
+  return scope === 'managedService'
+    ? 'managed service MiMo Code binary'
+    : 'mimo-code binary';
+}
+
+export const mimoCodeAgentRuntimeDiagnostic: AgentRuntimeDiagnostic<MimoCodeConfig> =
+  {
+    binChecks(context): AgentRuntimeBinCheck[] {
+      return [
+        {
+          name: mimoBinCheckName(context.scope),
+          bin: context.config.bin || DEFAULT_MIMO_CODE_BIN,
+          args: ['--help'],
+        },
+      ];
+    },
+    async runDiagnostic(): Promise<AgentRuntimeDiagnosticResult> {
+      return {
+        ok: true,
+        detail:
+          'MiMo Code runtime diagnostics are limited to binary checks in this package slice',
+        errors: [],
+      };
+    },
+  };

--- a/packages/agent-runtime/mimo-code/src/index.ts
+++ b/packages/agent-runtime/mimo-code/src/index.ts
@@ -1,0 +1,33 @@
+export {
+  createMimoCodeAgentRuntimeProvider,
+  default,
+  type MimoCodeAgentRuntimeProviderOptions,
+  type MimoCodeProviderFactoryContext,
+  MIMO_CODE_AGENT_RUNTIME_CAPABILITIES,
+} from './provider.js';
+export {
+  DEFAULT_MIMO_CODE_BIN,
+  DEFAULT_MIMO_CODE_STARTUP_TIMEOUT_MS,
+  DEFAULT_MIMO_CODE_TURN_TIMEOUT_MS,
+  defaultMimoCodeConfig,
+  readMimoCodeConfig,
+  type MimoCodeConfig,
+  type MimoCodePermissionMode,
+} from './config.js';
+export { MIMO_CODE_PROVIDER_REF } from './provider-ref.js';
+export { MimoCodeRuntime, selectMimoSystemPrompt } from './runtime.js';
+export {
+  MimoBusyError,
+  MimoHttpClient,
+  MimoHttpError,
+  type MimoClient,
+  type MimoCreateSessionInput,
+  type MimoMessageInput,
+  type MimoMessageResult,
+} from './client.js';
+export {
+  createDefaultMimoServer,
+  type MimoServerFactory,
+  type MimoServerHandle,
+  type MimoServerStartOptions,
+} from './supervisor.js';

--- a/packages/agent-runtime/mimo-code/src/provider-ref.ts
+++ b/packages/agent-runtime/mimo-code/src/provider-ref.ts
@@ -1,0 +1,1 @@
+export const MIMO_CODE_PROVIDER_REF = 'npm:@excitedjs/agent-runtime-mimo-code';

--- a/packages/agent-runtime/mimo-code/src/provider.ts
+++ b/packages/agent-runtime/mimo-code/src/provider.ts
@@ -1,0 +1,103 @@
+import {
+  assertNoNativeMcpConfig,
+  DEFAULT_MIMO_CODE_BIN,
+  readMimoCodeConfig,
+  type MimoCodeConfig,
+} from './config.js';
+import { mimoCodeAgentRuntimeDiagnostic } from './diagnostic.js';
+import { MIMO_CODE_PROVIDER_REF } from './provider-ref.js';
+import {
+  MimoCodeRuntime,
+  type MimoCodeRuntimeDeps,
+} from './runtime.js';
+import type { MimoServerFactory } from './supervisor.js';
+import type {
+  AgentRuntime,
+  AgentRuntimeCapabilities,
+  AgentRuntimeCreateContext,
+  AgentRuntimeProvider,
+  AgentRuntimeProviderDescriptor,
+  AgentRuntimeProviderFactory,
+  ProviderDescriptor,
+  ProviderFactoryContext,
+} from '@excitedjs/dreamux-types';
+
+export interface MimoCodeAgentRuntimeProviderOptions {
+  descriptor?: ProviderDescriptor;
+  serverFactory?: MimoServerFactory;
+}
+
+export const MIMO_CODE_AGENT_RUNTIME_CAPABILITIES: AgentRuntimeCapabilities = {
+  resume: { supported: true },
+};
+
+const DEFAULT_DESCRIPTOR: AgentRuntimeProviderDescriptor = {
+  id: 'mimo-code',
+  kind: 'agentRuntime',
+  ref: {
+    source: 'npm',
+    package: '@excitedjs/agent-runtime-mimo-code',
+    export: null,
+    raw: MIMO_CODE_PROVIDER_REF,
+  },
+};
+
+function asAgentRuntimeDescriptor(
+  descriptor: ProviderDescriptor,
+): AgentRuntimeProviderDescriptor {
+  if (descriptor.kind !== 'agentRuntime') {
+    throw new Error(
+      `@excitedjs/agent-runtime-mimo-code: descriptor.kind must be ` +
+        `'agentRuntime' (got ${JSON.stringify(descriptor.kind)})`,
+    );
+  }
+  return { ...descriptor, kind: descriptor.kind };
+}
+
+export function createMimoCodeAgentRuntimeProvider(
+  options: MimoCodeAgentRuntimeProviderOptions = {},
+): AgentRuntimeProvider<MimoCodeConfig> {
+  return {
+    ref: MIMO_CODE_PROVIDER_REF,
+    descriptor:
+      options.descriptor === undefined
+        ? DEFAULT_DESCRIPTOR
+        : asAgentRuntimeDescriptor(options.descriptor),
+    getCapabilities: () => MIMO_CODE_AGENT_RUNTIME_CAPABILITIES,
+    diagnostic: mimoCodeAgentRuntimeDiagnostic,
+    onboard: {
+      async collect(_context, prompts): Promise<Record<string, unknown>> {
+        const bin = await prompts.text({
+          message: 'MiMo Code CLI binary',
+          initialValue: DEFAULT_MIMO_CODE_BIN,
+          required: true,
+        });
+        return { bin, permission_mode: 'deny' };
+      },
+    },
+    readConfig(rawConfig, context) {
+      assertNoNativeMcpConfig(rawConfig, context.file, context.prefix);
+      return readMimoCodeConfig(rawConfig, context.file, context.prefix);
+    },
+    createRuntime(context: AgentRuntimeCreateContext<MimoCodeConfig>): AgentRuntime {
+      const deps: MimoCodeRuntimeDeps = {
+        context,
+        ...(options.serverFactory !== undefined
+          ? { serverFactory: options.serverFactory }
+          : {}),
+      };
+      return new MimoCodeRuntime(context.identity, deps);
+    },
+  };
+}
+
+export { readMimoCodeConfig };
+
+export type MimoCodeProviderFactoryContext =
+  ProviderFactoryContext<AgentRuntimeProviderDescriptor>;
+
+const mimoCodeAgentRuntimeProviderFactory: AgentRuntimeProviderFactory<MimoCodeConfig> =
+  (context) =>
+    createMimoCodeAgentRuntimeProvider({ descriptor: context.descriptor });
+
+export default mimoCodeAgentRuntimeProviderFactory;

--- a/packages/agent-runtime/mimo-code/src/runtime.ts
+++ b/packages/agent-runtime/mimo-code/src/runtime.ts
@@ -1,0 +1,346 @@
+import { renderChannelInput } from '@excitedjs/dreamux-utils';
+
+import type { MimoClient } from './client.js';
+import { MimoBusyError } from './client.js';
+import type { MimoCodeConfig } from './config.js';
+import type {
+  MimoServerFactory,
+  MimoServerHandle,
+  MimoServerStartOptions,
+} from './supervisor.js';
+import { createDefaultMimoServer } from './supervisor.js';
+import { MIMO_CODE_AGENT_RUNTIME_CAPABILITIES } from './provider.js';
+import { MIMO_CODE_PROVIDER_REF } from './provider-ref.js';
+import type {
+  AgentRuntime,
+  AgentRuntimeCapabilities,
+  AgentRuntimeCreateContext,
+  AgentRuntimeIdentity,
+  AgentRuntimeLastResult,
+  AgentRuntimeStatus,
+  AgentRuntimeTextInput,
+  AgentRuntimeTurnResult,
+  DreamuxLogger,
+  InboundDeliveryHooks,
+  InboundTurnInput,
+  TurnSettledSignal,
+} from '@excitedjs/dreamux-types';
+
+export interface MimoCodeRuntimeDeps {
+  context: AgentRuntimeCreateContext<MimoCodeConfig>;
+  serverFactory?: MimoServerFactory;
+}
+
+let nextRuntimeInstanceId = 0;
+
+function errMessage(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => {
+    globalThis.setTimeout(resolve, ms);
+  });
+}
+
+export function selectMimoSystemPrompt(
+  systemPrompt: AgentRuntimeCreateContext<MimoCodeConfig>['systemPrompt'],
+): string | null {
+  if (systemPrompt === undefined) return null;
+  const append = (systemPrompt.append ?? []).filter((prompt) => prompt !== '');
+  if (systemPrompt.replace !== undefined) {
+    return [systemPrompt.replace, ...append].filter((prompt) => prompt !== '').join(
+      '\n\n',
+    );
+  }
+  if (append.length === 0) return null;
+  return append.join('\n\n');
+}
+
+export class MimoCodeRuntime implements AgentRuntime {
+  readonly providerRef = MIMO_CODE_PROVIDER_REF;
+
+  private readonly runtimeId: string;
+  private readonly config: MimoCodeConfig;
+  private readonly context: AgentRuntimeCreateContext<MimoCodeConfig>;
+  private readonly logger: DreamuxLogger | null;
+  private readonly serverFactory: MimoServerFactory;
+  private readonly runtimeInstanceId = ++nextRuntimeInstanceId;
+  private status: AgentRuntimeStatus = 'declared';
+  private stopped = false;
+  private server: MimoServerHandle | null = null;
+  private sessionId: string | null;
+  private resumed: boolean;
+  private queue: Promise<void> = Promise.resolve();
+  private readonly seenChannelSourceIds = new Set<string>();
+  private readonly seenTextSourceIds = new Set<string>();
+  private turnCounter = 0;
+  private queuedTurnCount = 0;
+  private idlePromise: Promise<void> | null = null;
+  private idleResolve: (() => void) | null = null;
+  private lastResult: AgentRuntimeLastResult | null = null;
+
+  constructor(identity: AgentRuntimeIdentity, deps: MimoCodeRuntimeDeps) {
+    this.runtimeId = identity.runtime_id;
+    this.context = deps.context;
+    this.config = deps.context.config;
+    this.logger = deps.context.logger ?? null;
+    this.serverFactory = deps.serverFactory ?? createDefaultMimoServer;
+    this.sessionId = identity.checkpoint_id ?? null;
+    this.resumed = this.sessionId !== null;
+  }
+
+  getStatus(): AgentRuntimeStatus {
+    return this.status;
+  }
+
+  getCapabilities(): AgentRuntimeCapabilities {
+    return MIMO_CODE_AGENT_RUNTIME_CAPABILITIES;
+  }
+
+  getCheckpoint(): { id: string } | null {
+    return this.sessionId === null ? null : { id: this.sessionId };
+  }
+
+  wasCheckpointResumed(): boolean {
+    return this.resumed;
+  }
+
+  async getLast(): Promise<AgentRuntimeLastResult | null> {
+    return this.lastResult;
+  }
+
+  async getContext(): Promise<null> {
+    return null;
+  }
+
+  async start(): Promise<void> {
+    if (this.context.paths === undefined) {
+      throw new Error('mimo-code runtime requires a path context in the create context');
+    }
+    if (this.context.state === undefined) {
+      throw new Error('mimo-code runtime requires a state sink in the create context');
+    }
+    await this.setStatus('starting');
+    try {
+      const startOptions: MimoServerStartOptions = {
+        runtimeId: this.runtimeId,
+        config: this.config,
+        cwd: this.context.cwd,
+        paths: this.context.paths,
+        mcpServers: this.context.mcpServers,
+        systemPrompt: selectMimoSystemPrompt(this.context.systemPrompt),
+        ...(this.context.injectEnv !== undefined
+          ? { injectEnv: this.context.injectEnv }
+          : {}),
+      };
+      this.server = await this.serverFactory(startOptions);
+      if (this.sessionId === null) {
+        this.sessionId = await this.client().createSession({
+          cwd: this.context.cwd,
+          model: this.config.model,
+          agent: this.config.agent,
+          systemPrompt: startOptions.systemPrompt,
+          mcpServers: this.context.mcpServers,
+        });
+        await this.context.state.setCheckpoint({ id: this.sessionId });
+      }
+      await this.setStatus('ready');
+    } catch (err) {
+      await this.setStatus('degraded', err);
+      throw err;
+    }
+  }
+
+  async resume(): Promise<void> {
+    await this.start();
+  }
+
+  async stop(): Promise<void> {
+    if (this.stopped) return;
+    this.stopped = true;
+    await this.setStatus('stopping');
+    const server = this.server;
+    this.server = null;
+    if (server !== null) {
+      try {
+        await server.stop();
+      } catch (err) {
+        this.log('warn', 'mimo-code server stop errored', err);
+      }
+    }
+    this.queuedTurnCount = 0;
+    this.resolveIdleWaitersIfIdle();
+    await this.setStatus('stopped');
+  }
+
+  async completionInput(input: AgentRuntimeTextInput): Promise<AgentRuntimeTurnResult> {
+    if (this.stopped) return { status: 'stopped' };
+    const key = input.sourceId;
+    if (key !== undefined && key !== '' && this.seenTextSourceIds.has(key)) {
+      return { status: 'duplicate' };
+    }
+    if (key !== undefined && key !== '') this.seenTextSourceIds.add(key);
+    const turnId = this.nextTurnId();
+    this.recordQueuedTurnStart();
+    void this.runTurnOnQueue(input.text, turnId).then(
+      (resultText) => this.markTurnSucceeded(turnId, resultText),
+      (err) => this.markTurnFailed(turnId, err),
+    );
+    return { status: 'submitted', turnId };
+  }
+
+  async channelInput(
+    input: InboundTurnInput,
+    hooks: InboundDeliveryHooks = {},
+  ): Promise<AgentRuntimeTurnResult> {
+    if (this.stopped) return { status: 'stopped' };
+    const key = input.sourceId;
+    if (key !== '' && this.seenChannelSourceIds.has(key)) {
+      return { status: 'duplicate' };
+    }
+    if (key !== '') this.seenChannelSourceIds.add(key);
+    try {
+      await hooks.onAccepted?.(input);
+    } catch (err) {
+      this.log('warn', 'mimo-code onAccepted hook failed', err);
+    }
+    const turnId = this.nextTurnId();
+    this.recordQueuedTurnStart();
+    void this.runTurnOnQueue(renderChannelInput(input), turnId).then(
+      (resultText) => this.markTurnSucceeded(turnId, resultText),
+      (err) => this.markTurnFailed(turnId, err),
+    );
+    return { status: 'submitted', turnId };
+  }
+
+  waitIdle(): Promise<void> {
+    if (this.queuedTurnCount === 0) return Promise.resolve();
+    if (this.idlePromise === null) {
+      this.idlePromise = new Promise((resolve) => {
+        this.idleResolve = resolve;
+      });
+    }
+    return this.idlePromise;
+  }
+
+  private runTurnOnQueue(
+    text: string,
+    turnId: string,
+  ): Promise<string | null> {
+    const run = this.queue.then(() => this.runTurn(text, turnId));
+    this.queue = run.then(
+      () => undefined,
+      () => undefined,
+    );
+    return run;
+  }
+
+  private async runTurn(text: string, turnId: string): Promise<string | null> {
+    if (this.stopped) throw new Error('mimo-code runtime is stopped');
+    const sessionId = this.sessionId;
+    if (sessionId === null) {
+      throw new Error('mimo-code runtime has no bound session');
+    }
+    const startedAt = Date.now();
+    for (;;) {
+      try {
+        const result = await this.client().sendMessage(sessionId, {
+          text,
+          turnId,
+          timeoutMs: this.config.turn_timeout_ms,
+          model: this.config.model,
+          agent: this.config.agent,
+          systemPrompt: selectMimoSystemPrompt(this.context.systemPrompt),
+        });
+        if (result.text !== null) this.lastResult = { text: result.text };
+        return result.text;
+      } catch (err) {
+        if (!(err instanceof MimoBusyError)) throw err;
+        if (Date.now() - startedAt >= this.config.turn_timeout_ms) {
+          throw new Error(`MiMo session stayed busy for turn ${turnId}`);
+        }
+        await sleep(50);
+      }
+    }
+  }
+
+  private async markTurnSucceeded(
+    turnId: string,
+    resultText: string | null,
+  ): Promise<void> {
+    this.recordQueuedTurnEnd();
+    this.context.onTurnSettled?.({
+      turnId,
+      status: 'completed',
+      result: { text: resultText },
+    });
+    if (this.stopped) return;
+    if (this.status !== 'ready') await this.setStatus('ready');
+  }
+
+  private async markTurnFailed(turnId: string, err: unknown): Promise<void> {
+    this.recordQueuedTurnEnd();
+    this.log('error', `mimo-code turn ${turnId} failed`, err);
+    const settled: TurnSettledSignal = {
+      turnId,
+      status: this.stopped ? 'stopped' : 'failed',
+      result: { text: null },
+      error: err instanceof Error ? err : new Error(String(err)),
+    };
+    this.context.onTurnSettled?.(settled);
+    if (this.stopped) return;
+    await this.setStatus('degraded', err);
+  }
+
+  private recordQueuedTurnStart(): void {
+    this.queuedTurnCount += 1;
+  }
+
+  private recordQueuedTurnEnd(): void {
+    this.queuedTurnCount = Math.max(0, this.queuedTurnCount - 1);
+    this.resolveIdleWaitersIfIdle();
+  }
+
+  private resolveIdleWaitersIfIdle(): void {
+    if (this.queuedTurnCount !== 0) return;
+    const resolve = this.idleResolve;
+    this.idlePromise = null;
+    this.idleResolve = null;
+    resolve?.();
+  }
+
+  private client(): MimoClient {
+    if (this.server === null) {
+      throw new Error('mimo-code server is not started');
+    }
+    return this.server.client;
+  }
+
+  private nextTurnId(): string {
+    return `mimo-turn-${this.runtimeInstanceId}-${++this.turnCounter}`;
+  }
+
+  private async setStatus(
+    status: AgentRuntimeStatus,
+    err?: unknown,
+  ): Promise<void> {
+    this.status = status;
+    try {
+      await this.context.state?.setStatus(
+        status,
+        err !== undefined ? { last_error: errMessage(err) } : {},
+      );
+    } catch (stateErr) {
+      this.log('warn', 'mimo-code status persistence failed', stateErr);
+    }
+  }
+
+  private log(level: 'info' | 'warn' | 'error', msg: string, err?: unknown): void {
+    if (err === undefined) {
+      this.logger?.[level]?.(msg);
+      return;
+    }
+    this.logger?.[level]?.({ err }, msg);
+  }
+}

--- a/packages/agent-runtime/mimo-code/src/supervisor.ts
+++ b/packages/agent-runtime/mimo-code/src/supervisor.ts
@@ -159,8 +159,6 @@ export function buildMimoNativeConfig(
     ),
   };
   if (options.config.model !== null) config.model = options.config.model;
-  if (options.config.agent !== null) config.agent = options.config.agent;
-  if (options.systemPrompt !== null) config.system = options.systemPrompt;
   config.permission = 'deny';
   return `${JSON.stringify(config, null, 2)}\n`;
 }

--- a/packages/agent-runtime/mimo-code/src/supervisor.ts
+++ b/packages/agent-runtime/mimo-code/src/supervisor.ts
@@ -1,0 +1,236 @@
+import { spawn, type ChildProcessByStdio } from 'node:child_process';
+import { mkdir, readFile, rm, writeFile } from 'node:fs/promises';
+import { dirname, join, resolve } from 'node:path';
+import type { Readable } from 'node:stream';
+
+import { MimoHttpClient, type MimoClient } from './client.js';
+import type { MimoCodeConfig } from './config.js';
+import type {
+  AgentRuntimeMcpServer,
+  AgentRuntimePathContext,
+} from '@excitedjs/dreamux-types';
+
+export interface MimoServerStartOptions {
+  runtimeId: string;
+  config: MimoCodeConfig;
+  cwd: string;
+  paths: AgentRuntimePathContext;
+  injectEnv?: Record<string, string>;
+  mcpServers: readonly AgentRuntimeMcpServer[];
+  systemPrompt: string | null;
+}
+
+export interface MimoProcessEnvOptions {
+  config: MimoCodeConfig;
+  homeDir: string;
+  username: string;
+  password: string;
+  configPath: string;
+  injectEnv?: Record<string, string>;
+}
+
+export interface MimoServerHandle {
+  readonly homeDir: string;
+  readonly baseUrl: string;
+  readonly username: string | null;
+  readonly password: string | null;
+  readonly client: MimoClient;
+  stop(): Promise<void>;
+}
+
+export type MimoServerFactory = (
+  options: MimoServerStartOptions,
+) => Promise<MimoServerHandle>;
+
+type MimoChildProcess = ChildProcessByStdio<null, Readable, Readable>;
+
+export class MimoServeProcess implements MimoServerHandle {
+  readonly client: MimoClient;
+
+  constructor(
+    readonly homeDir: string,
+    readonly baseUrl: string,
+    readonly username: string | null,
+    readonly password: string | null,
+    private readonly child: MimoChildProcess,
+    private readonly keepHome: boolean,
+  ) {
+    this.client = new MimoHttpClient({ baseUrl, username, password });
+  }
+
+  async stop(): Promise<void> {
+    if (!this.child.killed) this.child.kill('SIGTERM');
+    await new Promise<void>((resolveStop) => {
+      if (this.child.exitCode !== null || this.child.signalCode !== null) {
+        resolveStop();
+        return;
+      }
+      const timer = globalThis.setTimeout(() => {
+        if (!this.child.killed) this.child.kill('SIGKILL');
+        resolveStop();
+      }, 2_000);
+      this.child.once('exit', () => {
+        globalThis.clearTimeout(timer);
+        resolveStop();
+      });
+    });
+    if (!this.keepHome) {
+      await rm(this.homeDir, { recursive: true, force: true });
+    }
+  }
+}
+
+export async function createDefaultMimoServer(
+  options: MimoServerStartOptions,
+): Promise<MimoServerHandle> {
+  const homeDir = resolve(
+    join(options.paths.dispatcherDir(options.runtimeId), 'mimo-code-home'),
+  );
+  await mkdir(homeDir, { recursive: true });
+  const configPath = join(homeDir, 'config.json');
+  await writeFile(
+    configPath,
+    buildMimoNativeConfig(options, await readOperatorNativeConfig(options.config)),
+    { mode: 0o600 },
+  );
+
+  const username = 'mimocode';
+  const password = `dreamux-${options.runtimeId}-${Date.now()}`;
+  const env = buildMimoProcessEnv({
+    config: options.config,
+    homeDir,
+    username,
+    password,
+    configPath,
+    ...(options.injectEnv !== undefined ? { injectEnv: options.injectEnv } : {}),
+  });
+  const args = ['serve', '--hostname', '127.0.0.1', '--port', '0'];
+  const child = spawn(options.config.bin, args, {
+    cwd: options.cwd,
+    env,
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+  const baseUrl = await waitForServerUrl(child, options.config.startup_timeout_ms);
+  return new MimoServeProcess(
+    homeDir,
+    baseUrl,
+    username,
+    password,
+    child,
+    options.config.keep_home,
+  );
+}
+
+export function buildMimoProcessEnv(
+  options: MimoProcessEnvOptions,
+): NodeJS.ProcessEnv {
+  return {
+    ...globalThis.process.env,
+    ...(options.injectEnv ?? {}),
+    ...options.config.extra_env,
+    MIMOCODE_HOME: options.homeDir,
+    MIMOCODE_MIMO_ONLY: 'true',
+    MIMOCODE_DISABLE_EXTERNAL_SKILLS: 'true',
+    MIMOCODE_DISABLE_DEFAULT_PLUGINS: 'true',
+    MIMOCODE_DISABLE_MODELS_FETCH: 'true',
+    MIMOCODE_DISABLE_CLAUDE_CODE_MCP: 'true',
+    MIMOCODE_ENABLE_ANALYSIS: 'false',
+    MIMOCODE_SERVER_USERNAME: options.username,
+    MIMOCODE_SERVER_PASSWORD: options.password,
+    MIMOCODE_CONFIG: options.configPath,
+  };
+}
+
+export function buildMimoNativeConfig(
+  options: MimoServerStartOptions,
+  operatorConfig: Record<string, unknown> = {},
+): string {
+  const config: Record<string, unknown> = {
+    ...operatorConfig,
+    share: 'disabled',
+    mcp: Object.fromEntries(
+      options.mcpServers.map((server) => [
+        server.name,
+        {
+          type: 'local',
+          command: [server.command, ...server.args],
+        },
+      ]),
+    ),
+  };
+  if (options.config.model !== null) config.model = options.config.model;
+  if (options.config.agent !== null) config.agent = options.config.agent;
+  if (options.systemPrompt !== null) config.system = options.systemPrompt;
+  config.permission = 'deny';
+  return `${JSON.stringify(config, null, 2)}\n`;
+}
+
+async function readOperatorNativeConfig(
+  config: MimoCodeConfig,
+): Promise<Record<string, unknown>> {
+  const raw =
+    config.config_content ??
+    (config.config_path === null
+      ? null
+      : await readFile(config.config_path, 'utf8'));
+  if (raw === null) return {};
+  const parsed: unknown = JSON.parse(raw);
+  if (parsed === null || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    throw new Error('MiMo native config must be a JSON object');
+  }
+  const record = parsed as Record<string, unknown>;
+  if ('mcp' in record || 'mcpServers' in record) {
+    throw new Error(
+      'MiMo native config must not declare MCP servers; Dreamux mcpServers are authoritative',
+    );
+  }
+  return record;
+}
+
+async function waitForServerUrl(
+  child: MimoChildProcess,
+  timeoutMs: number,
+): Promise<string> {
+  return await new Promise((resolveUrl, reject) => {
+    let settled = false;
+    let output = '';
+    const finish = (err: Error | null, url?: string): void => {
+      if (settled) return;
+      settled = true;
+      globalThis.clearTimeout(timer);
+      child.stdout.off('data', onData);
+      child.stderr.off('data', onData);
+      child.off('exit', onExit);
+      if (err !== null) reject(err);
+      else resolveUrl(url ?? '');
+    };
+    const timer = globalThis.setTimeout(() => {
+      finish(new Error('timed out waiting for MiMo server URL'));
+    }, timeoutMs);
+    const onExit = (): void => {
+      finish(new Error(`MiMo server exited before startup: ${output.trim()}`));
+    };
+    const onData = (chunk: Buffer): void => {
+      output += chunk.toString('utf8');
+      const match = output.match(/https?:\/\/127\.0\.0\.1:\d+/);
+      if (match !== null) finish(null, match[0]);
+    };
+    child.stdout.on('data', onData);
+    child.stderr.on('data', onData);
+    child.once('exit', onExit);
+  });
+}
+
+export function mimoStderrLogPath(
+  paths: AgentRuntimePathContext,
+  runtimeId: string,
+): string {
+  return join(paths.logsDir(), 'mimo-code', `${runtimeId}.stderr.log`);
+}
+
+export function mimoConfigPath(
+  paths: AgentRuntimePathContext,
+  runtimeId: string,
+): string {
+  return join(dirname(mimoStderrLogPath(paths, runtimeId)), `${runtimeId}.json`);
+}

--- a/packages/agent-runtime/mimo-code/tests/client.test.ts
+++ b/packages/agent-runtime/mimo-code/tests/client.test.ts
@@ -1,0 +1,166 @@
+import { createServer, type IncomingMessage, type ServerResponse } from 'node:http';
+import type { AddressInfo } from 'node:net';
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { MimoBusyError, MimoHttpClient } from '../src/client.js';
+
+describe('MiMo HTTP client', () => {
+  const servers: Array<{ close: () => Promise<void> }> = [];
+
+  afterEach(async () => {
+    await Promise.all(servers.splice(0).map((server) => server.close()));
+  });
+
+  it('creates sessions and submits message turns through the durable HTTP path', async () => {
+    const requests: Array<{
+      method: string | undefined;
+      url: string | undefined;
+      headers: { authorization: string | undefined };
+      body: unknown;
+    }> = [];
+    const server = await startFakeHttpServer(async (req, res) => {
+      const body = await readJson(req);
+      requests.push({
+        method: req.method,
+        url: req.url,
+        headers: { authorization: req.headers.authorization },
+        body,
+      });
+      if (req.method === 'POST' && req.url === '/session') {
+        writeJson(res, { id: 'sess-http-1' });
+        return;
+      }
+      if (req.method === 'POST' && req.url === '/session/sess-http-1/message') {
+        res.writeHead(200, { 'content-type': 'application/json' });
+        res.end(
+          `\n\n ${JSON.stringify({
+            info: { id: 'assistant-1', role: 'assistant' },
+            parts: [
+              { type: 'reasoning', text: 'thinking' },
+              { type: 'text', text: 'done' },
+            ],
+          })}\n`,
+        );
+        return;
+      }
+      res.writeHead(404);
+      res.end('not found');
+    });
+    servers.push(server);
+    const client = new MimoHttpClient({ baseUrl: server.url, password: 'pw' });
+
+    await expect(
+      client.createSession({
+        cwd: '/workspace',
+        model: 'model-a',
+        agent: 'agent-a',
+        systemPrompt: 'system',
+        mcpServers: [{ name: 'tool', command: 'node', args: ['tool.mjs'] }],
+      }),
+    ).resolves.toBe('sess-http-1');
+    await expect(
+      client.sendMessage('sess-http-1', {
+        text: 'plain text',
+        turnId: 'turn-1',
+        timeoutMs: 1_000,
+        model: 'model-a',
+        agent: 'agent-a',
+        systemPrompt: 'system',
+      }),
+    ).resolves.toEqual({ text: 'done' });
+
+    expect(requests).toMatchObject([
+      {
+        method: 'POST',
+        url: '/session',
+        headers: {
+          authorization: `Basic ${Buffer.from('mimocode:pw').toString('base64')}`,
+        },
+        body: {},
+      },
+      {
+        method: 'POST',
+        url: '/session/sess-http-1/message',
+        headers: {
+          authorization: `Basic ${Buffer.from('mimocode:pw').toString('base64')}`,
+        },
+        body: {
+          modelRef: 'model-a',
+          agent: 'agent-a',
+          system: 'system',
+          parts: [{ type: 'text', text: 'plain text' }],
+        },
+      },
+    ]);
+  });
+
+  it('maps 409 busy responses to MimoBusyError', async () => {
+    const server = await startFakeHttpServer((_req, res) => {
+      res.writeHead(409);
+      res.end('busy');
+    });
+    servers.push(server);
+    const client = new MimoHttpClient({ baseUrl: server.url });
+
+    await expect(
+      client.sendMessage('sess-busy', {
+        text: 'work',
+        turnId: 'turn-busy',
+        timeoutMs: 1_000,
+        model: null,
+        agent: null,
+        systemPrompt: null,
+      }),
+    ).rejects.toBeInstanceOf(MimoBusyError);
+  });
+});
+
+interface FakeHttpServer {
+  url: string;
+  close(): Promise<void>;
+}
+
+async function startFakeHttpServer(
+  handler: (req: IncomingMessage, res: ServerResponse) => void | Promise<void>,
+): Promise<FakeHttpServer> {
+  const server = createServer((req, res) => {
+    void Promise.resolve(handler(req, res)).catch((err) => {
+      if (!res.headersSent) res.writeHead(500);
+      res.end(err instanceof Error ? err.message : String(err));
+    });
+  });
+  await new Promise<void>((resolve) => {
+    server.listen(0, '127.0.0.1', resolve);
+  });
+  const address = server.address();
+  if (address === null || typeof address === 'string') {
+    throw new Error('fake server did not bind a TCP address');
+  }
+  const tcpAddress: AddressInfo = address;
+  return {
+    url: `http://127.0.0.1:${tcpAddress.port}`,
+    close: async () => {
+      await new Promise<void>((resolve, reject) => {
+        server.close((err) => {
+          if (err !== undefined) reject(err);
+          else resolve();
+        });
+      });
+    },
+  };
+}
+
+async function readJson(req: IncomingMessage): Promise<unknown> {
+  const chunks: Buffer[] = [];
+  for await (const chunk of req) {
+    chunks.push(typeof chunk === 'string' ? Buffer.from(chunk) : chunk);
+  }
+  const text = Buffer.concat(chunks).toString('utf8');
+  return text === '' ? null : JSON.parse(text);
+}
+
+function writeJson(res: ServerResponse, body: unknown): void {
+  res.writeHead(200, { 'content-type': 'application/json' });
+  res.end(JSON.stringify(body));
+}

--- a/packages/agent-runtime/mimo-code/tests/config.test.ts
+++ b/packages/agent-runtime/mimo-code/tests/config.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  defaultMimoCodeConfig,
+  readMimoCodeConfig,
+} from '../src/config.js';
+import {
+  buildMimoNativeConfig,
+  buildMimoProcessEnv,
+} from '../src/supervisor.js';
+
+describe('MiMo Code config parsing', () => {
+  it('applies safe defaults', () => {
+    expect(readMimoCodeConfig({}, 'config.json', 'agents[0].config.')).toMatchObject({
+      bin: 'mimo',
+      model: null,
+      agent: null,
+      extra_env: {},
+      permission_mode: 'deny',
+      startup_timeout_ms: 30_000,
+      turn_timeout_ms: 600_000,
+      keep_home: false,
+    });
+  });
+
+  it('rejects unsupported ask permission mode', () => {
+    expect(() =>
+      readMimoCodeConfig(
+        { permission_mode: 'ask' },
+        'config.json',
+        'agents[0].config.',
+      ),
+    ).toThrow(/ask.*not supported/i);
+  });
+
+  it('rejects unsupported auto approve permission mode', () => {
+    expect(() =>
+      readMimoCodeConfig(
+        { permission_mode: 'auto-approve' },
+        'config.json',
+        'agents[0].config.',
+      ),
+    ).toThrow(/auto-approve.*not supported/i);
+  });
+
+  it('rejects mutually exclusive native config inputs', () => {
+    expect(() =>
+      readMimoCodeConfig(
+        { config_content: '{}', config_path: '/tmp/mimo.json' },
+        'config.json',
+        'agents[0].config.',
+      ),
+    ).toThrow(/mutually exclusive/i);
+  });
+});
+
+describe('MiMo Code env shaping', () => {
+  it('isolates home, disables telemetry/default inheritance, and keeps provider auth authoritative', () => {
+    const config = readMimoCodeConfig(
+      {
+        extra_env: {
+          CUSTOM: 'provider',
+          MIMOCODE_ENABLE_ANALYSIS: 'true',
+          MIMOCODE_SERVER_PASSWORD: 'operator',
+        },
+      },
+      'config.json',
+      'agents[0].config.',
+    );
+    const env = buildMimoProcessEnv({
+      config,
+      homeDir: '/tmp/dreamux-mimo-home',
+      username: 'mimocode',
+      password: 'pw',
+      configPath: '/tmp/dreamux-mimo-home/config.json',
+      injectEnv: { CUSTOM: 'host' },
+    });
+
+    expect(env.MIMOCODE_HOME).toBe('/tmp/dreamux-mimo-home');
+    expect(env.MIMOCODE_MIMO_ONLY).toBe('true');
+    expect(env.MIMOCODE_DISABLE_EXTERNAL_SKILLS).toBe('true');
+    expect(env.MIMOCODE_DISABLE_DEFAULT_PLUGINS).toBe('true');
+    expect(env.MIMOCODE_DISABLE_MODELS_FETCH).toBe('true');
+    expect(env.MIMOCODE_DISABLE_CLAUDE_CODE_MCP).toBe('true');
+    expect(env.MIMOCODE_ENABLE_ANALYSIS).toBe('false');
+    expect(env.MIMOCODE_SERVER_USERNAME).toBe('mimocode');
+    expect(env.MIMOCODE_SERVER_PASSWORD).toBe('pw');
+    expect(env.CUSTOM).toBe('provider');
+  });
+});
+
+describe('MiMo Code native config shaping', () => {
+  it('maps Dreamux MCP servers to MiMo native mcp config and keeps safety fields authoritative', () => {
+    const nativeConfig = JSON.parse(
+      buildMimoNativeConfig(
+        {
+          runtimeId: 'runtime-1',
+          config: {
+            ...defaultMimoCodeConfig(),
+            model: 'mimo/model',
+            agent: 'build',
+          },
+          cwd: '/workspace',
+          paths: {
+            dispatcherDir: (id) => `/tmp/dreamux/${id}`,
+            logsDir: () => '/tmp/dreamux/logs',
+            runtimeSocketDirs: () => ['/tmp'],
+          },
+          mcpServers: [{ name: 'tool', command: 'node', args: ['tool.mjs'] }],
+          systemPrompt: 'system prompt',
+        },
+        {
+          share: 'auto',
+          model: 'operator/model',
+          permission: 'allow',
+        },
+      ),
+    ) as Record<string, unknown>;
+
+    expect(nativeConfig).toMatchObject({
+      share: 'disabled',
+      model: 'mimo/model',
+      agent: 'build',
+      system: 'system prompt',
+      permission: 'deny',
+      mcp: {
+        tool: {
+          type: 'local',
+          command: ['node', 'tool.mjs'],
+        },
+      },
+    });
+  });
+});

--- a/packages/agent-runtime/mimo-code/tests/config.test.ts
+++ b/packages/agent-runtime/mimo-code/tests/config.test.ts
@@ -120,8 +120,6 @@ describe('MiMo Code native config shaping', () => {
     expect(nativeConfig).toMatchObject({
       share: 'disabled',
       model: 'mimo/model',
-      agent: 'build',
-      system: 'system prompt',
       permission: 'deny',
       mcp: {
         tool: {
@@ -130,5 +128,7 @@ describe('MiMo Code native config shaping', () => {
         },
       },
     });
+    expect(nativeConfig).not.toHaveProperty('agent');
+    expect(nativeConfig).not.toHaveProperty('system');
   });
 });

--- a/packages/agent-runtime/mimo-code/tests/runtime.test.ts
+++ b/packages/agent-runtime/mimo-code/tests/runtime.test.ts
@@ -1,0 +1,305 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  createMimoCodeAgentRuntimeProvider,
+  defaultMimoCodeConfig,
+  type MimoClient,
+  type MimoMessageInput,
+  type MimoMessageResult,
+  type MimoServerFactory,
+  type MimoServerHandle,
+} from '../src/index.js';
+import type {
+  AgentRuntime,
+  AgentRuntimeCreateContext,
+  AgentRuntimeMcpServer,
+  AgentRuntimeStateCallbacks,
+  AgentRuntimeStatus,
+  TurnSettledSignal,
+} from '@excitedjs/dreamux-types';
+
+describe('MiMo Code runtime', () => {
+  it('starts and creates a checkpoint-backed MiMo session', async () => {
+    const fake = new FakeMimoServerFactory();
+    const state = new FakeState();
+    const runtime = makeRuntime(fake, { state });
+
+    await runtime.start();
+
+    expect(fake.handles).toHaveLength(1);
+    expect(fake.client.sessions).toHaveLength(1);
+    expect(state.checkpoints).toEqual([{ id: 'session-1' }]);
+    expect(runtime.getCheckpoint()).toEqual({ id: 'session-1' });
+    expect(runtime.wasCheckpointResumed()).toBe(false);
+    expect(runtime.getStatus()).toBe('ready');
+
+    await runtime.stop();
+    expect(fake.handles[0]?.stopped).toBe(true);
+    expect(state.statuses.at(-1)?.status).toBe('stopped');
+  });
+
+  it('resumes from an existing checkpoint without creating a new session', async () => {
+    const fake = new FakeMimoServerFactory();
+    const state = new FakeState();
+    const runtime = makeRuntime(fake, {
+      state,
+      checkpointId: 'existing-session',
+    });
+
+    await runtime.resume();
+
+    expect(fake.client.sessions).toEqual([]);
+    expect(runtime.getCheckpoint()).toEqual({ id: 'existing-session' });
+    expect(runtime.wasCheckpointResumed()).toBe(true);
+  });
+
+  it('delivers completionInput as pure plain text and dedupes sourceId', async () => {
+    const fake = new FakeMimoServerFactory();
+    const settled: TurnSettledSignal[] = [];
+    const runtime = makeRuntime(fake, { settled });
+    await runtime.start();
+
+    await expect(
+      runtime.completionInput({
+        text: '<completion><message>done</message></completion>',
+        sourceId: 'completion-1',
+      }),
+    ).resolves.toMatchObject({ status: 'submitted' });
+    await expect(
+      runtime.completionInput({ text: 'duplicate', sourceId: 'completion-1' }),
+    ).resolves.toEqual({ status: 'duplicate' });
+    await runtime.waitIdle?.();
+
+    expect(fake.client.messages.map((message) => message.input.text)).toEqual([
+      '<completion><message>done</message></completion>',
+    ]);
+    expect(settled).toHaveLength(1);
+    expect(settled[0]).toMatchObject({
+      status: 'completed',
+      result: { text: 'echo:<completion><message>done</message></completion>' },
+    });
+    await expect(runtime.getLast()).resolves.toEqual({
+      text: 'echo:<completion><message>done</message></completion>',
+    });
+  });
+
+  it('renders channelInput through the channel envelope path', async () => {
+    const fake = new FakeMimoServerFactory();
+    const accepted: string[] = [];
+    const runtime = makeRuntime(fake);
+    await runtime.start();
+
+    await expect(
+      runtime.channelInput(
+        {
+          sourceId: 'msg-1',
+          text: 'fallback',
+          source: 'feishu',
+          attrs: [['chat_id', 'chat-1']],
+          body: 'hello',
+        },
+        {
+          onAccepted: (input) => {
+            accepted.push(input.sourceId);
+          },
+        },
+      ),
+    ).resolves.toMatchObject({ status: 'submitted' });
+    await expect(
+      runtime.channelInput({
+        sourceId: 'msg-1',
+        text: 'duplicate',
+      }),
+    ).resolves.toEqual({ status: 'duplicate' });
+    await runtime.waitIdle?.();
+
+    expect(accepted).toEqual(['msg-1']);
+    expect(fake.client.messages[0]?.input.text).toBe(
+      '<channel source="feishu" chat_id="chat-1">\nhello\n</channel>',
+    );
+  });
+
+  it('treats queued and MiMo-busy turns as busy until durable settlement', async () => {
+    const fake = new FakeMimoServerFactory();
+    fake.client.enqueueBusy();
+    const settled: TurnSettledSignal[] = [];
+    const runtime = makeRuntime(fake, { settled, turnTimeoutMs: 2_000 });
+    await runtime.start();
+
+    await runtime.completionInput({ text: 'first', sourceId: 'first' });
+    let idle = false;
+    void runtime.waitIdle?.().then(() => {
+      idle = true;
+    });
+    await flush();
+    expect(idle).toBe(false);
+
+    await waitFor(() => settled.length === 1);
+    expect(idle).toBe(true);
+    expect(fake.client.messages).toHaveLength(2);
+    expect(fake.client.messages.map((message) => message.input.text)).toEqual([
+      'first',
+      'first',
+    ]);
+    expect(settled[0]?.status).toBe('completed');
+  });
+
+  it('fires onTurnSettled exactly once on failed turns', async () => {
+    const fake = new FakeMimoServerFactory();
+    fake.client.failNext = new Error('model failed');
+    const settled: TurnSettledSignal[] = [];
+    const runtime = makeRuntime(fake, { settled });
+    await runtime.start();
+
+    await runtime.completionInput({ text: 'will fail', sourceId: 'fail' });
+    await runtime.waitIdle?.();
+
+    expect(settled).toHaveLength(1);
+    expect(settled[0]?.status).toBe('failed');
+    expect(runtime.getStatus()).toBe('degraded');
+  });
+
+  it('returns null for unsupported context snapshot', async () => {
+    const fake = new FakeMimoServerFactory();
+    const runtime = makeRuntime(fake);
+    await expect(runtime.getContext()).resolves.toBeNull();
+  });
+});
+
+function makeRuntime(
+  fake: FakeMimoServerFactory,
+  options: {
+    state?: FakeState;
+    settled?: TurnSettledSignal[];
+    checkpointId?: string;
+    turnTimeoutMs?: number;
+  } = {},
+): AgentRuntime {
+  const provider = createMimoCodeAgentRuntimeProvider({
+    serverFactory: fake.factory,
+  });
+  const state = options.state ?? new FakeState();
+  const config = {
+    ...defaultMimoCodeConfig(),
+    turn_timeout_ms: options.turnTimeoutMs ?? 5_000,
+  };
+  const context: AgentRuntimeCreateContext = {
+    identity: {
+      runtime_id: 'runtime-1',
+      checkpoint_id: options.checkpointId ?? null,
+    },
+    config,
+    cwd: '/workspace',
+    mcpServers: [{ name: 'tool', command: 'node', args: ['tool.mjs'] }],
+    state,
+    paths: {
+      dispatcherDir: (id) => `/tmp/dreamux/${id}`,
+      logsDir: () => '/tmp/dreamux/logs',
+      runtimeSocketDirs: () => ['/tmp'],
+    },
+    onTurnSettled: (settled) => {
+      options.settled?.push(settled);
+    },
+  };
+  return provider.createRuntime(context);
+}
+
+class FakeState implements AgentRuntimeStateCallbacks {
+  readonly statuses: Array<{ status: AgentRuntimeStatus; lastError: string | null }> =
+    [];
+  readonly checkpoints: Array<{ id: string }> = [];
+
+  async setStatus(
+    status: AgentRuntimeStatus,
+    extras?: { last_error?: string | null },
+  ): Promise<void> {
+    this.statuses.push({ status, lastError: extras?.last_error ?? null });
+  }
+
+  async setCheckpoint(checkpoint: { id: string }): Promise<void> {
+    this.checkpoints.push(checkpoint);
+  }
+}
+
+class FakeMimoServerFactory {
+  readonly client = new FakeMimoClient();
+  readonly handles: FakeMimoServerHandle[] = [];
+  readonly factory: MimoServerFactory = async (options) => {
+    this.startOptions.push({
+      mcpServers: options.mcpServers,
+      systemPrompt: options.systemPrompt,
+    });
+    const handle = new FakeMimoServerHandle(this.client);
+    this.handles.push(handle);
+    return handle;
+  };
+  readonly startOptions: Array<{
+    mcpServers: readonly AgentRuntimeMcpServer[];
+    systemPrompt: string | null;
+  }> = [];
+}
+
+class FakeMimoServerHandle implements MimoServerHandle {
+  readonly homeDir = '/tmp/fake-mimo-home';
+  readonly baseUrl = 'http://127.0.0.1:12345';
+  readonly username = 'mimocode';
+  readonly password = 'pw';
+  stopped = false;
+
+  constructor(readonly client: MimoClient) {}
+
+  async stop(): Promise<void> {
+    this.stopped = true;
+  }
+}
+
+class FakeMimoClient implements MimoClient {
+  readonly sessions: unknown[] = [];
+  readonly messages: Array<{ sessionId: string; input: MimoMessageInput }> = [];
+  private nextBusy = 0;
+  failNext: Error | null = null;
+
+  async createSession(input: unknown): Promise<string> {
+    this.sessions.push(input);
+    return `session-${this.sessions.length}`;
+  }
+
+  enqueueBusy(): void {
+    this.nextBusy += 1;
+  }
+
+  async sendMessage(
+    sessionId: string,
+    input: MimoMessageInput,
+  ): Promise<MimoMessageResult> {
+    this.messages.push({ sessionId, input });
+    if (this.failNext !== null) {
+      const err = this.failNext;
+      this.failNext = null;
+      throw err;
+    }
+    if (this.nextBusy > 0) {
+      this.nextBusy -= 1;
+      const { MimoBusyError } = await import('../src/client.js');
+      throw new MimoBusyError();
+    }
+    return { text: `echo:${input.text}` };
+  }
+}
+
+async function flush(): Promise<void> {
+  await new Promise((resolve) => {
+    globalThis.setTimeout(resolve, 0);
+  });
+}
+
+async function waitFor(predicate: () => boolean, timeoutMs = 2_000): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (predicate()) return;
+    await new Promise((resolve) => {
+      globalThis.setTimeout(resolve, 10);
+    });
+  }
+  throw new Error('waitFor timed out');
+}

--- a/packages/agent-runtime/mimo-code/tsconfig.json
+++ b/packages/agent-runtime/mimo-code/tsconfig.json
@@ -1,0 +1,27 @@
+{
+  "compilerOptions": {
+    "target": "ES2023",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "lib": ["ES2023"],
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "resolveJsonModule": true,
+    "strict": true,
+    "noImplicitAny": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "isolatedModules": true,
+    "verbatimModuleSyntax": false,
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules", "dist", "tests"]
+}

--- a/packages/agent-runtime/mimo-code/tsconfig.tests.json
+++ b/packages/agent-runtime/mimo-code/tsconfig.tests.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "rootDir": ".",
+    "types": ["node"]
+  },
+  "include": ["src/**/*.ts", "tests/**/*.ts"]
+}

--- a/rush.json
+++ b/rush.json
@@ -72,6 +72,11 @@
       "packageName": "@excitedjs/agent-runtime-claude-code",
       "projectFolder": "packages/agent-runtime/claude-code",
       "shouldPublish": true
+    },
+    {
+      "packageName": "@excitedjs/agent-runtime-mimo-code",
+      "projectFolder": "packages/agent-runtime/mimo-code",
+      "shouldPublish": true
     }
   ]
 }


### PR DESCRIPTION
## Summary

- Add `@excitedjs/agent-runtime-mimo-code` as an external npm AgentRuntime provider for MiMo Code.
- Supervise a private loopback `mimo serve` process with isolated `MIMOCODE_HOME`, safe env shaping, Basic auth, and Dreamux-authoritative native MCP config.
- Implement session checkpoint/resume, channel/completion input handling, busy retry/idle settlement, diagnostics, README, Rush metadata, and focused fake-server tests.

## Review Gate

- `claude-seed`: PASS after Basic auth fix.
- `trae-gpt`: PASS after Basic auth and lockfile churn fixes.
- `trae-claude`: PASS via recovery reviewer after the original reviewer lineage stalled at runtime delivery.

## Validation

- `git diff --cached --check`
- `.agents/scripts/check.sh`
- `node common/scripts/install-run-rush.js install`
- `node common/scripts/install-run-rush.js test --to @excitedjs/agent-runtime-mimo-code --verbose`
- `node common/scripts/install-run-rush.js typecheck:tests --to @excitedjs/agent-runtime-mimo-code --verbose`
- `node common/scripts/install-run-rush.js build --to @excitedjs/agent-runtime-mimo-code --verbose`
- `node common/scripts/install-run-rush.js lint --to @excitedjs/agent-runtime-mimo-code --verbose`

Note: Rush warns that Node 22.16.0 has not been tested with Rush 5.140.0, but the scoped commands completed successfully.
