### PR TITLE
Add Kimi Code ACP runtime provider

### DIFF
--- a/.agents/proposals/kimi-code-acp-agent-runtime-provider.md
+++ b/.agents/proposals/kimi-code-acp-agent-runtime-provider.md
@@ -1,0 +1,189 @@
+# Kimi Code ACP AgentRuntime provider
+
+- **Status:** Draft for review
+- **Date:** 2026-07-02
+- **Affects:** Agent Runtime providers, external provider loading,
+  `@excitedjs/dreamux-types` consumers
+- **Dreamux source snapshot:** `origin/next@5363c8d63506dd0ced833508f9d6c079355b9a5a`
+- **Kimi Code source snapshot:** `MoonshotAI/kimi-code@93ec6cb6526021156a951f8c513c45f138bf5dbb`
+
+## Intent
+
+Add a Kimi Code Agent Runtime provider without expanding Dreamux core's neutral
+runtime contract.
+
+Kimi Code does not expose a Claude Code-compatible `-p --stream-json` resident
+RPC process. Its public resident integration surface is `kimi acp`, an Agent
+Client Protocol server over stdio. The provider should therefore be a
+provider-owned ACP adapter: Dreamux core calls the existing `AgentRuntime`
+methods, and the Kimi package translates those calls into ACP session lifecycle
+and prompt calls.
+
+## Source Facts
+
+Dreamux's current runtime contract is small and provider-neutral:
+
+- `AgentRuntimeCapabilities` declares only `resume.supported`.
+- `AgentRuntimeCreateContext` passes explicit `systemPrompt`, `mcpServers`,
+  `skillSources`, `disableFeatures`, `cwd`, `paths`, `state`, `injectEnv`, and
+  `onTurnSettled`. It no longer passes Dreamux role topology.
+- `completionInput()` is required and receives plain text only; channel XML
+  rendering belongs only in `channelInput()`.
+- Runtime checkpoint APIs are `getCheckpoint()` and
+  `wasCheckpointResumed()`.
+
+Kimi Code current source has these relevant properties:
+
+- The public CLI package is `@moonshot-ai/kimi-code`, and its `kimi` bin has an
+  `acp` subcommand.
+- `@moonshot-ai/kimi-code-sdk` is still `private: true` in source and is not
+  published on the public npm registry. Dreamux's public package should not
+  depend on it directly.
+- `kimi acp` constructs a Kimi harness internally and exposes ACP
+  `initialize`, `session/new`, `session/load`, `session/resume`,
+  `session/prompt`, `session/cancel`, and related session configuration methods.
+- Kimi ACP forwards ACP MCP server descriptors into Kimi's kernel-side
+  `mcpServers` session field.
+- Kimi's public session creation surface accepts MCP injection through ACP, but
+  it does not expose a public SDK option to replace the base system prompt.
+- Kimi loads user-level brand instructions from `KIMI_CODE_HOME/AGENTS.md`.
+- Kimi loads user-level brand skills from `KIMI_CODE_HOME/skills/` when it is
+  set, and discovers each child directory containing `SKILL.md` as a skill.
+
+## Provider Shape
+
+The first implementation should be an npm external provider package:
+
+```json
+{
+  "provider": "npm:@excitedjs/agent-runtime-kimi-code"
+}
+```
+
+It should not be registered as `builtin:kimi-code` yet. Keeping it external
+avoids adding Kimi Code's CLI dependency to Dreamux's default runtime set, and
+matches the fact that ACP-specific prompt and skill injection support still has
+native limitations.
+
+The provider should depend on public packages only:
+
+- `@excitedjs/dreamux-types`;
+- `@excitedjs/dreamux-utils`;
+- `@agentclientprotocol/sdk`.
+
+It should not depend directly on the Kimi Code CLI package yet. Like the Claude
+Code provider, it should invoke a configurable binary (`kimi` by default) so the
+operator controls the native tool installation and version.
+
+The runtime process is a supervised `kimi acp` child over stdio. The provider
+owns ACP client connection setup, session creation/resume, prompt submission,
+result collection, and child teardown. Dreamux core never imports ACP types.
+
+## Runtime Mapping
+
+Capabilities:
+
+```ts
+{ resume: { supported: true } }
+```
+
+Checkpoint mapping:
+
+- A Kimi ACP session id is the Dreamux runtime checkpoint id.
+- `start()` creates a new ACP session unless `identity.checkpoint_id` exists.
+- `resume()` resumes `identity.checkpoint_id`.
+- `getCheckpoint()` returns the active ACP session id after session setup.
+- `wasCheckpointResumed()` reports whether the active session came from a
+  supplied checkpoint id.
+- If ACP resume fails for a stored checkpoint, the provider starts a fresh ACP
+  session and calls `state.recordLostCheckpoint(lost, replacement, error)` when
+  the host supplied that callback. If the callback is absent, it still persists
+  the replacement through `state.setCheckpoint()` and marks the runtime degraded
+  with the resume error.
+
+Turn mapping:
+
+- `channelInput(input, hooks)` renders `input` through
+  `renderChannelInput(input)`, then submits the rendered text as an ACP prompt.
+- `completionInput({ text, sourceId })` submits `text` as an ACP prompt without
+  channel rendering.
+- The provider allocates a Dreamux logical turn id before submitting to ACP.
+- `sourceId` is dedupe metadata: non-empty duplicate `sourceId` values return
+  `{ status: "duplicate" }` and must not create a second native ACP prompt.
+- `channelInput(..., hooks)` calls `hooks.onAccepted` only after dedupe accepts
+  the channel turn and before the provider submits it to the serial prompt
+  queue. A hook failure is logged but must not drop the turn.
+- Accepted turns must settle exactly once through `onTurnSettled`.
+- The provider should serialize prompts. Kimi native `steer`/active-turn
+  buffering is not part of ACP's Dreamux mapping, and serializing keeps one
+  Dreamux logical turn aligned with one ACP `session/prompt` response.
+- `agent_message_chunk` text updates are concatenated into the turn result.
+  Other ACP updates are provider-internal unless a future Dreamux capability
+  explicitly asks for them.
+- ACP `stopReason: "cancelled"` maps to Dreamux `stopped`; all other successful
+  ACP prompt responses map to `completed` unless the prompt request throws.
+
+MCP mapping:
+
+- `AgentRuntimeMcpServer` maps to ACP stdio MCP descriptors.
+- Dreamux's current MCP descriptor has only `name`, `command`, and `args`, so
+  the Kimi provider must not invent env/cwd values.
+
+Environment and paths:
+
+- The child command is `<config.bin> acp ...config.extra_args`, with `bin`
+  defaulting to `kimi`.
+- The child environment is `{ ...process.env, ...context.injectEnv,
+  ...config.extra_env }`.
+- `KIMI_CODE_HOME` should default to a runtime-owned directory under
+  `context.paths.dispatcherDir(runtime_id)`.
+- Logs should be written under `context.paths.logsDir()/kimi-code`.
+- `systemPrompt.append` is materialized into `KIMI_CODE_HOME/AGENTS.md` as a
+  provider-owned generated file. Existing non-generated `AGENTS.md` content must
+  not be overwritten.
+- `skillSources` are materialized as provider-owned links under
+  `KIMI_CODE_HOME/skills/<name>`. Existing non-provider files at those paths
+  must fail loud instead of being overwritten.
+- `disableFeatures` has no direct ACP session field. The provider must handle
+  interactive ACP permission/question requests conservatively by returning
+  cancellation/dismissal so disabled user-interrupt flows cannot wedge Dreamux.
+
+## Unsupported Or Deferred
+
+System prompt replacement is unsupported in the first provider. Kimi Code's
+public ACP/CLI surface does not expose a base-prompt replacement hook, and
+pretending `replace` is an ordinary user turn would violate Dreamux's prompt
+contract. When Dreamux supplies both `replace` and `append`, the provider uses
+the append-only instructions and does not claim replacement semantics. When
+Dreamux supplies only `replace`, the provider must fail loud or require an
+explicit operator override before starting.
+
+Interactive approval bridging is deferred. A first provider can fail or cancel
+Kimi permission requests conservatively rather than asking Dreamux core to model
+Kimi-specific approval details.
+
+## Hard Constraints
+
+- No dependency on `@moonshot-ai/kimi-code-sdk` while it is unpublished/private.
+- No Kimi or ACP imports from `@excitedjs/dreamux` core.
+- No system-prompt replacement approximation through user-visible turns.
+- No overwrite of pre-existing non-provider `KIMI_CODE_HOME/AGENTS.md` or skill
+  paths while materializing Dreamux prompts or skills.
+- No parallel logical prompt submission until the provider can prove each
+  submitted Dreamux turn settles exactly once.
+- No Dreamux core special cases for Kimi Code.
+
+## Acceptance
+
+- The package exports a default `AgentRuntimeProviderFactory`.
+- The provider loads through the existing `npm:` provider loader.
+- `createRuntime()` requires `context.paths` and `context.state` and fails loud
+  if they are missing.
+- `start()`, `resume()`, `stop()`, `channelInput()`, `completionInput()`,
+  `waitIdle()`, `getStatus()`, `getCheckpoint()`, `wasCheckpointResumed()`,
+  `getLast()`, `getContext()`, and `getCapabilities()` satisfy the current
+  `AgentRuntime` interface.
+- Focused tests cover config parsing, descriptor/ref behavior, MCP mapping,
+  prompt/skill materialization, source-id dedupe, accepted-hook ordering, turn
+  settlement, lost-checkpoint replacement, and ACP process lifecycle through
+  injected fakes.

