### PR TITLE
fix(daemon): persist operator PATH in managed services

### DIFF
--- a/.agents/reference/state-and-paths.md
+++ b/.agents/reference/state-and-paths.md
@@ -136,6 +136,60 @@ Key source:
 - `/packages/dreamux/src/platform/runtime-sockets.ts`
 - `/packages/dreamux/src/admin/socket.ts`
 
+## Managed Service PATH
+
+`dreamux onboard` and `dreamux daemon install` generate a systemd user service
+or launchd plist with an explicit `PATH` environment. The same effective PATH
+resolves bare provider/agent binaries during service installation.
+
+Order, built by `buildServicePath()` in
+`/packages/dreamux/src/platform/paths.ts` (the single source of truth):
+
+1. Stable Dreamux-owned dirs: selected Node bin dir, resolved provider bin dirs,
+   dreamux bin dir.
+2. Captured interactive-session `PATH` from the env the operator ran
+   `onboard`/`daemon install` under, in its original order.
+3. Fresh-install fallback dirs: `$XDG_BIN_HOME` when set, `$HOME/.local/bin`,
+   and portable platform system dirs (`standardExecDirs`).
+
+Entries are de-duplicated while preserving first occurrence. Re-running
+`daemon install` after switching nvm/pyenv/Homebrew environments regenerates the
+service PATH.
+
+`withServicePath(env, input)` returns a copy of `env` with `PATH` set to
+`buildServicePath(input)`; it never mutates the caller's env or `process.env`.
+`env`/`homeDir`/`platform` are passed explicitly by callers — the path builders
+never read `process.env`.
+
+The callers (`runOnboard` in `onboard/run.ts` and `runDaemonInstall` in
+`daemon/install.ts`) resolve the *effective* values before persisting them into
+`ServiceInstallAnswers`/`EffectiveOnboardAnswers`: `env` is
+`options.env ?? process.env`, `homeDir` is `options.homeDir ?? homedir()`, and
+`platform` is `options.platform ?? process.platform`. In normal CLI use
+`options.env` is undefined, so the ambient `process.env.PATH` is captured into
+the service unit. Both the resolve-time PATH and the service-unit PATH use these
+same effective values.
+
+Resolve-time binary resolution uses `withUserLocalBinPath()` in
+`/packages/dreamux/src/onboard/service.ts`, a thin wrapper that builds the
+effective PATH from the captured session PATH + fallback dirs (no stable dirs,
+since the Node bin is not yet selected at resolve time). The service-unit PATH
+is rendered by `managedServicePath()` in the same module, which adds the stable
+dirs and delegates to `buildServicePath()`. Both share the single source.
+
+Key source:
+
+- `/packages/dreamux/src/platform/paths.ts` (`buildServicePath`,
+  `withServicePath`, `standardExecDirs`, `userLocalBinDirs`,
+  `systemExecDirs`, `dedupeExecDirs`)
+- `/packages/dreamux/src/onboard/service.ts` (`managedServicePath`,
+  `managedServiceEnvironment`, `withUserLocalBinPath`,
+  `resolveServiceExecutable`)
+- `/packages/dreamux/src/onboard/service-node.ts` (Node selection and
+  version-manager detection)
+- `/packages/dreamux/src/onboard/run.ts`
+- `/packages/dreamux/src/daemon/install.ts`
+
 ## Cache And Logs
 
 `~/.dreamux/cache/<dispatcher-id>/` is rebuildable cache:

--- a/common/changes/@excitedjs/dreamux/managed-service-user-local-bin-path_2026-07-20-00-00.json
+++ b/common/changes/@excitedjs/dreamux/managed-service-user-local-bin-path_2026-07-20-00-00.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@excitedjs/dreamux",
+      "comment": "Capture the full interactive-session PATH from `dreamux onboard` / `daemon install` and persist it into the generated systemd user service and launchd plist. The managed-service PATH leads with stable Dreamux-owned dirs (selected Node bin dir, resolved provider bin dirs, dreamux bin dir), then appends every entry of the captured session PATH in its original order, then appends fresh-install fallback dirs (`$XDG_BIN_HOME` when set, `$HOME/.local/bin`, and portable platform system dirs). All entries are de-duplicated while preserving first occurrence. Re-running `daemon install` after switching nvm/pyenv/Homebrew environments regenerates the service PATH. The same effective PATH resolves provider/agent binaries during service installation. No `process.env` mutation and no shell profile edits. `buildServicePath()`/`withServicePath()` in `platform/paths.ts` are the single source of truth; `withUserLocalBinPath()` builds the resolve-time effective PATH.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@excitedjs/dreamux",
+  "email": "15624809+YourWildDad@users.noreply.github.com"
+}

--- a/packages/dreamux/src/daemon/install.ts
+++ b/packages/dreamux/src/daemon/install.ts
@@ -10,12 +10,14 @@
  */
 
 import { ExecaCommandRunner } from '../onboard/commands.js';
