### PR TITLE
docs: strengthen dev workflow reviews

### DIFF
--- a/.agents/skills/dev-workflow/SKILL.md
+++ b/.agents/skills/dev-workflow/SKILL.md
@@ -1,13 +1,51 @@
 ---
 name: dev-workflow
-description: The development process for changing the dreamux repo itself, for a TeamLeader coordinating TeamMates. Use when implementing any non-trivial change — a feature, a refactor, or a fix. Covers landing a spec, heterogeneous review before and after implementation, opening a PR to the default branch, and the gate before the operator sees it.
+description: The development process for changing the dreamux repo itself, for a TeamLeader coordinating TeamMates. Use when implementing any non-trivial change — a feature, a refactor, or a fix. Covers landing a spec, resident-panel review across spec, implementation, fixes, and exact final heads, opening a PR to the default branch, and the gate before the operator sees it.
 ---
 
 # Dreamux Repo Development Workflow
 
 The default flow for any non-trivial change to this repo. Start here; do not skip a
 stage to save time — each skipped stage is a class of defect that reaches the
-operator. This is a simple baseline; the real process is richer and will grow.
+operator.
+
+When an operator instruction materially conflicts with this workflow, stop before
+deviating and ask whether the instruction is a one-off exception for the current
+change or a standing amendment to this skill. A one-off exception applies only to
+the current change through its final head and does not rewrite this workflow. A
+standing amendment must update and review this skill before it applies by default;
+the operator decides whether the current change proceeds under a one-off exception
+or pauses until the amendment lands.
+
+## Resident roster
+
+Normally run with a resident TeamMate roster: three read-only reviewers with
+complementary stable identities/focuses plus one developer (3-4 TeamMates total).
+Use [reviewer-identities.md](references/reviewer-identities.md) as the bundled
+static reference for the three reviewer identity texts and focus split.
+Establishing a seat means reading that reference and passing the selected copyable
+identity text to `teammate.spawn.identity`. Recovering an existing seat means
+reusing its concrete name via `send`/recovery; `send` cannot change identity, so do
+not respawn solely to retrofit wording. Reinforce focus in the task prompt if
+necessary.
+
+Reuse the same concrete TeamMate names across changes via send/recovery, using
+existing TeamMate identity and PR/commit records. Do not spawn extra TeamMates or
+fresh panels. The bundled reference is the sole documentation owner for resident
+reviewer identities/focuses and is not a runtime registry; do not create additional
+ad-hoc profile, roster, rationale, or other process-artifact registries. Any
+operator-requested deviation from roster, authorship, or process-artifact rules is
+a material conflict and must be classified under the one-off-versus-amendment guard
+above before proceeding. If a seat is unavailable, pause and escalate to the
+operator.
+
+The developer owns implementation. Reviewers stay read-only. Choose the reviewer
+panel before spec review. Identity/focus is stable and additive, never a substitute
+for holistic review. Use heterogeneous runtimes where available, but do not rotate
+concrete names just for heterogeneity.
+
+The same panel reviews the spec, implementation, every fix, and the exact final
+head. Approval attaches to an exact head and never carries forward.
 
 ## The loop
 
@@ -16,11 +54,9 @@ operator. This is a simple baseline; the real process is richer and will grow.
    fuzzy ask or an unsettled design decision. Write a short spec: intent, scope,
    hard constraints, acceptance, and what is explicitly OUT of scope.
 
-2. **Heterogeneous spec review (before any code).** Have independent TeamMate
-   reviewers check the SPEC — heterogeneous engines (different `agent_runtime` where
-   the config offers them), 2–3 recommended, scaled to what is available. They check
-   completeness, the design, and fit with the repo's EXISTING architecture. Fold the
-   findings back into the spec.
+2. **Spec review before any code.** Route the SPEC to the resident reviewer panel.
+   They check completeness, design, scope, and fit with the repo's EXISTING
+   architecture. Fold findings back into the spec before implementation.
 
 3. **Implement to a PR.** Drive the implementation — a workflow orchestration if the
    runtime supports it, otherwise a dev TeamMate — and open a PR to the default
@@ -28,18 +64,47 @@ operator. This is a simple baseline; the real process is richer and will grow.
    single-writer rule the TeamLeader reviews the local diff and commits (never edit
    the tree while a dev TeamMate is live on it).
 
-4. **Heterogeneous PR review (author ≠ reviewer).** Route the PR to independent
-   reviewers — never the author, never self-review — 2–3 heterogeneous. Review the
-   WHOLE change holistically (not a narrow "did it fix X"):
+4. **Implementation review (author != reviewer).** Route the exact head to the
+   resident reviewer panel — never the author, never self-review. Review the WHOLE
+   change holistically (not a narrow "did it fix X"):
    - requirement fully landed;
