### PR TITLE
Clean admin control-plane namespace

### DIFF
--- a/.agents/decisions/cli-and-package-naming.md
+++ b/.agents/decisions/cli-and-package-naming.md
@@ -2,9 +2,9 @@
 
 - **Status:** Accepted; bin-alias portion superseded by [global-bin-onboard-serve](global-bin-onboard-serve.md), historical dispatcher `tm` bin surface superseded by MCP-only workflow skills
 - **Date:** 2026-05-28
-- **Updated:** 2026-07-02
+- **Updated:** 2026-07-14
 - **Affects:** public CLI surface, npm package name, package bin entries
-- **PR / Issue:** [issue #4](https://github.com/excitedjs/dreamux/issues/4), [issue #18](https://github.com/excitedjs/dreamux/issues/18)
+- **PR / Issue:** [issue #4](https://github.com/excitedjs/dreamux/issues/4), [issue #18](https://github.com/excitedjs/dreamux/issues/18), [issue #295](https://github.com/excitedjs/dreamux/issues/295)
 
 ## Context
 
@@ -35,8 +35,6 @@ delegation, but the MCP-only workflow-skill update removed that wrapper again.
   dreamux serve
   dreamux status
   dreamux doctor
-  dreamux dispatcher add
-  dreamux dispatcher remove
   dreamux dispatcher list
   dreamux dispatcher status
   dreamux dispatcher start
@@ -48,8 +46,9 @@ delegation, but the MCP-only workflow-skill update removed that wrapper again.
   ```
 
 - Runtime support subcommands injected by Dreamux-managed MCP descriptors:
-  `dreamux feishu-mcp` and `dreamux teammate-mcp`. These are process shims, not
-  operator-facing admin command groups.
+  `dreamux channel-mcp`, `dreamux collaboration-space-mcp`,
+  `dreamux teammate-mcp`, `dreamux team-mcp`, and `dreamux cron-mcp`. These are
+  process shims, not operator-facing admin command groups.
 
 - `dreamux changelog` prints the installed package's rush-generated
   `CHANGELOG.md` (`--json` prints `CHANGELOG.json`). It is an offline,
@@ -60,6 +59,9 @@ delegation, but the MCP-only workflow-skill update removed that wrapper again.
 
 - `dreamux serve` is the foreground server entry point. Service managers also
   invoke `dreamux serve`.
+- Dispatcher declarations are config-owned. Add or remove entries in
+  `~/.dreamux/config.json` and restart `dreamux serve`; the operator CLI has no
+  `dispatcher add` or `dispatcher remove` commands.
 - `src/cli/server.ts` and `src/cli/server-ctl.ts` remain internal delegated
   modules while the CLI is migrated. They are not package-global bins.
 - Repo-root `/bin/dreamux` remains as a source-checkout convenience shim. There

--- a/.agents/domains/provider-runtime.md
+++ b/.agents/domains/provider-runtime.md
@@ -105,7 +105,9 @@ The context is neutral:
 - `systemPrompt` with optional `replace` and `append` forms;
 - exactly the MCP server descriptors core selected for this role;
 - effective `skillSources`, composed by core from required role roots and any
-  authorized custom roots;
+  authorized custom roots. Core stores custom roots as canonical absolute
+  directories and guarantees each path is a skill root whose direct children are
+  skill directories;
 - optional feature-disable names such as `cron`;
 - neutral logger, path, state, and environment injection seams;
 - optional `onTurnSettled` callback.

--- a/.agents/domains/provider-runtime.md
+++ b/.agents/domains/provider-runtime.md
@@ -104,7 +104,8 @@ The context is neutral:
 - launcher-supplied `cwd`;
 - `systemPrompt` with optional `replace` and `append` forms;
 - exactly the MCP server descriptors core selected for this role;
-- role-selected `skillSources`;
+- effective `skillSources`, composed by core from required role roots and any
+  authorized custom roots;
 - optional feature-disable names such as `cron`;
 - neutral logger, path, state, and environment injection seams;
 - optional `onTurnSettled` callback.
@@ -124,13 +125,19 @@ Source:
 
 Dreamux ships bundled skills under `/packages/dreamux/skills/`, but it does not
 install them into dispatcher workspaces during `onboard` or runtime startup.
-Core passes role-specific skill roots through `AgentRuntimeCreateContext`.
+Core passes effective skill roots through `AgentRuntimeCreateContext`.
 
 Current role gate:
 
 - Dispatcher roles receive the dispatcher workflow and maintenance root.
 - TeamLeader roles receive the Team workflow root.
 - Ordinary TeamMate and team-member roles receive no bundled Dreamux skills.
+
+The admin creation surface may add runtime-neutral custom roots for a
+TeamMate, team member, or TeamLeader. Core persists only those additions on the
+agent identity and recomposes them on every launch. TeamLeader composition
+always retains the required bundled Team workflow root. This capability is not
+part of MCP tool schemas or model-facing runtime discovery.
 
 Runtime packages own engine-specific application:
 
@@ -142,6 +149,8 @@ Source:
 
 - `/packages/dreamux/src/platform/paths.ts`
 - `/packages/dreamux/src/service/dispatcher-service/agent.ts`
+- `/packages/dreamux/src/service/agent-entity/identity-store.ts`
+- `/packages/dreamux/src/service/teammate-collection/index.ts`
 - `/packages/dreamux/src/service/team-service/index.ts`
 - `/packages/agent-runtime/codex/src/skill-roots.ts`
 - `/packages/agent-runtime/claude-code/src/args.ts`

--- a/.agents/proposals/admin-control-plane-surface.md
+++ b/.agents/proposals/admin-control-plane-surface.md
@@ -2,7 +2,8 @@
 
 - **Status:** Draft
 - **Date:** 2026-07-14
-- **Affects:** `/packages/dreamux/src/admin/`, `/packages/dreamux/src/mcp/`, admin socket consumers
+- **Affects:** `/packages/dreamux/src/admin/`, `/packages/dreamux/src/mcp/`, agent identity/runtime creation, admin socket consumers
+- **Issue:** [#295](https://github.com/excitedjs/dreamux/issues/295)
 
 ## Intent
 
@@ -13,9 +14,8 @@ tool set, adapts model-friendly arguments, and may compose one or more admin
 socket calls when that is the cleanest way to implement an MCP tool.
 
 The admin socket should therefore use product/control-plane names and errors,
-not MCP-specific names. In particular, the `mcp.` prefix currently present on
-Team, TeamMate, and collaboration-space admin RPCs should be removed from the
-admin method namespace.
+not MCP-specific names. The namespace slice removes the pre-stable `mcp.`
+prefix from Team, TeamMate, and collaboration-space admin RPCs.
 
 The same control plane must also support outbound events. A larger system
 cannot integrate with Dreamux only by polling passive request/response methods;
@@ -23,9 +23,19 @@ it needs to observe state transitions such as submitted turns, settled turns,
 Team/TeamMate lifecycle changes, channel route changes, scheduler fires, and
 collaboration target lifecycle changes.
 
-## Current Admin Surface
+## Namespace Slice Status
 
-Admin socket requests are one-line NDJSON RPC envelopes with dotted lowercase
+The namespace-cleanup slice implements the canonical product method names,
+removes the pre-stable `mcp.*` names and dispatcher mutation placeholders, and
+keeps Dreamux-owned MCP shims on their existing model-facing surface. It also
+adds admin-only custom skill roots to TeamMate and TeamLeader creation. The
+event surface, protocol baseline, introspection, inventory, and authentication
+work in this proposal remain future slices.
+
+## Pre-Cleanup Admin Surface
+
+Before the namespace slice, admin socket requests were one-line NDJSON RPC
+envelopes with dotted lowercase
 method names. The method registry lives in
 [`/packages/dreamux/src/admin/methods.ts`](/packages/dreamux/src/admin/methods.ts),
 and dispatch happens in
@@ -36,16 +46,16 @@ The current socket protocol is request/response only: protocol comments say
 and `processLine()` writes exactly one response for each request in
 [`/packages/dreamux/src/admin/socket.ts`](/packages/dreamux/src/admin/socket.ts).
 
-Current non-MCP-prefixed methods:
+The non-MCP-prefixed methods were:
 
 | Area | Methods | Notes |
 |---|---|---|
 | Server | `server.status` | Returns process status plus dispatcher summaries. |
-| Dispatcher | `dispatcher.list`, `dispatcher.status`, `dispatcher.start`, `dispatcher.stop` | Dispatcher declarations are config-owned. The current unsupported `dispatcher.add` and `dispatcher.remove` placeholders should be deleted rather than promoted. |
+| Dispatcher | `dispatcher.list`, `dispatcher.status`, `dispatcher.start`, `dispatcher.stop` | Dispatcher declarations are config-owned. The unsupported `dispatcher.add` and `dispatcher.remove` placeholders were deletion targets rather than product capabilities. |
 | Scheduler | `scheduler.cron.list`, `scheduler.cron.create`, `scheduler.cron.update`, `scheduler.cron.delete`, `scheduler.cron.run_now` | Already scoped as a scheduler/admin capability rather than an MCP capability. |
 | Channel tools | `channel.invoke_tool` | Generic provider-owned tool conduit. Provider tool metadata remains descriptor-owned; calls route through the live channel session and caller authorization. |
 
-Current MCP-prefixed admin methods:
+The pre-cleanup MCP-prefixed admin methods were:
 
 | Area | Methods | Notes |
 |---|---|---|
@@ -53,7 +63,7 @@ Current MCP-prefixed admin methods:
 | Team | `mcp.team.create`, `mcp.team.send`, `mcp.team.list`, `mcp.team.status`, `mcp.team.history`, `mcp.team.bind_channel`, `mcp.team.transfer_back`, `mcp.team.dissolve` | Dispatcher MCP exposes the lifecycle/read tools; TeamLeader MCP only exposes `transfer_back`. |
 | Collaboration space | `mcp.collaboration_space.bind`, `mcp.collaboration_space.dissolve`, `mcp.collaboration_space.status`, `mcp.collaboration_space.list` | This is already a control-plane capability in behavior, but the method names still carry MCP terminology. |
 
-## Current MCP Adapter Surface
+## Pre-Cleanup MCP Adapter Surface
 
 The MCP shims are stdio JSON-RPC adapters. They expose model-facing tool schemas
 and translate `tools/call` into admin socket calls.
@@ -66,8 +76,8 @@ and translate `tools/call` into admin socket calls.
 | Channel MCP | Lists static provider descriptors and forwards raw provider tool calls to `channel.invoke_tool`. See [`channel-mcp.ts`](/packages/dreamux/src/mcp/channel-mcp.ts). | Already maps to `channel.invoke_tool`. |
 | Collaboration-space MCP | Exposes `bind`, `dissolve`, `status`, `list`. | Maps to `mcp.collaboration_space.*` in [`collaboration-space-mcp.ts`](/packages/dreamux/src/mcp/collaboration-space-mcp.ts). |
 
-Some filtering is still expressed in the admin layer. For example, Team MCP
-TeamLeader callers are rejected for `mcp.team.send` with MCP-specific wording
+Before cleanup, some filtering was still expressed with MCP wording in the
+admin layer. For example, TeamLeader callers were rejected for `mcp.team.send`
 in [`methods.ts`](/packages/dreamux/src/admin/methods.ts). TeamLeader TeamMate
 spawn also rejects `repo`, but that message already describes the product rule:
 Team TeamMates use the Team shared workspace, while dispatcher callers may pass
@@ -83,7 +93,7 @@ These gaps matter if admin.sock is the external system integration surface:
 | Method and schema introspection | No admin method lists its supported params/result shape through the socket. Consumers must know method names out of band or read source/docs. |
 | Adapter diagnostics | Admin can create runtime descriptors internally, but there is no diagnostic method to ask which MCP servers/tools a dispatcher or TeamLeader adapter would expose. This is not a domain control-plane capability unless an external consumer explicitly needs adapter diagnostics. |
 | Channel inventory and binding inventory | Admin can invoke provider tools and bind/transfer Team routes, but there is no first-class `channel.list`, `channel.status`, `channel.binding.list`, or `channel.resolve_target`. |
-| Dispatcher declaration mutation | This should not be a control-plane capability for now. Config editing remains outside admin.sock, and the unsupported `dispatcher.add` / `dispatcher.remove` placeholders should be removed. |
+| Dispatcher declaration mutation | This is not a control-plane capability. Config editing remains outside admin.sock, and the unsupported `dispatcher.add` / `dispatcher.remove` placeholders were removed in the namespace slice. |
 | Dispatcher-root turn submission | Admin can send a TeamLeader turn and TeamMate turns; there is no direct dispatcher-agent submit method. |
 | Collaboration target control | Admin can bind/list/status/dissolve spaces; target-level inspection, retry, detach, or close controls are not exposed as first-class methods. |
 | Channel session lifecycle detail | `dispatcher.status` summarizes dispatcher runtime, not per-channel live session status. |
@@ -148,14 +158,14 @@ admin namespace.
 
 ## Compatibility Boundary
 
-Treat the current `mcp.*` admin methods as pre-stable internal names. This is
+The pre-cleanup `mcp.*` admin methods were pre-stable internal names. This was
 the cleanup window before admin.sock is advertised as the external integration
-contract, so the namespace change should replace the old methods rather than
-keep deprecated aliases.
+contract, so the namespace change replaces the old methods rather than keeping
+deprecated aliases.
 
-The first implementation should update Dreamux-owned MCP adapters and tests to
-the canonical names, remove `mcp.*` admin registry entries, and let old names
-fail as unknown methods. After the stable external control-plane protocol is
+The implemented slice updates Dreamux-owned MCP adapters and tests to the
+canonical names, removes `mcp.*` admin registry entries, and lets old names fail
+as unknown methods. After the stable external control-plane protocol is
 published, future namespace or protocol changes must follow backward-compatible
 migration rules.
 
@@ -332,6 +342,30 @@ The owner-only socket mode remains the current coarse security boundary. Any
 external system integration that needs multiple local principals must not treat
 the flat `caller_kind/team_id/leader_name` tuple as sufficient authorization.
 
+## Admin-Only Creation Skill Sources
+
+`teammate.spawn` and `team.create` accept an optional `skill_sources` array on
+the admin wire. Each entry must be an object with non-empty string `name`,
+`path`, and `source` fields; malformed input returns `BAD_REQUEST`. The shape is
+runtime-neutral and reuses `AgentRuntimeSkillSource`.
+
+The capability applies to dispatcher-scope TeamMates, TeamLeaders, and direct
+admin calls that spawn a Team-scoped member. The service boundary already owns
+member runtime context cleanly, so Team-scoped support does not alter shared
+workspace or role policy. TeamLeader-scoped MCP calls still cannot supply the
+parameter.
+
+Only custom roots are persisted on the agent identity. At runtime the owning
+service recomposes required built-in role roots with the stored additions; a
+TeamLeader therefore always keeps the bundled Dreamux Team workflow root.
+Custom roots do not reintroduce workspace skill installation or symlink
+behavior. Admin DTOs and public model-facing views do not project the stored
+paths.
+
+This is deliberately an admin-only capability. MCP tool schemas, descriptions,
+argument parsing, and forwarded requests omit `skill_sources`, including when
+an untrusted caller adds the field to raw MCP call arguments.
+
 ## Backward Compatibility
 
 The current admin namespace is treated as pre-stable for this cleanup. Do not
@@ -359,8 +393,8 @@ must preserve backward compatibility or provide an explicit versioned migration.
   ownership gate that verifies Team read composition remains in
   `admin/methods.ts`.
 - Admin-layer rejection messages do not refer to "MCP caller" or "MCP tool";
-  the currently verified MCP-specific message is the TeamLeader rejection for
-  `mcp.team.send`.
+  the previously MCP-specific TeamLeader rejection now identifies the
+  dispatcher-only `team.send` product rule.
 - MCP adapter tests assert that Team, TeamMate, and collaboration-space tools
   call the renamed admin methods.
 - MCP tool visibility remains unchanged for dispatcher and TeamLeader callers.
@@ -369,6 +403,18 @@ must preserve backward compatibility or provide an explicit versioned migration.
 - The KB records admin.sock as the target external control plane and MCP as an
   adapter surface, with source links to the method registry and adapters. It
   does not claim that the stable external protocol baseline is complete.
+
+### Admin-Only Skill Injection
+
+- Admin `teammate.spawn` forwards validated custom roots for dispatcher and
+  Team-scoped TeamMate creation.
+- Admin `team.create` forwards validated custom roots to TeamLeader runtime
+  creation.
+- Malformed `skill_sources` input returns `BAD_REQUEST` before domain mutation.
+- Custom roots survive runtime and process rebuild through agent identity state.
+- Required bundled role roots remain present alongside custom roots.
+- MCP schemas and descriptions do not expose `skill_sources`, and MCP adapters
+  do not forward it even when it appears in raw call arguments.
 
 ### Future Event Slice
 
@@ -405,6 +451,7 @@ must preserve backward compatibility or provide an explicit versioned migration.
   owner-only socket remains the coarse boundary until a separate design changes
   it.
 - Changing provider-owned channel tool descriptors.
+- Exposing custom creation skill roots through any MCP or model-facing surface.
 
 ## Review Focus
 

--- a/.agents/proposals/admin-control-plane-surface.md
+++ b/.agents/proposals/admin-control-plane-surface.md
@@ -1,0 +1,426 @@
+# Admin Control Plane Surface
+
+- **Status:** Draft
+- **Date:** 2026-07-14
+- **Affects:** `/packages/dreamux/src/admin/`, `/packages/dreamux/src/mcp/`, admin socket consumers
+
+## Intent
+
+Dreamux is becoming a component inside larger systems. The target external
+control-plane entry point should be the local admin socket, not the stdio MCP
+adapter surface. MCP remains a model-facing adapter that exposes a filtered
+tool set, adapts model-friendly arguments, and may compose one or more admin
+socket calls when that is the cleanest way to implement an MCP tool.
+
+The admin socket should therefore use product/control-plane names and errors,
+not MCP-specific names. In particular, the `mcp.` prefix currently present on
+Team, TeamMate, and collaboration-space admin RPCs should be removed from the
+admin method namespace.
+
+The same control plane must also support outbound events. A larger system
+cannot integrate with Dreamux only by polling passive request/response methods;
+it needs to observe state transitions such as submitted turns, settled turns,
+Team/TeamMate lifecycle changes, channel route changes, scheduler fires, and
+collaboration target lifecycle changes.
+
+## Current Admin Surface
+
+Admin socket requests are one-line NDJSON RPC envelopes with dotted lowercase
+method names. The method registry lives in
+[`/packages/dreamux/src/admin/methods.ts`](/packages/dreamux/src/admin/methods.ts),
+and dispatch happens in
+[`/packages/dreamux/src/admin/socket.ts`](/packages/dreamux/src/admin/socket.ts).
+The current socket protocol is request/response only: protocol comments say
+"one line in / one line out" in
+[`/packages/dreamux/src/admin/protocol.ts`](/packages/dreamux/src/admin/protocol.ts),
+and `processLine()` writes exactly one response for each request in
+[`/packages/dreamux/src/admin/socket.ts`](/packages/dreamux/src/admin/socket.ts).
+
+Current non-MCP-prefixed methods:
+
+| Area | Methods | Notes |
+|---|---|---|
+| Server | `server.status` | Returns process status plus dispatcher summaries. |
+| Dispatcher | `dispatcher.list`, `dispatcher.status`, `dispatcher.start`, `dispatcher.stop` | Dispatcher declarations are config-owned. The current unsupported `dispatcher.add` and `dispatcher.remove` placeholders should be deleted rather than promoted. |
+| Scheduler | `scheduler.cron.list`, `scheduler.cron.create`, `scheduler.cron.update`, `scheduler.cron.delete`, `scheduler.cron.run_now` | Already scoped as a scheduler/admin capability rather than an MCP capability. |
+| Channel tools | `channel.invoke_tool` | Generic provider-owned tool conduit. Provider tool metadata remains descriptor-owned; calls route through the live channel session and caller authorization. |
+
+Current MCP-prefixed admin methods:
+
+| Area | Methods | Notes |
+|---|---|---|
+| TeamMate | `mcp.teammate.spawn`, `mcp.teammate.send`, `mcp.teammate.close`, `mcp.teammate.history`, `mcp.teammate.list`, `mcp.teammate.status`, `mcp.teammate.last`, `mcp.teammate.capabilities` | These can target dispatcher scope or TeamLeader scope via `caller_kind` and `team_id`. |
+| Team | `mcp.team.create`, `mcp.team.send`, `mcp.team.list`, `mcp.team.status`, `mcp.team.history`, `mcp.team.bind_channel`, `mcp.team.transfer_back`, `mcp.team.dissolve` | Dispatcher MCP exposes the lifecycle/read tools; TeamLeader MCP only exposes `transfer_back`. |
+| Collaboration space | `mcp.collaboration_space.bind`, `mcp.collaboration_space.dissolve`, `mcp.collaboration_space.status`, `mcp.collaboration_space.list` | This is already a control-plane capability in behavior, but the method names still carry MCP terminology. |
+
+## Current MCP Adapter Surface
+
+The MCP shims are stdio JSON-RPC adapters. They expose model-facing tool schemas
+and translate `tools/call` into admin socket calls.
+
+| Adapter | Current filtering behavior | Current admin mapping |
+|---|---|---|
+| Team MCP | `teamTools('team_leader')` returns only `transfer_back`; dispatcher callers see Team lifecycle/read/bind tools. See [`team-mcp.ts`](/packages/dreamux/src/mcp/team-mcp.ts). | Maps tool calls to `mcp.team.*` methods in [`mapToolCall`](/packages/dreamux/src/mcp/team-mcp.ts). |
+| TeamMate MCP | TeamLeader `spawn` omits `repo`; dispatcher `spawn` accepts `repo`. See [`teammateTools`](/packages/dreamux/src/mcp/teammate-mcp.ts). | Maps tool calls to `mcp.teammate.*` methods in [`mapToolCall`](/packages/dreamux/src/mcp/teammate-mcp.ts). |
+| Cron MCP | The descriptor-bound dispatcher/team scope is applied after stripping model-supplied `dispatcher_id` and `team_id`. See [`cron-mcp.ts`](/packages/dreamux/src/mcp/cron-mcp.ts). | Already maps to `scheduler.cron.*`. |
+| Channel MCP | Lists static provider descriptors and forwards raw provider tool calls to `channel.invoke_tool`. See [`channel-mcp.ts`](/packages/dreamux/src/mcp/channel-mcp.ts). | Already maps to `channel.invoke_tool`. |
+| Collaboration-space MCP | Exposes `bind`, `dissolve`, `status`, `list`. | Maps to `mcp.collaboration_space.*` in [`collaboration-space-mcp.ts`](/packages/dreamux/src/mcp/collaboration-space-mcp.ts). |
+
+Some filtering is still expressed in the admin layer. For example, Team MCP
+TeamLeader callers are rejected for `mcp.team.send` with MCP-specific wording
+in [`methods.ts`](/packages/dreamux/src/admin/methods.ts). TeamLeader TeamMate
+spawn also rejects `repo`, but that message already describes the product rule:
+Team TeamMates use the Team shared workspace, while dispatcher callers may pass
+`repo`. The safety and ownership checks must remain enforceable by admin, but
+the MCP visibility model and MCP-specific wording should live in the adapter.
+
+## Missing First-Class Admin Capabilities
+
+These gaps matter if admin.sock is the external system integration surface:
+
+| Capability | Current state |
+|---|---|
+| Method and schema introspection | No admin method lists its supported params/result shape through the socket. Consumers must know method names out of band or read source/docs. |
+| Adapter diagnostics | Admin can create runtime descriptors internally, but there is no diagnostic method to ask which MCP servers/tools a dispatcher or TeamLeader adapter would expose. This is not a domain control-plane capability unless an external consumer explicitly needs adapter diagnostics. |
+| Channel inventory and binding inventory | Admin can invoke provider tools and bind/transfer Team routes, but there is no first-class `channel.list`, `channel.status`, `channel.binding.list`, or `channel.resolve_target`. |
+| Dispatcher declaration mutation | This should not be a control-plane capability for now. Config editing remains outside admin.sock, and the unsupported `dispatcher.add` / `dispatcher.remove` placeholders should be removed. |
+| Dispatcher-root turn submission | Admin can send a TeamLeader turn and TeamMate turns; there is no direct dispatcher-agent submit method. |
+| Collaboration target control | Admin can bind/list/status/dissolve spaces; target-level inspection, retry, detach, or close controls are not exposed as first-class methods. |
+| Channel session lifecycle detail | `dispatcher.status` summarizes dispatcher runtime, not per-channel live session status. |
+| Outbound events | No admin event stream, subscription method, event cursor, or durable event replay exists. Consumers must poll read APIs or infer from MCP completion delivery. |
+| Versioned protocol contract | Request/response envelopes have no `protocol_version`, max-frame rule, public error taxonomy, idempotency key, or streaming client contract. See "Protocol Baseline". |
+
+This proposal does not claim all gaps must be filled in the first slice. It
+records them so the admin surface can grow as a coherent control plane rather
+than a collection of MCP-derived entry points.
+
+## Protocol Baseline
+
+The admin protocol needs a stable baseline before it can be treated as an
+external system contract. The namespace cleanup may stay mechanical, but the
+control-plane design should reserve space for:
+
+- `protocol_version` on request, response, and event frames;
+- maximum frame size and buffer behavior;
+- response ordering when one connection sends multiple requests;
+- mutation idempotency keys for external retry;
+- stable public error codes and safe error details;
+- a separate streaming client API for event subscriptions;
+- shutdown behavior for one-shot requests versus subscribed connections.
+
+Unexpected exceptions should not become the long-term external error contract.
+The current `INTERNAL` response exposes the raw exception message; later
+externalization should define public-safe details separately from server logs.
+Until this baseline is implemented, docs and release notes should describe
+admin.sock as the target external control plane, not as a completed stable
+external protocol.
+
+## Target Admin Namespace
+
+The minimal namespace cleanup is:
+
+| Current method | Target method |
+|---|---|
+| `mcp.teammate.spawn` | `teammate.spawn` |
+| `mcp.teammate.send` | `teammate.send` |
+| `mcp.teammate.close` | `teammate.close` |
+| `mcp.teammate.history` | `teammate.history` |
+| `mcp.teammate.list` | `teammate.list` |
+| `mcp.teammate.status` | `teammate.status` |
+| `mcp.teammate.last` | `teammate.last` |
+| `mcp.teammate.capabilities` | `teammate.capabilities` |
+| `mcp.team.create` | `team.create` |
+| `mcp.team.send` | `team.send` |
+| `mcp.team.list` | `team.list` |
+| `mcp.team.status` | `team.status` |
+| `mcp.team.history` | `team.history` |
+| `mcp.team.bind_channel` | `team.bind_channel` |
+| `mcp.team.transfer_back` | `team.transfer_back` |
+| `mcp.team.dissolve` | `team.dissolve` |
+| `mcp.collaboration_space.bind` | `collaboration_space.bind` |
+| `mcp.collaboration_space.dissolve` | `collaboration_space.dissolve` |
+| `mcp.collaboration_space.status` | `collaboration_space.status` |
+| `mcp.collaboration_space.list` | `collaboration_space.list` |
+
+`scheduler.cron.*` and `channel.invoke_tool` already use control-plane names
+and should stay as they are unless a broader naming decision changes the whole
+admin namespace.
+
+## Compatibility Boundary
+
+Treat the current `mcp.*` admin methods as pre-stable internal names. This is
+the cleanup window before admin.sock is advertised as the external integration
+contract, so the namespace change should replace the old methods rather than
+keep deprecated aliases.
+
+The first implementation should update Dreamux-owned MCP adapters and tests to
+the canonical names, remove `mcp.*` admin registry entries, and let old names
+fail as unknown methods. After the stable external control-plane protocol is
+published, future namespace or protocol changes must follow backward-compatible
+migration rules.
+
+## Target Event Surface
+
+Admin events should represent facts committed by the same ownership layers that
+mutate state, not facts scraped from logs, MCP tool results, or provider-specific
+callbacks. The event transport can belong to admin control-plane
+infrastructure, but domain services and coordinators remain the authority for
+when a state transition exists. This keeps event emission provider-neutral and
+avoids making MCP adapters or channel providers responsible for Dreamux
+control-plane facts.
+
+The minimum admin event surface should include:
+
+| Method | Purpose |
+|---|---|
+| `event.subscribe` | Keep one admin socket connection open after an initial acknowledgement and stream future event frames that match filters. This is a transport/session feature, not a normal one-shot `AdminHandler`. |
+| `event.history` | If durable replay is required by the integration contract, read recent event envelopes by cursor/time/type/dispatcher filter so an external system can recover after reconnect. |
+
+Event frames should be distinct from request responses. A subscribed connection
+can still use normal response frames for the subscription acknowledgement, then
+receive push frames. Push frames are not tied to a request `id`, so the admin
+transport needs an explicit subscribed-session path instead of treating
+subscription delivery as another `processLine()` response.
+
+For a durable feed, event frames can be shaped like:
+
+```json
+{
+  "protocol_version": 1,
+  "type": "event",
+  "event": {
+    "schema_version": 1,
+    "event_id": "dispatcher-a:0000000000000001",
+    "cursor": "dispatcher-a:0000000000000001",
+    "timestamp": 1784020000000,
+    "topic": "agent.turn.settled",
+    "dispatcher_id": "dispatcher-a",
+    "resource": {
+      "kind": "teammate",
+      "name": "reviewer-abc"
+    },
+    "payload": {}
+  }
+}
+```
+
+The exact payload fields should be topic-specific, but the envelope should keep
+a stable base: timestamp, topic, dispatcher scope, resource identity, schema
+version, and a public-safe payload. Durable replay adds `event_id` and `cursor`
+once its ordering and retention semantics are defined. Full prompts, full
+assistant text, provider secrets, local private paths, and raw provider
+metadata should not be emitted by default. Events can carry previews or
+identifiers that let a trusted local consumer call the existing read APIs for
+details.
+
+Initial event topics should cover control-plane transitions rather than every
+internal implementation step:
+
+| Topic family | Example events |
+|---|---|
+| Dispatcher lifecycle | `dispatcher.ready`, `dispatcher.stopped`, `dispatcher.failed`; `ready` means input sources, scheduler, channel sessions, and root runtime resume requirements are satisfied by the dispatcher start flow in [`dispatcher-service/index.ts`](/packages/dreamux/src/service/dispatcher-service/index.ts). |
+| Team lifecycle | `team.created`, `team.started`, `team.dissolved` |
+| TeamMate lifecycle | `teammate.spawned`, `teammate.closed`, `teammate.status.changed` |
+| Turns | `agent.turn.submitted`, `agent.turn.settled`; resource role/team scope identifies dispatcher root, TeamLeader, or TeamMate. |
+| Channel routing | `channel.binding.changed`; this is the authoritative route-change fact, including Team route changes. |
+| Collaboration spaces | `collaboration_space.bound`, `collaboration_space.dissolved`, `collaboration_space.target.changed` |
+| Scheduler | `scheduler.job.created`, `scheduler.job.updated`, `scheduler.job.deleted`, `scheduler.job.fired` |
+
+`channel.tool.invoked` is intentionally not part of the default state event set.
+It is an audit event, not a state transition, and should only exist behind a
+separate audit surface with allowlisted payload fields that exclude raw
+provider arguments and raw results.
+
+Durability is a separate event-contract tier. A volatile subscription can
+satisfy consumers that only need live notifications. A durable event feed is
+required only when consumers need reconnect recovery or no-loss integration.
+If durable replay is required, use the existing domain stores as the canonical
+state source and treat the event log as an at-least-once change feed. The design
+must then define a stable `event_id`, idempotent consumer behavior, retention,
+cursor scope/order/inclusivity, `CURSOR_EXPIRED`, and reconciliation from domain
+state after crash/retry. This proposal does not make the event log a canonical
+journal unless a later decision record explicitly changes the state model.
+
+Every topic must have a closed payload schema and schema version. Payloads
+should be redacted at construction time by topic-specific helpers, not by a
+generic `Record<string, unknown>` callback that trusts callers to remember which
+fields are safe.
+
+`event.subscribe(after_cursor)` needs an atomic replay-to-live handoff if
+durable replay is present. A client must not have to call `event.history` and
+then separately subscribe with a gap where events can be missed. The transport
+also needs explicit slow-consumer, backpressure, disconnect, and shutdown
+semantics.
+
+The current one-shot client in
+[`/packages/dreamux/src/admin/client.ts`](/packages/dreamux/src/admin/client.ts)
+settles on the first response line and closes the socket. Event streaming
+therefore requires a separate streaming client API; it should not overload
+`sendAdminRequest()`.
+
+## Adapter Boundary
+
+Admin handlers own request framing, parameter validation, session/admission
+coordination, and public error projection. Domain services and the existing
+cross-domain coordinators own durable state mutation, runtime lifecycle
+admission, cross-service ownership checks, provider-neutral authorization, and
+the authoritative transition points that can produce typed domain transitions.
+A control-plane projector should map those transitions into versioned,
+public-safe admin event DTOs; transport and journal infrastructure should only
+deliver or persist those DTOs. MCP adapters own model-facing projection.
+
+The adapter layer should own:
+
+- tool visibility by caller type;
+- model-facing tool names and descriptions;
+- model-facing argument schemas;
+- stripping or overriding model-supplied scope fields such as `dispatcher_id`
+  and `team_id` when the descriptor already binds that scope;
+- translating one MCP tool into one or more admin socket calls when the model
+  contract needs a composed result;
+- MCP wording in errors returned to the model.
+
+The admin layer should own:
+
+- `dispatcher_id`, Team, TeamMate, channel, and collaboration-space validation;
+- admin socket session state and shutdown/drain interaction;
+- schema validation and stable public errors;
+- dispatching to typed command/query capabilities owned by domain services;
+- product/control-plane errors that are useful to non-MCP clients.
+
+The domain layer should own:
+
+- shutdown/admission gates for resource mutations;
+- TeamLeader lease and generation checks;
+- channel target resolution and route ownership authorization;
+- worktree and shared-workspace authority;
+- typed domain transition construction at the commit point of each state
+  transition.
+
+This boundary means admin may still reject unauthorized or incoherent requests,
+including TeamLeader attempts to use a dispatcher-only capability. It should not
+name those rules as MCP tool visibility.
+
+The implementation should avoid a single God `ControlPlaneService`. Prefer
+typed command/query capability objects per domain area, with admin acting as the
+transport adapter over those capabilities.
+
+## Parameter Scope Model
+
+The existing `caller_kind` parameter is currently doing double duty: it models
+the caller's authority and it leaks the fact that a particular request came from
+an MCP adapter. A control-plane shape should keep authority explicit without
+making MCP the namespace.
+
+For the first slice, the least disruptive option is to keep `caller_kind`,
+`team_id`, and `leader_name` as admin parameters while renaming methods and
+removing MCP-specific wording. This must be treated as a v0 compatibility shape,
+not the final stable identity contract. The current params are parsed in
+[`/packages/dreamux/src/admin/params.ts`](/packages/dreamux/src/admin/params.ts)
+and helper code in
+[`/packages/dreamux/src/admin/methods.ts`](/packages/dreamux/src/admin/methods.ts).
+
+A stable control-plane identity model should separate:
+
+- `actor` or `principal`, derived from the connection boundary or an explicit
+  future local credential rather than trusted only from free-form params;
+- `scope`, such as dispatcher scope or a specific Team scope;
+- generation fencing or an opaque scoped capability for TeamLeader operations,
+  so an old TeamLeader-scoped caller cannot act on a replacement Team.
+
+The owner-only socket mode remains the current coarse security boundary. Any
+external system integration that needs multiple local principals must not treat
+the flat `caller_kind/team_id/leader_name` tuple as sufficient authorization.
+
+## Backward Compatibility
+
+The current admin namespace is treated as pre-stable for this cleanup. Do not
+add `mcp.*` compatibility aliases. The canonical namespace after this change is
+the non-`mcp.` namespace, and old method names should return `UNKNOWN_METHOD`.
+
+Once admin.sock is published as a stable external protocol, subsequent changes
+must preserve backward compatibility or provide an explicit versioned migration.
+
+## Acceptance
+
+### Namespace Slice
+
+- The canonical admin method names for Team, TeamMate, and collaboration space
+  do not start with `mcp.`.
+- `mcp.*` admin registry entries are removed rather than kept as aliases; old
+  method names return `UNKNOWN_METHOD`.
+- `dispatcher.add` and `dispatcher.remove` are removed from the admin registry;
+  dispatcher declarations remain config-owned.
+- Tests cover the admin registry namespace and assert that no canonical admin
+  method starts with `mcp.`.
+- Tests that encode admin method names are updated without weakening their
+  load-bearing invariant. This includes MCP adapter tests, direct
+  `adminMethods[...]` tests, default-workspace admin tests, and the architecture
+  ownership gate that verifies Team read composition remains in
+  `admin/methods.ts`.
+- Admin-layer rejection messages do not refer to "MCP caller" or "MCP tool";
+  the currently verified MCP-specific message is the TeamLeader rejection for
+  `mcp.team.send`.
+- MCP adapter tests assert that Team, TeamMate, and collaboration-space tools
+  call the renamed admin methods.
+- MCP tool visibility remains unchanged for dispatcher and TeamLeader callers.
+- Cron and channel MCP behavior remains unchanged.
+- The change does not add provider-specific logic to core admin handlers.
+- The KB records admin.sock as the target external control plane and MCP as an
+  adapter surface, with source links to the method registry and adapters. It
+  does not claim that the stable external protocol baseline is complete.
+
+### Future Event Slice
+
+- The event design identifies the admin event envelope, the subscription/replay
+  methods, initial topic families, transport/session changes, and whether the
+  first event slice is volatile-only or durable replay.
+- Event delivery is implemented as explicit transport/session state, not as a
+  normal one-shot `AdminHandler` that keeps an admin request promise pending.
+- Public event DTOs are produced through a control-plane projection boundary
+  from owner-created typed domain transitions; domain services do not depend on
+  admin transport DTOs or raw string-topic callbacks.
+- Any durable event design states that domain stores remain canonical unless a
+  later decision explicitly makes the event log a journal. It defines
+  `event_id`, cursor semantics, retention, cursor-expired behavior,
+  at-least-once delivery, idempotent consumption, replay-to-live handoff, and
+  the commit-coupling mechanism that prevents committed transitions from being
+  silently lost.
+- Redaction sentinel tests exist before event payloads are emitted. They must
+  cover prompts, assistant text, local paths, provider metadata, secrets, and
+  raw error messages.
+
+## Out Of Scope
+
+- Adding HTTP or remote network control-plane transport.
+- Implementing dispatcher add/remove through admin.sock.
+- Adding full admin schema introspection.
+- Adding channel inventory/binding inventory APIs.
+- Adding dispatcher-root turn submission.
+- Adding collaboration target-level admin controls.
+- Implementing the event stream in the namespace-cleanup slice. The first slice
+  may land the event contract as design only, but it must not make choices that
+  block either volatile live events or a later durable replay tier.
+- Defining a multi-principal authentication model for admin.sock. The current
+  owner-only socket remains the coarse boundary until a separate design changes
+  it.
+- Changing provider-owned channel tool descriptors.
+
+## Review Focus
+
+Reviewers should check whether this keeps ownership clean:
+
+- Does the admin layer read as a product control plane rather than an MCP
+  backend implementation detail?
+- Are model-facing filters and model wording isolated in the MCP adapters?
+- Are safety checks still enforceable when a non-MCP external system calls the
+  same admin methods directly?
+- Does the namespace leave room for future admin introspection and channel
+  inventory without another rename?
+- Does the event surface belong to the admin control plane rather than logs,
+  MCP completion delivery, or provider-specific channel callbacks?
+- Is the event envelope redacted and typed enough for a larger system to
+  integrate without polling every read API?
+- If durable replay is proposed, does it preserve a single canonical state
+  source and define replay-to-live, idempotency, retention, and cursor-expiry
+  semantics?

--- a/.agents/proposals/admin-control-plane-surface.md
+++ b/.agents/proposals/admin-control-plane-surface.md
@@ -347,7 +347,10 @@ the flat `caller_kind/team_id/leader_name` tuple as sufficient authorization.
 `teammate.spawn` and `team.create` accept an optional `skill_sources` array on
 the admin wire. Each entry must be an object with non-empty string `name`,
 `path`, and `source` fields; malformed input returns `BAD_REQUEST`. The shape is
-runtime-neutral and reuses `AgentRuntimeSkillSource`.
+runtime-neutral and reuses `AgentRuntimeSkillSource`. Core canonicalizes custom
+roots before persistence: paths must be existing readable absolute directories,
+are stored as realpaths, duplicate roots collapse, and direct-child skill name
+collisions are rejected.
 
 The capability applies to dispatcher-scope TeamMates, TeamLeaders, and direct
 admin calls that spawn a Team-scoped member. The service boundary already owns
@@ -358,9 +361,9 @@ parameter.
 Only custom roots are persisted on the agent identity. At runtime the owning
 service recomposes required built-in role roots with the stored additions; a
 TeamLeader therefore always keeps the bundled Dreamux Team workflow root.
-Custom roots do not reintroduce workspace skill installation or symlink
-behavior. Admin DTOs and public model-facing views do not project the stored
-paths.
+Custom roots cannot shadow the bundled `team-workflow` skill name, and they do
+not reintroduce workspace skill installation or symlink behavior. Admin DTOs
+and public model-facing views do not project the stored paths.
 
 This is deliberately an admin-only capability. MCP tool schemas, descriptions,
 argument parsing, and forwarded requests omit `skill_sources`, including when
@@ -411,6 +414,9 @@ must preserve backward compatibility or provide an explicit versioned migration.
 - Admin `team.create` forwards validated custom roots to TeamLeader runtime
   creation.
 - Malformed `skill_sources` input returns `BAD_REQUEST` before domain mutation.
+- Custom root paths are canonical absolute readable directories; relative or
+  missing paths and direct-child skill-name conflicts are rejected before domain
+  mutation.
 - Custom roots survive runtime and process rebuild through agent identity state.
 - Required bundled role roots remain present alongside custom roots.
 - MCP schemas and descriptions do not expose `skill_sources`, and MCP adapters

--- a/.agents/proposals/team-mcp-dispatcher-send-technical-design.md
+++ b/.agents/proposals/team-mcp-dispatcher-send-technical-design.md
@@ -1,8 +1,12 @@
 # Dispatcher Team MCP send to TeamLeader technical design
 
-- **Status:** Draft design for review
+- **Status:** Implemented design history; current behavior is in [Current architecture](../reference/current-architecture.md)
 - **Companion to:** [Dispatcher Team MCP send to TeamLeader](team-mcp-dispatcher-send.md)
 - **Source baseline:** `origin/next` at `c88ec2e`
+
+Admin method strings in this design preserve the pre-namespace-cleanup names
+from that source baseline. Current product names are documented in
+[Current architecture](../reference/current-architecture.md).
 
 ## Settled choices
 
@@ -20,7 +24,7 @@
 | TeamLeader caller | Reject `mcp.team.send` with `BAD_REQUEST`; peer send stays future. |
 | Future peer send | Preserve a reusable initiator seam, but do not expose peer send here. |
 
-## Current source facts
+## Source-baseline facts
 
 - `packages/dreamux/src/mcp/team-mcp.ts` defines a caller kind split:
   `dispatcher` sees the full Team MCP surface and `team_leader` sees only

--- a/.agents/proposals/team-mcp-dispatcher-send.md
+++ b/.agents/proposals/team-mcp-dispatcher-send.md
@@ -1,11 +1,15 @@
 # Proposal: Dispatcher Team MCP send to TeamLeader
 
-- **Status:** Draft proposal for review
+- **Status:** Implemented design history; current behavior is in [Current architecture](../reference/current-architecture.md)
 - **Date:** 2026-06-30
 - **Affects:** `@excitedjs/dreamux` Team MCP surface, admin IPC routing,
   TeamLeader turn submission, completion reverse delivery, bundled dispatcher
   prompt and skill text
 - **Companion design:** [Dispatcher Team MCP send to TeamLeader technical design](team-mcp-dispatcher-send-technical-design.md)
+
+Admin method strings in this proposal preserve the pre-namespace-cleanup names
+used when it was implemented. Current product names are documented in
+[Current architecture](../reference/current-architecture.md).
 
 ## Context
 
@@ -13,12 +17,12 @@ The previous Team MCP slice made the Team MCP caller-scoped and exposed
 `transfer_back` to TeamLeaders. That work also recorded a future `team.send`
 requirement, but it intentionally did not implement it.
 
-Current Team MCP behavior on `next` is:
+At this proposal's source baseline, Team MCP behavior on `next` was:
 
 - the dispatcher Team MCP exposes lifecycle tools, channel binding, and
   `transfer_back`;
 - the TeamLeader Team MCP exposes only `transfer_back`;
-- there is no `team.send` tool or `mcp.team.send` admin method;
+- there is no `team.send` tool or pre-cleanup `mcp.team.send` admin method;
 - the Team `create` tool already documents that an idle TeamLeader can later be
   driven by a send, but that send surface does not exist yet.
 

--- a/.agents/proposals/team-mcp-teamleader-transfer-back-technical-design.md
+++ b/.agents/proposals/team-mcp-teamleader-transfer-back-technical-design.md
@@ -1,10 +1,14 @@
 # TeamLeader-scoped Team MCP transfer back technical design
 
-- **Status:** Draft implementation design for review
+- **Status:** Implemented design history; current behavior is in [Current architecture](../reference/current-architecture.md)
 - **Companion to:** [TeamLeader-scoped Team MCP transfer back](team-mcp-teamleader-transfer-back.md)
 - **Source baseline:** `team/codex-next-0629-1928` at `91f02bc`
 
-This design implements only the current slice: expose `team.transfer_back` to a
+Admin method strings in this design preserve the pre-namespace-cleanup names
+from that source baseline. Current product names are documented in
+[Current architecture](../reference/current-architecture.md).
+
+This design implemented only its original slice: expose `team.transfer_back` to a
 TeamLeader and create a clear core Channel service boundary for channel-binding
 ownership. It does not implement `team.send` or Team peer messaging.
 
@@ -23,7 +27,7 @@ ownership. It does not implement `team.send` or Team peer messaging.
 | Admin IPC trust | Do not add per-tool/admin-method identity restrictions; local admin IPC remains trusted. |
 | Future `team.send` | Record the requirement, but leave it out of this slice. |
 
-## Current source facts
+## Source-baseline facts
 
 - Team MCP is currently dispatcher-only in practice: the descriptor is assembled
   for the dispatcher at

--- a/.agents/proposals/team-mcp-teamleader-transfer-back.md
+++ b/.agents/proposals/team-mcp-teamleader-transfer-back.md
@@ -1,6 +1,6 @@
 # Proposal: TeamLeader-scoped Team MCP transfer back
 
-- **Status:** Active proposal (draft for review)
+- **Status:** Implemented design history; current behavior is in [Current architecture](../reference/current-architecture.md)
 - **Date:** 2026-06-29
 - **Affects:** `@excitedjs/dreamux` Team MCP surface, TeamLeader launch MCP
   descriptors, admin IPC routing, channel binding ownership, bundled dispatcher
@@ -8,10 +8,14 @@
 - **PR / Issue:** TBD
 - **Implementation design:** [TeamLeader-scoped Team MCP transfer back technical design](team-mcp-teamleader-transfer-back-technical-design.md)
 
+Admin method strings in this proposal preserve the pre-namespace-cleanup names
+used when it was implemented. Current product names are documented in
+[Current architecture](../reference/current-architecture.md).
+
 ## Context
 
-The Team MCP is currently dispatcher-scoped. It exposes Team lifecycle tools and
-the channel-binding verbs:
+At this proposal's source baseline, the Team MCP was dispatcher-scoped. It
+exposed Team lifecycle tools and the channel-binding verbs:
 
 - `create`, `list`, `status`, `history`, `dissolve`
 - `bind_channel({ team_name, channel_id?, meta })`
@@ -24,7 +28,7 @@ tool implementation is in `/packages/dreamux/src/mcp/team-mcp.ts`.
 Team leaders already receive caller-scoped MCP descriptors for other surfaces:
 channel tools are scoped by `callerKind: 'team_leader'`, `team_id`, and
 `leader_name`, and the TeamMate MCP already has a dispatcher-vs-team-leader
-projection. This proposal records the next Team MCP slice: make
+projection. This proposal recorded the next Team MCP slice: make
 `transfer_back` available to TeamLeaders without exposing the dispatcher-only
 Team lifecycle surface.
 
@@ -189,10 +193,9 @@ Suggested issue title:
 
 ## Future send requirement record
 
-`team.send` is intentionally out of scope for this slice, but the requirement is
-recorded here so the transfer-back work does not block the future shape.
-
-A future Team MCP `send` capability should align with `teammate.send`:
+`team.send` was intentionally out of scope for this slice and was implemented
+later by [Dispatcher Team MCP send to TeamLeader](team-mcp-dispatcher-send.md).
+That later capability aligns with `teammate.send`:
 
 - submit a turn to the addressed Team participant;
 - preserve the runtime-native continuation semantics of the target;

--- a/.agents/reference/current-architecture.md
+++ b/.agents/reference/current-architecture.md
@@ -117,10 +117,13 @@ product/control-plane wording rather than describing MCP visibility.
 
 Admin callers may pass strictly validated `skill_sources` when calling
 `teammate.spawn` or `team.create`. These are additional runtime-neutral skill
-roots, not replacements for Dreamux's required role roots. They are persisted
-on the created agent identity and restored when that TeamMate, team member, or
-TeamLeader is rebuilt. The MCP adapters neither advertise nor forward this
-parameter.
+roots, not replacements for Dreamux's required role roots. Core requires each
+custom root to be an existing readable absolute directory, persists its
+canonical realpath, removes duplicate roots, and rejects direct-child skill
+name collisions. TeamLeader creation also fences the bundled `team-workflow`
+skill name so custom roots cannot replace the required Team workflow. The
+stored roots are restored when that TeamMate, team member, or TeamLeader is
+rebuilt. The MCP adapters neither advertise nor forward this parameter.
 
 Key source:
 

--- a/.agents/reference/current-architecture.md
+++ b/.agents/reference/current-architecture.md
@@ -98,6 +98,40 @@ Key source:
 - `/packages/dreamux/src/mcp/team-mcp.ts`
 - `/packages/dreamux/src/mcp/teammate-mcp.ts`
 
+## Admin Control Plane
+
+The owner-only local `admin.sock` is Dreamux's target external control-plane
+entry point. Its current protocol is still the v0 one-request/one-response
+NDJSON shape, so it is not yet a completed stable external protocol.
+
+The product method namespaces are `teammate.*`, `team.*`, and
+`collaboration_space.*`. Scheduler methods remain `scheduler.cron.*`, and
+provider tool calls use `channel.invoke_tool`. No `mcp.*` aliases are
+registered, and dispatcher declarations remain config-owned rather than
+mutable through `dispatcher.add` or `dispatcher.remove`.
+
+Dreamux-owned MCP shims call those canonical admin methods but retain ownership
+of model-facing schemas, caller-specific visibility, and scope projection. The
+admin registry independently enforces domain and caller safety; its errors use
+product/control-plane wording rather than describing MCP visibility.
+
+Admin callers may pass strictly validated `skill_sources` when calling
+`teammate.spawn` or `team.create`. These are additional runtime-neutral skill
+roots, not replacements for Dreamux's required role roots. They are persisted
+on the created agent identity and restored when that TeamMate, team member, or
+TeamLeader is rebuilt. The MCP adapters neither advertise nor forward this
+parameter.
+
+Key source:
+
+- `/packages/dreamux/src/admin/methods.ts`
+- `/packages/dreamux/src/admin/params.ts`
+- `/packages/dreamux/src/admin/socket.ts`
+- `/packages/dreamux/src/agent-runtime/skill-sources.ts`
+- `/packages/dreamux/src/mcp/collaboration-space-mcp.ts`
+- `/packages/dreamux/src/mcp/team-mcp.ts`
+- `/packages/dreamux/src/mcp/teammate-mcp.ts`
+
 ## Channels And Feishu
 
 The Channel provider owns provider-specific session behavior. The built-in
@@ -262,11 +296,14 @@ Key source:
 ## Bundled Skills
 
 Dreamux ships bundled skills under `/packages/dreamux/skills/`. Core selects
-skill sources by role:
+required skill sources by role and may compose authorized admin-supplied roots:
 
 - Dispatcher roles receive Dreamux workflow and maintenance skills; TeamLeader
   roles receive the Team workflow skill.
 - Ordinary TeamMate and team-member roles receive none by default.
+- Additional roots supplied through admin creation are persisted with the
+  agent identity. TeamLeader launch always prepends the required bundled role
+  root before those additions; custom roots cannot replace or disable it.
 - Core emits only role-specific skill roots (`skills/dispatcher/` and
   `skills/team-leader/`), never per-skill selector paths. Codex passes those
   roots directly to `skills/extraRoots/set` so root scanning cannot expose
@@ -281,6 +318,8 @@ onboard or runtime startup.
 Key source:
 
 - `/packages/dreamux/src/service/dispatcher-service/agent.ts`
+- `/packages/dreamux/src/service/agent-entity/identity-store.ts`
+- `/packages/dreamux/src/service/team-service/index.ts`
 - `/packages/dreamux/src/service/teammate-service/index.ts`
 - `/packages/dreamux/src/platform/paths.ts`
 - `/packages/agent-runtime/codex/src/skill-roots.ts`

--- a/.agents/reference/dispatcher-skill.md
+++ b/.agents/reference/dispatcher-skill.md
@@ -39,6 +39,12 @@ sites pass role-specific skill roots through the Agent Runtime create context as
 - Claude Code materializes runtime-owned `.claude/skills/<name>` add-dir roots
   and passes them through `--add-dir`.
 
+Admin-supplied custom skill roots use the same neutral create-context shape, but
+core first normalizes them into canonical absolute readable directories and
+rejects duplicate roots or duplicate direct-child skill names. TeamLeader roots
+also reserve the bundled `team-workflow` skill name, so custom roots cannot
+shadow the required Team workflow skill.
+
 `dreamux onboard` and dispatcher startup do not install bundled skills into a
 workspace. Bundled skills are package-shipped runtime injection sources.
 

--- a/.agents/reference/dispatcher-skill.md
+++ b/.agents/reference/dispatcher-skill.md
@@ -41,9 +41,9 @@ sites pass role-specific skill roots through the Agent Runtime create context as
 
 Admin-supplied custom skill roots use the same neutral create-context shape, but
 core first normalizes them into canonical absolute readable directories and
-rejects duplicate roots or duplicate direct-child skill names. TeamLeader roots
-also reserve the bundled `team-workflow` skill name, so custom roots cannot
-shadow the required Team workflow skill.
+collapses duplicate roots while rejecting duplicate direct-child skill names.
+TeamLeader roots also reserve the bundled `team-workflow` skill name, so custom
+roots cannot shadow the required Team workflow skill.
 
 `dreamux onboard` and dispatcher startup do not install bundled skills into a
 workspace. Bundled skills are package-shipped runtime injection sources.

--- a/.agents/reference/state-and-paths.md
+++ b/.agents/reference/state-and-paths.md
@@ -94,9 +94,11 @@ Important children:
 
 TeamMate, team-member, and TeamLeader identities persist admin-supplied
 `skill_sources` so runtime relaunch and process restart preserve authorized
-extra skill roots. Old identity records without that field read as an empty
-list. Required bundled role roots remain code-owned and are recomposed at launch
-rather than persisted.
+extra skill roots. Stored paths are canonical absolute skill-root directories;
+relative paths, unreadable/missing directories, duplicate roots, and direct
+child skill-name collisions are rejected at the admin boundary. Old identity
+records without that field read as an empty list. Required bundled role roots
+remain code-owned and are recomposed at launch rather than persisted.
 
 Legacy identity records that point at old under-state worktree paths are read
 verbatim. Dreamux does not rewrite or delete them during ordinary startup.

--- a/.agents/reference/state-and-paths.md
+++ b/.agents/reference/state-and-paths.md
@@ -92,6 +92,12 @@ Important children:
 - `~/.dreamux/state/<dispatcher-id>/team/`: Team durable ledgers and channel
   binding state.
 
+TeamMate, team-member, and TeamLeader identities persist admin-supplied
+`skill_sources` so runtime relaunch and process restart preserve authorized
+extra skill roots. Old identity records without that field read as an empty
+list. Required bundled role roots remain code-owned and are recomposed at launch
+rather than persisted.
+
 Legacy identity records that point at old under-state worktree paths are read
 verbatim. Dreamux does not rewrite or delete them during ordinary startup.
 

--- a/.agents/reference/state-and-paths.md
+++ b/.agents/reference/state-and-paths.md
@@ -95,8 +95,9 @@ Important children:
 TeamMate, team-member, and TeamLeader identities persist admin-supplied
 `skill_sources` so runtime relaunch and process restart preserve authorized
 extra skill roots. Stored paths are canonical absolute skill-root directories;
-relative paths, unreadable/missing directories, duplicate roots, and direct
-child skill-name collisions are rejected at the admin boundary. Old identity
+relative paths and unreadable/missing directories are rejected, duplicate roots
+are collapsed, and direct child skill-name collisions are rejected at the admin
+boundary. Old identity
 records without that field read as an empty list. Required bundled role roots
 remain code-owned and are recomposed at launch rather than persisted.
 

--- a/.agents/root.md
+++ b/.agents/root.md
@@ -119,17 +119,18 @@ history and rationale; when you need current behavior, pair them with
   provider-owned role prompt injection, and external runtime handle validation
   while keeping native CLI/daemon details provider-owned.
 - [Admin control plane surface](proposals/admin-control-plane-surface.md)
-  — draft requirement/spec for making admin.sock the stable external control
-  plane, removing MCP-specific prefixes from Team, TeamMate, and
-  collaboration-space admin methods, keeping model-facing filtering in the MCP
-  adapters, and recording admin capability gaps for later slices.
+  — draft requirement/spec for making admin.sock the target external control
+  plane. Its implemented namespace slice uses product method names, keeps
+  model-facing filtering in the MCP adapters, and permits additional runtime
+  skill roots only on admin TeamMate/TeamLeader creation; event and protocol
+  gaps remain later slices.
 - [TeamMate identity system prompt](proposals/teammate-identity-system-prompt.md)
   — draft requirement/spec for adding a minimal `identity` input to
   `teammate.spawn` and `team.create`, persisting it on TeamMate identity records,
   and rendering it as provider-neutral system-prompt append guidance rather than
   first-turn prompt text.
 - [Dispatcher Team MCP send to TeamLeader](proposals/team-mcp-dispatcher-send.md)
-  — draft requirement/spec for adding a dispatcher-only Team MCP `send` tool
+  — retained implementation design for the dispatcher-only Team MCP `send` tool
   that submits turns to an existing Team's TeamLeader, registers completion
   delivery back to the dispatcher at send time, and leaves Team peer messaging
   out of this slice.
@@ -140,12 +141,11 @@ history and rationale; when you need current behavior, pair them with
   a Team, and target closure dissolves that Team without routing through the
   dispatcher agent runtime.
 - [TeamLeader-scoped Team MCP transfer back](proposals/team-mcp-teamleader-transfer-back.md)
-  — draft requirement/spec for exposing only `transfer_back` from Team MCP to
+  — retained implementation design for exposing only `transfer_back` from Team MCP to
   TeamLeaders, keeping dispatcher Team lifecycle tools private, keeping explicit
   provider target `meta`, moving channel binding ownership to a core
-  `ChannelService` over live sessions plus `ChannelBindingStore`, and recording
-  the future `team.send` parity requirement without implementing it in this
-  slice.
+  `ChannelService` over live sessions plus `ChannelBindingStore`; the later
+  dispatcher `team.send` slice is recorded separately above.
 - [Post-#110 architecture sustainability](proposals/post-110-architecture-sustainability.md)
   — diagnostic of why agent-written code drifted from the intended architecture
   after the #110 pluginization inflection (load-bearing invariants are prose with

--- a/.agents/root.md
+++ b/.agents/root.md
@@ -118,6 +118,11 @@ history and rationale; when you need current behavior, pair them with
   terminal completion-delivery semantics, instance-scoped runtime state facts,
   provider-owned role prompt injection, and external runtime handle validation
   while keeping native CLI/daemon details provider-owned.
+- [Admin control plane surface](proposals/admin-control-plane-surface.md)
+  — draft requirement/spec for making admin.sock the stable external control
+  plane, removing MCP-specific prefixes from Team, TeamMate, and
+  collaboration-space admin methods, keeping model-facing filtering in the MCP
+  adapters, and recording admin capability gaps for later slices.
 - [TeamMate identity system prompt](proposals/teammate-identity-system-prompt.md)
   — draft requirement/spec for adding a minimal `identity` input to
   `teammate.spawn` and `team.create`, persisting it on TeamMate identity records,

--- a/common/changes/@excitedjs/agent-runtime-claude-code/admin-control-plane-surface_2026-07-14-15-41.json
+++ b/common/changes/@excitedjs/agent-runtime-claude-code/admin-control-plane-surface_2026-07-14-15-41.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@excitedjs/agent-runtime-claude-code",
+      "comment": "Reject relative skill source root paths before materializing Claude add-dir links.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@excitedjs/agent-runtime-claude-code"
+}

--- a/common/changes/@excitedjs/agent-runtime-codex/admin-control-plane-surface_2026-07-14-15-41.json
+++ b/common/changes/@excitedjs/agent-runtime-codex/admin-control-plane-surface_2026-07-14-15-41.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@excitedjs/agent-runtime-codex",
+      "comment": "Reject relative skill source root paths before applying Codex extra roots.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@excitedjs/agent-runtime-codex"
+}

--- a/common/changes/@excitedjs/dreamux-types/admin-control-plane-surface_2026-07-14-14-53.json
+++ b/common/changes/@excitedjs/dreamux-types/admin-control-plane-surface_2026-07-14-14-53.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@excitedjs/dreamux-types",
+      "comment": "Clarify the AgentRuntimeSkillSource create-context contract to cover core-composed required and authorized custom skill roots.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@excitedjs/dreamux-types"
+}

--- a/common/changes/@excitedjs/dreamux/admin-control-plane-surface_2026-07-14-14-53.json
+++ b/common/changes/@excitedjs/dreamux/admin-control-plane-surface_2026-07-14-14-53.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@excitedjs/dreamux",
+      "comment": "BREAKING: Rename the pre-stable TeamMate, Team, and collaboration-space admin socket methods to product namespaces without compatibility aliases; remove the unsupported public dreamux dispatcher add/remove commands and their admin registry entries; and add persistent admin-only custom skill sources for TeamMate and TeamLeader creation. Dreamux-owned MCP tools keep their existing model-facing surface; direct admin clients must use canonical method names.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@excitedjs/dreamux"
+}

--- a/common/changes/@excitedjs/dreamux/admin-control-plane-surface_2026-07-14-15-41.json
+++ b/common/changes/@excitedjs/dreamux/admin-control-plane-surface_2026-07-14-15-41.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@excitedjs/dreamux",
+      "comment": "Normalize admin skill_sources to canonical absolute skill roots and reject collisions before persistence.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@excitedjs/dreamux"
+}

--- a/packages/agent-runtime/claude-code/src/skill-adapter.ts
+++ b/packages/agent-runtime/claude-code/src/skill-adapter.ts
@@ -1,6 +1,6 @@
 import { createHash } from 'node:crypto';
 import { access, readdir } from 'node:fs/promises';
-import { join, resolve } from 'node:path';
+import { isAbsolute, join, resolve } from 'node:path';
 
 import type { AgentRuntimeSkillSource } from '@excitedjs/dreamux-types';
 
@@ -32,7 +32,14 @@ export function uniqueSkillSources(
   sources: readonly AgentRuntimeSkillSource[],
 ): AgentRuntimeSkillSource[] {
   const byRoot = new Map<string, AgentRuntimeSkillSource>();
-  for (const source of sources) byRoot.set(resolve(source.path), source);
+  for (const source of sources) {
+    if (!isAbsolute(source.path)) {
+      throw new Error(
+        `skill source ${JSON.stringify(source.name)} path must be absolute`,
+      );
+    }
+    byRoot.set(resolve(source.path), source);
+  }
   return [...byRoot.entries()]
     .sort(([a], [b]) => a.localeCompare(b))
     .map(([, source]) => source);

--- a/packages/agent-runtime/codex/src/skill-roots.ts
+++ b/packages/agent-runtime/codex/src/skill-roots.ts
@@ -1,6 +1,7 @@
 import type {
   AgentRuntimeSkillSource,
 } from '@excitedjs/dreamux-types';
+import { isAbsolute } from 'node:path';
 
 import type { CodexWsClient } from './rpc.js';
 
@@ -10,6 +11,7 @@ export async function applyCodexSkillExtraRoots(input: {
   log: (level: 'info' | 'warn' | 'error', msg: string, err?: unknown) => void;
 }): Promise<void> {
   if (input.sources.length === 0) return;
+  assertAbsoluteSkillRootPaths(input.sources);
   const extraRoots = [
     ...new Set(
       input.sources.map((source) => source.path),
@@ -33,6 +35,18 @@ export async function applyCodexSkillExtraRoots(input: {
     'info',
     `applied ${extraRoots.length} skill extra root(s): ${extraRoots.join(', ')}`,
   );
+}
+
+function assertAbsoluteSkillRootPaths(
+  sources: readonly AgentRuntimeSkillSource[],
+): void {
+  for (const source of sources) {
+    if (!isAbsolute(source.path)) {
+      throw new Error(
+        `skill source ${JSON.stringify(source.name)} path must be absolute`,
+      );
+    }
+  }
 }
 
 /**

--- a/packages/agent-runtime/codex/tests/skill-extra-roots.test.ts
+++ b/packages/agent-runtime/codex/tests/skill-extra-roots.test.ts
@@ -225,6 +225,16 @@ describe('codex skills/extraRoots/set injection', () => {
     expect(startIdx).toBeGreaterThan(setIdx);
   });
 
+  it('rejects relative skill root paths instead of applying cwd-dependent roots', async () => {
+    const client = new FakeClient();
+    const runtime = buildRuntime(client, [
+      { name: 'relative', path: 'relative/skills', source: 'test' },
+    ]);
+
+    await expect(runtime.start()).rejects.toThrow(/path must be absolute/);
+    expect(client.extraRootsCalls).toEqual([]);
+  });
+
   it('passes append-only systemPrompt as developerInstructions before first turn', async () => {
     const client = new FakeClient();
     const runtime = buildRuntime(

--- a/packages/dreamux-types/src/agent-runtime.ts
+++ b/packages/dreamux-types/src/agent-runtime.ts
@@ -40,8 +40,9 @@ export interface AgentRuntimeMcpServer {
 }
 
 /**
- * A bundled skill root core hands to a runtime. Core selects roots by role; the
- * runtime package owns the mechanics of applying them to its engine.
+ * A skill root core hands to a runtime. Core composes required bundled roots
+ * with any authorized custom roots; the runtime package owns the mechanics of
+ * applying them to its engine.
  */
 export interface AgentRuntimeSkillSource {
   name: string;
@@ -216,8 +217,8 @@ export interface AgentRuntimeCreateContext<TConfig = unknown> {
    */
   mcpServers: readonly AgentRuntimeMcpServer[];
   /**
-   * Bundled skill sources core selected for this role. Empty for roles that
-   * receive no bundled Dreamux skills (ordinary teammate/team-member).
+   * Effective skill sources core selected for this runtime. This can include
+   * required bundled role roots and authorized custom roots.
    */
   skillSources?: readonly AgentRuntimeSkillSource[];
   /**

--- a/packages/dreamux-types/src/agent-runtime.ts
+++ b/packages/dreamux-types/src/agent-runtime.ts
@@ -46,7 +46,10 @@ export interface AgentRuntimeMcpServer {
  */
 export interface AgentRuntimeSkillSource {
   name: string;
-  /** Directory whose direct children are skill directories. */
+  /**
+   * Absolute canonical directory whose direct children are skill directories.
+   * Dreamux core validates and normalizes custom roots before persistence.
+   */
   path: string;
   source: 'dreamux-core' | string;
 }

--- a/packages/dreamux/src/admin/methods.ts
+++ b/packages/dreamux/src/admin/methods.ts
@@ -1,5 +1,6 @@
 
 import type { Server } from '../server.js';
+import { bundledTeamLeaderSkillRoot } from '../platform/paths.js';
 import type {
   ChannelToolCaller,
   DispatcherService,
@@ -35,6 +36,12 @@ export type AdminHandler = (
   server: Server,
   params: Record<string, unknown> | undefined,
 ) => Promise<unknown> | unknown;
+
+const TEAM_LEADER_REQUIRED_SKILL_SOURCES = [{
+  name: 'team-leader',
+  path: bundledTeamLeaderSkillRoot(),
+  source: 'dreamux-core',
+}] as const;
 
 export const adminMethods: Record<string, AdminHandler> = {
   'server.status': async (server) => ({
@@ -152,7 +159,7 @@ export const adminMethods: Record<string, AdminHandler> = {
     const intent = mustNonEmptyString(params, 'intent');
     const agentRuntime = optionalString(params, 'agent_runtime');
     const identity = optionalNonBlankString(params, 'identity');
-    const skillSources = optionalSkillSources(params);
+    const skillSources = await optionalSkillSources(params);
     const dispatcher = server.getDispatcher(id);
     const target = await teammateTargetFor(dispatcher, params);
     if (target.callerKind === 'team_leader' && params?.['repo'] !== undefined) {
@@ -289,7 +296,9 @@ export const adminMethods: Record<string, AdminHandler> = {
     const worktree = repo?.worktree ?? null;
     const prompt = optionalString(params, 'prompt');
     const identity = optionalNonBlankString(params, 'identity');
-    const skillSources = optionalSkillSources(params);
+    const skillSources = await optionalSkillSources(params, {
+      requiredSources: TEAM_LEADER_REQUIRED_SKILL_SOURCES,
+    });
     try {
       const created = await dispatcher.createTeam({
         name,

--- a/packages/dreamux/src/admin/methods.ts
+++ b/packages/dreamux/src/admin/methods.ts
@@ -23,6 +23,7 @@ import {
   optionalNullableRecordField,
   optionalNullableStringField,
   optionalRecordField,
+  optionalSkillSources,
   optionalString,
   optionalStringField,
   optionalTeamStatus,
@@ -41,24 +42,6 @@ export const adminMethods: Record<string, AdminHandler> = {
     uptimeSec: Math.floor(process.uptime()),
     dispatchers: await server.summarize(),
   }),
-
-  'dispatcher.add': (server, params) => {
-    void server;
-    void params;
-    throw new AdminError(
-      'UNSUPPORTED',
-      'dispatcher declarations live in ~/.dreamux/config.json; edit the dispatchers array and restart dreamux serve',
-    );
-  },
-
-  'dispatcher.remove': async (server, params) => {
-    void server;
-    void params;
-    throw new AdminError(
-      'UNSUPPORTED',
-      'dispatcher declarations live in ~/.dreamux/config.json; edit the dispatchers array and restart dreamux serve',
-    );
-  },
 
   'dispatcher.list': async (server) => ({ dispatchers: await server.summarize() }),
 
@@ -161,7 +144,7 @@ export const adminMethods: Record<string, AdminHandler> = {
     }
   },
 
-  'mcp.teammate.spawn': async (server, params) => {
+  'teammate.spawn': async (server, params) => {
     const id = mustDispatcherId(params);
     mustExistingDispatcher(server, id);
     const name = mustString(params, 'name_prefix');
@@ -169,6 +152,7 @@ export const adminMethods: Record<string, AdminHandler> = {
     const intent = mustNonEmptyString(params, 'intent');
     const agentRuntime = optionalString(params, 'agent_runtime');
     const identity = optionalNonBlankString(params, 'identity');
+    const skillSources = optionalSkillSources(params);
     const dispatcher = server.getDispatcher(id);
     const target = await teammateTargetFor(dispatcher, params);
     if (target.callerKind === 'team_leader' && params?.['repo'] !== undefined) {
@@ -190,6 +174,7 @@ export const adminMethods: Record<string, AdminHandler> = {
       ...(cwd !== null ? { cwd } : {}),
       ...(agentRuntime !== null ? { agentRuntime } : {}),
       ...(identity !== null ? { identity } : {}),
+      ...(skillSources !== null ? { skillSources } : {}),
       ...(worktree !== null ? { worktree } : {}),
     };
     try {
@@ -204,7 +189,7 @@ export const adminMethods: Record<string, AdminHandler> = {
     }
   },
 
-  'mcp.teammate.send': async (server, params) => {
+  'teammate.send': async (server, params) => {
     const id = mustDispatcherId(params);
     mustExistingDispatcher(server, id);
     const dispatcher = server.getDispatcher(id);
@@ -224,7 +209,7 @@ export const adminMethods: Record<string, AdminHandler> = {
     }
   },
 
-  'mcp.teammate.close': async (server, params) => {
+  'teammate.close': async (server, params) => {
     const id = mustDispatcherId(params);
     mustExistingDispatcher(server, id);
     const dispatcher = server.getDispatcher(id);
@@ -242,7 +227,7 @@ export const adminMethods: Record<string, AdminHandler> = {
     }
   },
 
-  'mcp.teammate.history': async (server, params) => {
+  'teammate.history': async (server, params) => {
     const id = mustDispatcherId(params);
     mustExistingDispatcher(server, id);
     return (
@@ -250,7 +235,7 @@ export const adminMethods: Record<string, AdminHandler> = {
     ).service.teammates.history(historyQuery(params));
   },
 
-  'mcp.teammate.list': async (server, params) => {
+  'teammate.list': async (server, params) => {
     const id = mustDispatcherId(params);
     mustExistingDispatcher(server, id);
     return {
@@ -260,7 +245,7 @@ export const adminMethods: Record<string, AdminHandler> = {
     };
   },
 
-  'mcp.teammate.status': async (server, params) => {
+  'teammate.status': async (server, params) => {
     const id = mustDispatcherId(params);
     mustExistingDispatcher(server, id);
     const name = mustString(params, 'name');
@@ -271,7 +256,7 @@ export const adminMethods: Record<string, AdminHandler> = {
     };
   },
 
-  'mcp.teammate.last': async (server, params) => {
+  'teammate.last': async (server, params) => {
     const id = mustDispatcherId(params);
     mustExistingDispatcher(server, id);
     const name = mustString(params, 'name');
@@ -281,7 +266,7 @@ export const adminMethods: Record<string, AdminHandler> = {
     ).service.teammates.last(name, turns ?? undefined);
   },
 
-  'mcp.teammate.capabilities': async (server, params) => {
+  'teammate.capabilities': async (server, params) => {
     const id = mustDispatcherId(params);
     mustExistingDispatcher(server, id);
     return (
@@ -289,7 +274,7 @@ export const adminMethods: Record<string, AdminHandler> = {
     ).service.teammates.getCapabilities();
   },
 
-  'mcp.team.create': async (server, params) => {
+  'team.create': async (server, params) => {
     const id = mustDispatcherId(params);
     mustExistingDispatcher(server, id);
     const name = mustString(params, 'team_name');
@@ -304,6 +289,7 @@ export const adminMethods: Record<string, AdminHandler> = {
     const worktree = repo?.worktree ?? null;
     const prompt = optionalString(params, 'prompt');
     const identity = optionalNonBlankString(params, 'identity');
+    const skillSources = optionalSkillSources(params);
     try {
       const created = await dispatcher.createTeam({
         name,
@@ -313,6 +299,7 @@ export const adminMethods: Record<string, AdminHandler> = {
         ...(worktree !== null ? { worktree } : {}),
         ...(prompt !== null ? { prompt } : {}),
         ...(identity !== null ? { identity } : {}),
+        ...(skillSources !== null ? { skillSources } : {}),
       });
       return { ...created, bound_target: null };
     } catch (err) {
@@ -320,13 +307,13 @@ export const adminMethods: Record<string, AdminHandler> = {
     }
   },
 
-  'mcp.team.send': async (server, params) => {
+  'team.send': async (server, params) => {
     const id = mustDispatcherId(params);
     mustExistingDispatcher(server, id);
     if (teamCallerKind(params) === 'team_leader') {
       throw new AdminError(
         'BAD_REQUEST',
-        'mcp.team.send is not available for this Team MCP caller',
+        'team.send is available only to dispatcher callers',
       );
     }
     const name = mustString(params, 'team_name');
@@ -346,7 +333,7 @@ export const adminMethods: Record<string, AdminHandler> = {
     }
   },
 
-  'mcp.team.list': async (server, params) => {
+  'team.list': async (server, params) => {
     const id = mustDispatcherId(params);
     mustExistingDispatcher(server, id);
     const dispatcher = server.getDispatcher(id);
@@ -361,7 +348,7 @@ export const adminMethods: Record<string, AdminHandler> = {
     };
   },
 
-  'mcp.team.status': async (server, params) => {
+  'team.status': async (server, params) => {
     const id = mustDispatcherId(params);
     mustExistingDispatcher(server, id);
     const name = mustString(params, 'team_name');
@@ -375,7 +362,7 @@ export const adminMethods: Record<string, AdminHandler> = {
     };
   },
 
-  'mcp.team.history': async (server, params) => {
+  'team.history': async (server, params) => {
     const id = mustDispatcherId(params);
     mustExistingDispatcher(server, id);
     const name = optionalString(params, 'team_name');
@@ -407,7 +394,7 @@ export const adminMethods: Record<string, AdminHandler> = {
       ),
     };
   },
-  'mcp.team.bind_channel': async (server, params) => {
+  'team.bind_channel': async (server, params) => {
     const id = mustDispatcherId(params);
     mustExistingDispatcher(server, id);
     const channelId = optionalString(params, 'channel_id');
@@ -418,7 +405,7 @@ export const adminMethods: Record<string, AdminHandler> = {
     });
   },
 
-  'mcp.team.transfer_back': async (server, params) => {
+  'team.transfer_back': async (server, params) => {
     const id = mustDispatcherId(params);
     mustExistingDispatcher(server, id);
     const channelId = optionalString(params, 'channel_id');
@@ -446,7 +433,7 @@ export const adminMethods: Record<string, AdminHandler> = {
     };
   },
 
-  'mcp.team.dissolve': async (server, params) => {
+  'team.dissolve': async (server, params) => {
     const id = mustDispatcherId(params);
     mustExistingDispatcher(server, id);
     const name = mustString(params, 'team_name');
@@ -458,7 +445,7 @@ export const adminMethods: Record<string, AdminHandler> = {
     return { ...dissolved, bound_target: null };
   },
 
-  'mcp.collaboration_space.bind': async (server, params) => {
+  'collaboration_space.bind': async (server, params) => {
     const id = mustDispatcherId(params);
     mustExistingDispatcher(server, id);
     const channelId = optionalString(params, 'channel_id');
@@ -492,7 +479,7 @@ export const adminMethods: Record<string, AdminHandler> = {
     }
   },
 
-  'mcp.collaboration_space.dissolve': async (server, params) => {
+  'collaboration_space.dissolve': async (server, params) => {
     const id = mustDispatcherId(params);
     mustExistingDispatcher(server, id);
     try {
@@ -505,7 +492,7 @@ export const adminMethods: Record<string, AdminHandler> = {
     }
   },
 
-  'mcp.collaboration_space.status': async (server, params) => {
+  'collaboration_space.status': async (server, params) => {
     const id = mustDispatcherId(params);
     mustExistingDispatcher(server, id);
     try {
@@ -517,7 +504,7 @@ export const adminMethods: Record<string, AdminHandler> = {
     }
   },
 
-  'mcp.collaboration_space.list': async (server, params) => {
+  'collaboration_space.list': async (server, params) => {
     const id = mustDispatcherId(params);
     mustExistingDispatcher(server, id);
     try {

--- a/packages/dreamux/src/admin/params.ts
+++ b/packages/dreamux/src/admin/params.ts
@@ -1,6 +1,9 @@
 import type { AgentRuntimeSkillSource } from '@excitedjs/dreamux-types';
 
-import { parseAgentRuntimeSkillSources } from '../agent-runtime/skill-sources.js';
+import {
+  normalizeAgentRuntimeSkillSources,
+  parseAgentRuntimeSkillSources,
+} from '../agent-runtime/skill-sources.js';
 import type { Server } from '../server.js';
 import { validateDispatcherId } from '../state/dispatcher-id.js';
 import type {
@@ -79,15 +82,24 @@ export function optionalNonBlankString(
   return value;
 }
 
-export function optionalSkillSources(
+export async function optionalSkillSources(
   params: Record<string, unknown> | undefined,
-): readonly AgentRuntimeSkillSource[] | null {
+  options: {
+    requiredSources?: readonly AgentRuntimeSkillSource[];
+  } = {},
+): Promise<readonly AgentRuntimeSkillSource[] | null> {
   if (params === undefined || params['skill_sources'] === undefined) return null;
   try {
-    return parseAgentRuntimeSkillSources(
+    const parsed = parseAgentRuntimeSkillSources(
       params['skill_sources'],
       "param 'skill_sources'",
     );
+    return await normalizeAgentRuntimeSkillSources(parsed, {
+      label: "param 'skill_sources'",
+      ...(options.requiredSources !== undefined
+        ? { requiredSources: options.requiredSources }
+        : {}),
+    });
   } catch (err) {
     throw new AdminError('BAD_REQUEST', parseMessage(err));
   }

--- a/packages/dreamux/src/admin/params.ts
+++ b/packages/dreamux/src/admin/params.ts
@@ -1,3 +1,6 @@
+import type { AgentRuntimeSkillSource } from '@excitedjs/dreamux-types';
+
+import { parseAgentRuntimeSkillSources } from '../agent-runtime/skill-sources.js';
 import type { Server } from '../server.js';
 import { validateDispatcherId } from '../state/dispatcher-id.js';
 import type {
@@ -74,6 +77,20 @@ export function optionalNonBlankString(
     throw new AdminError('BAD_REQUEST', `param '${key}' must be a non-empty string`);
   }
   return value;
+}
+
+export function optionalSkillSources(
+  params: Record<string, unknown> | undefined,
+): readonly AgentRuntimeSkillSource[] | null {
+  if (params === undefined || params['skill_sources'] === undefined) return null;
+  try {
+    return parseAgentRuntimeSkillSources(
+      params['skill_sources'],
+      "param 'skill_sources'",
+    );
+  } catch (err) {
+    throw new AdminError('BAD_REQUEST', parseMessage(err));
+  }
 }
 
 export function repoRequest(

--- a/packages/dreamux/src/agent-runtime/skill-sources.ts
+++ b/packages/dreamux/src/agent-runtime/skill-sources.ts
@@ -1,0 +1,29 @@
+import type { AgentRuntimeSkillSource } from '@excitedjs/dreamux-types';
+
+/** Parse the runtime-neutral skill-source shape at host-owned trust boundaries. */
+export function parseAgentRuntimeSkillSources(
+  value: unknown,
+  label: string,
+): AgentRuntimeSkillSource[] {
+  if (!Array.isArray(value)) {
+    throw new Error(`${label} must be an array`);
+  }
+  return value.map((entry, index) => {
+    if (entry === null || typeof entry !== 'object' || Array.isArray(entry)) {
+      throw new Error(`${label}[${index}] must be an object`);
+    }
+    const record = entry as Record<string, unknown>;
+    return {
+      name: nonBlankString(record['name'], `${label}[${index}].name`),
+      path: nonBlankString(record['path'], `${label}[${index}].path`),
+      source: nonBlankString(record['source'], `${label}[${index}].source`),
+    };
+  });
+}
+
+function nonBlankString(value: unknown, label: string): string {
+  if (typeof value !== 'string' || value.trim() === '') {
+    throw new Error(`${label} must be a non-empty string`);
+  }
+  return value;
+}

--- a/packages/dreamux/src/agent-runtime/skill-sources.ts
+++ b/packages/dreamux/src/agent-runtime/skill-sources.ts
@@ -1,4 +1,6 @@
 import type { AgentRuntimeSkillSource } from '@excitedjs/dreamux-types';
+import { readdir, realpath } from 'node:fs/promises';
+import { isAbsolute } from 'node:path';
 
 /** Parse the runtime-neutral skill-source shape at host-owned trust boundaries. */
 export function parseAgentRuntimeSkillSources(
@@ -13,12 +15,70 @@ export function parseAgentRuntimeSkillSources(
       throw new Error(`${label}[${index}] must be an object`);
     }
     const record = entry as Record<string, unknown>;
+    const path = nonBlankString(record['path'], `${label}[${index}].path`);
+    if (!isAbsolute(path)) {
+      throw new Error(`${label}[${index}].path must be an absolute path`);
+    }
     return {
       name: nonBlankString(record['name'], `${label}[${index}].name`),
-      path: nonBlankString(record['path'], `${label}[${index}].path`),
+      path,
       source: nonBlankString(record['source'], `${label}[${index}].source`),
     };
   });
+}
+
+export interface NormalizeAgentRuntimeSkillSourcesOptions {
+  label: string;
+  /**
+   * Required roots are owned by core (for example a TeamLeader role root). They
+   * are not returned, but their canonical roots and child skill names fence the
+   * caller-provided roots so custom roots cannot replace role-critical skills.
+   */
+  requiredSources?: readonly AgentRuntimeSkillSource[];
+}
+
+/**
+ * Normalize caller-provided skill roots into a stable provider-neutral shape:
+ * paths are existing readable directories, stored as canonical realpaths, root
+ * duplicates are removed, and direct child skill names are globally unique.
+ */
+export async function normalizeAgentRuntimeSkillSources(
+  sources: readonly AgentRuntimeSkillSource[],
+  opts: NormalizeAgentRuntimeSkillSourcesOptions,
+): Promise<AgentRuntimeSkillSource[]> {
+  const seenRoots = new Set<string>();
+  const seenSkillNames = new Map<string, string>();
+
+  for (const source of opts.requiredSources ?? []) {
+    const root = await canonicalSkillRoot(source, opts.label, 'required source');
+    seenRoots.add(root.path);
+    for (const skillName of root.skillNames) {
+      seenSkillNames.set(skillName, `required source ${JSON.stringify(source.name)}`);
+    }
+  }
+
+  const normalized: AgentRuntimeSkillSource[] = [];
+  for (let index = 0; index < sources.length; index += 1) {
+    const source = sources[index]!;
+    const itemLabel = `${opts.label}[${index}]`;
+    const root = await canonicalSkillRoot(source, itemLabel, 'path');
+    if (seenRoots.has(root.path)) continue;
+    for (const skillName of root.skillNames) {
+      const previous = seenSkillNames.get(skillName);
+      if (previous !== undefined) {
+        throw new Error(
+          `${itemLabel}.path contains skill ${JSON.stringify(skillName)} ` +
+            `which conflicts with ${previous}`,
+        );
+      }
+    }
+    seenRoots.add(root.path);
+    for (const skillName of root.skillNames) {
+      seenSkillNames.set(skillName, `${itemLabel}.path`);
+    }
+    normalized.push({ ...source, path: root.path });
+  }
+  return normalized;
 }
 
 function nonBlankString(value: unknown, label: string): string {
@@ -26,4 +86,45 @@ function nonBlankString(value: unknown, label: string): string {
     throw new Error(`${label} must be a non-empty string`);
   }
   return value;
+}
+
+async function canonicalSkillRoot(
+  source: AgentRuntimeSkillSource,
+  label: string,
+  field: string,
+): Promise<{ path: string; skillNames: string[] }> {
+  if (!isAbsolute(source.path)) {
+    throw new Error(`${label}.${field} must be an absolute path`);
+  }
+  let canonicalPath: string;
+  try {
+    canonicalPath = await realpath(source.path);
+  } catch (err) {
+    throw new Error(
+      `${label}.${field} must be an existing readable directory: ${messageOf(err)}`,
+    );
+  }
+  let skillNames: string[];
+  try {
+    const entries = await readdir(canonicalPath, {
+      encoding: 'utf8',
+      withFileTypes: true,
+    });
+    skillNames = entries
+      .filter((entry) => entry.isDirectory())
+      .map((entry) => entry.name)
+      .sort((a, b) => a.localeCompare(b));
+  } catch (err) {
+    throw new Error(
+      `${label}.${field} must be an existing readable directory: ${messageOf(err)}`,
+    );
+  }
+  return {
+    path: canonicalPath,
+    skillNames,
+  };
+}
+
+function messageOf(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
 }

--- a/packages/dreamux/src/cli/commands/dispatcher.ts
+++ b/packages/dreamux/src/cli/commands/dispatcher.ts
@@ -11,7 +11,7 @@ import {
   type DreamuxCommand,
 } from './types.js';
 
-type DispatcherVerb = 'remove' | 'status' | 'start' | 'stop';
+type DispatcherVerb = 'status' | 'start' | 'stop';
 
 interface DispatcherArgv {
   id: string;
@@ -25,8 +25,6 @@ export function createDispatcherCommand(deps: CliDeps): CommandModule {
       y
         .command([
           createDispatcherListCommand(deps),
-          createDispatcherAddCommand(deps),
-          createDispatcherVerbCommand(deps, 'remove'),
           createDispatcherVerbCommand(deps, 'status'),
           createDispatcherVerbCommand(deps, 'start'),
           createDispatcherVerbCommand(deps, 'stop'),
@@ -43,23 +41,6 @@ function createDispatcherListCommand(deps: CliDeps): CommandModule {
     describe: 'List configured dispatchers',
     handler: async () =>
       deps.execEntry(deps.serverCtlEntry, ['dispatcher', 'list'], adminEnv()),
-  };
-}
-
-function createDispatcherAddCommand(
-  deps: CliDeps,
-): CommandModule<{}, DispatcherArgv> {
-  return {
-    command: 'add',
-    describe: 'Add a dispatcher',
-    builder: withRequiredDispatcherId,
-    handler: async (argv) => {
-      await deps.execEntry(
-        deps.serverCtlEntry,
-        ['dispatcher', 'add', '--id', requiredDispatcherId(argv.id)],
-        adminEnv(),
-      );
-    },
   };
 }
 

--- a/packages/dreamux/src/cli/server-ctl.ts
+++ b/packages/dreamux/src/cli/server-ctl.ts
@@ -79,8 +79,6 @@ function resolveMethod(obj: string | undefined, verb: string | undefined): strin
   if (o === 'server' && v === 'status') return 'server.status';
   if (o === 'dispatcher') {
     switch (v) {
-      case 'add': return 'dispatcher.add';
-      case 'remove': return 'dispatcher.remove';
       case 'list': return 'dispatcher.list';
       case 'status': return 'dispatcher.status';
       case 'start': return 'dispatcher.start';

--- a/packages/dreamux/src/mcp/collaboration-space-mcp.ts
+++ b/packages/dreamux/src/mcp/collaboration-space-mcp.ts
@@ -174,13 +174,13 @@ function mapToolCall(
 ): { method: string; params: Record<string, unknown> } {
   switch (call.name) {
     case 'bind':
-      return { method: 'mcp.collaboration_space.bind', params: bindArgs(call.arguments) };
+      return { method: 'collaboration_space.bind', params: bindArgs(call.arguments) };
     case 'dissolve':
-      return { method: 'mcp.collaboration_space.dissolve', params: dissolveArgs(call.arguments) };
+      return { method: 'collaboration_space.dissolve', params: dissolveArgs(call.arguments) };
     case 'status':
-      return { method: 'mcp.collaboration_space.status', params: spaceNameArgs(call.arguments) };
+      return { method: 'collaboration_space.status', params: spaceNameArgs(call.arguments) };
     case 'list':
-      return { method: 'mcp.collaboration_space.list', params: {} };
+      return { method: 'collaboration_space.list', params: {} };
     default:
       throw new Error(`unknown collaboration_space tool '${String(call.name)}'`);
   }

--- a/packages/dreamux/src/mcp/team-mcp.ts
+++ b/packages/dreamux/src/mcp/team-mcp.ts
@@ -230,21 +230,21 @@ function mapToolCall(
   }
   switch (call.name) {
     case 'create':
-      return { method: 'mcp.team.create', params: createArgs(call.arguments) };
+      return { method: 'team.create', params: createArgs(call.arguments) };
     case 'send':
-      return { method: 'mcp.team.send', params: sendArgs(call.arguments) };
+      return { method: 'team.send', params: sendArgs(call.arguments) };
     case 'list':
-      return { method: 'mcp.team.list', params: {} };
+      return { method: 'team.list', params: {} };
     case 'status':
-      return { method: 'mcp.team.status', params: teamNameArgs(call.arguments) };
+      return { method: 'team.status', params: teamNameArgs(call.arguments) };
     case 'history':
-      return { method: 'mcp.team.history', params: historyArgs(call.arguments) };
+      return { method: 'team.history', params: historyArgs(call.arguments) };
     case 'dissolve':
-      return { method: 'mcp.team.dissolve', params: dissolveArgs(call.arguments) };
+      return { method: 'team.dissolve', params: dissolveArgs(call.arguments) };
     case 'bind_channel':
-      return { method: 'mcp.team.bind_channel', params: bindChannelArgs(call.arguments) };
+      return { method: 'team.bind_channel', params: bindChannelArgs(call.arguments) };
     case 'transfer_back':
-      return { method: 'mcp.team.transfer_back', params: transferBackArgs(call.arguments) };
+      return { method: 'team.transfer_back', params: transferBackArgs(call.arguments) };
     default:
       throw new Error(`unknown Team tool '${String(call.name)}'`);
   }

--- a/packages/dreamux/src/mcp/teammate-mcp.ts
+++ b/packages/dreamux/src/mcp/teammate-mcp.ts
@@ -255,21 +255,21 @@ function mapToolCall(
 } {
   switch (call.name) {
     case 'spawn':
-      return { method: 'mcp.teammate.spawn', params: spawnArgs(call.arguments, callerKind) };
+      return { method: 'teammate.spawn', params: spawnArgs(call.arguments, callerKind) };
     case 'send':
-      return { method: 'mcp.teammate.send', params: sendArgs(call.arguments) };
+      return { method: 'teammate.send', params: sendArgs(call.arguments) };
     case 'close':
-      return { method: 'mcp.teammate.close', params: closeArgs(call.arguments) };
+      return { method: 'teammate.close', params: closeArgs(call.arguments) };
     case 'history':
-      return { method: 'mcp.teammate.history', params: historyArgs(call.arguments) };
+      return { method: 'teammate.history', params: historyArgs(call.arguments) };
     case 'list':
-      return { method: 'mcp.teammate.list', params: {} };
+      return { method: 'teammate.list', params: {} };
     case 'status':
-      return { method: 'mcp.teammate.status', params: nameArgs(call.arguments) };
+      return { method: 'teammate.status', params: nameArgs(call.arguments) };
     case 'last':
-      return { method: 'mcp.teammate.last', params: lastArgs(call.arguments) };
+      return { method: 'teammate.last', params: lastArgs(call.arguments) };
     case 'get_capabilities':
-      return { method: 'mcp.teammate.capabilities', params: {} };
+      return { method: 'teammate.capabilities', params: {} };
     default:
       throw new Error(`unknown TeamMate tool '${String(call.name)}'`);
   }

--- a/packages/dreamux/src/service/agent-entity/identity-store.ts
+++ b/packages/dreamux/src/service/agent-entity/identity-store.ts
@@ -1,8 +1,12 @@
 import { readFile, readdir } from 'node:fs/promises';
 import { join } from 'node:path';
 
-import type { DreamuxLogger } from '@excitedjs/dreamux-types';
+import type {
+  AgentRuntimeSkillSource,
+  DreamuxLogger,
+} from '@excitedjs/dreamux-types';
 
+import { parseAgentRuntimeSkillSources } from '../../agent-runtime/skill-sources.js';
 import { writeFileAtomic } from '../../platform/atomic-write.js';
 import { isNotFound } from '../../platform/fs-errors.js';
 import {
@@ -36,6 +40,7 @@ export interface AgentIdentityCreateInput {
   worktree: AgentEntityWorktreeIdentity;
   intent?: string | null;
   identityPrompt?: string | null;
+  skillSources?: readonly AgentRuntimeSkillSource[];
   status?: AgentEntityIdentityStatus;
 }
 
@@ -254,6 +259,7 @@ export class AgentIdentityStore {
       worktree: input.worktree,
       intent: input.intent ?? null,
       identity_prompt: input.identityPrompt ?? null,
+      skill_sources: [...(input.skillSources ?? [])],
       created_at: now,
       updated_at: now,
       status: input.status ?? 'starting',
@@ -395,6 +401,10 @@ function readIdentity(
       typeof record['identity_prompt'] === 'string'
         ? record['identity_prompt']
         : null,
+    skill_sources: parseAgentRuntimeSkillSources(
+      record['skill_sources'] ?? [],
+      `agent identity ${JSON.stringify(storedName)} skill_sources`,
+    ),
     created_at: createdAt,
     updated_at: updatedAt,
     status: readStatus(record['status']),

--- a/packages/dreamux/src/service/agent-entity/types.ts
+++ b/packages/dreamux/src/service/agent-entity/types.ts
@@ -1,5 +1,6 @@
 import type {
   AgentRuntimeCapabilities,
+  AgentRuntimeSkillSource,
   AgentRuntimeStatus,
 } from "@excitedjs/dreamux-types";
 
@@ -69,6 +70,8 @@ export interface AgentEntityIdentity {
   worktree: AgentEntityWorktreeIdentity;
   intent: string | null;
   identity_prompt: string | null;
+  /** Persisted admin-supplied sources only; bundled role sources stay owner-composed. */
+  skill_sources: readonly AgentRuntimeSkillSource[];
   created_at: number;
   updated_at: number;
   status: AgentEntityIdentityStatus;

--- a/packages/dreamux/src/service/channel-service/index.ts
+++ b/packages/dreamux/src/service/channel-service/index.ts
@@ -165,7 +165,7 @@ export class ChannelService {
     if (allowedChannelId !== channelId) {
       throw new ChannelToolAuthorizationError(
         'CHANNEL_SCOPE_DENIED',
-        'TeamLeader may use only the channel MCP server bound to the target',
+        'TeamLeader may use only the configured channel bound to the target',
       );
     }
     return { channelId, target };

--- a/packages/dreamux/src/service/dispatcher-service/identity.ts
+++ b/packages/dreamux/src/service/dispatcher-service/identity.ts
@@ -76,6 +76,7 @@ export async function ensureDispatcherIdentity(
       worktree: input.worktree,
       intent: null,
       identity_prompt: null,
+      skill_sources: [],
       created_at: now,
       updated_at: now,
       status: 'stopped',

--- a/packages/dreamux/src/service/team-collection/index.ts
+++ b/packages/dreamux/src/service/team-collection/index.ts
@@ -187,6 +187,9 @@ export class TeamCollection {
           leaderAgentRuntime: input.leaderAgentRuntime,
           intent: input.intent,
           ...(input.identity !== undefined ? { identity: input.identity } : {}),
+          ...(input.skillSources !== undefined
+            ? { skillSources: input.skillSources }
+            : {}),
           workspace,
           existing,
         },

--- a/packages/dreamux/src/service/team-collection/types.ts
+++ b/packages/dreamux/src/service/team-collection/types.ts
@@ -5,6 +5,7 @@ import {
   type AgentEntityTurnResult,
   type AgentEntityWorktreeIdentity,
 } from '../agent-entity/types.js';
+import type { AgentRuntimeSkillSource } from '@excitedjs/dreamux-types';
 import type { TeamMateWorktreeRequest } from '../teammate-collection/types.js';
 
 export const TEAM_ID_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._-]{0,63}$/;
@@ -45,6 +46,8 @@ export interface TeamCreateInput {
   /** Required recovery subject for the Team (issue #182 PR-3). */
   intent: string;
   identity?: string;
+  /** Additional admin-supplied TeamLeader skill roots. */
+  skillSources?: readonly AgentRuntimeSkillSource[];
   prompt?: string;
 }
 

--- a/packages/dreamux/src/service/team-service/index.ts
+++ b/packages/dreamux/src/service/team-service/index.ts
@@ -1,5 +1,6 @@
 import type {
   AgentRuntimeMcpServer,
+  AgentRuntimeSkillSource,
   AgentRuntimeSystemPrompt,
   AgentRuntimeTurnResult,
   DreamuxLogger,
@@ -85,6 +86,7 @@ export interface TeamServiceCreateInput {
   leaderAgentRuntime: string;
   intent: string;
   identity?: string;
+  skillSources?: readonly AgentRuntimeSkillSource[];
   workspace: TeamMateSharedWorkspace;
   existing: TeamRecord | null;
 }
@@ -210,6 +212,9 @@ export class TeamService {
       worktree: input.workspace.worktree,
       intent: input.intent,
       identityPrompt,
+      ...(input.skillSources !== undefined
+        ? { skillSources: input.skillSources }
+        : {}),
       status: 'starting',
     });
     const leader = service.buildLeader(identity);
@@ -493,11 +498,14 @@ export class TeamService {
       dispatcherId: this.deps.dispatcherId,
       identity,
       mcpServers: this.leaderMcpServers(identity.name),
-      skillSources: [{
-        name: 'team-leader',
-        path: bundledTeamLeaderSkillRoot(),
-        source: 'dreamux-core',
-      }],
+      skillSources: [
+        {
+          name: 'team-leader',
+          path: bundledTeamLeaderSkillRoot(),
+          source: 'dreamux-core',
+        },
+        ...identity.skill_sources,
+      ],
       disableFeatures: [DISABLE_FEATURE_CRON],
       systemPrompt: teamLeaderSystemPrompt(this.id, identity.identity_prompt),
       config: this.deps.config,

--- a/packages/dreamux/src/service/teammate-collection/index.ts
+++ b/packages/dreamux/src/service/teammate-collection/index.ts
@@ -260,6 +260,9 @@ export class TeammateCollection implements TeammateOps {
       worktree: workspace.worktree,
       intent: input.intent,
       identityPrompt,
+      ...(input.skillSources !== undefined
+        ? { skillSources: input.skillSources }
+        : {}),
       status: 'starting',
     });
     const entity = this.entityFor(identity);
@@ -487,6 +490,7 @@ export class TeammateCollection implements TeammateOps {
           this.teamScope === null
             ? assertDispatcherScopedTeammate
             : assertTeamScopedAgent(this.teamScope),
+        skillSources: identity.skill_sources,
         ...(systemPromptOptions ?? {}),
       },
       config: this.opts.config,

--- a/packages/dreamux/src/service/teammate-collection/types.ts
+++ b/packages/dreamux/src/service/teammate-collection/types.ts
@@ -1,3 +1,5 @@
+import type { AgentRuntimeSkillSource } from '@excitedjs/dreamux-types';
+
 export interface TeamMateWorktreeRequest {
   mode: 'reuse-cwd' | 'managed';
   slug?: string;
@@ -14,6 +16,8 @@ export interface SpawnTeamMateInput {
   worktree?: TeamMateWorktreeRequest;
   intent: string;
   identity?: string;
+  /** Additional admin-supplied runtime skill roots; bundled role policy is separate. */
+  skillSources?: readonly AgentRuntimeSkillSource[];
 }
 
 export interface SendTeamMateInput {

--- a/packages/dreamux/tests/admin-default-workspace.test.ts
+++ b/packages/dreamux/tests/admin-default-workspace.test.ts
@@ -28,7 +28,7 @@ describe('admin no-repo spawn/create → default work dir (#199)', () => {
     const server = spawnStub((input) => {
       captured = input as Record<string, unknown>;
     });
-    await adminMethods['mcp.teammate.spawn']!(server, {
+    await adminMethods['teammate.spawn']!(server, {
       dispatcher_id: 'flow',
       name_prefix: 'solo',
       prompt: 'go',
@@ -43,7 +43,7 @@ describe('admin no-repo spawn/create → default work dir (#199)', () => {
     const server = spawnStub((input) => {
       captured = input as Record<string, unknown>;
     });
-    await adminMethods['mcp.teammate.spawn']!(server, {
+    await adminMethods['teammate.spawn']!(server, {
       dispatcher_id: 'flow',
       name_prefix: 'solo',
       prompt: 'go',
@@ -58,7 +58,7 @@ describe('admin no-repo spawn/create → default work dir (#199)', () => {
     const server = spawnStub((input) => {
       captured = input as Record<string, unknown>;
     });
-    await adminMethods['mcp.teammate.spawn']!(server, {
+    await adminMethods['teammate.spawn']!(server, {
       dispatcher_id: 'flow',
       name_prefix: 'solo',
       prompt: 'go',
@@ -83,7 +83,7 @@ describe('admin no-repo spawn/create → default work dir (#199)', () => {
         },
       }),
     } as unknown as Server;
-    await adminMethods['mcp.team.create']!(server, {
+    await adminMethods['team.create']!(server, {
       dispatcher_id: 'flow',
       team_name: 'plain',
       leader_agent_runtime: 'codex',
@@ -107,7 +107,7 @@ describe('admin no-repo spawn/create → default work dir (#199)', () => {
         },
       }),
     } as unknown as Server;
-    await adminMethods['mcp.team.create']!(server, {
+    await adminMethods['team.create']!(server, {
       dispatcher_id: 'flow',
       team_name: 'plain',
       leader_agent_runtime: 'codex',

--- a/packages/dreamux/tests/admin-method-namespace.test.ts
+++ b/packages/dreamux/tests/admin-method-namespace.test.ts
@@ -1,0 +1,97 @@
+import { mkdtemp, readFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+import { sendOneAdminRequest } from '../src/admin/client.js';
+import { adminMethods } from '../src/admin/methods.js';
+import {
+  createAdminSocketServer,
+  type AdminSocketServer,
+} from '../src/admin/socket.js';
+import type { Server } from '../src/server.js';
+
+const PRODUCT_METHODS = [
+  'teammate.spawn',
+  'teammate.send',
+  'teammate.close',
+  'teammate.history',
+  'teammate.list',
+  'teammate.status',
+  'teammate.last',
+  'teammate.capabilities',
+  'team.create',
+  'team.send',
+  'team.list',
+  'team.status',
+  'team.history',
+  'team.bind_channel',
+  'team.transfer_back',
+  'team.dissolve',
+  'collaboration_space.bind',
+  'collaboration_space.dissolve',
+  'collaboration_space.status',
+  'collaboration_space.list',
+] as const;
+
+const RETIRED_METHODS = [
+  ...PRODUCT_METHODS.map((method) => `mcp.${method}`),
+  'dispatcher.add',
+  'dispatcher.remove',
+] as const;
+
+describe('admin control-plane method namespace', () => {
+  let root: string;
+  let socketPath: string;
+  let socketServer: AdminSocketServer;
+
+  beforeAll(async () => {
+    root = await mkdtemp(join(tmpdir(), 'dreamux-admin-namespace-'));
+    socketPath = join(root, 'admin.sock');
+    socketServer = createAdminSocketServer({} as Server, socketPath);
+    await socketServer.start();
+  });
+
+  afterAll(async () => {
+    await socketServer.close();
+    await rm(root, { recursive: true, force: true });
+  });
+
+  it('registers canonical product names without mcp.* or dispatcher mutation entries', () => {
+    for (const method of PRODUCT_METHODS) {
+      expect(typeof adminMethods[method], method).toBe('function');
+    }
+    expect(Object.keys(adminMethods).filter((method) => method.startsWith('mcp.')))
+      .toEqual([]);
+    expect(adminMethods['dispatcher.add']).toBeUndefined();
+    expect(adminMethods['dispatcher.remove']).toBeUndefined();
+    expect(typeof adminMethods['scheduler.cron.list']).toBe('function');
+    expect(typeof adminMethods['channel.invoke_tool']).toBe('function');
+  });
+
+  it('returns UNKNOWN_METHOD for every retired method through socket dispatch', async () => {
+    for (const [index, method] of RETIRED_METHODS.entries()) {
+      await expect(
+        sendOneAdminRequest(
+          socketPath,
+          { id: `retired-${index}`, method, params: {} },
+        ),
+        method,
+      ).rejects.toMatchObject({
+        name: 'AdminClientError',
+        code: 'UNKNOWN_METHOD',
+        message: `unknown method '${method}'`,
+      });
+    }
+  });
+
+  it('does not retain dispatcher add/remove in either CLI dispatch layer', async () => {
+    const [commandSource, ctlSource] = await Promise.all([
+      readFile(new URL('../src/cli/commands/dispatcher.ts', import.meta.url), 'utf8'),
+      readFile(new URL('../src/cli/server-ctl.ts', import.meta.url), 'utf8'),
+    ]);
+    expect(commandSource).not.toMatch(/command:\s*['"](?:add|remove)['"]/);
+    expect(ctlSource).not.toMatch(/case\s+['"](?:add|remove)['"]/);
+  });
+});

--- a/packages/dreamux/tests/admin-methods-intent-note.test.ts
+++ b/packages/dreamux/tests/admin-methods-intent-note.test.ts
@@ -1,4 +1,7 @@
 import { describe, expect, it } from 'vitest';
+import { mkdirSync, mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 
 import { adminMethods } from '../src/admin/methods.js';
 import { AdminError } from '../src/admin/protocol.js';
@@ -60,6 +63,7 @@ describe('admin layer enforces required non-empty intent/note (#182 PR-3)', () =
       {},
       [{}],
       [{ name: 'custom', path: '/skills/custom', source: '' }],
+      [{ name: 'custom', path: 'relative/skills', source: 'admin' }],
       [{ name: 'custom', path: 42, source: 'admin' }],
       [{ name: '   ', path: '/skills/custom', source: 'admin' }],
     ];
@@ -78,6 +82,26 @@ describe('admin layer enforces required non-empty intent/note (#182 PR-3)', () =
         intent: 'work',
         skill_sources,
       });
+    }
+  });
+
+  it('rejects TeamLeader skill roots that shadow required bundled skills', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'dreamux-skill-shadow-'));
+    try {
+      mkdirSync(join(root, 'team-workflow'), { recursive: true });
+      await expectBadRequest('team.create', {
+        dispatcher_id: 'flow',
+        team_name: 'alpha',
+        leader_agent_runtime: 'codex',
+        intent: 'work',
+        skill_sources: [{
+          name: 'shadow-root',
+          path: root,
+          source: 'admin',
+        }],
+      });
+    } finally {
+      rmSync(root, { recursive: true, force: true });
     }
   });
 

--- a/packages/dreamux/tests/admin-methods-intent-note.test.ts
+++ b/packages/dreamux/tests/admin-methods-intent-note.test.ts
@@ -40,12 +40,12 @@ describe('admin layer enforces required non-empty intent/note (#182 PR-3)', () =
 
   it('rejects teammate.spawn with missing or empty intent', async () => {
     const base = { dispatcher_id: 'flow', name_prefix: 'a', prompt: 'go' };
-    await expectBadRequest('mcp.teammate.spawn', base);
-    await expectBadRequest('mcp.teammate.spawn', { ...base, intent: '' });
+    await expectBadRequest('teammate.spawn', base);
+    await expectBadRequest('teammate.spawn', { ...base, intent: '' });
   });
 
   it('rejects teammate.spawn with blank identity', async () => {
-    await expectBadRequest('mcp.teammate.spawn', {
+    await expectBadRequest('teammate.spawn', {
       dispatcher_id: 'flow',
       name_prefix: 'a',
       prompt: 'go',
@@ -54,10 +54,37 @@ describe('admin layer enforces required non-empty intent/note (#182 PR-3)', () =
     });
   });
 
+  it('strictly rejects malformed admin-only skill_sources before creation', async () => {
+    const malformed: unknown[] = [
+      null,
+      {},
+      [{}],
+      [{ name: 'custom', path: '/skills/custom', source: '' }],
+      [{ name: 'custom', path: 42, source: 'admin' }],
+      [{ name: '   ', path: '/skills/custom', source: 'admin' }],
+    ];
+    for (const skill_sources of malformed) {
+      await expectBadRequest('teammate.spawn', {
+        dispatcher_id: 'flow',
+        name_prefix: 'a',
+        prompt: 'go',
+        intent: 'work',
+        skill_sources,
+      });
+      await expectBadRequest('team.create', {
+        dispatcher_id: 'flow',
+        team_name: 'alpha',
+        leader_agent_runtime: 'codex',
+        intent: 'work',
+        skill_sources,
+      });
+    }
+  });
+
   it('rejects teammate.close with missing or empty note', async () => {
     const base = { dispatcher_id: 'flow', name: 'a' };
-    await expectBadRequest('mcp.teammate.close', base);
-    await expectBadRequest('mcp.teammate.close', { ...base, note: '' });
+    await expectBadRequest('teammate.close', base);
+    await expectBadRequest('teammate.close', { ...base, note: '' });
   });
 
   it('rejects team.create with missing or empty intent', async () => {
@@ -66,12 +93,12 @@ describe('admin layer enforces required non-empty intent/note (#182 PR-3)', () =
       team_name: 'alpha',
       leader_agent_runtime: 'codex',
     };
-    await expectBadRequest('mcp.team.create', base);
-    await expectBadRequest('mcp.team.create', { ...base, intent: '' });
+    await expectBadRequest('team.create', base);
+    await expectBadRequest('team.create', { ...base, intent: '' });
   });
 
   it('rejects team.create with blank identity', async () => {
-    await expectBadRequest('mcp.team.create', {
+    await expectBadRequest('team.create', {
       dispatcher_id: 'flow',
       team_name: 'alpha',
       leader_agent_runtime: 'codex',
@@ -82,33 +109,45 @@ describe('admin layer enforces required non-empty intent/note (#182 PR-3)', () =
 
   it('rejects team.dissolve with missing or empty note', async () => {
     const base = { dispatcher_id: 'flow', team_name: 'alpha' };
-    await expectBadRequest('mcp.team.dissolve', base);
-    await expectBadRequest('mcp.team.dissolve', { ...base, note: '' });
+    await expectBadRequest('team.dissolve', base);
+    await expectBadRequest('team.dissolve', { ...base, note: '' });
   });
 
   it('rejects team.send for TeamLeader callers and requires a non-empty prompt', async () => {
     const base = { dispatcher_id: 'flow', team_name: 'alpha' };
-    await expectBadRequest('mcp.team.send', base);
-    await expectBadRequest('mcp.team.send', { ...base, prompt: '' });
-    await expectBadRequest('mcp.team.send', {
+    await expectBadRequest('team.send', base);
+    await expectBadRequest('team.send', { ...base, prompt: '' });
+    await expectBadRequest('team.send', {
       ...base,
       caller_kind: 'team_leader',
       team_id: 'alpha',
       leader_name: 'alpha-leader',
       prompt: 'follow up',
     });
+    await expect(
+      adminMethods['team.send']!(stubServer, {
+        ...base,
+        caller_kind: 'team_leader',
+        team_id: 'alpha',
+        leader_name: 'alpha-leader',
+        prompt: 'follow up',
+      }),
+    ).rejects.toMatchObject({
+      code: 'BAD_REQUEST',
+      message: 'team.send is available only to dispatcher callers',
+    });
   });
 });
 
-describe('Channel MCP admin methods replace the Team binding methods (#209 slice 8)', () => {
+describe('Team channel admin methods replace the old binding methods (#209 slice 8)', () => {
   it('removes the old Feishu binding methods without aliases', () => {
-    expect(adminMethods['mcp.team.bind_group']).toBeUndefined();
-    expect(adminMethods['mcp.team.transfer_channel_back']).toBeUndefined();
+    expect(adminMethods['team.bind_group']).toBeUndefined();
+    expect(adminMethods['team.transfer_channel_back']).toBeUndefined();
   });
 
-  it('registers the Team MCP channel-binding methods (and no generic channel.* aliases)', () => {
-    expect(typeof adminMethods['mcp.team.bind_channel']).toBe('function');
-    expect(typeof adminMethods['mcp.team.transfer_back']).toBe('function');
+  it('registers the Team channel-binding methods (and no generic channel.* aliases)', () => {
+    expect(typeof adminMethods['team.bind_channel']).toBe('function');
+    expect(typeof adminMethods['team.transfer_back']).toBe('function');
     expect(adminMethods['mcp.channel.bind_channel']).toBeUndefined();
     expect(adminMethods['mcp.channel.transfer_back']).toBeUndefined();
   });
@@ -130,12 +169,12 @@ describe('Channel MCP admin methods replace the Team binding methods (#209 slice
       }),
     } as unknown as Server;
 
-    const bound = await adminMethods['mcp.team.bind_channel']!(channelStub, {
+    const bound = await adminMethods['team.bind_channel']!(channelStub, {
       dispatcher_id: 'flow',
       team_name: 'alpha',
       meta: { chat_id: 'chat-demo' },
     });
-    const transferred = await adminMethods['mcp.team.transfer_back']!(channelStub, {
+    const transferred = await adminMethods['team.transfer_back']!(channelStub, {
       dispatcher_id: 'flow',
       meta: { chat_id: 'chat-demo' },
     });
@@ -161,7 +200,7 @@ describe('Channel MCP admin methods replace the Team binding methods (#209 slice
       }),
     } as unknown as Server;
 
-    const transferred = await adminMethods['mcp.team.transfer_back']!(channelStub, {
+    const transferred = await adminMethods['team.transfer_back']!(channelStub, {
       dispatcher_id: 'flow',
       caller_kind: 'team_leader',
       team_id: 'alpha',
@@ -186,7 +225,7 @@ describe('Channel MCP admin methods replace the Team binding methods (#209 slice
       getDispatcher: () => ({ bindTeamChannel: async () => ({}) }),
     } as unknown as Server;
     await expect(
-      adminMethods['mcp.team.bind_channel']!(channelStub, {
+      adminMethods['team.bind_channel']!(channelStub, {
         dispatcher_id: 'flow',
         team_name: 'alpha',
       }),
@@ -194,7 +233,7 @@ describe('Channel MCP admin methods replace the Team binding methods (#209 slice
   });
 });
 
-describe('Collaboration Space MCP admin methods', () => {
+describe('Collaboration Space admin methods', () => {
   it('parses bind identity, container, and repo policy', async () => {
     const seen: Array<Record<string, unknown>> = [];
     const server = {
@@ -208,7 +247,7 @@ describe('Collaboration Space MCP admin methods', () => {
     } as unknown as Server;
 
     await expect(
-      adminMethods['mcp.collaboration_space.bind']!(server, {
+      adminMethods['collaboration_space.bind']!(server, {
         dispatcher_id: 'flow',
         channel_id: 'primary',
         space_name: 'space-alpha',
@@ -237,7 +276,7 @@ describe('Collaboration Space MCP admin methods', () => {
   });
 
   it('rejects collaboration_space.bind with blank identity', async () => {
-    await expectBadRequest('mcp.collaboration_space.bind', {
+    await expectBadRequest('collaboration_space.bind', {
       dispatcher_id: 'flow',
       space_name: 'space-alpha',
       leader_agent_runtime: 'agent-a',
@@ -258,7 +297,7 @@ describe('Collaboration Space MCP admin methods', () => {
     } as unknown as Server;
 
     await expect(
-      adminMethods['mcp.collaboration_space.bind']!(server, {
+      adminMethods['collaboration_space.bind']!(server, {
         dispatcher_id: 'flow',
         space_name: 'space-alpha',
         container: {
@@ -276,7 +315,7 @@ describe('Collaboration Space MCP admin methods', () => {
   });
 });
 
-describe('Team MCP admin read methods compose channel binding summaries', () => {
+describe('Team admin read methods compose channel binding summaries', () => {
   it('team.send forwards to the dispatcher and returns only team, leader, and turn', async () => {
     const sent = {
       team: {
@@ -324,7 +363,7 @@ describe('Team MCP admin read methods compose channel binding summaries', () => 
       }),
     } as unknown as Server;
 
-    const result = await adminMethods['mcp.team.send']!(server, {
+    const result = await adminMethods['team.send']!(server, {
       dispatcher_id: 'flow',
       caller_kind: 'dispatcher',
       team_name: 'alpha',
@@ -355,7 +394,7 @@ describe('Team MCP admin read methods compose channel binding summaries', () => 
     } as unknown as Server;
 
     await expect(
-      adminMethods['mcp.team.send']!(server, {
+      adminMethods['team.send']!(server, {
         dispatcher_id: 'flow',
         team_name: 'ghost',
         prompt: 'follow up',
@@ -439,12 +478,12 @@ describe('Team MCP admin read methods compose channel binding summaries', () => 
     } as unknown as Server;
 
     await expect(
-      adminMethods['mcp.team.list']!(server, { dispatcher_id: 'flow' }),
+      adminMethods['team.list']!(server, { dispatcher_id: 'flow' }),
     ).resolves.toMatchObject({
       teams: [{ team_name: 'alpha', bound_target: binding }],
     });
     await expect(
-      adminMethods['mcp.team.status']!(server, {
+      adminMethods['team.status']!(server, {
         dispatcher_id: 'flow',
         team_name: 'alpha',
       }),
@@ -453,7 +492,7 @@ describe('Team MCP admin read methods compose channel binding summaries', () => 
       bound_target: binding,
     });
     await expect(
-      adminMethods['mcp.team.history']!(server, { dispatcher_id: 'flow' }),
+      adminMethods['team.history']!(server, { dispatcher_id: 'flow' }),
     ).resolves.toMatchObject({
       items: [{ team_name: 'alpha', bound_target: binding }],
       next_cursor: null,

--- a/packages/dreamux/tests/architecture-ownership-gate.test.ts
+++ b/packages/dreamux/tests/architecture-ownership-gate.test.ts
@@ -519,20 +519,20 @@ describe('architecture ownership gate (#233)', () => {
     const adminMethods = await readSource('admin/methods.ts');
     assertContains(
       adminMethods,
-      /'mcp\.team\.list'[\s\S]*bound_target:\s*await dispatcher\.activeTeamBindingSummary/,
-      'Team read composition invariant violated: mcp.team.list must add bound_target in admin/methods.ts.',
+      /'team\.list'[\s\S]*bound_target:\s*await dispatcher\.activeTeamBindingSummary/,
+      'Team read composition invariant violated: team.list must add bound_target in admin/methods.ts.',
       '../admin/methods.ts',
     );
     assertContains(
       adminMethods,
-      /'mcp\.team\.status'[\s\S]*bound_target:\s*await dispatcher\.activeTeamBindingSummary/,
-      'Team read composition invariant violated: mcp.team.status must add bound_target in admin/methods.ts.',
+      /'team\.status'[\s\S]*bound_target:\s*await dispatcher\.activeTeamBindingSummary/,
+      'Team read composition invariant violated: team.status must add bound_target in admin/methods.ts.',
       '../admin/methods.ts',
     );
     assertContains(
       adminMethods,
-      /'mcp\.team\.history'[\s\S]*bound_target:\s*await dispatcher\.activeTeamBindingSummary/,
-      'Team read composition invariant violated: mcp.team.history must add bound_target in admin/methods.ts.',
+      /'team\.history'[\s\S]*bound_target:\s*await dispatcher\.activeTeamBindingSummary/,
+      'Team read composition invariant violated: team.history must add bound_target in admin/methods.ts.',
       '../admin/methods.ts',
     );
   });

--- a/packages/dreamux/tests/claude-code-runtime.test.ts
+++ b/packages/dreamux/tests/claude-code-runtime.test.ts
@@ -498,6 +498,14 @@ describe('ClaudeCodeRuntime resident lifecycle (fake session)', () => {
     ).toBe(skillDir);
   });
 
+  it('rejects relative skill source roots instead of materializing cwd-dependent links', async () => {
+    const fleet = fakeFleet();
+    await expect(makeRuntime(fleet, {
+      skillSources: [{ name: 'relative', path: 'relative/skills', source: 'test' }],
+    })).rejects.toThrow(/path must be absolute/);
+    expect(fleet.sessions).toEqual([]);
+  });
+
   it('removes stale materialized skill links before rebuilding add-dir roots', async () => {
     const fleet = fakeFleet();
     const staleSource = join(home, 'stale-source');

--- a/packages/dreamux/tests/collaboration-space-mcp.test.ts
+++ b/packages/dreamux/tests/collaboration-space-mcp.test.ts
@@ -103,7 +103,7 @@ describe('collaboration-space-mcp stdio shim', () => {
     ]);
   });
 
-  it('forwards bind and dissolve to admin IPC', async () => {
+  it('forwards every tool through the canonical admin namespace', async () => {
     const admin = await startFakeAdminServer((request) => ({
       id: request.id,
       ok: true,
@@ -147,7 +147,7 @@ describe('collaboration-space-mcp stdio shim', () => {
           content: [{ text: 'bind forwarded to dreamux serve' }],
           structuredContent: {
             ok: true,
-            method: 'mcp.collaboration_space.bind',
+            method: 'collaboration_space.bind',
           },
         },
       });
@@ -164,14 +164,47 @@ describe('collaboration-space-mcp stdio shim', () => {
       expect(await reader.next()).toMatchObject({
         result: {
           structuredContent: {
-            method: 'mcp.collaboration_space.dissolve',
+            method: 'collaboration_space.dissolve',
+          },
+        },
+      });
+
+      writeJson(input, {
+        jsonrpc: '2.0',
+        id: 3,
+        method: 'tools/call',
+        params: {
+          name: 'status',
+          arguments: { space_name: 'space-alpha' },
+        },
+      });
+      expect(await reader.next()).toMatchObject({
+        result: {
+          structuredContent: {
+            method: 'collaboration_space.status',
+          },
+        },
+      });
+
+      writeJson(input, {
+        jsonrpc: '2.0',
+        id: 4,
+        method: 'tools/call',
+        params: { name: 'list', arguments: {} },
+      });
+      expect(await reader.next()).toMatchObject({
+        result: {
+          structuredContent: {
+            method: 'collaboration_space.list',
           },
         },
       });
 
       expect(admin.requests.map((request) => request.method)).toEqual([
-        'mcp.collaboration_space.bind',
-        'mcp.collaboration_space.dissolve',
+        'collaboration_space.bind',
+        'collaboration_space.dissolve',
+        'collaboration_space.status',
+        'collaboration_space.list',
       ]);
       expect(admin.requests[0]?.params).toMatchObject({
         dispatcher_id: 'dispatcher-a',

--- a/packages/dreamux/tests/legacy-state-fail-loud.test.ts
+++ b/packages/dreamux/tests/legacy-state-fail-loud.test.ts
@@ -127,6 +127,7 @@ describe('issue #199 Slice 5 — pre-#199 local state fails loud', () => {
       const store = new AgentIdentityStore(silentLog);
       const identity = await store.get(DISPATCHER, 'alice');
       expect(identity?.name).toBe('alice');
+      expect(identity?.skill_sources).toEqual([]);
     });
 
     it('fails loud (does NOT skip) on the list() path for a removed-field record', async () => {

--- a/packages/dreamux/tests/team-mcp.test.ts
+++ b/packages/dreamux/tests/team-mcp.test.ts
@@ -158,6 +158,8 @@ describe('team-mcp stdio shim', () => {
     // The create-time `bind_group` convenience is removed; bind a channel after
     // create with the dedicated Team `bind_channel` tool.
     expect(schemaOf(tools, 'create').properties).not.toHaveProperty('bind_group');
+    expect(schemaOf(tools, 'create').properties).not.toHaveProperty('skill_sources');
+    expect(JSON.stringify(tools)).not.toContain('skill_sources');
     // #199 Slice 1: public addressing is by the concrete `team_name`.
     expect(schemaOf(tools, 'create').required).toContain('team_name');
     expect(schemaOf(tools, 'create').properties).not.toHaveProperty('name');
@@ -256,6 +258,11 @@ describe('team-mcp stdio shim', () => {
             intent: 'lead alpha',
             identity: 'architecture lead',
             prompt: 'start',
+            skill_sources: [{
+              name: 'must-not-forward',
+              path: '/skills/untrusted-leader',
+              source: 'mcp',
+            }],
           },
         },
       });
@@ -277,7 +284,7 @@ describe('team-mcp stdio shim', () => {
       expect(JSON.stringify(response)).not.toContain(TEAMMATE_DISPATCH_SUCCESS_REMINDER);
       expect(admin.requests).toHaveLength(1);
       expect(admin.requests[0]).toMatchObject({
-        method: 'mcp.team.create',
+        method: 'team.create',
         params: {
           dispatcher_id: 'dispatcher-a',
           caller_kind: 'dispatcher',
@@ -288,6 +295,7 @@ describe('team-mcp stdio shim', () => {
           prompt: 'start',
         },
       });
+      expect(admin.requests[0]?.params).not.toHaveProperty('skill_sources');
 
       input.end();
       await run;
@@ -366,18 +374,18 @@ describe('team-mcp stdio shim', () => {
     };
     const admin = await startFakeAdminServer((request) => {
       const results: Record<string, unknown> = {
-        'mcp.team.list': {
+        'team.list': {
           teams: [{ team_name: 'alpha', bound_target: boundTarget }],
         },
-        'mcp.team.status': {
+        'team.status': {
           team: { team_name: 'alpha' },
           bound_target: boundTarget,
         },
-        'mcp.team.history': {
+        'team.history': {
           items: [{ team_name: 'alpha', bound_target: boundTarget }],
           next_cursor: null,
         },
-        'mcp.team.send': {
+        'team.send': {
           team: { team_name: 'alpha' },
           leader: { name: 'alpha-leader', status: 'running' },
           turn: { status: 'submitted', turn_id: 'turn-2' },
@@ -441,10 +449,10 @@ describe('team-mcp stdio shim', () => {
       const sendResponse = await reader.next();
 
       expect(admin.requests.map((r) => r.method)).toEqual([
-        'mcp.team.list',
-        'mcp.team.status',
-        'mcp.team.history',
-        'mcp.team.send',
+        'team.list',
+        'team.status',
+        'team.history',
+        'team.send',
       ]);
       expect(listResponse).toMatchObject({
         result: {
@@ -668,7 +676,7 @@ describe('team-mcp stdio shim', () => {
         },
       });
       expect(JSON.stringify(response)).not.toContain(TEAM_DISPATCH_SUCCESS_REMINDER);
-      expect(admin.requests[0]?.method).toBe('mcp.team.dissolve');
+      expect(admin.requests[0]?.method).toBe('team.dissolve');
 
       input.end();
       await run;
@@ -713,7 +721,7 @@ describe('team-mcp stdio shim', () => {
       });
       await reader.next();
 
-      expect(admin.requests[0]?.method).toBe('mcp.team.transfer_back');
+      expect(admin.requests[0]?.method).toBe('team.transfer_back');
       expect(admin.requests[0]?.params).toMatchObject({
         caller_kind: 'team_leader',
         team_id: 'alpha',
@@ -742,7 +750,7 @@ describe('team-mcp stdio shim', () => {
         });
       }
       expect(admin.requests.map((request) => request.method)).toEqual([
-        'mcp.team.transfer_back',
+        'team.transfer_back',
       ]);
 
       input.end();

--- a/packages/dreamux/tests/team-scheduler.test.ts
+++ b/packages/dreamux/tests/team-scheduler.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
-import { existsSync, mkdirSync, mkdtempSync, rmSync } from 'node:fs';
+import { existsSync, mkdirSync, mkdtempSync, realpathSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
@@ -169,6 +169,23 @@ function skillSourceNames(
     ))
     ?.skillSources
     ?.map((source) => source.name);
+}
+
+function skillSourcesFor(
+  contexts: readonly AgentRuntimeCreateContext[],
+  requiredName: string,
+) {
+  return contexts
+    .find((context) => context.skillSources?.some(
+      (source) => source.name === requiredName,
+    ))
+    ?.skillSources;
+}
+
+function createSkillRoot(parent: string, rootName: string, skillName: string): string {
+  const root = join(parent, rootName);
+  mkdirSync(join(root, skillName), { recursive: true });
+  return root;
 }
 
 function noopLog(): DreamuxLogger {
@@ -753,19 +770,35 @@ describe('TeamLeader cron scheduler lifecycle', () => {
       },
       getDispatcher: () => dispatcher,
     } as unknown as Server;
+    const skillRoots = join(root, 'admin-skills');
+    const teammateRoot = createSkillRoot(
+      skillRoots,
+      'teammate-root',
+      'teammate-skill',
+    );
+    const leaderRoot = createSkillRoot(
+      skillRoots,
+      'team-leader-root',
+      'team-leader-skill',
+    );
+    const memberRoot = createSkillRoot(
+      skillRoots,
+      'team-member-root',
+      'team-member-skill',
+    );
     const teammateSource = {
       name: 'admin-teammate',
-      path: '/skills/admin/teammate',
+      path: join(teammateRoot, '..', 'teammate-root'),
       source: 'admin',
     };
     const leaderSource = {
       name: 'admin-team-leader',
-      path: '/skills/admin/team-leader',
+      path: join(leaderRoot, '..', 'team-leader-root'),
       source: 'admin',
     };
     const memberSource = {
       name: 'admin-team-member',
-      path: '/skills/admin/team-member',
+      path: join(memberRoot, '..', 'team-member-root'),
       source: 'admin',
     };
 
@@ -796,14 +829,32 @@ describe('TeamLeader cron scheduler lifecycle', () => {
     expect(skillSourceNames(contexts, 'admin-teammate')).toEqual([
       'admin-teammate',
     ]);
+    expect(skillSourcesFor(contexts, 'admin-teammate')).toEqual([{
+      name: 'admin-teammate',
+      path: realpathSync(teammateRoot),
+      source: 'admin',
+    }]);
     expect(skillSourceNames(contexts, 'admin-team-leader')).toEqual([
       'team-leader',
       'admin-team-leader',
     ]);
+    expect(skillSourcesFor(contexts, 'admin-team-leader')).toEqual([
+      expect.objectContaining({ name: 'team-leader', source: 'dreamux-core' }),
+      {
+        name: 'admin-team-leader',
+        path: realpathSync(leaderRoot),
+        source: 'admin',
+      },
+    ]);
     expect(skillSourceNames(contexts, 'admin-team-member')).toEqual([
       'admin-team-member',
     ]);
-    expect(JSON.stringify({ teammate, team, member })).not.toContain('/skills/admin/');
+    expect(skillSourcesFor(contexts, 'admin-team-member')).toEqual([{
+      name: 'admin-team-member',
+      path: realpathSync(memberRoot),
+      source: 'admin',
+    }]);
+    expect(JSON.stringify({ teammate, team, member })).not.toContain(skillRoots);
     await dispatcher.stop();
 
     const rebuiltContexts: AgentRuntimeCreateContext[] = [];
@@ -838,13 +889,31 @@ describe('TeamLeader cron scheduler lifecycle', () => {
     expect(skillSourceNames(rebuiltContexts, 'admin-teammate')).toEqual([
       'admin-teammate',
     ]);
+    expect(skillSourcesFor(rebuiltContexts, 'admin-teammate')).toEqual([{
+      name: 'admin-teammate',
+      path: realpathSync(teammateRoot),
+      source: 'admin',
+    }]);
     expect(skillSourceNames(rebuiltContexts, 'admin-team-leader')).toEqual([
       'team-leader',
       'admin-team-leader',
     ]);
+    expect(skillSourcesFor(rebuiltContexts, 'admin-team-leader')).toEqual([
+      expect.objectContaining({ name: 'team-leader', source: 'dreamux-core' }),
+      {
+        name: 'admin-team-leader',
+        path: realpathSync(leaderRoot),
+        source: 'admin',
+      },
+    ]);
     expect(skillSourceNames(rebuiltContexts, 'admin-team-member')).toEqual([
       'admin-team-member',
     ]);
+    expect(skillSourcesFor(rebuiltContexts, 'admin-team-member')).toEqual([{
+      name: 'admin-team-member',
+      path: realpathSync(memberRoot),
+      source: 'admin',
+    }]);
     await rebuilt.stop();
   });
 

--- a/packages/dreamux/tests/team-scheduler.test.ts
+++ b/packages/dreamux/tests/team-scheduler.test.ts
@@ -23,6 +23,7 @@ import type {
 } from '@excitedjs/dreamux-types';
 
 import type { AgentRuntimeProviderCatalog } from '../src/agent-runtime/index.js';
+import { adminMethods } from '../src/admin/methods.js';
 import { CompletionRouter } from '../src/service/completion-router/index.js';
 import { DispatcherService } from '../src/service/dispatcher-service/index.js';
 import { CronJobStore } from '../src/service/scheduler/store.js';
@@ -156,6 +157,18 @@ function fakeRuntimeCatalog(input: {
       return provider;
     },
   } as AgentRuntimeProviderCatalog;
+}
+
+function skillSourceNames(
+  contexts: readonly AgentRuntimeCreateContext[],
+  requiredName: string,
+): string[] | undefined {
+  return contexts
+    .find((context) => context.skillSources?.some(
+      (source) => source.name === requiredName,
+    ))
+    ?.skillSources
+    ?.map((source) => source.name);
 }
 
 function noopLog(): DreamuxLogger {
@@ -705,6 +718,134 @@ describe('TeamLeader cron scheduler lifecycle', () => {
     expect(teammateContext?.systemPrompt).not.toHaveProperty('replace');
 
     await dispatcher.stop();
+  });
+
+  it('keeps admin-only custom skill sources across role composition and cold rebuild', async () => {
+    const workspace = join(root, 'workspace');
+    mkdirSync(workspace, { recursive: true });
+    const config = testDreamuxConfig([
+      testDispatcherConfig({
+        id: 'dispatcher-a',
+        cwd: workspace,
+        channels: [],
+        agentRuntime: 'agent-a',
+        runtimeProvider: FAKE_RUNTIME_REF,
+      }),
+    ]);
+    const log = noopLog();
+    const contexts: AgentRuntimeCreateContext[] = [];
+    const dispatcher = new DispatcherService({
+      id: 'dispatcher-a',
+      config,
+      dispatchers: new DispatcherStore(config),
+      agentRuntimeProviders: fakeRuntimeCatalog({ runtimes: [], contexts }),
+      channelProviders: fakeChannelCatalog(),
+      adminSocketPath: '/tmp/dreamux-admin.sock',
+      channelLoggerFactory: () => log,
+      log,
+    });
+    await dispatcher.start();
+    const server = {
+      repos: {
+        dispatchers: {
+          get: (id: string) => id === 'dispatcher-a' ? { dispatcher_id: id } : null,
+        },
+      },
+      getDispatcher: () => dispatcher,
+    } as unknown as Server;
+    const teammateSource = {
+      name: 'admin-teammate',
+      path: '/skills/admin/teammate',
+      source: 'admin',
+    };
+    const leaderSource = {
+      name: 'admin-team-leader',
+      path: '/skills/admin/team-leader',
+      source: 'admin',
+    };
+    const memberSource = {
+      name: 'admin-team-member',
+      path: '/skills/admin/team-member',
+      source: 'admin',
+    };
+
+    const teammate = await adminMethods['teammate.spawn']!(server, {
+      dispatcher_id: 'dispatcher-a',
+      name_prefix: 'helper',
+      prompt: 'help',
+      intent: 'admin helper',
+      skill_sources: [teammateSource],
+    }) as { teammate: { name: string } };
+    const team = await adminMethods['team.create']!(server, {
+      dispatcher_id: 'dispatcher-a',
+      team_name: 'alpha',
+      leader_agent_runtime: 'agent-a',
+      intent: 'lead alpha',
+      skill_sources: [leaderSource],
+    }) as { leader: { name: string } };
+    const member = await adminMethods['teammate.spawn']!(server, {
+      dispatcher_id: 'dispatcher-a',
+      caller_kind: 'team_leader',
+      team_id: 'alpha',
+      name_prefix: 'worker',
+      prompt: 'work',
+      intent: 'admin member',
+      skill_sources: [memberSource],
+    }) as { teammate: { name: string } };
+
+    expect(skillSourceNames(contexts, 'admin-teammate')).toEqual([
+      'admin-teammate',
+    ]);
+    expect(skillSourceNames(contexts, 'admin-team-leader')).toEqual([
+      'team-leader',
+      'admin-team-leader',
+    ]);
+    expect(skillSourceNames(contexts, 'admin-team-member')).toEqual([
+      'admin-team-member',
+    ]);
+    expect(JSON.stringify({ teammate, team, member })).not.toContain('/skills/admin/');
+    await dispatcher.stop();
+
+    const rebuiltContexts: AgentRuntimeCreateContext[] = [];
+    const rebuilt = new DispatcherService({
+      id: 'dispatcher-a',
+      config,
+      dispatchers: new DispatcherStore(config),
+      agentRuntimeProviders: fakeRuntimeCatalog({
+        runtimes: [],
+        contexts: rebuiltContexts,
+      }),
+      channelProviders: fakeChannelCatalog(),
+      adminSocketPath: '/tmp/dreamux-admin.sock',
+      channelLoggerFactory: () => log,
+      log,
+    });
+    await rebuilt.start();
+    await rebuilt.teammates.send({
+      name: teammate.teammate.name,
+      prompt: 'resume helper',
+    });
+    await rebuilt.sendTeamLeader({
+      teamId: 'alpha',
+      prompt: 'resume leader',
+    });
+    const rebuiltTeam = await rebuilt.team('alpha');
+    await rebuiltTeam.teammates.send({
+      name: member.teammate.name,
+      prompt: 'resume member',
+    });
+
+    expect(skillSourceNames(rebuiltContexts, 'admin-teammate')).toEqual([
+      'admin-teammate',
+    ]);
+    expect(skillSourceNames(rebuiltContexts, 'admin-team-leader')).toEqual([
+      'team-leader',
+      'admin-team-leader',
+    ]);
+    expect(skillSourceNames(rebuiltContexts, 'admin-team-member')).toEqual([
+      'admin-team-member',
+    ]);
+    await rebuilt.stop();
   });
 
   it('dispatcher team.send submits to the TeamLeader and rejects shutdown sends', async () => {

--- a/packages/dreamux/tests/teammate-mcp.test.ts
+++ b/packages/dreamux/tests/teammate-mcp.test.ts
@@ -197,6 +197,8 @@ describe('teammate-mcp stdio shim', () => {
     expect(spawn.inputSchema.properties).toHaveProperty('repo');
     expect(spawn.inputSchema.properties).not.toHaveProperty('cwd');
     expect(spawn.inputSchema.properties).not.toHaveProperty('worktree');
+    expect(spawn.inputSchema.properties).not.toHaveProperty('skill_sources');
+    expect(JSON.stringify(tools)).not.toContain('skill_sources');
     // The repo object exposes the reuse-cwd / managed work modes + cleanup.
     const repo = JSON.stringify(spawn.inputSchema.properties['repo']);
     expect(repo).toContain('reuse-cwd');
@@ -306,6 +308,11 @@ describe('teammate-mcp stdio shim', () => {
             },
             intent: 'review',
             identity: 'architecture reviewer',
+            skill_sources: [{
+              name: 'must-not-forward',
+              path: '/skills/untrusted-teammate',
+              source: 'mcp',
+            }],
           },
         },
       });
@@ -331,7 +338,7 @@ describe('teammate-mcp stdio shim', () => {
       expect(admin.requests).toEqual([
         {
           id: expect.any(String) as string,
-          method: 'mcp.teammate.spawn',
+          method: 'teammate.spawn',
           params: {
             dispatcher_id: 'dispatcher-a',
             caller_kind: 'dispatcher',
@@ -458,7 +465,7 @@ describe('teammate-mcp stdio shim', () => {
       expect(JSON.stringify(response)).not.toContain(
         TEAMMATE_DISPATCH_SUCCESS_REMINDER,
       );
-      expect(admin.requests[0]?.method).toBe('mcp.teammate.close');
+      expect(admin.requests[0]?.method).toBe('teammate.close');
 
       input.end();
       await run;
@@ -639,6 +646,11 @@ describe('teammate-mcp stdio shim', () => {
             worktree: { mode: 'managed', cleanup: 'delete-on-close' },
             intent: 'build',
             identity: 'implementation specialist',
+            skill_sources: [{
+              name: 'must-not-forward',
+              path: '/skills/untrusted-member',
+              source: 'mcp',
+            }],
           },
         },
       });
@@ -656,7 +668,7 @@ describe('teammate-mcp stdio shim', () => {
       expect(admin.requests).toEqual([
         {
           id: expect.any(String) as string,
-          method: 'mcp.teammate.spawn',
+          method: 'teammate.spawn',
           params: {
             dispatcher_id: 'dispatcher-a',
             name_prefix: 'builder',
@@ -815,9 +827,9 @@ describe('teammate-mcp stdio shim', () => {
       );
 
       expect(admin.requests.map((request) => request.method)).toEqual([
-        'mcp.teammate.history',
-        'mcp.teammate.last',
-        'mcp.teammate.last',
+        'teammate.history',
+        'teammate.last',
+        'teammate.last',
       ]);
       expect(admin.requests.map((request) => request.params)).toEqual([
         {


### PR DESCRIPTION
## Summary

This PR implements the first admin control-plane slice from #295.

- renames pre-stable admin socket methods from `mcp.teammate.*`, `mcp.team.*`, and `mcp.collaboration_space.*` to canonical `teammate.*`, `team.*`, and `collaboration_space.*` names
- removes `mcp.*` admin aliases entirely, so old names now return `UNKNOWN_METHOD`
- removes unsupported `dispatcher.add` / `dispatcher.remove` admin and CLI placeholders; dispatcher declarations remain config-owned
- updates Dreamux-owned MCP shims to keep the same model-facing tools while calling canonical admin method names
- adds admin-only `skill_sources` for TeamMate, Team member, and TeamLeader creation, persisted on agent identity and recomposed with required bundled role skills
- updates KB/proposal docs and Rush change files

## Out of scope

This does not implement event streaming, protocol versioning, schema introspection, channel inventory, dispatcher-root turn submission, multi-principal auth, or durable event storage.

## Validation

- `git diff --check HEAD --`
- `.agents/scripts/check.sh`
- `pnpm --filter @excitedjs/dreamux exec vitest run tests/admin-method-namespace.test.ts tests/admin-methods-intent-note.test.ts tests/admin-default-workspace.test.ts tests/team-mcp.test.ts tests/teammate-mcp.test.ts tests/collaboration-space-mcp.test.ts tests/team-scheduler.test.ts`
- `pnpm --filter @excitedjs/dreamux run typecheck`
- `pnpm --filter @excitedjs/dreamux run typecheck:tests`
- `pnpm --filter @excitedjs/dreamux run lint`
- `pnpm --filter @excitedjs/dreamux-types run typecheck`
- `node common/scripts/install-run-rush.js build --to @excitedjs/dreamux`
- `DREAMUX_SKIP_LIVE_CODEX=1 pnpm --filter @excitedjs/dreamux test`

Note: Rush prints its existing Node 22.16.0 untested-version warning, but the build passes.
