### PR TITLE
fix(daemon): create managed service working directory

### DIFF
--- a/.agents/reference/state-and-paths.md
+++ b/.agents/reference/state-and-paths.md
@@ -190,6 +190,20 @@ Key source:
 - `/packages/dreamux/src/onboard/run.ts`
 - `/packages/dreamux/src/daemon/install.ts`
 
+## Managed Service Working Directory
+
+Both the systemd unit and launchd plist use `stateRoot()`
+(`~/.dreamux/state/`) as their working directory. `installUserService()` owns
+creating that directory before either service manager registers or starts the
+service, so `dreamux daemon install --start` works even when onboarding did not
+previously create server state. Dry runs record the planned directory creation
+in the transparent file ledger without changing the filesystem.
+
+Key source:
+
+- `/packages/dreamux/src/onboard/service.ts`
+- `/packages/dreamux/src/onboard/ledger.ts`
+
 ## Cache And Logs
 
 `~/.dreamux/cache/<dispatcher-id>/` is rebuildable cache:

--- a/common/changes/@excitedjs/dreamux/fix-managed-service-state-dir_2026-07-20-07-24.json
+++ b/common/changes/@excitedjs/dreamux/fix-managed-service-state-dir_2026-07-20-07-24.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Create the managed service state working directory before systemd or launchd registration.",
+      "type": "patch",
+      "packageName": "@excitedjs/dreamux"
+    }
+  ],
+  "packageName": "@excitedjs/dreamux",
+  "email": "15624809+YourWildDad@users.noreply.github.com"
+}

--- a/packages/dreamux/src/onboard/service.ts
+++ b/packages/dreamux/src/onboard/service.ts
@@ -110,9 +110,16 @@ export async function installUserService(
 ): Promise<ServiceInstallResult> {
   const homeDir = options.homeDir ?? homedir();
   const unit = serviceUnitPath(options.platform, homeDir);
+  const workingDir = stateRoot();
   const logDir = logsRoot();
   const stdoutLog = join(logDir, 'daemon.stdout.log');
   const stderrLog = join(logDir, 'daemon.stderr.log');
+  await ensureDirectory(
+    workingDir,
+    options.ledger,
+    'managed service working directory',
+    { dryRun: options.answers.dryRun },
+  );
   await ensureDirectory(logDir, options.ledger, 'daemon log directory', {
     dryRun: options.answers.dryRun,
   });

--- a/packages/dreamux/tests/daemon.test.ts
+++ b/packages/dreamux/tests/daemon.test.ts
@@ -26,6 +26,7 @@ import type { CommandRunner } from '../src/onboard/types.js';
 import {
   buildServicePath,
   resetRuntimeConfig,
+  stateRoot,
   standardExecDirs,
   systemExecDirs,
   userLocalBinDirs,
@@ -182,6 +183,109 @@ class InstallRunner implements CommandRunner {
     throw new Error(`unexpected capture: ${args.join(' ')}`);
   }
 }
+
+class WorkingDirectoryOrderRunner extends InstallRunner {
+  readonly registrationChecks: boolean[] = [];
+
+  constructor(private readonly workingDirectory: string) {
+    super();
+  }
+
+  override async run(
+    command: string,
+    args: string[],
+    options: { dryRun?: boolean } = {},
+  ): Promise<void> {
+    if (
+      !options.dryRun &&
+      (command === 'systemctl' ||
+        (command === 'launchctl' &&
+          (args[0] === 'bootstrap' || args[0] === 'kickstart')))
+    ) {
+      this.registrationChecks.push(existsSync(this.workingDirectory));
+    }
+    await super.run(command, args, options);
+  }
+}
+
+describe('managed service working directory ownership', () => {
+  let root: string;
+  let oldHome: string | undefined;
+  let oldConfigDir: string | undefined;
+
+  beforeEach(() => {
+    root = mkdtempSync(join(tmpdir(), 'dreamux-service-working-dir-'));
+    oldHome = process.env['HOME'];
+    oldConfigDir = process.env['DREAMUX_CONFIG_DIR'];
+    process.env['HOME'] = join(root, 'home');
+    process.env['DREAMUX_CONFIG_DIR'] = join(root, 'config');
+    writeInstallConfig(join(root, 'config'));
+  });
+
+  afterEach(() => {
+    restoreEnv('HOME', oldHome);
+    restoreEnv('DREAMUX_CONFIG_DIR', oldConfigDir);
+    resetRuntimeConfig();
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  it.each([
+    ['linux', undefined],
+    ['darwin', 501],
+  ] as const)(
+    'creates the state working directory before %s service registration',
+    async (platform, uid) => {
+      const workingDirectory = stateRoot();
+      const runner = new WorkingDirectoryOrderRunner(workingDirectory);
+      const nodeProbe: ServiceNodeProbe = {
+        realpath: async (path) => path,
+        isExecutable: async () => false,
+      };
+
+      const result = await runDaemonInstall({
+        runner,
+        platform,
+        homeDir: join(root, 'home'),
+        nodeProbe,
+        env: {
+          ...process.env,
+          CODEX_HOST_CODEX_BIN: process.execPath,
+        },
+        ...(uid === undefined ? {} : { uid }),
+      });
+
+      expect(existsSync(workingDirectory)).toBe(true);
+      expect(runner.registrationChecks.length).toBeGreaterThan(0);
+      expect(runner.registrationChecks.every(Boolean)).toBe(true);
+      expect(result.files).toContainEqual({
+        path: workingDirectory,
+        status: 'created',
+        reason: 'managed service working directory',
+      });
+    },
+  );
+
+  it('reports the missing working directory without creating it on dry-run', async () => {
+    const workingDirectory = stateRoot();
+    const runner = new WorkingDirectoryOrderRunner(workingDirectory);
+
+    const result = await runDaemonInstall({
+      runner,
+      platform: 'linux',
+      homeDir: join(root, 'home'),
+      dryRun: true,
+      env: { ...process.env },
+    });
+
+    expect(existsSync(workingDirectory)).toBe(false);
+    expect(runner.registrationChecks).toEqual([]);
+    expect(result.files).toContainEqual({
+      path: workingDirectory,
+      status: 'created',
+      reason: 'managed service working directory',
+    });
+  });
+});
 
 describe('daemon install (stable service Node, issue #83)', () => {
   let root: string;


### PR DESCRIPTION
## Summary

- create the managed service working directory before systemd or launchd registration
- preserve dry-run ledger behavior without touching the filesystem
- cover Linux and macOS registration ordering with focused tests

## Root cause

The generated unit/plist uses the Dreamux state directory as WorkingDirectory, but a fresh install could register and start the service before that directory existed, causing systemd to fail with CHDIR.

## Validation

- rush typecheck --to @excitedjs/dreamux
- rush lint --to @excitedjs/dreamux
- rush build --to @excitedjs/dreamux
- focused daemon/onboard tests: 46 passed
- knowledge-base link check
- rush change --verify --target-branch origin/next
- git diff --check