-   - no scope creep (no capability added that was not requested);
-   - architecture sound and consistent with the repo's existing design;
-   - refactor thorough, not glued on;
-   - module responsibilities clear;
-   - plus correctness, tests not weakened to pass, and public-artifact safety.
+   - no unrelated or unjustified scope expansion; creating or reshaping the owner
+     capability that is the correct home for the requested behavior is in scope;
+   - complexity/reuse/layering: no duplicate implementations, state machines, or
+     helpers; no redundant abstractions, entities, DTOs, or capabilities; no
+     accidental public API growth; shared owner capabilities are justified; package,
+     layer, owner, and neutral seams are correct; tests protect contracts instead
+     of mirroring implementation complexity;
+   - correctness, lifecycle, concurrency, and failure behavior are sound;
+   - tests are not weakened to pass, and public-artifact safety holds.
 
-5. **Gate before the operator.** Send the PR to the operator ONLY after CI is green
-   AND every reviewer's blocking findings are cleared.
+5. **Adjudicate and gate before the operator.** Reviewer severity is input, not the
+   TeamLeader's verdict; the TeamLeader judges every finding. A blocker is cleared
+   by fix plus exact-head re-review, or rejected with concise concrete rationale in
+   the PR/commit summary. Record concise PR/commit rationale whenever rejecting any
+   finding or deviating from either default. Escalate unsettled product-contract
+   decisions to the operator. Send the PR to the operator ONLY after CI is green
+   AND every accepted blocking finding is cleared.
 
 6. **Fixes follow the same bar.** Any fix — review follow-up, regression, hotfix —
-   runs the same multi-reviewer gate, reviewed holistically, never self-approved.
+   is implemented by the developer and re-reviewed by the same panel at the new
+   exact head. Rerun the step 5 gate after that re-review. Never self-approve.
+
+## Review finding defaults
+
+- Accept behavior-preserving, in-scope refactoring recommendations by default.
+  Prefer simplification, glue removal, deletion or consolidation of duplication,
+  ownership/layering corrections, and moving a fact or action to its single
+  correct owner. Decline one only for a clear, concrete reason recorded in the
+  PR/commit summary. Scope-expanding cleanup requires operator agreement or a
+  tracked follow-up.
+- Reject edge-case defensive recommendations by default. Accept one only for a
+  clear, concrete reason recorded in the PR/commit summary, grounded in an
+  operator request, observed failure or failing test, established production
+  contract, or concrete proportionate production risk. Apply the same
+  reject-by-default evidence standard to speculative new abstractions or
+  entities. When a recommendation combines refactoring with edge-case defense,
+  this second default governs the defensive portion; independently justified
+  simplification or ownership benefits remain under the first default.
+  Fail-loud invariants and load-bearing tests count as established contracts,
+  not edge-case defensive machinery.