--- a/.agents/root.md
+++ b/.agents/root.md
@@ -103,6 +103,11 @@ history and rationale; when you need current behavior, pair them with
   terminal completion-delivery semantics, instance-scoped runtime state facts,
   provider-owned role prompt injection, and external runtime handle validation
   while keeping native CLI/daemon details provider-owned.
+- [Kimi Code ACP Agent Runtime provider](proposals/kimi-code-acp-agent-runtime-provider.md)
+  — draft technical design for integrating Kimi Code through its public ACP
+  server as an external Agent Runtime provider, including prompt append and
+  skill materialization through `KIMI_CODE_HOME`, MCP descriptor mapping,
+  logical turn semantics, and checkpoint replacement on lost ACP sessions.
 - [TeamMate identity system prompt](proposals/teammate-identity-system-prompt.md)
   — draft requirement/spec for adding a minimal `identity` input to
   `teammate.spawn` and `team.create`, persisting it on TeamMate identity records,

--- a/common/changes/@excitedjs/agent-runtime-kimi-code/kimi-code-acp-provider_2026-07-02-14-45.json
+++ b/common/changes/@excitedjs/agent-runtime-kimi-code/kimi-code-acp-provider_2026-07-02-14-45.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@excitedjs/agent-runtime-kimi-code",
+      "comment": "Add the Kimi Code ACP Agent Runtime provider package.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@excitedjs/agent-runtime-kimi-code"
+}

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -69,6 +69,37 @@ importers:
         specifier: ^2.1.0
         version: 2.1.9(@types/node@22.19.19)
 
+  ../../packages/agent-runtime/kimi-code:
+    dependencies:
+      '@agentclientprotocol/sdk':
+        specifier: ^1.1.0
+        version: 1.1.0(zod@4.4.3)
+      '@excitedjs/dreamux-types':
+        specifier: workspace:*
+        version: link:../../dreamux-types
+      '@excitedjs/dreamux-utils':
+        specifier: workspace:*
+        version: link:../../dreamux-utils
+      zod:
+        specifier: ^4.3.6
+        version: 4.4.3
+    devDependencies:
+      '@excitedjs/eslint-config':
+        specifier: workspace:*
+        version: link:../../eslint-config
+      '@types/node':
+        specifier: ^22.10.0
+        version: 22.19.19
+      eslint:
+        specifier: ^9.39.0
+        version: 9.39.4
+      typescript:
+        specifier: ^5.7.0
+        version: 5.9.3
+      vitest:
+        specifier: ^2.1.0
+        version: 2.1.9(@types/node@22.19.19)
+
   ../../packages/channel/feishu-channel:
     dependencies:
       '@excitedjs/dreamux-types':
@@ -246,6 +277,11 @@ importers:
         version: 9.39.4
 
 packages:
+
+  '@agentclientprotocol/sdk@1.1.0':
+    resolution: {integrity: sha512-NT2KqphUJ3w6EksUL51ZhJgIYgq/ZLGcBPkyMKgRSO5PMVwe9DnKKX+Htnvk6KHh6dUuh34UHK4gKp+4te1Mdg==}
+    peerDependencies:
+      zod: ^3.25.0 || ^4.0.0
 
   '@clack/core@1.4.0':
     resolution: {integrity: sha512-7Wctjq6f7c1CPz8sPpkwUnz8yRgVANkpNupb81q432FjcJg4l+Sw7XANdNSdWfAKq0IHI0JTcUeK5dxs/HrGPw==}
@@ -1627,7 +1663,14 @@ packages:
     resolution: {integrity: sha512-CzhO+pFNo8ajLM2d2IW/R93ipy99LWjtwblvC1RsoSUMZgyLbYFr221TnSNT7GjGdYui6P459mw9JH/g/zW2ug==}
     engines: {node: '>=18'}
 
+  zod@4.4.3:
+    resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
+
 snapshots:
+
+  '@agentclientprotocol/sdk@1.1.0(zod@4.4.3)':
+    dependencies:
+      zod: 4.4.3
 
   '@clack/core@1.4.0':
     dependencies:
@@ -2919,3 +2962,5 @@ snapshots:
   yocto-queue@0.1.0: {}
 
   yoctocolors@2.1.2: {}
+
+  zod@4.4.3: {}

--- a/packages/agent-runtime/kimi-code/LICENSE
+++ b/packages/agent-runtime/kimi-code/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 excitedjs
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/agent-runtime/kimi-code/README.md
+++ b/packages/agent-runtime/kimi-code/README.md
@@ -1,0 +1,31 @@
+# @excitedjs/agent-runtime-kimi-code
+
+External Dreamux Agent Runtime provider for Kimi Code.
+
+This package implements the public `AgentRuntimeProvider` contract from
+`@excitedjs/dreamux-types` by supervising the public `kimi acp` stdio server.
+It is intentionally an `npm:` provider rather than a Dreamux builtin while Kimi
+Code's public integration surface is ACP-only and its TypeScript SDK remains
+unpublished.
+
+Example config:
+
+```json
+{
+  "agents": [
+    {
+      "id": "kimi",
+      "provider": "npm:@excitedjs/agent-runtime-kimi-code",
+      "config": {}
+    }
+  ]
+}
+```
+
+The first implementation supports resident ACP sessions, plain text
+`completionInput`, channel-rendered `channelInput`, MCP stdio injection, and
+resume checkpoint mapping. Dreamux append-only system prompt fragments are
+materialized into a runtime-owned `KIMI_CODE_HOME/AGENTS.md`, and Dreamux skill
+sources are linked under `KIMI_CODE_HOME/skills`. Kimi Code system prompt
+replacement is not supported because the public `kimi acp` CLI does not
+currently expose that hook.

--- a/packages/agent-runtime/kimi-code/eslint.config.js
+++ b/packages/agent-runtime/kimi-code/eslint.config.js
@@ -1,0 +1,7 @@
+// Lint config for @excitedjs/agent-runtime-kimi-code.
+//
+// Provider packages implement the neutral @excitedjs/dreamux-types contract and
+// must not import @excitedjs/dreamux core. The shared config owns that boundary.
+import baseConfig, { withProviderImportBoundary } from '@excitedjs/eslint-config';
+
+export default withProviderImportBoundary(baseConfig);

--- a/packages/agent-runtime/kimi-code/package.json
+++ b/packages/agent-runtime/kimi-code/package.json
@@ -1,0 +1,56 @@
+{
+  "name": "@excitedjs/agent-runtime-kimi-code",
+  "version": "0.1.0",
+  "description": "External Kimi Code Agent Runtime provider for Dreamux. Implements the @excitedjs/dreamux-types AgentRuntimeProvider contract against the public `kimi acp` stdio server.",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/excitedjs/dreamux.git",
+    "directory": "packages/agent-runtime/kimi-code"
+  },
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "default": "./dist/index.js"
+    },
+    "./config": {
+      "types": "./dist/config.d.ts",
+      "import": "./dist/config.js",
+      "default": "./dist/config.js"
+    }
+  },
+  "engines": {
+    "node": ">=22.7"
+  },
+  "files": [
+    "dist",
+    "README.md",
+    "LICENSE"
+  ],
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "lint": "eslint .",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "clean": "rm -rf dist",
+    "prepublishOnly": "npm run build"
+  },
+  "dependencies": {
+    "@agentclientprotocol/sdk": "^1.1.0",
+    "@excitedjs/dreamux-types": "workspace:*",
+    "@excitedjs/dreamux-utils": "workspace:*",
+    "zod": "^4.3.6"
+  },
+  "devDependencies": {
+    "@excitedjs/eslint-config": "workspace:*",
+    "@types/node": "^22.10.0",
+    "eslint": "^9.39.0",
+    "typescript": "^5.7.0",
+    "vitest": "^2.1.0"
+  }
+}