+import { homedir } from 'node:os';
 import {
   installUserService,
   removeUserService,
   resolveServiceExecutable,
   selectServiceNodeBin,
   validateManagedServiceLaunch,
+  withUserLocalBinPath,
   type ServiceInstallAnswers,
   type ServiceInstallResult,
   type ServiceNodeProbe,
@@ -73,6 +75,8 @@ export async function runDaemonInstall(
 ): Promise<DaemonInstallResult> {
   const runner = options.runner ?? new ExecaCommandRunner();
   const env = options.env ?? process.env;
+  const platform = options.platform ?? process.platform;
+  const homeDir = options.homeDir ?? homedir();
   const dryRun = options.dryRun ?? false;
   const startService = options.startService ?? true;
 
@@ -93,7 +97,12 @@ export async function runDaemonInstall(
   const providerBinChecks = await Promise.all(
     serviceProviderBinChecks(config, env, catalogs).map(async (check) => ({
       ...check,
-      bin: dryRun ? check.bin : await resolveServiceExecutable(check.bin, env),
+      bin: dryRun
+        ? check.bin
+        : await resolveServiceExecutable(
+            check.bin,
+            withUserLocalBinPath(env, homeDir, platform),
+          ),
     })),
   );
   // Pin the managed service to a stable system Node (issue #83) rather than the
@@ -102,11 +111,16 @@ export async function runDaemonInstall(
   const nodeBin = dryRun
     ? process.execPath
     : await selectServiceNodeBin({
-        platform: options.platform ?? process.platform,
+        platform,
         currentNodeBin: process.execPath,
         runner,
         ...(options.nodeProbe !== undefined ? { probe: options.nodeProbe } : {}),
       });
+  // Persist the effective resolved env/homeDir/platform (not the optional raw
+  // options values) so managedServicePath renders the captured session PATH and
+  // the preflight uses the exact same inputs. In normal CLI use options.env is
+  // undefined, so env falls back to process.env — that ambient PATH must be
+  // persisted into the service unit.
   const answers: ServiceInstallAnswers = {
     configDir: globalConfigDir(),
     dreamuxBin: dreamuxBinPath(env),
@@ -114,6 +128,9 @@ export async function runDaemonInstall(
     providerBinChecks,
     startService,
     dryRun,
+    homeDir,
+    platform,
+    env,
   };
 
   if (!dryRun) {
@@ -134,8 +151,8 @@ export async function runDaemonInstall(
     answers,
     ledger,
     runner,
-    platform: options.platform,
-    homeDir: options.homeDir,
+    platform,
+    homeDir,
     uid: options.uid,
   });
   return { service, files: ledger.entries() };

--- a/packages/dreamux/src/onboard/run.ts
+++ b/packages/dreamux/src/onboard/run.ts
@@ -1,4 +1,5 @@
 import { pathExists } from '../platform/fs-errors.js';
+import { homedir } from 'node:os';
 
 import type { ProviderBinCheck } from '@excitedjs/dreamux-types';
 import {
@@ -37,6 +38,7 @@ import {
   selectServiceNodeBin,
   type ServiceNodeProbe,
   validateManagedServiceLaunch,
+  withUserLocalBinPath,
 } from './service.js';
 import type {
   CommandRunner,
@@ -69,12 +71,14 @@ export async function runOnboard(
   const ledger = options.ledger ?? new TransparentFileLedger();
   const runner = options.runner ?? new ExecaCommandRunner();
   const env = options.env ?? process.env;
+  const platform = options.platform ?? process.platform;
+  const homeDir = options.homeDir ?? homedir();
   const configPath = globalConfigFile({ configDir: answers.configDir });
   const existingConfig = await readExistingDreamuxConfig(answers.configDir);
   const dreamuxConfig = dreamuxConfigFromAnswers(answers, existingConfig);
   const serviceNodeBin = answers.registerService && !answers.dryRun
     ? await selectServiceNodeBin({
-        platform: options.platform ?? process.platform,
+        platform,
         currentNodeBin: process.execPath,
         runner,
         probe: options.nodeProbe,
@@ -125,12 +129,26 @@ export async function runOnboard(
   const catalogs = loaded === null ? null : catalogsFromLoadedConfig(loaded);
   const providerBinChecks =
     answers.registerService && !answers.dryRun && loaded !== null && catalogs !== null
-      ? await resolveProviderBinChecks(loaded.config, catalogs, env)
+      ? await resolveProviderBinChecks(
+          loaded.config,
+          catalogs,
+          env,
+          platform,
+          homeDir,
+        )
       : [];
+  // Persist the effective resolved env/homeDir/platform (not the optional raw
+  // options values) so managedServicePath renders the captured session PATH and
+  // the preflight uses the exact same inputs. In normal CLI use options.env is
+  // undefined, so env falls back to process.env — that ambient PATH must be
+  // persisted into the service unit.
   const effectiveAnswers = {
     ...answers,
     nodeBin: serviceNodeBin,
     providerBinChecks,
+    homeDir,
+    platform,
+    env,
   };
 
   const doctor = await runDispatcherDoctor(
@@ -158,8 +176,8 @@ export async function runOnboard(
         answers: effectiveAnswers,
         ledger,
         runner,
-        platform: options.platform,
-        homeDir: options.homeDir,
+        platform,
+        homeDir,
         uid: options.uid,
       })
     : null;
@@ -203,6 +221,8 @@ async function resolveProviderBinChecks(
   config: DreamuxConfig,
   catalogs: ProviderDiagnosticCatalogs,
   env: NodeJS.ProcessEnv,
+  platform: NodeJS.Platform,
+  homeDir: string,
 ): Promise<ProviderBinCheck[]> {
   const checks = providerBinChecksForConfig({
     config,
@@ -210,10 +230,16 @@ async function resolveProviderBinChecks(
     env,
     scope: 'managedService',
   });
+  // Bare provider binaries (e.g. a `local-agent` installed to
+  // $HOME/.local/bin) resolve against the effective service PATH, which the
+  // service unit also includes. Resolve against that augmented PATH so the
+  // daemon-install preflight and the running service agree. process.env is
+  // never mutated; platform/homeDir/env are passed explicitly by the caller.
+  const resolveEnv = withUserLocalBinPath(env, homeDir, platform);
   return await Promise.all(
     checks.map(async (check) => ({
       ...check,
-      bin: await resolveServiceExecutable(check.bin, env),
+      bin: await resolveServiceExecutable(check.bin, resolveEnv),
     })),
   );
 }

--- a/packages/dreamux/src/onboard/service-node.ts
+++ b/packages/dreamux/src/onboard/service-node.ts
@@ -1,0 +1,218 @@
+import { constants } from 'node:fs';
+import { access, realpath } from 'node:fs/promises';
+
+import type { CommandRunner } from '../onboard/types.js';
+
+/**
+ * Minimum Node version the managed-service environment requires. The launchd
+ * plist and systemd user unit persist a stable Node binary; selection (see
+ * {@link selectServiceNodeBin}) refuses candidates below this version.
+ */
+export const MIN_SERVICE_NODE_VERSION = '22.7.0';
+
+/**
+ * Parse a `node --version` (or `v<major>.<minor>.<patch>`) string and decide
+ * whether it satisfies {@link MIN_SERVICE_NODE_VERSION}. Pure and side-effect
+ * free so selection and the launch doctor share one comparison.
+ */
+export function nodeVersionSatisfies(raw: string): boolean {
+  const match = raw.trim().match(/^v?(\d+)\.(\d+)\.(\d+)/);
+  if (match === null) return false;
+  const major = Number(match[1]);
+  const minor = Number(match[2]);
+  if (!Number.isInteger(major) || !Number.isInteger(minor)) return false;
+  if (major > 22) return true;
+  return major === 22 && minor >= 7;
+}
+
+/**
+ * Filesystem probes for service-Node selection and doctor drift check.
+ * Injectable so tests can model symlinks, candidate existence, and
+ * version-manager layouts without touching the real filesystem.
+ */
+export interface ServiceNodeProbe {
+  realpath: (path: string) => Promise<string>;
+  isExecutable: (path: string) => Promise<boolean>;
+}
+
+export const defaultServiceNodeProbe: ServiceNodeProbe = {
+  realpath: (path) => realpath(path),
+  isExecutable: (path) => isExecutable(path),
+};
+
+// Markers matched (case-insensitively) against a Node binary's resolved path.
+// Each keeps a leading `/.<name>/` or segment anchor so a user dir like
+// `/home/volta/` never matches `/.volta/`. macOS fnm installs under
+// `~/Library/Application Support/fnm/`; dreamux supports launchd so cover it.
+const VERSION_MANAGER_MARKERS: Array<{ manager: string; markers: string[] }> = [
+  { manager: 'nvm', markers: ['/.nvm/versions/node/'] },
+  {
+    manager: 'fnm',
+    markers: [
+      '/.fnm/',
+      'fnm_multishells',
+      '/.local/share/fnm/',
+      '/library/application support/fnm/',
+    ],
+  },
+  { manager: 'asdf', markers: ['/.asdf/installs/nodejs/', '/.asdf/shims/'] },
+  { manager: 'volta', markers: ['/.volta/'] },
+];
+
+/** Pure marker match on a single path; returns the manager name or null. */
+export function versionManagerOfPath(path: string): string | null {
+  const needle = path.toLowerCase();
+  for (const entry of VERSION_MANAGER_MARKERS) {
+    if (entry.markers.some((marker) => needle.includes(marker))) {
+      return entry.manager;
+    }
+  }
+  return null;
+}
+
+/**
+ * Single async/injectable predicate selection and doctor share. Resolves
+ * symlinks first so a `/usr/local/bin/node` shim into nvm/fnm/asdf is caught;
+ * falls back to the raw path when realpath fails.
+ */
+export async function detectServiceNodeVersionManager(
+  nodeBin: string,
+  probe: ServiceNodeProbe = defaultServiceNodeProbe,
+): Promise<string | null> {
+  const raw = versionManagerOfPath(nodeBin);
+  if (raw !== null) return raw;
+  let resolved: string;
+  try {
+    resolved = await probe.realpath(nodeBin);
+  } catch {
+    return null;
+  }
+  return versionManagerOfPath(resolved);
+}
+
+/**
+ * Platform-aware stable Node candidates. macOS covers Homebrew (Apple Silicon
+ * and Intel prefixes); Linux covers standard system locations.
+ */
+export function stableNodeCandidates(platform: NodeJS.Platform): string[] {
+  if (platform === 'darwin') {
+    return [
+      '/opt/homebrew/bin/node',
+      '/opt/homebrew/opt/node/bin/node',
+      '/opt/homebrew/opt/node@24/bin/node',
+      '/opt/homebrew/opt/node@22/bin/node',
+      '/usr/local/bin/node',
+      '/usr/local/opt/node/bin/node',
+      '/usr/local/opt/node@24/bin/node',
+      '/usr/local/opt/node@22/bin/node',
+      '/usr/bin/node',
+    ];
+  }
+  return ['/usr/local/bin/node', '/usr/bin/node', '/bin/node'];
+}
+
+export interface SelectServiceNodeOptions {
+  platform: NodeJS.Platform;
+  currentNodeBin: string;
+  runner: CommandRunner;
+  probe?: ServiceNodeProbe;
+}
+
+/**
+ * Choose the Node binary persisted into the managed-service environment.
+ * Prefers a stable system Node (exists, not version-manager-bound, satisfies
+ * MIN_SERVICE_NODE_VERSION); falls back to the current Node otherwise.
+ */
+export async function selectServiceNodeBin(
+  options: SelectServiceNodeOptions,
+): Promise<string> {
+  const probe = options.probe ?? defaultServiceNodeProbe;
+  for (const candidate of stableNodeCandidates(options.platform)) {
+    if (!(await probe.isExecutable(candidate))) continue;
+    if ((await detectServiceNodeVersionManager(candidate, probe)) !== null) {
+      continue;
+    }
+    let version: string;
+    try {
+      version = await options.runner.capture(candidate, ['--version']);
+    } catch {
+      continue;
+    }
+    if (!nodeVersionSatisfies(version)) continue;
+    // Persist the candidate path itself (a stable symlink), never its realpath,
+    // so a Homebrew symlink keeps the volatile Cellar path out of the service.
+    return candidate;
+  }
+  return stabilizeHomebrewCellarNode(
+    options.currentNodeBin,
+    options.platform,
+    probe,
+  );
+}
+
+const HOMEBREW_PREFIXES = ['/opt/homebrew', '/usr/local'];
+
+interface HomebrewCellarMatch {
+  prefix: string;
+  major: string | null;
+}
+
+function matchHomebrewCellar(path: string): HomebrewCellarMatch | null {
+  for (const prefix of HOMEBREW_PREFIXES) {
+    const cellar = `${prefix}/Cellar/node`;
+    if (!path.startsWith(`${cellar}/`) && !path.startsWith(`${cellar}@`)) {
+      continue;
+    }
+    const major = path.slice(cellar.length).match(/^@(\d+)\//);
+    return { prefix, major: major === null ? null : major[1] };
+  }
+  return null;
+}
+
+/**
+ * Homebrew Cellar (`<prefix>/Cellar/node[@major]/<version>/bin/node`) is a
+ * version-pinned path unfit for a persistent service. Best-effort remap to the
+ * matching stable Homebrew symlink; no match returns the input unchanged and
+ * never throws. darwin-only.
+ */
+export async function stabilizeHomebrewCellarNode(
+  nodeBin: string,
+  platform: NodeJS.Platform,
+  probe: ServiceNodeProbe = defaultServiceNodeProbe,
+): Promise<string> {
+  if (platform !== 'darwin') return nodeBin;
+  let resolved: string;
+  try {
+    resolved = await probe.realpath(nodeBin);
+  } catch {
+    resolved = nodeBin;
+  }
+  const cellar = matchHomebrewCellar(nodeBin) ?? matchHomebrewCellar(resolved);
+  if (cellar === null) return nodeBin;
+
+  const links: string[] = [];
+  if (cellar.major !== null) {
+    links.push(`${cellar.prefix}/opt/node@${cellar.major}/bin/node`);
+  }
+  links.push(`${cellar.prefix}/opt/node/bin/node`, `${cellar.prefix}/bin/node`);
+
+  for (const link of links) {
+    if (!(await probe.isExecutable(link))) continue;
+    try {
+      if ((await probe.realpath(link)) === resolved) return link;
+    } catch {
+      // ignore and try the next candidate symlink
+    }
+  }
+  return nodeBin;
+}
+
+/** True when `path` is executable by the current process; never throws. */
+export async function isExecutable(path: string): Promise<boolean> {
+  try {
+    await access(path, constants.X_OK);
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/packages/dreamux/src/onboard/service.ts
+++ b/packages/dreamux/src/onboard/service.ts
@@ -1,13 +1,19 @@
 import { pathExists } from '../platform/fs-errors.js';
-import { constants } from 'node:fs';
-import { access, realpath, rm } from 'node:fs/promises';
+import { rm } from 'node:fs/promises';
 import { homedir } from 'node:os';
 import { delimiter, dirname, isAbsolute, join, resolve } from 'node:path';
 
 import { build as buildPlist } from 'plist';
 import type { ProviderBinCheck } from '@excitedjs/dreamux-types';
 import { expandHome } from '../config/config.js';
-import { logsRoot, stateRoot } from '../platform/paths.js';
+import {
+  buildServicePath,
+  logsRoot,
+  standardExecDirs,
+  stateRoot,
+  userLocalBinDirs,
+  withServicePath,
+} from '../platform/paths.js';
 
 import {
   ensureDirectory,
@@ -19,23 +25,43 @@ import type {
   OnboardFileLedger,
   ServicePlatform,
 } from '../onboard/types.js';
+import {
+  isExecutable,
+  MIN_SERVICE_NODE_VERSION,
+  nodeVersionSatisfies,
+} from './service-node.js';
 
 export const LAUNCHD_LABEL = 'dev.excited.dreamux';
 export const SYSTEMD_UNIT = 'dreamux.service';
-export const MIN_SERVICE_NODE_VERSION = '22.7.0';
-export const SERVICE_PATH_DEFAULTS = ['/usr/local/bin', '/usr/bin', '/bin'];
+
+export {
+  defaultServiceNodeProbe,
+  detectServiceNodeVersionManager,
+  isExecutable,
+  MIN_SERVICE_NODE_VERSION,
+  nodeVersionSatisfies,
+  selectServiceNodeBin,
+  stabilizeHomebrewCellarNode,
+  stableNodeCandidates,
+  versionManagerOfPath,
+  type SelectServiceNodeOptions,
+  type ServiceNodeProbe,
+} from './service-node.js';
 
 export interface ServiceInstallAnswers {
   configDir: string;
-  /**
-   * Provider-owned binary checks the managed-service PATH must resolve. Derived
-   * from provider diagnostics for daemon installs and onboard.
-   */
+  /** Provider-owned binary checks the managed-service PATH must resolve. */
   providerBinChecks?: ProviderBinCheck[];
   dreamuxBin: string;
   nodeBin: string;
   startService: boolean;
   dryRun: boolean;
+  /** Home directory the service runs under; resolves user-local bin dirs. Defaults to `homedir()`. */
+  homeDir?: string;
+  /** Platform selecting conventional system bin dirs. Defaults to `process.platform`. */
+  platform?: NodeJS.Platform;
+  /** Environment to read XDG_BIN_HOME from; path builders never read process.env. */
+  env?: NodeJS.ProcessEnv;
 }
 
 export interface ServiceInstallOptions {
@@ -52,12 +78,7 @@ export interface ServiceInstallResult {
   unitPath: string;
   registered: boolean;
   started: boolean;
-  /**
-   * systemd `--user` only: whether `loginctl enable-linger` succeeded so the
-   * service starts at boot without an interactive login. null when not
-   * applicable (launchd, or a dry run). Failure is non-fatal and surfaced via
-   * `warnings`.
-   */
+  /** systemd `--user` only: whether linger enabled so service boots without login. null when not applicable. Non-fatal. */
   lingerEnabled: boolean | null;
   /** Non-fatal operator-facing warnings (e.g. linger could not be enabled). */
   warnings: string[];
@@ -184,12 +205,11 @@ WantedBy=default.target
 export function managedServiceEnvironment(
   answers: ServiceInstallAnswers,
 ): Record<string, string> {
-  // Provider binary paths come from provider diagnostics. The unit PATH includes
-  // their directories (see managedServicePath) so provider-owned bare commands
-  // resolve under the service's minimal environment without core naming them.
+  const home = answers.homeDir ?? homedir();
+  // Unit PATH: stable dirs → captured session PATH → fallbacks (see managedServicePath).
   const env: Record<string, string> = {
     DREAMUX_CONFIG_DIR: answers.configDir,
-    HOME: homedir(),
+    HOME: home,
     DREAMUX_NODE_BIN: answers.nodeBin,
     PATH: managedServicePath(answers),
   };
@@ -243,7 +263,7 @@ export async function validateManagedServiceLaunch(
 
 export async function resolveServiceExecutable(
   command: string,
-  env: NodeJS.ProcessEnv = process.env,
+  env: NodeJS.ProcessEnv,
 ): Promise<string> {
   const trimmed = command.trim();
   if (trimmed === '') {
@@ -266,213 +286,48 @@ export async function resolveServiceExecutable(
   );
 }
 
-export function nodeVersionSatisfies(raw: string): boolean {
-  const match = raw.trim().match(/^v?(\d+)\.(\d+)\.(\d+)/);
-  if (match === null) return false;
-  const major = Number(match[1]);
-  const minor = Number(match[2]);
-  if (!Number.isInteger(major) || !Number.isInteger(minor)) return false;
-  if (major > 22) return true;
-  return major === 22 && minor >= 7;
-}
-
 /**
- * Filesystem probes the service-Node selection and the doctor drift check both
- * depend on. Injectable so tests can model symlinks, candidate existence, and
- * version-manager layouts without touching the real filesystem.
+ * Builds the resolve-time effective PATH used to resolve bare provider/agent
+ * binaries during `onboard`/`daemon install`. Captured session PATH leads, then
+ * fresh-install fallback dirs (XDG_BIN_HOME / ~/.local/bin + platform dirs).
+ * Stable Dreamux-owned dirs are added at service render time (see
+ * managedServicePath). Delegates to {@link withServicePath} in paths.ts. Never
+ * mutates env.
  */
-export interface ServiceNodeProbe {
-  realpath: (path: string) => Promise<string>;
-  isExecutable: (path: string) => Promise<boolean>;
+export function withUserLocalBinPath(
+  env: NodeJS.ProcessEnv,
+  homeDir?: string,
+  platform?: NodeJS.Platform,
+): NodeJS.ProcessEnv {
+  const sessionPath = env['PATH'] ?? '';
+  const fallbackDirs = standardExecDirs({
+    platform: platform ?? process.platform,
+    homeDir: homeDir ?? homedir(),
+    env,
+  });
+  return withServicePath(env, { stableDirs: [], sessionPath, fallbackDirs });
 }
 
-export const defaultServiceNodeProbe: ServiceNodeProbe = {
-  realpath: (path) => realpath(path),
-  isExecutable: (path) => isExecutable(path),
-};
-
-// Markers matched (case-insensitively) against a Node binary's resolved path.
-// Each marker keeps a leading `/.<name>/` or explicit segment anchor so a user
-// directory such as `/home/volta/` never matches the `/.volta/` marker. macOS
-// fnm installs under `~/Library/Application Support/fnm/`; dreamux supports
-// launchd, so that path must be covered.
-const VERSION_MANAGER_MARKERS: Array<{ manager: string; markers: string[] }> = [
-  { manager: 'nvm', markers: ['/.nvm/versions/node/'] },
-  {
-    manager: 'fnm',
-    markers: [
-      '/.fnm/',
-      'fnm_multishells',
-      '/.local/share/fnm/',
-      '/library/application support/fnm/',
-    ],
-  },
-  { manager: 'asdf', markers: ['/.asdf/installs/nodejs/', '/.asdf/shims/'] },
-  { manager: 'volta', markers: ['/.volta/'] },
-];
-
-/** Pure marker match on a single path; returns the manager name or null. */
-export function versionManagerOfPath(path: string): string | null {
-  const needle = path.toLowerCase();
-  for (const entry of VERSION_MANAGER_MARKERS) {
-    if (entry.markers.some((marker) => needle.includes(marker))) {
-      return entry.manager;
-    }
-  }
-  return null;
-}
-
-/**
- * The single async/injectable predicate selection and doctor share. Resolves
- * symlinks first so a `/usr/local/bin/node` shim pointing into nvm/fnm/asdf is
- * caught; falls back to the raw path when realpath fails (e.g. broken link).
- */
-export async function detectServiceNodeVersionManager(
-  nodeBin: string,
-  probe: ServiceNodeProbe = defaultServiceNodeProbe,
-): Promise<string | null> {
-  const raw = versionManagerOfPath(nodeBin);
-  if (raw !== null) return raw;
-  let resolved: string;
-  try {
-    resolved = await probe.realpath(nodeBin);
-  } catch {
-    return null;
-  }
-  return versionManagerOfPath(resolved);
-}
-
-/**
- * Platform-aware stable Node candidates, decoupled from SERVICE_PATH_DEFAULTS
- * (which only renders the service PATH). macOS covers Homebrew (Apple Silicon
- * and Intel prefixes); Linux covers the standard system locations.
- */
-export function stableNodeCandidates(platform: NodeJS.Platform): string[] {
-  if (platform === 'darwin') {
-    return [
-      '/opt/homebrew/bin/node',
-      '/opt/homebrew/opt/node/bin/node',
-      '/opt/homebrew/opt/node@24/bin/node',
-      '/opt/homebrew/opt/node@22/bin/node',
-      '/usr/local/bin/node',
-      '/usr/local/opt/node/bin/node',
-      '/usr/local/opt/node@24/bin/node',
-      '/usr/local/opt/node@22/bin/node',
-      '/usr/bin/node',
-    ];
-  }
-  return ['/usr/local/bin/node', '/usr/bin/node', '/bin/node'];
-}
-
-export interface SelectServiceNodeOptions {
-  platform: NodeJS.Platform;
-  currentNodeBin: string;
-  runner: CommandRunner;
-  probe?: ServiceNodeProbe;
-}
-
-/**
- * Choose the Node binary persisted into the managed-service environment.
- * Prefers a stable system Node (exists, not version-manager-bound, satisfies
- * MIN_SERVICE_NODE_VERSION); falls back to the current Node otherwise. The
- * fallback reproduces the original fragility when onboarding itself runs under
- * a version-manager Node — that case is the doctor drift advisory's job to
- * surface, not this function's.
- */
-export async function selectServiceNodeBin(
-  options: SelectServiceNodeOptions,
-): Promise<string> {
-  const probe = options.probe ?? defaultServiceNodeProbe;
-  for (const candidate of stableNodeCandidates(options.platform)) {
-    if (!(await probe.isExecutable(candidate))) continue;
-    if ((await detectServiceNodeVersionManager(candidate, probe)) !== null) {
-      continue;
-    }
-    let version: string;
-    try {
-      version = await options.runner.capture(candidate, ['--version']);
-    } catch {
-      continue;
-    }
-    if (!nodeVersionSatisfies(version)) continue;
-    // Persist the candidate path itself (a stable symlink), never its realpath,
-    // so a Homebrew symlink keeps the volatile Cellar path out of the service.
-    return candidate;
-  }
-  return stabilizeHomebrewCellarNode(
-    options.currentNodeBin,
-    options.platform,
-    probe,
-  );
-}
-
-const HOMEBREW_PREFIXES = ['/opt/homebrew', '/usr/local'];
-
-interface HomebrewCellarMatch {
-  prefix: string;
-  major: string | null;
-}
-
-function matchHomebrewCellar(path: string): HomebrewCellarMatch | null {
-  for (const prefix of HOMEBREW_PREFIXES) {
-    const cellar = `${prefix}/Cellar/node`;
-    if (!path.startsWith(`${cellar}/`) && !path.startsWith(`${cellar}@`)) {
-      continue;
-    }
-    const major = path.slice(cellar.length).match(/^@(\d+)\//);
-    return { prefix, major: major === null ? null : major[1] };
-  }
-  return null;
-}
-
-/**
- * Homebrew Cellar (`<prefix>/Cellar/node[@major]/<version>/bin/node`) is NOT a
- * version manager, but it is a version-pinned path unfit for a persistent
- * service. When the fallback Node is a Cellar path, best-effort remap it to the
- * matching stable Homebrew symlink. The realpath-equality guard disambiguates
- * `node` vs `node@<major>`; no match returns the input unchanged and never
- * throws, so a stabilization miss cannot fail onboarding. darwin-only.
- */
-export async function stabilizeHomebrewCellarNode(
-  nodeBin: string,
-  platform: NodeJS.Platform,
-  probe: ServiceNodeProbe = defaultServiceNodeProbe,
-): Promise<string> {
-  if (platform !== 'darwin') return nodeBin;
-  let resolved: string;
-  try {
-    resolved = await probe.realpath(nodeBin);
-  } catch {
-    resolved = nodeBin;
-  }
-  const cellar = matchHomebrewCellar(nodeBin) ?? matchHomebrewCellar(resolved);
-  if (cellar === null) return nodeBin;
-
-  const links: string[] = [];
-  if (cellar.major !== null) {
-    links.push(`${cellar.prefix}/opt/node@${cellar.major}/bin/node`);
-  }
-  links.push(`${cellar.prefix}/opt/node/bin/node`, `${cellar.prefix}/bin/node`);
-
-  for (const link of links) {
-    if (!(await probe.isExecutable(link))) continue;
-    try {
-      if ((await probe.realpath(link)) === resolved) return link;
-    } catch {
-      // ignore and try the next candidate symlink
-    }
-  }
-  return nodeBin;
-}
+/** Re-exported for service-level callers; canonical impl is in paths.ts. */
+export { userLocalBinDirs };
 
 function managedServicePath(answers: ServiceInstallAnswers): string {
-  const dirs = [
+  // Service PATH order: stable Dreamux-owned dirs (Node bin, provider bin dirs,
+  // dreamux bin) → captured session PATH (original order) → fresh-install
+  // fallback dirs from paths.ts. De-duped via buildServicePath. Never reads
+  // process.env; platform/homeDir/env passed explicitly.
+  const stableDirs = [
     dirname(answers.nodeBin),
     ...serviceProviderBinChecks(answers).flatMap((check) => absoluteDir(check.bin)),
     ...absoluteDir(answers.dreamuxBin),
-    ...SERVICE_PATH_DEFAULTS,
   ];
-  return uniqueNonEmpty(dirs).join(delimiter);
+  const sessionPath = answers.env?.['PATH'] ?? '';
+  const fallbackDirs = standardExecDirs({
+    platform: answers.platform ?? process.platform,
+    homeDir: answers.homeDir ?? homedir(),
+    env: answers.env ?? {},
+  });
+  return buildServicePath({ stableDirs, sessionPath, fallbackDirs });
 }
 
 function serviceProviderBinChecks(
@@ -489,29 +344,9 @@ function absoluteDir(path: string): string[] {
   return isAbsolute(path) ? [dirname(path)] : [];
 }
 
-function uniqueNonEmpty(values: string[]): string[] {
-  const out: string[] = [];
-  const seen = new Set<string>();
-  for (const value of values) {
-    if (value === '' || seen.has(value)) continue;
-    seen.add(value);
-    out.push(value);
-  }
-  return out;
-}
-
 async function assertExecutable(path: string, label: string): Promise<void> {
   if (await isExecutable(path)) return;
   throw new Error(`managed service executable is not runnable: ${label}`);
-}
-
-async function isExecutable(path: string): Promise<boolean> {
-  try {
-    await access(path, constants.X_OK);
-    return true;
-  } catch {
-    return false;
-  }
 }
 
 function errorMessage(err: unknown): string {
@@ -573,20 +408,15 @@ async function registerSystemd(
   });
   options.ledger.record(unitPath, 'unchanged', 'systemd user service registered');
 
-  // `systemctl --user enable` only schedules the service for an *active login
-  // session*. On a headless box with no graphical/SSH login the service never
-  // starts at boot. `loginctl enable-linger` is what makes a user service boot
-  // without a login — without it, "enabled" silently fails to autostart on
-  // reboot. Best-effort: a strict polkit / non-root setup may deny it, but that
-  // must not fail onboard / daemon install (issue #78).
+  // `systemctl --user enable` only schedules the service for an active login
+  // session. `loginctl enable-linger` makes a user service boot without a login;
+  // without it "enabled" silently fails to autostart on reboot. Best-effort: a
+  // strict polkit / non-root setup may deny it, but that must not fail onboard.
   const { lingerEnabled, warnings } = await enableSystemdLinger(options);
   return { lingerEnabled, warnings };
 }
 
-/**
- * Enable systemd user lingering for the calling user, best-effort. Returns the
- * outcome plus any operator-facing warning. Skipped (null) on a dry run.
- */
+/** Enable systemd user lingering, best-effort. Skipped (null) on dry run. */
 export async function enableSystemdLinger(
   options: Pick<ServiceInstallOptions, 'runner'> & {
     answers: Pick<ServiceInstallAnswers, 'dryRun'>;
@@ -621,10 +451,9 @@ export interface ServiceRemoveResult {
 }
 
 /**
- * Unregister and remove the user-level service unit only. Shared by the
- * top-level `dreamux uninstall` (which then also removes config/state/logs) and
- * `dreamux daemon uninstall` (which removes *nothing else*). Best-effort on the
- * service-manager calls — the unit-file removal is authoritative.
+ * Unregister and remove the user-level service unit only. Shared by
+ * `dreamux uninstall` (also removes config/state/logs) and
+ * `daemon uninstall` (removes nothing else). Unit-file removal is authoritative.
  */
 export async function removeUserService(
   options: ServiceRemoveOptions,

--- a/packages/dreamux/src/platform/paths.ts
+++ b/packages/dreamux/src/platform/paths.ts
@@ -38,7 +38,7 @@
 
 import { realpath } from 'node:fs/promises';
 import { homedir } from 'node:os';
-import { dirname, isAbsolute, join, relative, resolve, sep } from 'node:path';
+import { dirname, isAbsolute, join, relative, resolve, sep, delimiter } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 import {
@@ -413,4 +413,199 @@ export function teamMateNameSegment(name: string): string {
 
 export function dispatcherPathSegment(id: string): string {
   return validateDispatcherId(id);
+}
+
+// ---------------------------------------------------------------------------
+// Managed-service PATH builder
+//
+// The managed Dreamux service runs under a minimal environment that does NOT
+// inherit the operator's interactive shell PATH. Provider-owned bare binaries
+// (a `local-agent` installed into $HOME/.local/bin, a Homebrew-installed tool, an
+// nvm/pyenv shim, …) therefore must be explicitly placed on the service PATH
+// and searched during the daemon-install preflight so the launched service
+// resolves them.
+//
+// `buildServicePath` is the single source of truth for that PATH. It lives in
+// platform/ (the neutral path builder) so onboard/service.ts only orchestrates
+// the managed-service environment and never owns the home/PATH contract itself.
+//
+// Order (deduplicated while preserving first occurrence):
+//   1. Stable Dreamux-owned dirs (selected Node bin dir, resolved provider bin
+//      dirs, dreamux bin dir). These lead so the service always resolves the
+//      exact binaries the orchestrator pinned, regardless of the session PATH.
+//   2. The captured interactive-session PATH, in its original order. This is
+//      the full PATH the operator ran `dreamux onboard` / `daemon install`
+//      under, so binaries installed by nvm / pyenv / Homebrew / etc. resolve.
+//   3. Fresh-install fallback dirs (XDG_BIN_HOME when set, $HOME/.local/bin,
+//      and the portable platform system dirs). These cover a bare environment
+//      that has no interactive session PATH yet.
+//
+// Invariants:
+//   - Every helper takes its inputs explicitly ({ platform, homeDir, env }).
+//     They never read process.env, process.platform, or os.homedir() — the
+//     caller passes those values. This keeps the contract testable and prevents
+//     the ambient environment from silently changing the service PATH.
+//   - XDG_BIN_HOME is read from the passed env only. It is a widely-followed
+//     convention among some installers (e.g. language-ecosystem tools) but is
+//     NOT part of the formal XDG Base Directory specification; we honor it when
+//     the caller supplies it and also keep the conventional $HOME/.local/bin.
+//   - Results are ordered and de-duplicated. Earlier entries win. None of these
+//     dirs need to exist to appear on the service PATH (a non-existent dir is
+//     harmless); a bare binary that does not exist still fails loud at spawn.
+//   - No shell profile is read or written, brew --prefix is never executed, and
+//     the interactive shell PATH is never mutated. The dirs are deterministic.
+// ---------------------------------------------------------------------------
+
+export interface ExecDirOptions {
+  /** Platform selecting the conventional system dirs (darwin / linux). */
+  platform: NodeJS.Platform;
+  /** Home directory resolving $HOME/.local/bin. */
+  homeDir: string;
+  /**
+   * Environment to read conventions from (currently XDG_BIN_HOME). Passed
+   * explicitly by the caller; these helpers never read process.env.
+   */
+  env: NodeJS.ProcessEnv;
+}
+
+/**
+ * The operator's user-local standard bin dirs, in priority order. When
+ * XDG_BIN_HOME is set (in the passed env) and non-empty it is included first;
+ * the conventional $HOME/.local/bin is always included. Both are kept so a
+ * binary installed in either location resolves.
+ */
+export function userLocalBinDirs(options: ExecDirOptions): string[] {
+  const dirs: string[] = [];
+  const xdg = options.env['XDG_BIN_HOME'];
+  if (typeof xdg === 'string' && xdg.trim() !== '') {
+    dirs.push(xdg.trim());
+  }
+  dirs.push(join(options.homeDir, '.local', 'bin'));
+  return dirs;
+}
+
+/**
+ * Platform conventional system bin dirs (user-local dirs are NOT included here —
+ * see {@link userLocalBinDirs}). All platforms include /usr/local/bin,
+ * /usr/bin, /bin. macOS adds the Apple Silicon Homebrew prefix
+ * /opt/homebrew/bin (Intel Homebrew lands under /usr/local/bin, already
+ * covered). Linux adds the common Linuxbrew prefix
+ * /home/linuxbrew/.linuxbrew/bin.
+ *
+ * These are deterministic: no brew --prefix, no shell profile inspection.
+ */
+export function systemExecDirs(platform: NodeJS.Platform): string[] {
+  const dirs = ['/usr/local/bin', '/usr/bin', '/bin'];
+  if (platform === 'darwin') {
+    dirs.push('/opt/homebrew/bin');
+  } else if (platform === 'linux') {
+    dirs.push('/home/linuxbrew/.linuxbrew/bin');
+  }
+  return dirs;
+}
+
+/**
+ * The full ordered, de-duplicated standard executable dirs for a platform: the
+ * user-local bin dirs (see {@link userLocalBinDirs}) followed by the platform
+ * conventional system dirs (see {@link systemExecDirs}). Used as the
+ * fresh-install fallback dirs by {@link buildServicePath}.
+ */
+export function standardExecDirs(options: ExecDirOptions): string[] {
+  return dedupeExecDirs([
+    ...userLocalBinDirs(options),
+    ...systemExecDirs(options.platform),
+  ]);
+}
+
+/**
+ * Input for {@link buildServicePath} and {@link withServicePath}.
+ */
+export interface ServicePathInput {
+  /**
+   * Stable Dreamux-owned dirs that lead the PATH (selected Node bin dir,
+   * resolved provider bin dirs, dreamux bin dir).
+   */
+  stableDirs: string[];
+  /**
+   * The captured interactive-session PATH (the full `env.PATH` string the
+   * operator ran `dreamux onboard` / `daemon install` under). Its entries are
+   * appended in original order after the stable dirs.
+   */
+  sessionPath: string;
+  /**
+   * Fresh-install fallback dirs (XDG_BIN_HOME / $HOME/.local/bin + portable
+   * platform system dirs). Appended last so a bare environment still resolves.
+   */
+  fallbackDirs: string[];
+}
+
+/**
+ * Build the managed-service PATH: stable Dreamux-owned dirs first, then the
+ * captured session PATH in original order, then the fresh-install fallback
+ * dirs. Deduplicated while preserving first occurrence. Never reads
+ * process.env. This is the single source of truth for the service PATH order.
+ */
+export function buildServicePath(input: ServicePathInput): string {
+  return dedupeExecDirs([
+    ...input.stableDirs,
+    ...input.sessionPath.split(delimiter),
+    ...input.fallbackDirs,
+  ]).join(delimiter);
+}
+
+/**
+ * Return a copy of `env` with PATH set to {@link buildServicePath}. The
+ * caller's env object (and process.env) is never mutated.
+ */
+export function withServicePath(
+  env: NodeJS.ProcessEnv,
+  input: ServicePathInput,
+): NodeJS.ProcessEnv {
+  return { ...env, PATH: buildServicePath(input) };
+}
+
+/**
+ * Return a copy of `env` with PATH augmented so bare provider/agent binaries
+ * resolve against the standard executable dirs during `dreamux onboard` and
+ * `dreamux daemon install`. It places the captured session PATH (in original
+ * order) ahead of the fresh-install fallback dirs (XDG_BIN_HOME /
+ * $HOME/.local/bin + portable platform system + brew dirs), matching the order
+ * {@link buildServicePath} persists into the service unit — so the
+ * daemon-install preflight and the running service agree.
+ *
+ * Stable Dreamux-owned dirs (Node bin, provider bin dirs, dreamux bin) are NOT
+ * included here: at resolve time the Node bin is not yet selected and the
+ * dreamux bin dir is computed separately. Those are added when the service PATH
+ * is rendered (see `managedServicePath` in onboard/service.ts). Pass
+ * `extraDirs` to lead the PATH with explicit actual dirs (e.g. a resolved
+ * provider bin dir).
+ *
+ * The caller's env (and process.env) is never mutated; platform/homeDir/env are
+ * passed explicitly by the caller and these helpers never read process.env.
+ * XDG_BIN_HOME is a widely-followed convention (NOT part of the formal XDG Base
+ * Directory spec); it is honored alongside $HOME/.local/bin so binaries in
+ * either location resolve.
+ */
+export function withStandardExecPath(
+  env: NodeJS.ProcessEnv,
+  options: ExecDirOptions & { extraDirs?: string[] },
+): NodeJS.ProcessEnv {
+  const sessionPath = env['PATH'] ?? '';
+  const fallbackDirs = standardExecDirs(options);
+  return withServicePath(env, {
+    stableDirs: options.extraDirs ?? [],
+    sessionPath,
+    fallbackDirs,
+  });
+}
+
+function dedupeExecDirs(values: string[]): string[] {
+  const out: string[] = [];
+  const seen = new Set<string>();
+  for (const value of values) {
+    if (value === '' || seen.has(value)) continue;
+    seen.add(value);
+    out.push(value);
+  }
+  return out;
 }

--- a/packages/dreamux/tests/daemon.test.ts
+++ b/packages/dreamux/tests/daemon.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import {
+  chmodSync,
   existsSync,
   mkdirSync,
   mkdtempSync,
@@ -8,13 +9,28 @@ import {
   writeFileSync,
 } from 'node:fs';
 import { tmpdir } from 'node:os';
-import { dirname, join } from 'node:path';
+import { delimiter, dirname, join } from 'node:path';
+import { parse as parsePlist } from 'plist';
 
 import { controlUserService } from '../src/daemon/service-control.js';
 import { runDaemonInstall, runDaemonUninstall } from '../src/daemon/install.js';
-import type { ServiceNodeProbe } from '../src/onboard/service.js';
+import {
+  managedServiceEnvironment,
+  renderLaunchdPlist,
+  renderSystemdUnit,
+  resolveServiceExecutable,
+  withUserLocalBinPath,
+  type ServiceNodeProbe,
+} from '../src/onboard/service.js';
 import type { CommandRunner } from '../src/onboard/types.js';
-import { resetRuntimeConfig } from '../src/platform/paths.js';
+import {
+  buildServicePath,
+  resetRuntimeConfig,
+  standardExecDirs,
+  systemExecDirs,
+  userLocalBinDirs,
+  withServicePath,
+} from '../src/platform/paths.js';
 import { testSingleDispatcherFileObject } from './helpers/config.js';
 
 interface Call {
@@ -239,14 +255,582 @@ describe('daemon install (stable service Node, issue #83)', () => {
   });
 });
 
-function writeInstallConfig(configDir: string): void {
+// ---------------------------------------------------------------------------
+// Focused tests: managed-service PATH with captured session PATH
+// ---------------------------------------------------------------------------
+
+const localBin = (home: string) => join(home, '.local', 'bin');
+
+/** Synthetic session PATH entries that mimic nvm / pyenv / Homebrew layouts. */
+const SESSION_PATH_PARTS = [
+  '/home/example/.nvm/versions/node/v22.7.0/bin',
+  '/home/example/.pyenv/shims',
+  '/opt/homebrew/bin',
+  '/usr/local/bin',
+  '/usr/bin',
+  '/bin',
+];
+
+const SESSION_PATH = SESSION_PATH_PARTS.join(delimiter);
+
+function writeFakeBinary(dir: string, name: string): string {
+  mkdirSync(dir, { recursive: true });
+  const binPath = join(dir, name);
+  writeFileSync(
+    binPath,
+    '#!/usr/bin/env node\n' +
+      'const a = process.argv.slice(1);\n' +
+      "if (a.includes('--version')) { console.log('v1.0.0'); process.exit(0); }\n" +
+      'process.exit(0);\n',
+    { mode: 0o755 },
+  );
+  chmodSync(binPath, 0o755);
+  return binPath;
+}
+
+describe('buildServicePath ordering and deduplication', () => {
+  it('stable dirs precede the captured session PATH, which precedes fallbacks', () => {
+    const stableDirs = ['/opt/dreamux/bin', '/usr/local/bin'];
+    const fallbackDirs = ['/home/example/.local/bin', '/usr/bin', '/bin'];
+    const result = buildServicePath({
+      stableDirs,
+      sessionPath: SESSION_PATH,
+      fallbackDirs,
+    });
+    const parts = result.split(delimiter);
+
+    // Stable dirs lead, in their original order.
+    expect(parts[0]).toBe('/opt/dreamux/bin');
+    expect(parts[1]).toBe('/usr/local/bin');
+
+    // The session PATH follows, in its original order (minus the already-seen
+    // /usr/local/bin which is de-duplicated).
+    const afterStable = parts.slice(2);
+    expect(afterStable[0]).toBe('/home/example/.nvm/versions/node/v22.7.0/bin');
+    expect(afterStable[1]).toBe('/home/example/.pyenv/shims');
+    expect(afterStable[2]).toBe('/opt/homebrew/bin');
+    // /usr/local/bin was already in stableDirs, so it is de-duplicated here.
+    expect(afterStable[3]).toBe('/usr/bin');
+    expect(afterStable[4]).toBe('/bin');
+
+    // Fallback dirs come last (de-duplicated against what came before).
+    expect(afterStable[5]).toBe('/home/example/.local/bin');
+    // /usr/bin and /bin already seen, so they are de-duplicated.
+    expect(afterStable.slice(6)).toEqual([]);
+
+    // Total length = 2 stable + 5 unique session + 1 unique fallback.
+    expect(parts).toHaveLength(8);
+  });
+
+  it('de-duplicates while preserving first occurrence', () => {
+    const result = buildServicePath({
+      stableDirs: ['/a', '/b'],
+      sessionPath: ['/b', '/c', '/a'].join(delimiter),
+      fallbackDirs: ['/c', '/d'],
+    });
+    expect(result.split(delimiter)).toEqual(['/a', '/b', '/c', '/d']);
+  });
+
+  it('handles an empty session PATH without empty entries', () => {
+    const result = buildServicePath({
+      stableDirs: ['/a'],
+      sessionPath: '',
+      fallbackDirs: ['/b'],
+    });
+    expect(result.split(delimiter)).toEqual(['/a', '/b']);
+  });
+});
+
+describe('userLocalBinDirs and systemExecDirs (explicit deterministic fallbacks)', () => {
+  it('userLocalBinDirs honors XDG_BIN_HOME then $HOME/.local/bin', () => {
+    const home = '/home/example';
+    // Without XDG_BIN_HOME: only $HOME/.local/bin.
+    expect(userLocalBinDirs({ platform: 'linux', homeDir: home, env: {} })).toEqual([
+      localBin(home),
+    ]);
+    // With XDG_BIN_HOME: it leads, then $HOME/.local/bin.
+    expect(
+      userLocalBinDirs({ platform: 'linux', homeDir: home, env: { XDG_BIN_HOME: '/opt/userbin' } }),
+    ).toEqual(['/opt/userbin', localBin(home)]);
+    // Empty XDG_BIN_HOME is treated as unset.
+    expect(
+      userLocalBinDirs({ platform: 'linux', homeDir: home, env: { XDG_BIN_HOME: '' } }),
+    ).toEqual([localBin(home)]);
+  });
+
+  it('systemExecDirs are deterministic per platform', () => {
+    expect(systemExecDirs('darwin')).toEqual([
+      '/usr/local/bin',
+      '/usr/bin',
+      '/bin',
+      '/opt/homebrew/bin',
+    ]);
+    expect(systemExecDirs('linux')).toEqual([
+      '/usr/local/bin',
+      '/usr/bin',
+      '/bin',
+      '/home/linuxbrew/.linuxbrew/bin',
+    ]);
+  });
+
+  it('standardExecDirs combines user-local + system in order', () => {
+    const home = '/home/example';
+    const dirs = standardExecDirs({ platform: 'linux', homeDir: home, env: {} });
+    expect(dirs).toEqual([
+      localBin(home),
+      '/usr/local/bin',
+      '/usr/bin',
+      '/bin',
+      '/home/linuxbrew/.linuxbrew/bin',
+    ]);
+  });
+});
+
+describe('withUserLocalBinPath (resolve-time effective PATH)', () => {
+  it('includes the captured session PATH ahead of fallbacks and never mutates process.env', () => {
+    const home = '/home/example';
+    const before = process.env['PATH'];
+    const env = withUserLocalBinPath({ PATH: SESSION_PATH }, home, 'linux');
+    // process.env is untouched.
+    expect(process.env['PATH']).toBe(before);
+
+    const parts = env['PATH']?.split(delimiter) ?? [];
+    // Session PATH entries lead (in order).
+    expect(parts.slice(0, 6)).toEqual(SESSION_PATH_PARTS);
+    // Fallback dirs follow.
+    expect(parts).toContain(localBin(home));
+    expect(parts).toContain('/home/linuxbrew/.linuxbrew/bin');
+    // De-duplicated: a second call yields the same PATH.
+    const again = withUserLocalBinPath(env, home, 'linux');
+    expect(again['PATH']).toBe(env['PATH']);
+  });
+
+  it('works with an empty session PATH (fresh install)', () => {
+    const home = '/home/example';
+    const env = withUserLocalBinPath({ PATH: '' }, home, 'linux');
+    const parts = env['PATH']?.split(delimiter) ?? [];
+    // Only fallback dirs, no empty entries.
+    expect(parts).toContain(localBin(home));
+    expect(parts).not.toContain('');
+  });
+});
+
+describe('withServicePath does not mutate process.env or the input env', () => {
+  it('returns a fresh object and leaves process.env and the input env untouched', () => {
+    const inputEnv = { PATH: '/usr/bin:/bin', FOO: 'bar' };
+    const beforeProcess = process.env['PATH'];
+    const result = withServicePath(inputEnv, {
+      stableDirs: ['/opt/dreamux/bin'],
+      sessionPath: '/home/example/.nvm/versions/node/v22.7.0/bin',
+      fallbackDirs: ['/home/example/.local/bin'],
+    });
+
+    // Input env is not mutated.
+    expect(inputEnv).toEqual({ PATH: '/usr/bin:/bin', FOO: 'bar' });
+    // process.env is not mutated.
+    expect(process.env['PATH']).toBe(beforeProcess);
+    // Result is a fresh object with the merged PATH and other env vars kept.
+    expect(result['FOO']).toBe('bar');
+    expect(result['PATH']?.split(delimiter)).toEqual([
+      '/opt/dreamux/bin',
+      '/home/example/.nvm/versions/node/v22.7.0/bin',
+      '/home/example/.local/bin',
+    ]);
+  });
+});
+
+describe('provider binary resolution from captured session PATH', () => {
+  let root: string;
+  let oldHome: string | undefined;
+  let oldPath: string | undefined;
+
+  beforeEach(() => {
+    root = mkdtempSync(join(tmpdir(), 'dreamux-session-path-'));
+    oldHome = process.env['HOME'];
+    oldPath = process.env['PATH'];
+    process.env['HOME'] = join(root, 'home');
+  });
+
+  afterEach(() => {
+    if (oldHome === undefined) delete process.env['HOME'];
+    else process.env['HOME'] = oldHome;
+    if (oldPath === undefined) delete process.env['PATH'];
+    else process.env['PATH'] = oldPath;
+    resetRuntimeConfig();
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  it('resolves a bare binary only present in the captured session PATH', async () => {
+    const home = join(root, 'home');
+    // A synthetic nvm-style dir that is NOT a fallback dir.
+    const nvmBinDir = join(home, '.nvm', 'versions', 'node', 'v22.7.0', 'bin');
+    const binPath = writeFakeBinary(nvmBinDir, 'local-agent');
+    const sessionPath = [nvmBinDir, '/usr/bin', '/bin'].join(delimiter);
+
+    // Without the session PATH entry, the bare binary is not resolvable.
+    await expect(
+      resolveServiceExecutable('local-agent', { PATH: '/usr/bin:/bin' }),
+    ).rejects.toThrow();
+
+    // With the session PATH captured via withUserLocalBinPath, it resolves.
+    const resolved = await resolveServiceExecutable(
+      'local-agent',
+      withUserLocalBinPath({ PATH: sessionPath }, home, 'linux'),
+    );
+    expect(resolved).toBe(binPath);
+  });
+
+  it('resolves a bare binary in $HOME/.local/bin (fallback) when session PATH lacks it', async () => {
+    const home = join(root, 'home');
+    const binPath = writeFakeBinary(localBin(home), 'local-agent');
+
+    // Session PATH does not include .local/bin; the fallback dirs do.
+    const resolved = await resolveServiceExecutable(
+      'local-agent',
+      withUserLocalBinPath({ PATH: '/usr/bin:/bin' }, home, 'linux'),
+    );
+    expect(resolved).toBe(binPath);
+  });
+});
+
+describe('captured session PATH appears in systemd and launchd service config', () => {
+  const home = '/home/example';
+
+  function baseAnswers(env: NodeJS.ProcessEnv) {
+    return {
+      configDir: join(home, '.dreamux'),
+      dreamuxBin: '/usr/local/bin/dreamux',
+      nodeBin: '/usr/local/bin/node',
+      providerBinChecks: [],
+      startService: true,
+      dryRun: false,
+      homeDir: home,
+      platform: 'linux' as const,
+      env,
+    };
+  }
+
+  it('systemd Environment=PATH includes the captured session PATH entries', () => {
+    const unit = renderSystemdUnit(
+      baseAnswers({ PATH: SESSION_PATH }),
+      '/tmp/stdout.log',
+      '/tmp/stderr.log',
+    );
+    const pathLine = unit
+      .split('\n')
+      .find((l) => l.startsWith('Environment=PATH='))
+      ?.slice('Environment=PATH='.length) ?? '';
+    const parts = pathLine.split(delimiter);
+    // Stable dirs lead.
+    expect(parts[0]).toBe('/usr/local/bin'); // dirname(nodeBin)
+    // Session PATH entries are present and in order.
+    expect(parts).toContain('/home/example/.nvm/versions/node/v22.7.0/bin');
+    expect(parts).toContain('/home/example/.pyenv/shims');
+    expect(parts).toContain('/opt/homebrew/bin');
+    // Fallback dirs are present.
+    expect(parts).toContain(localBin(home));
+    expect(parts).toContain('/home/linuxbrew/.linuxbrew/bin');
+    // De-duplicated: /usr/local/bin appears exactly once.
+    expect(parts.filter((p) => p === '/usr/local/bin')).toHaveLength(1);
+  });
+
+  it('launchd EnvironmentVariables PATH includes the captured session PATH entries', () => {
+    const plist = renderLaunchdPlist(
+      baseAnswers({ PATH: SESSION_PATH }),
+      '/tmp/stdout.log',
+      '/tmp/stderr.log',
+    );
+    // The plist build returns a string; extract the PATH from the managed env
+    // directly (the same source the plist renders).
+    const env = managedServiceEnvironment(baseAnswers({ PATH: SESSION_PATH }));
+    const parts = (env['PATH'] ?? '').split(delimiter);
+    expect(parts[0]).toBe('/usr/local/bin');
+    expect(parts).toContain('/home/example/.nvm/versions/node/v22.7.0/bin');
+    expect(parts).toContain('/home/example/.pyenv/shims');
+    expect(parts).toContain('/opt/homebrew/bin');
+    expect(parts).toContain(localBin(home));
+    // Sanity: the plist string itself contains the PATH.
+    expect(plist).toContain('PATH');
+  });
+});
+
+describe('re-running daemon install refreshes the persisted service PATH', () => {
+  let root: string;
+  let oldHome: string | undefined;
+  let oldConfigDir: string | undefined;
+  let oldPath: string | undefined;
+
+  beforeEach(() => {
+    root = mkdtempSync(join(tmpdir(), 'dreamux-rerun-path-'));
+    oldHome = process.env['HOME'];
+    oldConfigDir = process.env['DREAMUX_CONFIG_DIR'];
+    oldPath = process.env['PATH'];
+    process.env['HOME'] = join(root, 'home');
+    process.env['DREAMUX_CONFIG_DIR'] = join(root, 'config');
+    writeInstallConfig(join(root, 'config'));
+  });
+
+  afterEach(() => {
+    restoreEnv('HOME', oldHome);
+    restoreEnv('DREAMUX_CONFIG_DIR', oldConfigDir);
+    restoreEnv('PATH', oldPath);
+    resetRuntimeConfig();
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  function readUnitPath(): string {
+    const unit = readFileSync(
+      join(root, 'home', '.config', 'systemd', 'user', 'dreamux.service'),
+      'utf8',
+    );
+    const line = unit.split('\n').find((l) => l.startsWith('Environment=PATH='));
+    return line?.slice('Environment=PATH='.length) ?? '';
+  }
+
+  it('regenerates the unit PATH when the supplied session PATH changes', async () => {
+    const runner = new InstallRunner();
+    const nodeProbe: ServiceNodeProbe = {
+      realpath: async (p) => p,
+      isExecutable: async () => false,
+    };
+    const home = join(root, 'home');
+
+    // First install with session PATH A.
+    const pathA = [join(home, '.nvm', 'versions', 'node', 'v22.7.0', 'bin'), '/usr/bin'].join(
+      delimiter,
+    );
+    await runDaemonInstall({
+      runner,
+      platform: 'linux',
+      homeDir: home,
+      nodeProbe,
+      env: { PATH: pathA, HOME: home, CODEX_HOST_CODEX_BIN: process.execPath },
+    });
+    const unitPathA = readUnitPath();
+    expect(unitPathA).toContain(join(home, '.nvm', 'versions', 'node', 'v22.7.0', 'bin'));
+
+    // Second install with session PATH B (different nvm version).
+    const pathB = [join(home, '.nvm', 'versions', 'node', 'v24.1.0', 'bin'), '/usr/bin'].join(
+      delimiter,
+    );
+    await runDaemonInstall({
+      runner,
+      platform: 'linux',
+      homeDir: home,
+      nodeProbe,
+      env: { PATH: pathB, HOME: home, CODEX_HOST_CODEX_BIN: process.execPath },
+    });
+    const unitPathB = readUnitPath();
+    expect(unitPathB).toContain(join(home, '.nvm', 'versions', 'node', 'v24.1.0', 'bin'));
+    expect(unitPathB).not.toContain(join(home, '.nvm', 'versions', 'node', 'v22.7.0', 'bin'));
+    expect(unitPathB).not.toBe(unitPathA);
+  });
+});
+
+// Regression: runDaemonInstall must persist the effective resolved env
+// (options.env ?? process.env) into the service answers, NOT the raw
+// options.env. In normal CLI use options.env is undefined, so the ambient
+// process.env PATH must be captured into the generated unit.
+describe('normal CLI invocation captures ambient process.env PATH (options.env omitted)', () => {
+  let root: string;
+  let oldHome: string | undefined;
+  let oldConfigDir: string | undefined;
+  let oldPath: string | undefined;
+  let oldCodexBin: string | undefined;
+
+  beforeEach(() => {
+    root = mkdtempSync(join(tmpdir(), 'dreamux-ambient-path-'));
+    oldHome = process.env['HOME'];
+    oldConfigDir = process.env['DREAMUX_CONFIG_DIR'];
+    oldPath = process.env['PATH'];
+    oldCodexBin = process.env['CODEX_HOST_CODEX_BIN'];
+    process.env['HOME'] = join(root, 'home');
+    process.env['DREAMUX_CONFIG_DIR'] = join(root, 'config');
+    // Normal CLI use: the host codex binary is in the ambient environment.
+    process.env['CODEX_HOST_CODEX_BIN'] = process.execPath;
+    writeInstallConfig(join(root, 'config'));
+  });
+
+  afterEach(() => {
+    restoreEnv('HOME', oldHome);
+    restoreEnv('DREAMUX_CONFIG_DIR', oldConfigDir);
+    restoreEnv('PATH', oldPath);
+    restoreEnv('CODEX_HOST_CODEX_BIN', oldCodexBin);
+    resetRuntimeConfig();
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  it('captures the ambient process.env PATH into the systemd unit when options.env is omitted', async () => {
+    const runner = new InstallRunner();
+    const nodeProbe: ServiceNodeProbe = {
+      realpath: async (p) => p,
+      isExecutable: async () => false,
+    };
+    const home = join(root, 'home');
+    // Synthetic nvm/pyenv dirs — NOT fallback dirs, so they can only come from
+    // the captured session PATH, not from standardExecDirs.
+    const nvmBin = join(home, '.nvm', 'versions', 'node', 'v22.7.0', 'bin');
+    const pyenvShims = join(home, '.pyenv', 'shims');
+    process.env['PATH'] = [nvmBin, pyenvShims, '/usr/bin', '/bin'].join(delimiter);
+
+    // No env option: normal CLI use falls back to process.env.
+    await runDaemonInstall({
+      runner,
+      platform: 'linux',
+      homeDir: home,
+      nodeProbe,
+    });
+
+    const unitPath = readUnitPathFrom(root);
+    expect(unitPath).toContain(nvmBin);
+    expect(unitPath).toContain(pyenvShims);
+    // Stable dirs still lead the PATH.
+    expect(unitPath.split(delimiter)[0]).toBe(dirname(process.execPath));
+    // Fallback dirs are present last.
+    expect(unitPath).toContain(localBin(home));
+  });
+
+  it('captures the ambient process.env PATH into the launchd plist when options.env is omitted', async () => {
+    const runner = new InstallRunner();
+    const nodeProbe: ServiceNodeProbe = {
+      realpath: async (p) => p,
+      isExecutable: async () => false,
+    };
+    const home = join(root, 'home');
+    const nvmBin = join(home, '.nvm', 'versions', 'node', 'v22.7.0', 'bin');
+    const pyenvShims = join(home, '.pyenv', 'shims');
+    process.env['PATH'] = [nvmBin, pyenvShims, '/usr/bin', '/bin'].join(delimiter);
+
+    // No env option: normal CLI use falls back to process.env.
+    await runDaemonInstall({
+      runner,
+      platform: 'darwin',
+      homeDir: home,
+      nodeProbe,
+      uid: 501,
+    });
+
+    const plistPath = join(home, 'Library', 'LaunchAgents', 'dev.excited.dreamux.plist');
+    const plist = parsePlist(readFileSync(plistPath, 'utf8')) as Record<string, any>;
+    const servicePath: string = plist['EnvironmentVariables']['PATH'] ?? '';
+    const parts = servicePath.split(delimiter);
+    expect(parts[0]).toBe(dirname(process.execPath));
+    expect(parts).toContain(nvmBin);
+    expect(parts).toContain(pyenvShims);
+    expect(parts).toContain(localBin(home));
+  });
+
+  it('still works with an explicit env (existing behavior preserved)', async () => {
+    const runner = new InstallRunner();
+    const nodeProbe: ServiceNodeProbe = {
+      realpath: async (p) => p,
+      isExecutable: async () => false,
+    };
+    const home = join(root, 'home');
+    const explicitNvm = join(home, '.nvm', 'versions', 'node', 'v24.1.0', 'bin');
+    const explicitEnv = {
+      PATH: [explicitNvm, '/usr/bin', '/bin'].join(delimiter),
+      HOME: home,
+      CODEX_HOST_CODEX_BIN: process.execPath,
+    };
+
+    await runDaemonInstall({
+      runner,
+      platform: 'linux',
+      homeDir: home,
+      nodeProbe,
+      env: explicitEnv,
+    });
+
+    const unitPath = readUnitPathFrom(root);
+    // Explicit env PATH is captured.
+    expect(unitPath).toContain(explicitNvm);
+    // Ambient process.env PATH (set in a different test) is NOT leaked in.
+    expect(unitPath).not.toContain(join(home, '.nvm', 'versions', 'node', 'v22.7.0', 'bin'));
+  });
+});
+
+describe('daemon install resolves bare provider bins and includes them in the service PATH', () => {
+  let root: string;
+  let oldHome: string | undefined;
+  let oldConfigDir: string | undefined;
+  let oldPath: string | undefined;
+
+  beforeEach(() => {
+    root = mkdtempSync(join(tmpdir(), 'dreamux-provider-bin-'));
+    oldHome = process.env['HOME'];
+    oldConfigDir = process.env['DREAMUX_CONFIG_DIR'];
+    oldPath = process.env['PATH'];
+    process.env['HOME'] = join(root, 'home');
+    process.env['DREAMUX_CONFIG_DIR'] = join(root, 'config');
+  });
+
+  afterEach(() => {
+    if (oldHome === undefined) delete process.env['HOME'];
+    else process.env['HOME'] = oldHome;
+    if (oldConfigDir === undefined) delete process.env['DREAMUX_CONFIG_DIR'];
+    else process.env['DREAMUX_CONFIG_DIR'] = oldConfigDir;
+    if (oldPath === undefined) delete process.env['PATH'];
+    else process.env['PATH'] = oldPath;
+    resetRuntimeConfig();
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  it('daemon install resolves a bare local-agent in $HOME/.local/bin and includes it in the service PATH', async () => {
+    const home = join(root, 'home');
+    const binPath = writeFakeBinary(localBin(home), 'local-agent');
+    // Strip any .local/bin from the ambient PATH so resolution must come from
+    // the user-local bin dir addition (mirrors a fresh/Docker environment).
+    process.env['PATH'] = (oldPath ?? '')
+      .split(delimiter)
+      .filter((p) => p && !p.endsWith('.local/bin'))
+      .join(delimiter);
+    writeInstallConfig(join(root, 'config'), { bin: 'local-agent' });
+
+    const runner = new InstallRunner();
+    const nodeProbe: ServiceNodeProbe = {
+      realpath: async (p) => p,
+      isExecutable: async () => false,
+    };
+
+    await runDaemonInstall({
+      runner,
+      platform: 'linux',
+      homeDir: home,
+      nodeProbe,
+      env: { ...process.env, HOME: home },
+    });
+
+    const servicePath = readUnitPathFrom(root);
+    expect(servicePath).toContain(localBin(home));
+    expect(servicePath).toContain(dirname(process.execPath));
+    // De-duplicated: the user-local bin dir appears exactly once.
+    expect(servicePath.split(delimiter).filter((p) => p === localBin(home))).toHaveLength(1);
+    expect(binPath).toBe(join(localBin(home), 'local-agent'));
+  });
+});
+
+function readUnitPathFrom(root: string): string {
+  const unit = readFileSync(
+    join(root, 'home', '.config', 'systemd', 'user', 'dreamux.service'),
+    'utf8',
+  );
+  const line = unit.split('\n').find((l) => l.startsWith('Environment=PATH='));
+  return line?.slice('Environment=PATH='.length) ?? '';
+}
+
+function writeInstallConfig(
+  configDir: string,
+  codexOverride: { bin?: string } = {},
+): void {
   mkdirSync(configDir, { recursive: true });
   writeFileSync(
     join(configDir, 'config.json'),
     // The codex binary path normally comes from each agent's config.bin;
     // CODEX_HOST_CODEX_BIN is only an optional host-level override. These tests
     // set that override to process.execPath so the managed-service launch check
-    // resolves to a runnable absolute path.
+    // resolves to a runnable absolute path, unless a codex override names a
+    // different (e.g. bare 'local-agent') binary.
     JSON.stringify(
       testSingleDispatcherFileObject({
         id: 'flow',
@@ -258,6 +842,7 @@ function writeInstallConfig(configDir: string): void {
           sandbox_mode: 'workspace-write',
           extra_args: [],
           extra_env: {},
+          ...codexOverride,
         },
       }),
     ),

--- a/packages/dreamux/tests/onboard.test.ts
+++ b/packages/dreamux/tests/onboard.test.ts
@@ -8,7 +8,7 @@ import {
   writeFileSync,
 } from 'node:fs';
 import { homedir } from 'node:os';
-import { dirname, join, sep } from 'node:path';
+import { delimiter, dirname, join, sep } from 'node:path';
 
 import { parse as parsePlist } from 'plist';
 
@@ -246,7 +246,17 @@ describe('dreamux onboard', () => {
     // codex dir below).
     expect(serviceUnit).not.toContain('CODEX_HOST_CODEX_BIN');
     expect(serviceUnit).toContain(`Environment=HOME=${join(root, 'home')}`);
-    expect(serviceUnit).toContain(`Environment=PATH=${dirname(process.execPath)}`);
+    // The service PATH leads with the stable Node dir and includes the user's
+    // local standard bin dir ($HOME/.local/bin here) so provider-owned bare
+    // binaries installed there (e.g. local-agent) resolve under the service env.
+    const servicePath =
+      serviceUnit
+        .split('\n')
+        .find((line) => line.startsWith('Environment=PATH='))
+        ?.slice('Environment=PATH='.length) ?? '';
+    expect(servicePath).toContain(dirname(process.execPath));
+    expect(servicePath).toContain(join(root, 'home', '.local', 'bin'));
+    expect(servicePath.split(':')[0]).toBe(dirname(process.execPath));
     expect(
       ledger.get(join(logsRoot(), 'daemon.stdout.log'))?.status,
     ).toBe('created');
@@ -283,10 +293,117 @@ describe('dreamux onboard', () => {
       'utf8',
     );
     expect(serviceUnit).toContain('Environment=DREAMUX_NODE_BIN=/usr/local/bin/node');
-    expect(serviceUnit).toContain('Environment=PATH=/usr/local/bin');
+    const servicePath =
+      serviceUnit
+        .split('\n')
+        .find((line) => line.startsWith('Environment=PATH='))
+        ?.slice('Environment=PATH='.length) ?? '';
+    // The stable Node dir leads the service PATH; the user's local standard bin
+    // dir is also included so bare provider binaries installed there resolve.
+    expect(servicePath.split(':')[0]).toBe('/usr/local/bin');
+    expect(servicePath).toContain(join(root, 'home', '.local', 'bin'));
     expect(serviceUnit).not.toContain(
       `Environment=DREAMUX_NODE_BIN=${process.execPath}`,
     );
+  });
+
+  it('captures the interactive session PATH into the service PATH after stable dirs', async () => {
+    const runner = new FakeRunner();
+    const answers = testAnswers({
+      configDir: join(root, 'config'),
+      dreamuxBin: '/usr/local/bin/dreamux',
+    });
+    writeGlobalCodexAuth(answers);
+    // No stable system Node so the current process Node is used (its dirname
+    // leads the service PATH). The session PATH carries synthetic nvm/pyenv
+    // entries that must be preserved in order after the stable dirs.
+    const sessionPath = [
+      join(root, 'home', '.nvm', 'versions', 'node', 'v22.7.0', 'bin'),
+      join(root, 'home', '.pyenv', 'shims'),
+      '/usr/bin',
+      '/bin',
+    ].join(':');
+
+    await runOnboard({
+      answers,
+      runner,
+      platform: 'linux',
+      homeDir: join(root, 'home'),
+      env: { PATH: sessionPath, CODEX_ACCESS_TOKEN: 'interactive-token-test' },
+      nodeProbe: noSystemNodeProbe,
+    });
+
+    const serviceUnit = readFileSync(
+      join(root, 'home', '.config', 'systemd', 'user', 'dreamux.service'),
+      'utf8',
+    );
+    const servicePath =
+      serviceUnit
+        .split('\n')
+        .find((line) => line.startsWith('Environment=PATH='))
+        ?.slice('Environment=PATH='.length) ?? '';
+    const parts = servicePath.split(':');
+    // Stable dirs lead (the current Node bin dir).
+    expect(parts[0]).toBe(dirname(process.execPath));
+    // Session PATH entries follow in their original order.
+    expect(parts).toContain(join(root, 'home', '.nvm', 'versions', 'node', 'v22.7.0', 'bin'));
+    expect(parts).toContain(join(root, 'home', '.pyenv', 'shims'));
+    // Fallback dirs are present last.
+    expect(parts).toContain(join(root, 'home', '.local', 'bin'));
+    // De-duplicated: /usr/bin appears exactly once (from session PATH; fallback
+    // does not re-add it).
+    expect(parts.filter((p) => p === '/usr/bin')).toHaveLength(1);
+  });
+
+  it('captures the ambient process.env PATH when options.env is omitted (normal CLI use)', async () => {
+    const runner = new FakeRunner();
+    const answers = testAnswers({
+      configDir: join(root, 'config'),
+      dreamuxBin: '/usr/local/bin/dreamux',
+    });
+    writeGlobalCodexAuth(answers);
+    const home = join(root, 'home');
+    // Synthetic nvm/pyenv dirs in the ambient PATH. Not fallback dirs, so they
+    // can only come from the captured session PATH.
+    const nvmBin = join(home, '.nvm', 'versions', 'node', 'v22.7.0', 'bin');
+    const pyenvShims = join(home, '.pyenv', 'shims');
+    const oldPath = process.env['PATH'];
+    const oldToken = process.env['CODEX_ACCESS_TOKEN'];
+    process.env['PATH'] = [nvmBin, pyenvShims, '/usr/bin', '/bin'].join(delimiter);
+    process.env['CODEX_ACCESS_TOKEN'] = 'interactive-token-test';
+
+    try {
+      // No env option: normal CLI use falls back to process.env.
+      await runOnboard({
+        answers,
+        runner,
+        platform: 'linux',
+        homeDir: home,
+        nodeProbe: noSystemNodeProbe,
+      });
+    } finally {
+      process.env['PATH'] = oldPath;
+      if (oldToken === undefined) delete process.env['CODEX_ACCESS_TOKEN'];
+      else process.env['CODEX_ACCESS_TOKEN'] = oldToken;
+    }
+
+    const serviceUnit = readFileSync(
+      join(home, '.config', 'systemd', 'user', 'dreamux.service'),
+      'utf8',
+    );
+    const servicePath =
+      serviceUnit
+        .split('\n')
+        .find((line) => line.startsWith('Environment=PATH='))
+        ?.slice('Environment=PATH='.length) ?? '';
+    const parts = servicePath.split(delimiter);
+    // Stable dirs lead (the current Node bin dir).
+    expect(parts[0]).toBe(dirname(process.execPath));
+    // Ambient session PATH entries are captured in order.
+    expect(parts).toContain(nvmBin);
+    expect(parts).toContain(pyenvShims);
+    // Fallback dirs are present last.
+    expect(parts).toContain(join(home, '.local', 'bin'));
   });
 
   it('excludes a version-manager-bound candidate and falls back to the current Node', async () => {
@@ -453,6 +570,11 @@ describe('dreamux onboard', () => {
     );
     expect(launchdPlist['EnvironmentVariables']['PATH']).toContain(
       dirname(process.execPath),
+    );
+    // The user's local standard bin dir is included so bare provider binaries
+    // installed there (e.g. local-agent in $HOME/.local/bin) resolve for the service.
+    expect(launchdPlist['EnvironmentVariables']['PATH']).toContain(
+      join(root, 'home', '.local', 'bin'),
     );
   });
 


### PR DESCRIPTION
## Summary

- capture the effective session `PATH` used by `dreamux onboard` and `dreamux daemon install`
- persist it into generated systemd user units and launchd plists
- keep selected Node, resolved provider binaries, and Dreamux directories first; then preserve the session PATH order; then add portable fallback directories
- de-duplicate entries while preserving first occurrence and reuse the same effective PATH for install-time binary resolution
- refresh the persisted service PATH whenever `dreamux daemon install` is rerun
- move service Node selection into a focused internal module and document the managed-service PATH invariant

## Validation

- `rush typecheck --to @excitedjs/dreamux`
- `rush lint --to @excitedjs/dreamux`
- `rush build --to @excitedjs/dreamux`
- full Vitest suite: 68 test files passed, 1 opt-in file skipped; 739 tests passed, 3 skipped
- `rush change --verify --target-branch origin/main`
- `bash .agents/scripts/check.sh`
- `git diff --check`

No public API or config schema changes.