--- a/.agents/skills/dev-workflow/references/reviewer-identities.md
+++ b/.agents/skills/dev-workflow/references/reviewer-identities.md
@@ -1,0 +1,83 @@
+# Resident Reviewer Identities
+
+`../SKILL.md` remains the owner of workflow, holistic review, adjudication, and
+gating rules. This reference owns only the three resident reviewer identity texts
+and their focus split.
+
+Use identity text only when spawning a seat. Recover existing seats by concrete
+name with `send`; existing seats are not respawned solely to retrofit wording.
+Deliberate roster changes follow the conflict guard in `../SKILL.md`.
+
+## Seat 1: Architecture and boundaries
+
+```identity
+You are a read-only resident reviewer for Architecture and boundaries. Review the
+whole current spec or exact head, never edit files, and return severity-ordered
+findings with file:line evidence or APPROVE.
+
+Ground findings in concrete current-source evidence, an operator request, an
+observed failure or failing test, an established production contract/load-bearing
+invariant, or concrete proportionate production risk. Current-source evidence is
+sufficient for refactoring findings such as duplication, unnecessary complexity,
+misplaced ownership, or layering violations. Recommendations to add edge-case
+defensive machinery or speculative abstractions require an operator request,
+observed failure or failing test, established production contract/load-bearing
+invariant, or concrete proportionate production risk; do not block on unsupported
+hypothetical possibilities.
+
+Focus on correct owner/package/layer placement, provider-neutral runtime/channel
+seams, capability vs glue or special case, public ABI/state/config boundaries,
+scope alignment, and behavior-preserving simplification. Do not encourage
+arbitrary abstraction.
+```
+
+## Seat 2: Lifecycle and correctness
+
+```identity
+You are a read-only resident reviewer for Lifecycle and correctness. Review the
+whole current spec or exact head, never edit files, and return severity-ordered
+findings with file:line evidence or APPROVE.
+
+Ground findings in concrete current-source evidence, an operator request, an
+observed failure or failing test, an established production contract/load-bearing
+invariant, or concrete proportionate production risk. Current-source evidence is
+sufficient for refactoring findings such as duplication, unnecessary complexity,
+misplaced ownership, or layering violations. Recommendations to add edge-case
+defensive machinery or speculative abstractions require an operator request,
+observed failure or failing test, established production contract/load-bearing
+invariant, or concrete proportionate production risk; do not block on unsupported
+hypothetical possibilities.
+
+Trace create/start/close/restart/recovery/failure transitions and authority.
+Check idempotency, atomicity, and ordering only when justified by the evidence
+standard. Focus on failure containment, load-bearing tests, and correctness
+without hypothetical concurrency machinery.
+```
+
+## Seat 3: Complexity and reuse
+
+```identity
+You are a read-only resident reviewer for Complexity and reuse. Review the whole
+current spec or exact head, never edit files, and return severity-ordered findings
+with file:line evidence or APPROVE.
+
+Ground findings in concrete current-source evidence, an operator request, an
+observed failure or failing test, an established production contract/load-bearing
+invariant, or concrete proportionate production risk. Current-source evidence is
+sufficient for refactoring findings such as duplication, unnecessary complexity,
+misplaced ownership, or layering violations. Recommendations to add edge-case
+defensive machinery or speculative abstractions require an operator request,
+observed failure or failing test, established production contract/load-bearing
+invariant, or concrete proportionate production risk; do not block on unsupported
+hypothetical possibilities.
+
+Concretely identify duplicate or near-duplicate implementations, state-machine
+paths, and helpers; redundant abstractions, entities, DTOs, and capabilities;
+accidental public-surface growth; and tests or fakes that mirror implementation
+complexity. Prefer deletion and consolidation. Primary focus is complexity and
+reuse, but still report any layering or ownership issue found.
+```
+
+Anti-drift: this is the only resident reviewer identity reference. Do not create
+extra per-reviewer profile files, rosters, or rationale registries; rationale
+stays in PR/commit summaries.


### PR DESCRIPTION
## Summary

- define a resident Dreamux development roster with three read-only reviewers and one developer
- reuse stable TeamMate identities and concrete names across spec, implementation, fixes, and exact-final-head reviews
- add a bundled reviewer-identity reference with copyable Architecture, Lifecycle, and Complexity reviewer prompts
- make complexity, reuse, layering, ownership, and accidental public API growth explicit review dimensions
- make the TeamLeader's finding defaults explicit: accept behavior-preserving, in-scope refactoring recommendations by default and reject edge-case defensive recommendations by default
- separate source-proven refactoring findings from the higher evidence bar required to add defensive machinery or speculative abstractions
- require TeamLeader adjudication instead of mechanically accepting reviewer severity
- when operator instructions materially conflict with the workflow, ask whether the deviation is one-off or a standing skill amendment

## Why

The workflow previously required heterogeneous spec and PR reviews but did not preserve reviewer continuity, assign stable review focuses, or state clearly how the TeamLeader should weigh refactoring against speculative defensive machinery. The updated skill keeps a small resident roster, binds approval to an exact head, and makes those judgment rules explicit without adding new TeamMate APIs or runtime registries. Detailed reviewer identity text lives in one progressively disclosed reference rather than bloating the core workflow.

## Review adjudication

- accepted the findings that roster/authorship deviations could bypass conflict classification, that scope wording duplicated and over-constrained capability changes, and that fixes should explicitly rerun the operator gate
- accepted the wording cleanup for process-artifact registries and made the bundled reference their sole static documentation owner
- accepted the finding that a primary reviewer focus must remain additive: the Complexity reviewer still reports layering or ownership issues it encounters
- accepted the finding that current source evidence is sufficient for duplication, complexity, ownership, and layering refactoring findings; only recommendations to add edge-case defenses or speculative abstractions require the higher evidence threshold
- retained explicit load-bearing/fail-loud protection and the operator-agreement or tracked-follow-up path for scope-expanding cleanup
- declined adding fixed examples for `materially conflicts`: the operator deliberately chose a judgment threshold for substantial conflicts, and examples would risk narrowing that authority into another mechanical checklist

## Validation

- skill-creator `quick_validate.py .agents/skills/dev-workflow`
- `.agents/scripts/check.sh`
- `git diff --check`
- the same three resident reviewers approved the policy spec, each follow-up, and exact final head `3c8df44`
- GitHub CI passed on Ubuntu and macOS; metadata, gitleaks, knowledge-base, change-declaration, and shellcheck gates also passed
- the Ubuntu full-test job passed when rerun after an unrelated `team-scheduler.test.ts` identity-isolation failure