--- a/packages/agent-runtime/kimi-code/src/acp-client.ts
+++ b/packages/agent-runtime/kimi-code/src/acp-client.ts
@@ -1,0 +1,279 @@
+import { spawn, type ChildProcess, type SpawnOptions } from 'node:child_process';
+import { mkdir, open } from 'node:fs/promises';
+import { dirname } from 'node:path';
+import { Readable, Writable } from 'node:stream';
+
+import {
+  client,
+  methods,
+  ndJsonStream,
+  PROTOCOL_VERSION,
+  type ClientConnection,
+  type ContentBlock,
+  type McpServer,
+  type PromptResponse,
+  type SessionNotification,
+  type StopReason,
+} from '@agentclientprotocol/sdk';
+import {
+  ensureOwnerOnlyDir,
+  isProcessAlive,
+  killProcessGroup,
+  removeEmptyLogFile,
+} from '@excitedjs/dreamux-utils';
+
+export interface KimiCodeAcpSessionRequest {
+  cwd: string;
+  mcpServers: readonly McpServer[];
+}
+
+export interface KimiCodeAcpPromptResult {
+  stopReason: StopReason;
+  text: string | null;
+}
+
+export interface KimiCodeAcpClient {
+  start(): Promise<void>;
+  createSession(input: KimiCodeAcpSessionRequest): Promise<string>;
+  resumeSession(
+    sessionId: string,
+    input: KimiCodeAcpSessionRequest,
+  ): Promise<string>;
+  prompt(sessionId: string, text: string): Promise<KimiCodeAcpPromptResult>;
+  stop(): Promise<void>;
+  isAlive(): boolean;
+}
+
+export interface KimiCodeAcpClientSpec {
+  bin: string;
+  args: readonly string[];
+  cwd: string;
+  env: Record<string, string | undefined>;
+  homeDir: string;
+  stderrLogPath: string;
+  turnTimeoutMs: number;
+  log?: (level: 'info' | 'warn' | 'error', message: string, err?: unknown) => void;
+}
+
+export type KimiCodeAcpClientFactory = (
+  spec: KimiCodeAcpClientSpec,
+) => KimiCodeAcpClient;
+
+interface ActivePrompt {
+  sessionId: string;
+  chunks: string[];
+}
+
+function errMessage(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}
+
+function textBlock(text: string): ContentBlock {
+  return { type: 'text', text };
+}
+
+function withTimeout<T>(
+  promise: Promise<T>,
+  ms: number,
+  label: string,
+): Promise<T> {
+  let timeout: NodeJS.Timeout | null = null;
+  const timeoutPromise = new Promise<never>((_, reject) => {
+    timeout = setTimeout(() => {
+      reject(new Error(`${label} timed out after ${ms}ms`));
+    }, ms);
+  });
+  return Promise.race([promise, timeoutPromise]).finally(() => {
+    if (timeout !== null) clearTimeout(timeout);
+  });
+}
+
+class LiveKimiCodeAcpClient implements KimiCodeAcpClient {
+  private child: ChildProcess | null = null;
+  private pid: number | null = null;
+  private exited = false;
+  private stopped = false;
+  private connection: ClientConnection | null = null;
+  private activePrompt: ActivePrompt | null = null;
+
+  constructor(private readonly spec: KimiCodeAcpClientSpec) {}
+
+  isAlive(): boolean {
+    return this.child !== null && !this.exited && this.connection !== null;
+  }
+
+  async start(): Promise<void> {
+    if (this.child !== null) {
+      throw new Error('KimiCodeAcpClient.start: already started');
+    }
+    await ensureOwnerOnlyDir(this.spec.homeDir);
+    await mkdir(this.spec.cwd, { recursive: true });
+    await mkdir(dirname(this.spec.stderrLogPath), { recursive: true });
+    const stderrHandle = await open(this.spec.stderrLogPath, 'a', 0o600);
+    const spawnOpts: SpawnOptions = {
+      cwd: this.spec.cwd,
+      env: this.spec.env,
+      detached: true,
+      stdio: ['pipe', 'pipe', stderrHandle.fd],
+    };
+    let child: ChildProcess;
+    try {
+      child = await new Promise<ChildProcess>((resolve, reject) => {
+        let settled = false;
+        const spawned = spawn(this.spec.bin, this.spec.args, spawnOpts);
+        spawned.once('error', (err) => {
+          if (settled) return;
+          settled = true;
+          reject(err);
+        });
+        spawned.once('spawn', () => {
+          if (settled) return;
+          settled = true;
+          resolve(spawned);
+        });
+      });
+    } finally {
+      await stderrHandle.close();
+    }
+    if (child.pid === undefined) {
+      throw new Error('kimi acp child spawned without a pid');
+    }
+    if (child.stdin === null || child.stdout === null) {
+      throw new Error('kimi acp child spawned without stdio pipes');
+    }
+    this.child = child;
+    this.pid = child.pid;
+    child.on('error', (err) => {
+      this.log('warn', 'kimi acp child error', err);
+    });
+    child.once('exit', () => {
+      this.exited = true;
+    });
+
+    const stream = ndJsonStream(
+      Writable.toWeb(child.stdin),
+      Readable.toWeb(child.stdout),
+    );
+    const app = client({ name: 'dreamux-kimi-code' })
+      .onRequest(methods.client.session.requestPermission, () => ({
+        outcome: { outcome: 'cancelled' },
+      }))
+      .onNotification(methods.client.session.update, (ctx) => {
+        this.onSessionUpdate(ctx.params);
+      });
+    this.connection = app.connect(stream);
+    await this.connection.agent.request(methods.agent.initialize, {
+      protocolVersion: PROTOCOL_VERSION,
+      clientCapabilities: {},
+    });
+  }
+
+  async createSession(input: KimiCodeAcpSessionRequest): Promise<string> {
+    const conn = this.requireConnection();
+    const response = await conn.agent.request(methods.agent.session.new, {
+      cwd: input.cwd,
+      mcpServers: [...input.mcpServers],
+    });
+    return response.sessionId;
+  }
+
+  async resumeSession(
+    sessionId: string,
+    input: KimiCodeAcpSessionRequest,
+  ): Promise<string> {
+    const conn = this.requireConnection();
+    await conn.agent.request(methods.agent.session.resume, {
+      sessionId,
+      cwd: input.cwd,
+      mcpServers: [...input.mcpServers],
+    });
+    return sessionId;
+  }
+
+  async prompt(sessionId: string, text: string): Promise<KimiCodeAcpPromptResult> {
+    const conn = this.requireConnection();
+    const active: ActivePrompt = { sessionId, chunks: [] };
+    this.activePrompt = active;
+    try {
+      const response = await withTimeout<PromptResponse>(
+        conn.agent.request(methods.agent.session.prompt, {
+          sessionId,
+          prompt: [textBlock(text)],
+        }),
+        this.spec.turnTimeoutMs,
+        'kimi acp prompt',
+      );
+      return {
+        stopReason: response.stopReason,
+        text: active.chunks.length === 0 ? null : active.chunks.join(''),
+      };
+    } catch (err) {
+      try {
+        await conn.agent.notify(methods.agent.session.cancel, { sessionId });
+      } catch (cancelErr) {
+        this.log('warn', 'kimi acp prompt cancellation failed', cancelErr);
+      }
+      throw err;
+    } finally {
+      if (this.activePrompt === active) this.activePrompt = null;
+    }
+  }
+
+  async stop(): Promise<void> {
+    if (this.stopped) return;
+    this.stopped = true;
+    this.connection?.close(new Error('kimi acp client stopped'));
+    const pid = this.pid;
+    if (pid !== null) {
+      if (isProcessAlive(pid)) {
+        killProcessGroup(pid, 'SIGTERM');
+        const deadline = Date.now() + 1000;
+        while (Date.now() < deadline) {
+          if (!isProcessAlive(pid)) break;
+          await new Promise<void>((resolve) => setTimeout(resolve, 25));
+        }
+      }
+      killProcessGroup(pid, 'SIGKILL');
+    }
+    this.exited = true;
+    this.connection = null;
+    this.child = null;
+    await removeEmptyLogFile(this.spec.stderrLogPath);
+  }
+
+  private requireConnection(): ClientConnection {
+    if (this.connection === null || this.stopped || this.exited) {
+      throw new Error('kimi acp client is not running');
+    }
+    return this.connection;
+  }
+
+  private onSessionUpdate(notification: SessionNotification): void {
+    const active = this.activePrompt;
+    if (active === null || notification.sessionId !== active.sessionId) return;
+    const update = notification.update;
+    if (
+      update.sessionUpdate === 'agent_message_chunk' &&
+      update.content.type === 'text'
+    ) {
+      active.chunks.push(update.content.text);
+    }
+  }
+
+  private log(
+    level: 'info' | 'warn' | 'error',
+    message: string,
+    err?: unknown,
+  ): void {
+    this.spec.log?.(level, message, err);
+    if (this.spec.log === undefined && level !== 'info') {
+      console.error(`[kimi-code] ${message}: ${errMessage(err)}`);
+    }
+  }
+}
+
+export function createDefaultKimiCodeAcpClient(
+  spec: KimiCodeAcpClientSpec,
+): KimiCodeAcpClient {
+  return new LiveKimiCodeAcpClient(spec);
+}

