### PR TITLE
fix(mcp): surface dispatch reminders in structured results

### DIFF
--- a/common/changes/@excitedjs/dreamux/dreamux-dreamux-codex-next-0708-2022_2026-07-08-14-59.json
+++ b/common/changes/@excitedjs/dreamux/dreamux-dreamux-codex-next-0708-2022_2026-07-08-14-59.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Fix Team and TeamMate MCP success reminders so they are visible in structured tool results.",
+      "type": "patch",
+      "packageName": "@excitedjs/dreamux"
+    }
+  ],
+  "packageName": "@excitedjs/dreamux",
+  "email": "15624809+YourWildDad@users.noreply.github.com"
+}

--- a/packages/dreamux/src/mcp/task-dispatch-reminder.ts
+++ b/packages/dreamux/src/mcp/task-dispatch-reminder.ts
@@ -14,6 +14,18 @@ export function appendTaskDispatchSuccessReminder(
     : text;
 }
 
+export function appendStructuredTaskDispatchSuccessReminder(
+  result: unknown,
+  reminder: string,
+): unknown {
+  return hasSubmittedTurn(result)
+    ? {
+        ...(result as Record<string, unknown>),
+        reminder,
+      }
+    : result;
+}
+
 function hasSubmittedTurn(result: unknown): boolean {
   if (result === null || typeof result !== 'object' || Array.isArray(result)) {
     return false;

--- a/packages/dreamux/src/mcp/team-mcp.ts
+++ b/packages/dreamux/src/mcp/team-mcp.ts
@@ -6,6 +6,7 @@ import { adminSocketPath as defaultAdminSocketPath } from '../platform/paths.js'
 import { validateDispatcherId } from '../state/dispatcher-id.js';
 import {
   appendTaskDispatchSuccessReminder,
+  appendStructuredTaskDispatchSuccessReminder,
   TEAM_DISPATCH_SUCCESS_REMINDER,
 } from './task-dispatch-reminder.js';
 import { optionalRepoInput, repoInputSchema } from './teammate-mcp.js';
@@ -207,7 +208,10 @@ async function callTool(
           TEAM_DISPATCH_SUCCESS_REMINDER,
         ),
       }],
-      structuredContent: result,
+      structuredContent: appendStructuredTaskDispatchSuccessReminder(
+        result,
+        TEAM_DISPATCH_SUCCESS_REMINDER,
+      ),
     };
   } catch (err) {
     const prefix = err instanceof AdminClientError ? `[${err.code}] ` : '';

--- a/packages/dreamux/src/mcp/teammate-mcp.ts
+++ b/packages/dreamux/src/mcp/teammate-mcp.ts
@@ -10,6 +10,7 @@ import { validateDispatcherId } from '../state/dispatcher-id.js';
 import { validateTeamId } from '../service/team-collection/types.js';
 import {
   appendTaskDispatchSuccessReminder,
+  appendStructuredTaskDispatchSuccessReminder,
   TEAMMATE_DISPATCH_SUCCESS_REMINDER,
 } from './task-dispatch-reminder.js';
 
@@ -305,7 +306,10 @@ async function forwardToolCall(
           TEAMMATE_DISPATCH_SUCCESS_REMINDER,
         ),
       }],
-      structuredContent: result,
+      structuredContent: appendStructuredTaskDispatchSuccessReminder(
+        result,
+        TEAMMATE_DISPATCH_SUCCESS_REMINDER,
+      ),
     };
   } catch (err) {
     const prefix = err instanceof AdminClientError ? `[${err.code}] ` : '';

--- a/packages/dreamux/tests/team-mcp.test.ts
+++ b/packages/dreamux/tests/team-mcp.test.ts
@@ -270,6 +270,7 @@ describe('team-mcp stdio shim', () => {
           }],
           structuredContent: {
             team: { team_name: 'alpha' },
+            reminder: TEAM_DISPATCH_SUCCESS_REMINDER,
           },
         },
       });
@@ -414,6 +415,9 @@ describe('team-mcp stdio shim', () => {
           content: [{
             text: expect.stringContaining(TEAM_DISPATCH_SUCCESS_REMINDER) as string,
           }],
+          structuredContent: {
+            reminder: TEAM_DISPATCH_SUCCESS_REMINDER,
+          },
         },
       });
       expect(JSON.stringify(sendResponse)).not.toContain(TEAMMATE_DISPATCH_SUCCESS_REMINDER);