--- a/packages/agent-runtime/kimi-code/src/capabilities.ts
+++ b/packages/agent-runtime/kimi-code/src/capabilities.ts
@@ -1,0 +1,5 @@
+import type { AgentRuntimeCapabilities } from '@excitedjs/dreamux-types';
+
+export const KIMI_CODE_AGENT_RUNTIME_CAPABILITIES: AgentRuntimeCapabilities = {
+  resume: { supported: true },
+};

--- a/packages/agent-runtime/kimi-code/src/config.ts
+++ b/packages/agent-runtime/kimi-code/src/config.ts
@@ -1,0 +1,80 @@
+import {
+  readOptionalString,
+  rejectUnknownKeys,
+  requirePositiveInt,
+  requireStringArray,
+  requireStringRecord,
+} from '@excitedjs/dreamux-utils';
+
+export interface DispatcherKimiCodeConfig {
+  /** Kimi Code CLI binary. */
+  bin: string;
+  home_dir: string | null;
+  extra_args: string[];
+  extra_env: Record<string, string>;
+  turn_timeout_ms: number;
+}
+
+export const DEFAULT_KIMI_CODE_TURN_TIMEOUT_MS = 600_000;
+export const DEFAULT_KIMI_CODE_BIN = 'kimi';
+
+export function defaultDispatcherKimiCodeConfig(): DispatcherKimiCodeConfig {
+  return {
+    bin: DEFAULT_KIMI_CODE_BIN,
+    home_dir: null,
+    extra_args: [],
+    extra_env: {},
+    turn_timeout_ms: DEFAULT_KIMI_CODE_TURN_TIMEOUT_MS,
+  };
+}
+
+export function readDispatcherKimiCodeConfig(
+  rawKimi: Record<string, unknown>,
+  file: string,
+  prefix: string,
+): DispatcherKimiCodeConfig {
+  rejectUnknownKeys(
+    rawKimi,
+    new Set(['bin', 'home_dir', 'extra_args', 'extra_env', 'turn_timeout_ms']),
+    file,
+    prefix,
+  );
+  const defaults = defaultDispatcherKimiCodeConfig();
+  const bin = readOptionalString(rawKimi, 'bin', file, prefix) ?? defaults.bin;
+  if (bin.trim() === '') {
+    throw new Error(
+      `dreamux config error in ${file}: ${prefix}bin must be a non-empty string`,
+    );
+  }
+  const homeDir = readOptionalString(rawKimi, 'home_dir', file, prefix);
+  if (homeDir !== null && homeDir.trim() === '') {
+    throw new Error(
+      `dreamux config error in ${file}: ${prefix}home_dir must be a non-empty string`,
+    );
+  }
+  return {
+    bin,
+    home_dir: homeDir,
+    extra_args: requireStringArray(
+      rawKimi,
+      'extra_args',
+      defaults.extra_args,
+      file,
+      prefix,
+    ),
+    extra_env: requireStringRecord(
+      rawKimi,
+      'extra_env',
+      defaults.extra_env,
+      file,
+      prefix,
+    ),
+    turn_timeout_ms: requirePositiveInt(
+      rawKimi,
+      'turn_timeout_ms',
+      defaults.turn_timeout_ms,
+      file,
+      prefix,
+    ),
+  };
+}

--- a/packages/agent-runtime/kimi-code/src/index.ts
+++ b/packages/agent-runtime/kimi-code/src/index.ts
@@ -1,0 +1,25 @@
+export {
+  createKimiCodeAgentRuntimeProvider,
+  default,
+  type KimiCodeAgentRuntimeProviderOptions,
+  type KimiCodeProviderFactoryContext,
+} from './provider.js';
+export { KIMI_CODE_AGENT_RUNTIME_CAPABILITIES } from './capabilities.js';
+export {
+  DEFAULT_KIMI_CODE_BIN,
+  DEFAULT_KIMI_CODE_TURN_TIMEOUT_MS,
+  defaultDispatcherKimiCodeConfig,
+  readDispatcherKimiCodeConfig,
+  type DispatcherKimiCodeConfig,
+} from './config.js';
+export { KIMI_CODE_PROVIDER_REF } from './provider-ref.js';
+export { kimiCodeAcpMcpServers } from './mcp.js';
+export {
+  createDefaultKimiCodeAcpClient,
+  type KimiCodeAcpClient,
+  type KimiCodeAcpClientFactory,
+  type KimiCodeAcpClientSpec,
+  type KimiCodeAcpPromptResult,
+  type KimiCodeAcpSessionRequest,
+} from './acp-client.js';
+export { KimiCodeRuntime, type KimiCodeRuntimeDeps } from './runtime.js';

--- a/packages/agent-runtime/kimi-code/src/mcp.ts
+++ b/packages/agent-runtime/kimi-code/src/mcp.ts
@@ -1,0 +1,13 @@
+import type { AgentRuntimeMcpServer } from '@excitedjs/dreamux-types';
+import type { McpServer } from '@agentclientprotocol/sdk';
+
+export function kimiCodeAcpMcpServers(
+  servers: readonly AgentRuntimeMcpServer[],
+): McpServer[] {
+  return servers.map((server) => ({
+    name: server.name,
+    command: server.command,
+    args: [...server.args],
+    env: [],
+  }));
+}

--- a/packages/agent-runtime/kimi-code/src/provider-ref.ts
+++ b/packages/agent-runtime/kimi-code/src/provider-ref.ts
@@ -1,0 +1,1 @@
+export const KIMI_CODE_PROVIDER_REF = 'npm:@excitedjs/agent-runtime-kimi-code';

--- a/packages/agent-runtime/kimi-code/src/provider.ts
+++ b/packages/agent-runtime/kimi-code/src/provider.ts
@@ -1,0 +1,129 @@
+import {
+  DEFAULT_KIMI_CODE_BIN,
+  readDispatcherKimiCodeConfig,
+  type DispatcherKimiCodeConfig,
+} from './config.js';
+import { createDefaultKimiCodeAcpClient } from './acp-client.js';
+import { KIMI_CODE_AGENT_RUNTIME_CAPABILITIES } from './capabilities.js';
+import { KimiCodeRuntime, type KimiCodeRuntimeDeps } from './runtime.js';
+import { KIMI_CODE_PROVIDER_REF } from './provider-ref.js';
+import type {
+  AgentRuntime,
+  AgentRuntimeCreateContext,
+  AgentRuntimeProvider,
+  AgentRuntimeProviderDescriptor,
+  AgentRuntimeProviderFactory,
+  ProviderDescriptor,
+  ProviderFactoryContext,
+} from '@excitedjs/dreamux-types';
+
+export interface KimiCodeAgentRuntimeProviderOptions {
+  descriptor?: ProviderDescriptor;
+  clientFactory?: KimiCodeRuntimeDeps['clientFactory'];
+}
+
+const DEFAULT_KIMI_CODE_DESCRIPTOR: AgentRuntimeProviderDescriptor = {
+  id: 'kimi-code',
+  kind: 'agentRuntime',
+  ref: {
+    source: 'npm',
+    package: '@excitedjs/agent-runtime-kimi-code',
+    export: null,
+    raw: KIMI_CODE_PROVIDER_REF,
+  },
+};
+
+function asAgentRuntimeDescriptor(
+  descriptor: ProviderDescriptor,
+): AgentRuntimeProviderDescriptor {
+  if (descriptor.kind !== 'agentRuntime') {
+    throw new Error(
+      `@excitedjs/agent-runtime-kimi-code: descriptor.kind must be 'agentRuntime' ` +
+        `(got ${JSON.stringify(descriptor.kind)})`,
+    );
+  }
+  return { ...descriptor, kind: descriptor.kind };
+}
+
+export function createKimiCodeAgentRuntimeProvider(
+  options: KimiCodeAgentRuntimeProviderOptions = {},
+): AgentRuntimeProvider<DispatcherKimiCodeConfig> {
+  const descriptor =
+    options.descriptor === undefined
+      ? DEFAULT_KIMI_CODE_DESCRIPTOR
+      : asAgentRuntimeDescriptor(options.descriptor);
+  return {
+    ref: descriptor.ref.raw,
+    descriptor,
+    getCapabilities: () => KIMI_CODE_AGENT_RUNTIME_CAPABILITIES,
+    onboard: {
+      async collect(_context, prompts): Promise<Record<string, unknown>> {
+        const bin = await prompts.text({
+          message: 'Kimi Code CLI binary',
+          initialValue: DEFAULT_KIMI_CODE_BIN,
+          required: true,
+        });
+        return { bin };
+      },
+    },
+    readConfig(rawConfig, context) {
+      return readDispatcherKimiCodeConfig(rawConfig, context.file, context.prefix);
+    },
+    createRuntime(context: AgentRuntimeCreateContext<DispatcherKimiCodeConfig>): AgentRuntime {
+      if (context.state === undefined) {
+        throw new Error('kimi-code runtime requires a state sink in the create context');
+      }
+      if (context.paths === undefined) {
+        throw new Error('kimi-code runtime requires a path context in the create context');
+      }
+      const systemPromptAppend =
+        context.systemPrompt?.append?.filter((entry) => entry !== '') ?? [];
+      if (
+        context.systemPrompt?.replace !== undefined &&
+        systemPromptAppend.length === 0
+      ) {
+        throw new Error(
+          'kimi-code runtime cannot apply systemPrompt.replace; Kimi ACP exposes no public replacement hook and no append fallback was supplied',
+        );
+      }
+      if (context.systemPrompt?.replace !== undefined) {
+        context.logger?.warn?.(
+          'kimi-code runtime cannot replace Kimi base instructions; applying append-only Dreamux instructions through KIMI_CODE_HOME/AGENTS.md',
+        );
+      }
+      return new KimiCodeRuntime(context.identity, {
+        providerRef: descriptor.ref.raw,
+        config: context.config,
+        cwd: context.cwd,
+        state: context.state,
+        paths: context.paths,
+        mcpServers: context.mcpServers,
+        clientFactory: options.clientFactory ?? createDefaultKimiCodeAcpClient,
+        ...(context.injectEnv !== undefined
+          ? { injectEnv: context.injectEnv }
+          : {}),
+        ...(systemPromptAppend.length > 0
+          ? { systemPromptAppend }
+          : {}),
+        ...(context.skillSources !== undefined
+          ? { skillSources: context.skillSources }
+          : {}),
+        ...(context.disableFeatures !== undefined
+          ? { disableFeatures: context.disableFeatures }
+          : {}),
+        ...(context.onTurnSettled !== undefined
+          ? { onTurnSettled: context.onTurnSettled }
+          : {}),
+        ...(context.logger !== undefined ? { logger: context.logger } : {}),
+      });
+    },
+  };
+}
+
+export type KimiCodeProviderFactoryContext =
+  ProviderFactoryContext<AgentRuntimeProviderDescriptor>;
+
+const kimiCodeAgentRuntimeProviderFactory: AgentRuntimeProviderFactory<DispatcherKimiCodeConfig> =
+  (context) => createKimiCodeAgentRuntimeProvider({ descriptor: context.descriptor });
+
+export default kimiCodeAgentRuntimeProviderFactory;