@@ -472,7 +476,8 @@ describe('team-mcp stdio shim', () => {
         },
       });
 
-      expect(await reader.next()).toMatchObject({
+      const response = await reader.next();
+      expect(response).toMatchObject({
         jsonrpc: '2.0',
         id: 1,
         result: {
@@ -482,6 +487,9 @@ describe('team-mcp stdio shim', () => {
           },
         },
       });
+      expect(JSON.stringify(response)).not.toContain(
+        TEAM_DISPATCH_SUCCESS_REMINDER,
+      );
 
       input.end();
       await run;

--- a/packages/dreamux/tests/team-mcp.test.ts
+++ b/packages/dreamux/tests/team-mcp.test.ts
@@ -394,6 +394,7 @@ describe('team-mcp stdio shim', () => {
           },
         },
       });
+      expect(JSON.stringify(listResponse)).not.toContain(TEAM_DISPATCH_SUCCESS_REMINDER);
       expect(statusResponse).toMatchObject({
         result: {
           structuredContent: {
@@ -402,6 +403,7 @@ describe('team-mcp stdio shim', () => {
           },
         },
       });
+      expect(JSON.stringify(statusResponse)).not.toContain(TEAM_DISPATCH_SUCCESS_REMINDER);
       expect(historyResponse).toMatchObject({
         result: {
           structuredContent: {
@@ -410,6 +412,7 @@ describe('team-mcp stdio shim', () => {
           },
         },
       });
+      expect(JSON.stringify(historyResponse)).not.toContain(TEAM_DISPATCH_SUCCESS_REMINDER);
       expect(sendResponse).toMatchObject({
         result: {
           content: [{
@@ -526,7 +529,8 @@ describe('team-mcp stdio shim', () => {
           arguments: { team_name: 'alpha', repo_cwd: '/repo', leader_agent_runtime: 'codex' },
         },
       });
-      expect(await reader.next()).toMatchObject({
+      const createResponse = (await reader.next()) as { result: Record<string, unknown> };
+      expect(createResponse).toMatchObject({
         jsonrpc: '2.0',
         id: 1,
         result: {
@@ -534,6 +538,7 @@ describe('team-mcp stdio shim', () => {
           content: [{ text: 'intent must be a non-empty string' }],
         },
       });
+      expect(createResponse.result).not.toHaveProperty('structuredContent');
 
       // dissolve without note → rejected before admin IPC.
       writeJson(input, {
@@ -542,7 +547,8 @@ describe('team-mcp stdio shim', () => {
         method: 'tools/call',
         params: { name: 'dissolve', arguments: { team_name: 'alpha' } },
       });
-      expect(await reader.next()).toMatchObject({
+      const dissolveResponse = (await reader.next()) as { result: Record<string, unknown> };
+      expect(dissolveResponse).toMatchObject({
         jsonrpc: '2.0',
         id: 2,
         result: {
@@ -550,6 +556,7 @@ describe('team-mcp stdio shim', () => {
           content: [{ text: 'note must be a non-empty string' }],
         },
       });
+      expect(dissolveResponse.result).not.toHaveProperty('structuredContent');
 
       expect(admin.requests).toEqual([]);
       input.end();

--- a/packages/dreamux/tests/team-mcp.test.ts
+++ b/packages/dreamux/tests/team-mcp.test.ts
@@ -296,6 +296,65 @@ describe('team-mcp stdio shim', () => {
     }
   });
 
+  it('omits the reminder when Team create starts an idle leader without a prompt', async () => {
+    const admin = await startFakeAdminServer((request) => ({
+      id: request.id,
+      ok: true,
+      result: {
+        team: { team_name: 'alpha' },
+        leader: { name: 'alpha-leader', status: 'running' },
+        member_count: 0,
+        turn: null,
+      },
+    }));
+    try {
+      const input = new PassThrough();
+      const output = new PassThrough();
+      const reader = new JsonLineReader(output);
+      const run = runTeamMcp({
+        dispatcherId: 'dispatcher-a',
+        adminSocketPath: admin.socketPath,
+        input,
+        output,
+        log: () => {},
+      });
+
+      writeJson(input, {
+        jsonrpc: '2.0',
+        id: 1,
+        method: 'tools/call',
+        params: {
+          name: 'create',
+          arguments: {
+            team_name: 'alpha',
+            leader_agent_runtime: 'codex',
+            intent: 'lead alpha',
+          },
+        },
+      });
+
+      const response = await reader.next();
+      expect(response).toMatchObject({
+        jsonrpc: '2.0',
+        id: 1,
+        result: {
+          content: [{ text: 'create forwarded to dreamux serve' }],
+          structuredContent: {
+            team: { team_name: 'alpha' },
+            turn: null,
+          },
+        },
+      });
+      expect(JSON.stringify(response)).not.toContain(TEAM_DISPATCH_SUCCESS_REMINDER);
+      expect(admin.requests[0]?.params).not.toHaveProperty('prompt');
+
+      input.end();
+      await run;
+    } finally {
+      await admin.close();
+    }
+  });
+
   it('forwards redesigned read verbs and preserves bound_target results (#182 PR-7)', async () => {
     const boundTarget = {
       channel_id: 'primary',
@@ -559,6 +618,58 @@ describe('team-mcp stdio shim', () => {
       expect(dissolveResponse.result).not.toHaveProperty('structuredContent');
 
       expect(admin.requests).toEqual([]);
+      input.end();
+      await run;
+    } finally {
+      await admin.close();
+    }
+  });
+
+  it('omits the reminder when dissolving a Team without submitting a turn', async () => {
+    const admin = await startFakeAdminServer((request) => ({
+      id: request.id,
+      ok: true,
+      result: {
+        team: { team_name: 'alpha', status: 'closed' },
+        leader: { name: 'alpha-leader', status: 'closed' },
+      },
+    }));
+    try {
+      const input = new PassThrough();
+      const output = new PassThrough();
+      const reader = new JsonLineReader(output);
+      const run = runTeamMcp({
+        dispatcherId: 'dispatcher-a',
+        adminSocketPath: admin.socketPath,
+        input,
+        output,
+        log: () => {},
+      });
+
+      writeJson(input, {
+        jsonrpc: '2.0',
+        id: 1,
+        method: 'tools/call',
+        params: {
+          name: 'dissolve',
+          arguments: { team_name: 'alpha', note: 'done' },
+        },
+      });
+
+      const response = await reader.next();
+      expect(response).toMatchObject({
+        jsonrpc: '2.0',
+        id: 1,
+        result: {
+          content: [{ text: 'dissolve forwarded to dreamux serve' }],
+          structuredContent: {
+            team: { team_name: 'alpha', status: 'closed' },
+          },
+        },
+      });
+      expect(JSON.stringify(response)).not.toContain(TEAM_DISPATCH_SUCCESS_REMINDER);
+      expect(admin.requests[0]?.method).toBe('mcp.team.dissolve');
+
       input.end();
       await run;
     } finally {

--- a/packages/dreamux/tests/teammate-mcp.test.ts
+++ b/packages/dreamux/tests/teammate-mcp.test.ts
@@ -413,6 +413,60 @@ describe('teammate-mcp stdio shim', () => {
     }
   });
 
+  it('omits the reminder when closing a TeamMate without submitting a turn', async () => {
+    const admin = await startFakeAdminServer((request) => ({
+      id: request.id,
+      ok: true,
+      result: {
+        teammate: { name: 'reviewer', status: 'closed' },
+      },
+    }));
+    try {
+      const input = new PassThrough();
+      const output = new PassThrough();
+      const reader = new JsonLineReader(output);
+      const run = runTeamMateMcp({
+        dispatcherId: 'dispatcher-a',
+        callerKind: 'dispatcher',
+        adminSocketPath: admin.socketPath,
+        input,
+        output,
+        log: () => {},
+      });
+
+      writeJson(input, {
+        jsonrpc: '2.0',
+        id: 1,
+        method: 'tools/call',
+        params: {
+          name: 'close',
+          arguments: { name: 'reviewer', note: 'done' },
+        },
+      });
+
+      const response = await reader.next();
+      expect(response).toMatchObject({
+        jsonrpc: '2.0',
+        id: 1,
+        result: {
+          content: [{ text: 'close forwarded to dreamux serve' }],
+          structuredContent: {
+            teammate: { name: 'reviewer', status: 'closed' },
+          },
+        },
+      });
+      expect(JSON.stringify(response)).not.toContain(
+        TEAMMATE_DISPATCH_SUCCESS_REMINDER,
+      );
+      expect(admin.requests[0]?.method).toBe('mcp.teammate.close');
+
+      input.end();
+      await run;
+    } finally {
+      await admin.close();
+    }
+  });
+
   it('rejects a repo input with an invalid mode before admin IPC (#199 Slice 2)', async () => {
     const admin = await startFakeAdminServer((request) => ({
       id: request.id,

--- a/packages/dreamux/tests/teammate-mcp.test.ts
+++ b/packages/dreamux/tests/teammate-mcp.test.ts
@@ -321,6 +321,7 @@ describe('teammate-mcp stdio shim', () => {
           structuredContent: {
             teammate: { name: 'reviewer', status: 'running' },
             turn: { status: 'submitted', turn_id: 'turn-1' },
+            reminder: TEAMMATE_DISPATCH_SUCCESS_REMINDER,
           },
         },
       });
@@ -390,7 +391,8 @@ describe('teammate-mcp stdio shim', () => {
         },
       });
 
-      expect(await reader.next()).toMatchObject({
+      const response = await reader.next();
+      expect(response).toMatchObject({
         jsonrpc: '2.0',
         id: 1,
         result: {
@@ -400,6 +402,9 @@ describe('teammate-mcp stdio shim', () => {
           },
         },
       });
+      expect(JSON.stringify(response)).not.toContain(
+        TEAMMATE_DISPATCH_SUCCESS_REMINDER,
+      );
 
       input.end();
       await run;
@@ -584,6 +589,7 @@ describe('teammate-mcp stdio shim', () => {
         result: {
           structuredContent: {
             teammate: { name: 'builder', status: 'running' },
+            reminder: TEAMMATE_DISPATCH_SUCCESS_REMINDER,
           },
         },
       });

--- a/packages/dreamux/tests/teammate-mcp.test.ts
+++ b/packages/dreamux/tests/teammate-mcp.test.ts
@@ -449,7 +449,8 @@ describe('teammate-mcp stdio shim', () => {
         },
       });
 
-      expect(await reader.next()).toMatchObject({
+      const repoResponse = (await reader.next()) as { result: Record<string, unknown> };
+      expect(repoResponse).toMatchObject({
         jsonrpc: '2.0',
         id: 1,
         result: {
@@ -457,6 +458,7 @@ describe('teammate-mcp stdio shim', () => {
           content: [{ text: "repo.mode must be 'reuse-cwd' or 'managed'" }],
         },
       });
+      expect(repoResponse.result).not.toHaveProperty('structuredContent');
       expect(admin.requests).toEqual([]);
 
       input.end();
@@ -495,7 +497,8 @@ describe('teammate-mcp stdio shim', () => {
           arguments: { name_prefix: 'reviewer', prompt: 'go', cwd: '/workspace' },
         },
       });
-      expect(await reader.next()).toMatchObject({
+      const spawnResponse = (await reader.next()) as { result: Record<string, unknown> };
+      expect(spawnResponse).toMatchObject({
         jsonrpc: '2.0',
         id: 1,
         result: {
@@ -503,6 +506,7 @@ describe('teammate-mcp stdio shim', () => {
           content: [{ text: 'intent must be a non-empty string' }],
         },
       });
+      expect(spawnResponse.result).not.toHaveProperty('structuredContent');
 
       // close without note → rejected before admin IPC.
       writeJson(input, {
@@ -511,7 +515,8 @@ describe('teammate-mcp stdio shim', () => {
         method: 'tools/call',
         params: { name: 'close', arguments: { name: 'reviewer' } },
       });
-      expect(await reader.next()).toMatchObject({
+      const closeResponse = (await reader.next()) as { result: Record<string, unknown> };
+      expect(closeResponse).toMatchObject({
         jsonrpc: '2.0',
         id: 2,
         result: {
@@ -519,6 +524,7 @@ describe('teammate-mcp stdio shim', () => {
           content: [{ text: 'note must be a non-empty string' }],
         },
       });
+      expect(closeResponse.result).not.toHaveProperty('structuredContent');
 
       expect(admin.requests).toEqual([]);
       input.end();
@@ -661,6 +667,9 @@ describe('teammate-mcp stdio shim', () => {
           { id: 'codex', spawn: { agent_runtime: 'codex' } },
         ],
       });
+      expect(JSON.stringify(response)).not.toContain(
+        TEAMMATE_DISPATCH_SUCCESS_REMINDER,
+      );
       expect(JSON.stringify(response.result.structuredContent)).not.toContain(
         'provider_ref',
       );
@@ -708,11 +717,15 @@ describe('teammate-mcp stdio shim', () => {
           },
         },
       });
-      expect(await reader.next()).toMatchObject({
+      const historyResponse = await reader.next();
+      expect(historyResponse).toMatchObject({
         jsonrpc: '2.0',
         id: 1,
         result: { structuredContent: { ok: true } },
       });
+      expect(JSON.stringify(historyResponse)).not.toContain(
+        TEAMMATE_DISPATCH_SUCCESS_REMINDER,
+      );
 
       // last without turns forwards just the name; last with turns forwards both.
       writeJson(input, {
@@ -721,11 +734,15 @@ describe('teammate-mcp stdio shim', () => {
         method: 'tools/call',
         params: { name: 'last', arguments: { name: 'reviewer' } },
       });
-      expect(await reader.next()).toMatchObject({
+      const lastResponse = await reader.next();
+      expect(lastResponse).toMatchObject({
         jsonrpc: '2.0',
         id: 2,
         result: { structuredContent: { ok: true } },
       });
+      expect(JSON.stringify(lastResponse)).not.toContain(
+        TEAMMATE_DISPATCH_SUCCESS_REMINDER,
+      );
 
       writeJson(input, {
         jsonrpc: '2.0',
@@ -733,11 +750,15 @@ describe('teammate-mcp stdio shim', () => {
         method: 'tools/call',
         params: { name: 'last', arguments: { name: 'reviewer', turns: 3 } },
       });
-      expect(await reader.next()).toMatchObject({
+      const lastWithTurnsResponse = await reader.next();
+      expect(lastWithTurnsResponse).toMatchObject({
         jsonrpc: '2.0',
         id: 3,
         result: { structuredContent: { ok: true } },
       });
+      expect(JSON.stringify(lastWithTurnsResponse)).not.toContain(
+        TEAMMATE_DISPATCH_SUCCESS_REMINDER,
+      );
 
       expect(admin.requests.map((request) => request.method)).toEqual([
         'mcp.teammate.history',


### PR DESCRIPTION
## Summary
- Add the dispatch success reminder to Team and TeamMate MCP `structuredContent` whenever a prompt turn is submitted.
- Keep the existing raw MCP text reminder for clients that read `content[0].text`.
- Extend Team/TeamMate MCP tests so submitted turns assert the model-visible structured reminder, failed turns remain reminder-free, and read/error/non-turn success responses cannot leak reminders.

## Root Cause
PR #285 appended the reminder only to raw MCP text content. The provider-exposed tools shown to agents surface the structured result, so real `mcp__teammate.spawn` / `send` responses did not include the reminder the agent could see.

## Validation
- `node common/scripts/install-run-rush.js update`
- `node common/scripts/install-run-rush.js build --to @excitedjs/dreamux`
- `node_modules/.bin/vitest run tests/teammate-mcp.test.ts tests/team-mcp.test.ts` (from `packages/dreamux`, 23 tests)
- `node_modules/.bin/tsc -p tsconfig.tests.json` (from `packages/dreamux`)
- `node_modules/.bin/eslint src/mcp/task-dispatch-reminder.ts src/mcp/team-mcp.ts src/mcp/teammate-mcp.ts tests/team-mcp.test.ts tests/teammate-mcp.test.ts` (from `packages/dreamux`)
- `node common/scripts/install-run-rush.js change --verify --target-branch origin/next --no-fetch`
- `git diff --check origin/next...HEAD`

## Review
- GLM read-only reviewer: 0 verified findings; optional read/error negative assertions were added afterward.
- Claude Seed read-only reviewer: 0 verified findings; optional non-turn success response coverage was added afterward.

## Notes
- A full local `rush test` run hit a known live Codex timing flake in `tests/codex-live.test.ts`; rerunning that exact live test passed.