--- a/packages/agent-runtime/kimi-code/src/runtime.ts
+++ b/packages/agent-runtime/kimi-code/src/runtime.ts
@@ -1,0 +1,511 @@
+import { lstat, mkdir, readFile, readlink, rm, symlink, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+
+import { ensureOwnerOnlyDir, renderChannelInput } from '@excitedjs/dreamux-utils';
+import { KIMI_CODE_AGENT_RUNTIME_CAPABILITIES } from './capabilities.js';
+import { kimiCodeAcpMcpServers } from './mcp.js';
+import type {
+  KimiCodeAcpClient,
+  KimiCodeAcpClientFactory,
+} from './acp-client.js';
+import type { DispatcherKimiCodeConfig } from './config.js';
+import type {
+  AgentRuntime,
+  AgentRuntimeCapabilities,
+  AgentRuntimeIdentity,
+  AgentRuntimeLastResult,
+  AgentRuntimePathContext,
+  AgentRuntimeSkillSource,
+  AgentRuntimeStateCallbacks,
+  AgentRuntimeStatus,
+  AgentRuntimeTextInput,
+  AgentRuntimeTurnResult,
+  DreamuxLogger,
+  InboundDeliveryHooks,
+  InboundTurnInput,
+  TurnSettledSignal,
+} from '@excitedjs/dreamux-types';
+
+export interface KimiCodeRuntimeDeps {
+  providerRef: string;
+  config: DispatcherKimiCodeConfig;
+  cwd: string;
+  state: AgentRuntimeStateCallbacks;
+  paths: AgentRuntimePathContext;
+  mcpServers: Parameters<typeof kimiCodeAcpMcpServers>[0];
+  clientFactory: KimiCodeAcpClientFactory;
+  injectEnv?: Record<string, string>;
+  systemPromptAppend?: readonly string[];
+  skillSources?: readonly AgentRuntimeSkillSource[];
+  disableFeatures?: readonly string[];
+  onTurnSettled?: (settled: TurnSettledSignal) => void;
+  logger?: DreamuxLogger;
+}
+
+const MANAGED_AGENTS_MD_MARKER = '<!-- dreamux:kimi-code-agent-runtime:AGENTS.md:v1 -->';
+const MANAGED_SKILLS_MANIFEST = '.dreamux-skill-links.json';
+const SAFE_SKILL_NAME = /^[A-Za-z0-9._-]+$/;
+
+function errMessage(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}
+
+function isErrnoException(err: unknown): err is NodeJS.ErrnoException {
+  return err instanceof Error && 'code' in err;
+}
+
+let nextRuntimeInstanceId = 0;
+
+export class KimiCodeRuntime implements AgentRuntime {
+  readonly providerRef: string;
+
+  private readonly runtimeId: string;
+  private readonly config: DispatcherKimiCodeConfig;
+  private readonly cwd: string;
+  private readonly logger: DreamuxLogger | undefined;
+  private status: AgentRuntimeStatus = 'declared';
+  private stopped = false;
+  private checkpointId: string | null;
+  private resumed = false;
+  private client: KimiCodeAcpClient | null = null;
+  private queue: Promise<void> = Promise.resolve();
+  private readonly seenChannelIds = new Set<string>();
+  private readonly seenTextInputIds = new Set<string>();
+  private readonly runtimeInstanceId = ++nextRuntimeInstanceId;
+  private turnCounter = 0;
+  private queuedTurnCount = 0;
+  private idlePromise: Promise<void> | null = null;
+  private idleResolve: (() => void) | null = null;
+  private lastResult: AgentRuntimeLastResult | null = null;
+
+  constructor(
+    identity: AgentRuntimeIdentity,
+    private readonly deps: KimiCodeRuntimeDeps,
+  ) {
+    this.providerRef = deps.providerRef;
+    this.runtimeId = identity.runtime_id;
+    this.config = deps.config;
+    this.cwd = deps.cwd;
+    this.checkpointId = identity.checkpoint_id ?? null;
+    this.logger = deps.logger;
+  }
+
+  getStatus(): AgentRuntimeStatus {
+    return this.status;
+  }
+
+  getCapabilities(): AgentRuntimeCapabilities {
+    return KIMI_CODE_AGENT_RUNTIME_CAPABILITIES;
+  }
+
+  getCheckpoint(): { id: string } | null {
+    return this.checkpointId === null ? null : { id: this.checkpointId };
+  }
+
+  wasCheckpointResumed(): boolean {
+    return this.resumed;
+  }
+
+  async getLast(): Promise<AgentRuntimeLastResult | null> {
+    return this.lastResult;
+  }
+
+  async getContext(): Promise<null> {
+    return null;
+  }
+
+  async start(): Promise<void> {
+    await this.startOrResume(false);
+  }
+
+  async resume(): Promise<void> {
+    await this.startOrResume(true);
+  }
+
+  async stop(): Promise<void> {
+    if (this.stopped) return;
+    this.stopped = true;
+    await this.setStatus('stopping');
+    const client = this.client;
+    this.client = null;
+    if (client !== null) {
+      try {
+        await client.stop();
+      } catch (err) {
+        this.log('warn', 'kimi-code client stop errored', err);
+      }
+    }
+    this.queuedTurnCount = 0;
+    this.resolveIdleWaitersIfIdle();
+    await this.setStatus('stopped');
+  }
+
+  async completionInput(input: AgentRuntimeTextInput): Promise<AgentRuntimeTurnResult> {
+    if (this.stopped) return { status: 'stopped' };
+    const key = input.sourceId;
+    if (key !== undefined && key !== '' && this.seenTextInputIds.has(key)) {
+      return { status: 'duplicate' };
+    }
+    if (key !== undefined && key !== '') this.seenTextInputIds.add(key);
+    return this.submitQueuedTurn(input.text);
+  }
+
+  async channelInput(
+    input: InboundTurnInput,
+    hooks: InboundDeliveryHooks = {},
+  ): Promise<AgentRuntimeTurnResult> {
+    if (this.stopped) return { status: 'stopped' };
+    const key = input.sourceId;
+    if (key !== '' && this.seenChannelIds.has(key)) return { status: 'duplicate' };
+    if (key !== '') this.seenChannelIds.add(key);
+    try {
+      await hooks.onAccepted?.(input);
+    } catch (err) {
+      this.log('warn', 'kimi-code onAccepted hook failed', err);
+    }
+    return this.submitQueuedTurn(renderChannelInput(input));
+  }
+
+  waitIdle(): Promise<void> {
+    if (this.queuedTurnCount === 0) return Promise.resolve();
+    if (this.idlePromise === null) {
+      this.idlePromise = new Promise((resolve) => {
+        this.idleResolve = resolve;
+      });
+    }
+    return this.idlePromise;
+  }
+
+  private async startOrResume(forceResume: boolean): Promise<void> {
+    if (this.client !== null && this.client.isAlive()) {
+      await this.setStatus('ready');
+      return;
+    }
+    await this.setStatus('starting');
+    try {
+      const client = this.deps.clientFactory({
+        bin: this.config.bin,
+        args: ['acp', ...this.config.extra_args],
+        cwd: this.cwd,
+        env: this.buildProcessEnv(),
+        homeDir: this.homeDir(),
+        stderrLogPath: this.stderrLogPath(),
+        turnTimeoutMs: this.config.turn_timeout_ms,
+        log: (level, message, err) => this.log(level, message, err),
+      });
+      await this.materializeKimiHome();
+      await client.start();
+      const sessionRequest = {
+        cwd: this.cwd,
+        mcpServers: kimiCodeAcpMcpServers(this.deps.mcpServers),
+      };
+      const checkpoint = this.checkpointId;
+      if (forceResume || checkpoint !== null) {
+        if (checkpoint === null) {
+          throw new Error('kimi-code resume requested without a checkpoint id');
+        }
+        try {
+          this.checkpointId = await client.resumeSession(checkpoint, sessionRequest);
+          this.resumed = true;
+        } catch (err) {
+          const message = `kimi-code session resume failed: ${errMessage(err)}`;
+          this.log('warn', `${message}; starting fresh session`, err);
+          const replacement = await client.createSession(sessionRequest);
+          this.checkpointId = replacement;
+          this.resumed = false;
+          if (this.deps.state.recordLostCheckpoint !== undefined) {
+            await this.deps.state.recordLostCheckpoint(
+              { id: checkpoint },
+              { id: replacement },
+              message,
+            );
+          } else {
+            await this.deps.state.setCheckpoint({ id: replacement });
+            await this.deps.state.setStatus('degraded', { last_error: message });
+          }
+        }
+      } else {
+        this.checkpointId = await client.createSession(sessionRequest);
+        this.resumed = false;
+      }
+      await this.deps.state.setCheckpoint({ id: this.checkpointId });
+      this.client = client;
+    } catch (err) {
+      await this.setStatus('degraded', err);
+      throw err;
+    }
+    await this.setStatus('ready');
+  }
+
+  private submitQueuedTurn(text: string): AgentRuntimeTurnResult {
+    const turnId = this.nextTurnId();
+    this.recordQueuedTurnStart();
+    void this.runTurnOnQueue(text, turnId).then(
+      (resultText) => this.markTurnSucceeded(turnId, resultText),
+      (err) => this.markTurnFailed(turnId, err),
+    );
+    return { status: 'submitted', turnId };
+  }
+
+  private runTurnOnQueue(text: string, turnId: string): Promise<string | null> {
+    const run = this.queue.then(() => this.runTurn(text, turnId));
+    this.queue = run.then(
+      () => undefined,
+      () => undefined,
+    );
+    return run;
+  }
+
+  private async runTurn(text: string, _turnId: string): Promise<string | null> {
+    const client = await this.ensureClient();
+    const checkpointId = this.checkpointId;
+    if (checkpointId === null) {
+      throw new Error('kimi-code session is missing a checkpoint id');
+    }
+    const result = await client.prompt(checkpointId, text);
+    if (result.stopReason === 'cancelled') {
+      throw new KimiCodeTurnStoppedError('kimi-code prompt was cancelled');
+    }
+    this.lastResult = { text: result.text };
+    return result.text;
+  }
+
+  private async ensureClient(): Promise<KimiCodeAcpClient> {
+    if (this.client !== null && this.client.isAlive()) return this.client;
+    await this.startOrResume(this.checkpointId !== null);
+    if (this.client === null) {
+      throw new Error('kimi-code client failed to start');
+    }
+    return this.client;
+  }
+
+  private async markTurnSucceeded(
+    turnId: string,
+    resultText: string | null,
+  ): Promise<void> {
+    this.recordQueuedTurnEnd();
+    this.deps.onTurnSettled?.({
+      turnId,
+      status: 'completed',
+      result: { text: resultText },
+    });
+    if (this.stopped) return;
+    if (this.status !== 'ready') await this.setStatus('ready');
+  }
+
+  private async markTurnFailed(turnId: string, err: unknown): Promise<void> {
+    this.recordQueuedTurnEnd();
+    const stopped = this.stopped || err instanceof KimiCodeTurnStoppedError;
+    this.deps.onTurnSettled?.({
+      turnId,
+      status: stopped ? 'stopped' : 'failed',
+      result: { text: null },
+      error: err instanceof Error ? err : new Error(String(err)),
+    });
+    if (this.stopped) return;
+    if (stopped) {
+      await this.setStatus('ready');
+      return;
+    }
+    this.log('error', `kimi-code turn ${turnId} failed`, err);
+    await this.setStatus('degraded', err);
+  }
+
+  private nextTurnId(): string {
+    this.turnCounter += 1;
+    return `${this.runtimeId}-kimi-${this.runtimeInstanceId}-${this.turnCounter}`;
+  }
+
+  private recordQueuedTurnStart(): void {
+    this.queuedTurnCount += 1;
+  }
+
+  private recordQueuedTurnEnd(): void {
+    this.queuedTurnCount = Math.max(0, this.queuedTurnCount - 1);
+    this.resolveIdleWaitersIfIdle();
+  }
+
+  private resolveIdleWaitersIfIdle(): void {
+    if (this.queuedTurnCount !== 0) return;
+    const resolve = this.idleResolve;
+    this.idlePromise = null;
+    this.idleResolve = null;
+    resolve?.();
+  }
+
+  private homeDir(): string {
+    return (
+      this.config.home_dir ??
+      join(this.deps.paths.dispatcherDir(this.runtimeId), 'kimi-code-home')
+    );
+  }
+
+  private async materializeKimiHome(): Promise<void> {
+    const homeDir = this.homeDir();
+    await ensureOwnerOnlyDir(homeDir);
+    await Promise.all([
+      this.materializeSystemPromptAppend(homeDir),
+      this.materializeSkillSources(homeDir),
+    ]);
+  }
+
+  private async materializeSystemPromptAppend(homeDir: string): Promise<void> {
+    const append = (this.deps.systemPromptAppend ?? []).filter((entry) => entry !== '');
+    if (append.length === 0) return;
+    const path = join(homeDir, 'AGENTS.md');
+    const existing = await readTextIfExists(path);
+    if (existing !== null && !existing.startsWith(MANAGED_AGENTS_MD_MARKER)) {
+      throw new Error(
+        `refusing to overwrite existing Kimi AGENTS.md at ${path}; use a dedicated kimi-code home_dir for Dreamux`,
+      );
+    }
+    const content = [
+      MANAGED_AGENTS_MD_MARKER,
+      '',
+      '# Dreamux Runtime Instructions',
+      '',
+      ...append,
+      '',
+    ].join('\n');
+    await writeFile(path, content, { mode: 0o600 });
+  }
+
+  private async materializeSkillSources(homeDir: string): Promise<void> {
+    const skillsRoot = join(homeDir, 'skills');
+    await mkdir(skillsRoot, { recursive: true, mode: 0o700 });
+    const sources = this.deps.skillSources ?? [];
+    const currentNames = new Set(sources.map((source) => source.name));
+    const previousNames = await this.readManagedSkillNames(homeDir);
+    await Promise.all(
+      previousNames
+        .filter((name) => !currentNames.has(name))
+        .map((name) => this.removeManagedSkillLink(skillsRoot, name)),
+    );
+    for (const source of sources) {
+      if (!SAFE_SKILL_NAME.test(source.name)) {
+        throw new Error(
+          `kimi-code skill source name ${JSON.stringify(source.name)} is not a safe path segment`,
+        );
+      }
+      const linkPath = join(skillsRoot, source.name);
+      await this.replaceManagedSkillLink(linkPath, source.path);
+    }
+    await writeFile(
+      join(homeDir, MANAGED_SKILLS_MANIFEST),
+      `${JSON.stringify({ version: 1, names: [...currentNames].sort() }, null, 2)}\n`,
+      { mode: 0o600 },
+    );
+  }
+
+  private async readManagedSkillNames(homeDir: string): Promise<string[]> {
+    const text = await readTextIfExists(join(homeDir, MANAGED_SKILLS_MANIFEST));
+    if (text === null) return [];
+    try {
+      const parsed = JSON.parse(text) as { names?: unknown };
+      if (!Array.isArray(parsed.names)) return [];
+      return parsed.names.filter((name): name is string => typeof name === 'string');
+    } catch {
+      return [];
+    }
+  }
+
+  private async removeManagedSkillLink(
+    skillsRoot: string,
+    name: string,
+  ): Promise<void> {
+    if (!SAFE_SKILL_NAME.test(name)) return;
+    const linkPath = join(skillsRoot, name);
+    const info = await lstatIfExists(linkPath);
+    if (info === null) return;
+    if (!info.isSymbolicLink()) {
+      throw new Error(
+        `refusing to remove non-symlink Kimi skill path ${linkPath}`,
+      );
+    }
+    await rm(linkPath, { force: true });
+  }
+
+  private async replaceManagedSkillLink(
+    linkPath: string,
+    targetPath: string,
+  ): Promise<void> {
+    const info = await lstatIfExists(linkPath);
+    if (info !== null) {
+      if (!info.isSymbolicLink()) {
+        throw new Error(
+          `refusing to overwrite existing non-symlink Kimi skill path ${linkPath}`,
+        );
+      }
+      const currentTarget = await readlink(linkPath);
+      if (currentTarget !== targetPath) await rm(linkPath, { force: true });
+      else return;
+    }
+    await symlink(targetPath, linkPath, 'dir');
+  }
+
+  private stderrLogPath(): string {
+    return join(this.deps.paths.logsDir(), 'kimi-code', `${this.runtimeId}.stderr.log`);
+  }
+
+  private buildProcessEnv(): Record<string, string | undefined> {
+    return {
+      ...process.env,
+      ...this.deps.injectEnv,
+      KIMI_CODE_HOME: this.homeDir(),
+      ...this.config.extra_env,
+    };
+  }
+
+  private async setStatus(
+    status: AgentRuntimeStatus,
+    err?: unknown,
+  ): Promise<void> {
+    this.status = status;
+    await this.deps.state.setStatus(status, {
+      ...(err !== undefined ? { last_error: errMessage(err) } : {}),
+      ...(status === 'starting' ? { last_started_at: Date.now() } : {}),
+      ...(status === 'ready' ? { last_ready_at: Date.now(), last_error: null } : {}),
+    });
+  }
+
+  private log(
+    level: 'info' | 'warn' | 'error',
+    message: string,
+    err?: unknown,
+  ): void {
+    this.logger?.[level]?.(
+      { runtime_id: this.runtimeId, error: errMessage(err) },
+      message,
+    );
+    if (this.logger === undefined && level !== 'info') {
+      console.error(`[kimi-code] ${message}: ${errMessage(err)}`);
+    }
+  }
+}
+
+async function readTextIfExists(path: string): Promise<string | null> {
+  try {
+    return await readFile(path, 'utf8');
+  } catch (err) {
+    if (isErrnoException(err) && err.code === 'ENOENT') return null;
+    throw err;
+  }
+}
+
+async function lstatIfExists(
+  path: string,
+): Promise<Awaited<ReturnType<typeof lstat>> | null> {
+  try {
+    return await lstat(path);
+  } catch (err) {
+    if (isErrnoException(err) && err.code === 'ENOENT') return null;
+    throw err;
+  }
+}
+
+class KimiCodeTurnStoppedError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'KimiCodeTurnStoppedError';
+  }
+}

--- a/packages/agent-runtime/kimi-code/tests/provider-runtime.test.ts
+++ b/packages/agent-runtime/kimi-code/tests/provider-runtime.test.ts
@@ -1,0 +1,283 @@
+import { mkdtemp, mkdir, readFile, realpath, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import {
+  createKimiCodeAgentRuntimeProvider,
+  kimiCodeAcpMcpServers,
+  readDispatcherKimiCodeConfig,
+  type KimiCodeAcpClient,
+  type KimiCodeAcpClientFactory,
+  type KimiCodeAcpClientSpec,
+  type KimiCodeAcpPromptResult,
+  type KimiCodeAcpSessionRequest,
+} from '../src/index.js';
+import type {
+  AgentRuntime,
+  AgentRuntimeCreateContext,
+  AgentRuntimeStateCallbacks,
+  TurnSettledSignal,
+} from '@excitedjs/dreamux-types';
+
+describe('kimi-code provider config', () => {
+  it('parses defaults and validates string fields', () => {
+    expect(readDispatcherKimiCodeConfig({}, 'config.json', 'agents[0].config.')).toMatchObject({
+      bin: 'kimi',
+      home_dir: null,
+      extra_args: [],
+      extra_env: {},
+    });
+    expect(() =>
+      readDispatcherKimiCodeConfig(
+        { bin: '' },
+        'config.json',
+        'agents[0].config.',
+      ),
+    ).toThrow(/bin must be a non-empty string/);
+  });
+
+  it('maps Dreamux MCP descriptors to ACP stdio descriptors', () => {
+    expect(
+      kimiCodeAcpMcpServers([
+        { name: 'fs', command: 'mcp-fs', args: ['--root', '/repo'] },
+      ]),
+    ).toEqual([
+      { name: 'fs', command: 'mcp-fs', args: ['--root', '/repo'], env: [] },
+    ]);
+  });
+});
+
+describe('kimi-code runtime', () => {
+  let root: string;
+  let client: FakeKimiClient;
+  let runtime: AgentRuntime | null;
+  let state: CapturingState;
+  let settled: TurnSettledSignal[];
+  let events: string[];
+
+  beforeEach(async () => {
+    root = await mkdtemp(join(tmpdir(), 'dreamux-kimi-runtime-'));
+    client = new FakeKimiClient();
+    runtime = null;
+    state = new CapturingState();
+    settled = [];
+    events = [];
+  });
+
+  afterEach(async () => {
+    await runtime?.stop().catch(() => {});
+    await rm(root, { recursive: true, force: true });
+  });
+
+  it('materializes append instructions and skill sources into KIMI_CODE_HOME', async () => {
+    const skillDir = await makeSkill(root, 'dispatcher');
+    runtime = makeRuntime({
+      systemPrompt: { append: ['Dreamux append prompt'] },
+      skillSources: [{ name: 'dispatcher', path: skillDir, source: 'dreamux-core' }],
+    });
+
+    await runtime.start();
+
+    const home = join(root, 'dispatcher', 'kimi-code-home');
+    await expect(readFile(join(home, 'AGENTS.md'), 'utf8')).resolves.toContain(
+      'Dreamux append prompt',
+    );
+    await expect(realpath(join(home, 'skills', 'dispatcher'))).resolves.toBe(
+      await realpath(skillDir),
+    );
+    expect(client.spec?.env['KIMI_CODE_HOME']).toBe(home);
+  });
+
+  it('submits completion turns once per source id and settles with text', async () => {
+    runtime = makeRuntime();
+    await runtime.start();
+
+    const first = await runtime.completionInput({ text: 'hello', sourceId: 'm1' });
+    const duplicate = await runtime.completionInput({ text: 'hello again', sourceId: 'm1' });
+    await runtime.waitIdle?.();
+
+    expect(first.status).toBe('submitted');
+    expect(duplicate).toEqual({ status: 'duplicate' });
+    expect(client.prompts).toEqual(['hello']);
+    expect(settled).toMatchObject([
+      { status: 'completed', result: { text: 'assistant: hello' } },
+    ]);
+  });
+
+  it('calls channel accepted hooks after dedupe and before prompt submission', async () => {
+    runtime = makeRuntime();
+    await runtime.start();
+
+    const first = await runtime.channelInput(
+      {
+        text: 'raw',
+        sourceId: 'channel-1',
+        source: 'feishu',
+        attrs: [['message_id', 'm1']],
+        body: 'body',
+      },
+      {
+        onAccepted: () => {
+          events.push('accepted');
+        },
+      },
+    );
+    const duplicate = await runtime.channelInput({
+      text: 'raw',
+      sourceId: 'channel-1',
+    });
+    await runtime.waitIdle?.();
+
+    expect(first.status).toBe('submitted');
+    expect(duplicate).toEqual({ status: 'duplicate' });
+    expect(events).toEqual(['accepted', 'prompt']);
+    expect(client.prompts[0]).toContain('<channel source="feishu"');
+  });
+
+  it('replaces a lost checkpoint when ACP resume fails', async () => {
+    client.resumeError = new Error('missing session');
+    client.nextSessionId = 'new-session';
+    runtime = makeRuntime({
+      identityCheckpoint: 'old-session',
+    });
+
+    await runtime.start();
+
+    expect(runtime.getCheckpoint()).toEqual({ id: 'new-session' });
+    expect(runtime.wasCheckpointResumed()).toBe(false);
+    expect(state.lost).toEqual([
+      {
+        lost: { id: 'old-session' },
+        replacement: { id: 'new-session' },
+        error: 'kimi-code session resume failed: missing session',
+      },
+    ]);
+  });
+
+  function makeRuntime(
+    options: {
+      systemPrompt?: AgentRuntimeCreateContext['systemPrompt'];
+      skillSources?: AgentRuntimeCreateContext['skillSources'];
+      identityCheckpoint?: string;
+    } = {},
+  ): AgentRuntime {
+    const provider = createKimiCodeAgentRuntimeProvider({
+      clientFactory: fakeClientFactory,
+    });
+    return provider.createRuntime({
+      identity: {
+        runtime_id: 'dispatcher',
+        checkpoint_id: options.identityCheckpoint ?? null,
+      },
+      config: readDispatcherKimiCodeConfig({}, 'config.json', 'agents[0].config.'),
+      cwd: join(root, 'work'),
+      mcpServers: [],
+      ...(options.systemPrompt !== undefined
+        ? { systemPrompt: options.systemPrompt }
+        : {}),
+      ...(options.skillSources !== undefined
+        ? { skillSources: options.skillSources }
+        : {}),
+      state,
+      paths: {
+        dispatcherDir: (id) => join(root, id),
+        logsDir: () => join(root, 'logs'),
+        runtimeSocketDirs: () => [join(root, 'run')],
+      },
+      logger: {
+        error: () => {},
+        warn: () => {},
+        info: () => {},
+        debug: () => {},
+        trace: () => {},
+      },
+      onTurnSettled: (signal) => settled.push(signal),
+    });
+  }
+
+  const fakeClientFactory: KimiCodeAcpClientFactory = (
+    spec: KimiCodeAcpClientSpec,
+  ) => {
+    client.spec = spec;
+    return client;
+  };
+
+  async function makeSkill(base: string, name: string): Promise<string> {
+    const dir = join(base, 'source-skills', name);
+    await mkdir(dir, { recursive: true });
+    await writeFile(
+      join(dir, 'SKILL.md'),
+      `---\nname: ${name}\ndescription: test\n---\n# ${name}\n`,
+    );
+    return dir;
+  }
+
+  class FakeKimiClient implements KimiCodeAcpClient {
+    spec: KimiCodeAcpClientSpec | null = null;
+    nextSessionId = 'session-1';
+    resumeError: Error | null = null;
+    prompts: string[] = [];
+    private alive = false;
+
+    async start(): Promise<void> {
+      this.alive = true;
+    }
+
+    async createSession(_input: KimiCodeAcpSessionRequest): Promise<string> {
+      return this.nextSessionId;
+    }
+
+    async resumeSession(
+      sessionId: string,
+      _input: KimiCodeAcpSessionRequest,
+    ): Promise<string> {
+      if (this.resumeError !== null) throw this.resumeError;
+      return sessionId;
+    }
+
+    async prompt(
+      _sessionId: string,
+      text: string,
+    ): Promise<KimiCodeAcpPromptResult> {
+      events.push('prompt');
+      this.prompts.push(text);
+      return { stopReason: 'end_turn', text: `assistant: ${text}` };
+    }
+
+    async stop(): Promise<void> {
+      this.alive = false;
+    }
+
+    isAlive(): boolean {
+      return this.alive;
+    }
+  }
+
+  class CapturingState implements AgentRuntimeStateCallbacks {
+    checkpoints: { id: string }[] = [];
+    lost: Array<{
+      lost: { id: string };
+      replacement: { id: string };
+      error: string;
+    }> = [];
+
+    async setStatus(): Promise<void> {
+      // Captured tests assert checkpoint/settlement behavior only.
+    }
+
+    async setCheckpoint(checkpoint: { id: string }): Promise<void> {
+      this.checkpoints.push(checkpoint);
+    }
+
+    async recordLostCheckpoint(
+      lost: { id: string },
+      replacement: { id: string },
+      error: string,
+    ): Promise<void> {
+      this.lost.push({ lost, replacement, error });
+      await this.setCheckpoint(replacement);
+    }
+  }
+});

--- a/packages/agent-runtime/kimi-code/tsconfig.json
+++ b/packages/agent-runtime/kimi-code/tsconfig.json
@@ -1,0 +1,27 @@
+{
+  "compilerOptions": {
+    "target": "ES2023",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "lib": ["ES2023"],
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "resolveJsonModule": true,
+    "strict": true,
+    "noImplicitAny": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "isolatedModules": true,
+    "verbatimModuleSyntax": false,
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules", "dist", "tests"]
+}

--- a/packages/agent-runtime/kimi-code/tsconfig.tests.json
+++ b/packages/agent-runtime/kimi-code/tsconfig.tests.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "rootDir": ".",
+    "types": ["node"]
+  },
+  "include": ["src/**/*.ts", "tests/**/*.ts"]
+}

--- a/rush.json
+++ b/rush.json
@@ -72,6 +72,11 @@
       "packageName": "@excitedjs/agent-runtime-claude-code",
       "projectFolder": "packages/agent-runtime/claude-code",
       "shouldPublish": true
+    },
+    {
+      "packageName": "@excitedjs/agent-runtime-kimi-code",
+      "projectFolder": "packages/agent-runtime/kimi-code",
+      "shouldPublish": true
     }
   ]
 }


### PR DESCRIPTION
## Summary
- add `@excitedjs/agent-runtime-kimi-code` as an external npm AgentRuntime provider backed by `kimi acp`
- map ACP sessions, prompt submission, MCP descriptors, source-id dedupe, channel acceptance hooks, turn settlement, and lost checkpoint replacement into the current neutral runtime interface
- materialize Dreamux append-only instructions and bundled skill sources through a runtime-owned `KIMI_CODE_HOME` without adding Dreamux core special cases
- document the Kimi ACP provider design and add a Rush change file

## Validation
- `node common/scripts/install-run-rush.js update`
- `node common/scripts/install-run-rush.js build --to @excitedjs/agent-runtime-kimi-code`
- `node common/scripts/install-run-rush.js test --to @excitedjs/agent-runtime-kimi-code`
- `node common/scripts/install-run-rush.js lint --to @excitedjs/agent-runtime-kimi-code`
- `node common/scripts/install-run-rush.js build`
- `node common/scripts/install-run-rush.js test`
- `node common/scripts/install-run-rush.js change --verify --no-fetch`
- `.agents/scripts/check.sh`
- `git diff --check`

## Notes
- The Kimi Code TypeScript SDK is still private/unpublished, so this provider shells a configurable `kimi` binary and depends only on public ACP/Dreamux packages.
- A real Kimi CLI/auth live smoke is still pending.