### PR TITLE
feat(channel): support per-target repositories

### DIFF
--- a/.agents/decisions/channel-scoped-collaboration-and-core-events.md
+++ b/.agents/decisions/channel-scoped-collaboration-and-core-events.md
@@ -1,10 +1,19 @@
 # Channel-scoped collaboration operations and core events
 
-- **Status:** Accepted
+- **Status:** Accepted (amended 2026-07-26)
 - **Date:** 2026-07-16
 - **Affects:** Channel provider ABI, collaboration-space routing, dispatcher
   composition, Team and agent fact publication
 - **PR / Issue:** N/A
+
+> **Amendment 2026-07-26 — optional per-target repo.** This decision originally
+> kept repository/cwd/workspace-mode entirely core-local and rejected letting a
+> provider select repository policy. It is superseded on that single point: a
+> provider may now supply an optional repo (a source `path` and a `base_ref`)
+> for one collaboration target. Core still owns everything else — it validates
+> the request, maps it onto the existing Team/worktree creation options, and
+> owns worktree lifecycle and cleanup. See "Optional per-target repository"
+> below.
 
 ## Context
 
@@ -30,8 +39,9 @@ Add three optional, provider-neutral capabilities to `ChannelRoutes`:
   in-process typed `EventEmitter` bus.
 
 Provider input contains only neutral container, target, title, expected Team,
-and turn data. Repository, cwd, workspace mode, dispatcher, channel, and
-provider authority remain core-local. Workspace placement follows the existing
+and turn data, plus the optional per-target repo described in the amendment
+below. Cwd, workspace mode, dispatcher, channel, and provider authority remain
+core-local. Absent an explicit repo, workspace placement follows the existing
 dispatcher configuration.
 
 ## Consequences
@@ -61,12 +71,34 @@ Guards live in the root-export/external-provider fixture tests, strict
 collaboration routing tests, owner-publisher payload tests, and event-source
 scope and cleanup tests.
 
+## Optional per-target repository
+
+`ChannelCollaborationTargetEnsureInput` gains an optional
+`repo: DreamuxManagedRepoRequest`, carrying a source `path` and a `base_ref`.
+
+- **Constrained provider input; core keeps authority.** Collaboration routing
+  validates the request with a small local validator (nonblank bounded `path`
+  and `base_ref`) and forwards it into the provision input. A malformed request
+  is rejected as `invalid_input`.
+- **Direct mapping onto existing worktree creation.** When `repo` is present,
+  core maps it onto the existing `TeamCollection.create` / `WorktreeManager`
+  managed-worktree options, so the target's Team is created in a managed
+  worktree branched from `base_ref`; managed mode and delete-on-close are core's
+  fixed behavior, not provider input. When `repo` is omitted, the existing
+  space-binding behavior is used.
+- **Existing failure semantics.** A worktree failure keeps the existing
+  `operation_failed` behavior.
+
 ## Alternatives Considered
 
 - **Change `targetLifecycle(target_created)` to block until ready:** rejected
   because it would change existing conversational behavior.
-- **Let the provider select repository or workspace policy:** rejected because
-  local resource placement belongs to the dispatcher and collaboration binding.
+- **Let the provider select repository or workspace policy:** originally
+  rejected because local resource placement belongs to the dispatcher and
+  collaboration binding. **Partially superseded (2026-07-26):** a provider may
+  now supply one repo (`path` + `base_ref`) per target. The blanket rejection
+  still holds for cwd, workspace mode, and any unconstrained repository/policy
+  selection; core retains allocation, worktree lifecycle, and cleanup authority.
 - **Expose a callback on `ChannelSession`:** rejected because the session is the
   consumer; a scoped source gives the consumer explicit listener ownership and
   keeps core implementation classes private.

--- a/.agents/domains/dispatcher-orchestration.md
+++ b/.agents/domains/dispatcher-orchestration.md
@@ -243,6 +243,10 @@ roles:
 Channel MCP descriptor rendering is a core-owned capability built in
 `service/channel-service/mcp-descriptors.ts`; `dispatcher-service/mcp-descriptors.ts`
 only composes the dispatcher-root aggregate (channel + team + teammate + cron).
+Built-in channels keep their provider id as the MCP server name. External
+channels use the dispatcher-local channel id because an `npm:` provider ref is
+not a valid MCP server name; the full provider ref remains in the shim's
+`--provider` routing argument.
 The channel service never imports back from `dispatcher-service`, and provider
 packages stay core-agnostic.
 

--- a/common/changes/@excitedjs/dreamux-types/repo-aware-channel-target_2026-07-26-14-18.json
+++ b/common/changes/@excitedjs/dreamux-types/repo-aware-channel-target_2026-07-26-14-18.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Add an optional per-target repository to the public Channel ABI: DreamuxManagedRepoRequest (a source path and base_ref) and an optional repo field on ChannelCollaborationTargetEnsureInput. Existing providers stay source- and behavior-compatible.",
+      "type": "minor",
+      "packageName": "@excitedjs/dreamux-types"
+    }
+  ],
+  "packageName": "@excitedjs/dreamux-types",
+  "email": "053700@gmail.com"
+}

--- a/common/changes/@excitedjs/dreamux/repo-aware-channel-target_2026-07-26-14-18.json
+++ b/common/changes/@excitedjs/dreamux/repo-aware-channel-target_2026-07-26-14-18.json
@@ -1,7 +1,7 @@
 {
   "changes": [
     {
-      "comment": "Support an optional per-target repository on collaboration target ensure. Collaboration routing validates the request (nonblank path/base_ref) and maps it onto the existing TeamCollection/WorktreeManager options, so the target's Team is created in a managed worktree branched from base_ref. Omitting the repo uses the existing space-binding behavior.",
+      "comment": "Support an optional per-target repository on collaboration target ensure. Collaboration routing validates the request (nonblank path/base_ref) and maps it onto the existing TeamCollection/WorktreeManager options, so the target's Team is created in a managed worktree branched from base_ref. Omitting the repo uses the existing space-binding behavior. External Channel tools now use the dispatcher-local channel id as their MCP server name so npm provider refs remain routing data instead of invalid MCP identifiers.",
       "type": "minor",
       "packageName": "@excitedjs/dreamux"
     }

--- a/common/changes/@excitedjs/dreamux/repo-aware-channel-target_2026-07-26-14-18.json
+++ b/common/changes/@excitedjs/dreamux/repo-aware-channel-target_2026-07-26-14-18.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Support an optional per-target repository on collaboration target ensure. Collaboration routing validates the request (nonblank path/base_ref) and maps it onto the existing TeamCollection/WorktreeManager options, so the target's Team is created in a managed worktree branched from base_ref. Omitting the repo uses the existing space-binding behavior.",
+      "type": "minor",
+      "packageName": "@excitedjs/dreamux"
+    }
+  ],
+  "packageName": "@excitedjs/dreamux",
+  "email": "053700@gmail.com"
+}

--- a/packages/dreamux-types/src/channel.ts
+++ b/packages/dreamux-types/src/channel.ts
@@ -139,14 +139,29 @@ export interface ChannelMessageTargetCheck {
 }
 
 /**
+ * An optional per-target repository a channel provider may supply on
+ * {@link ChannelCollaborationTargetEnsureInput.repo}. It selects the source
+ * repository and the ref the target's Team worktree is created from.
+ */
+export interface DreamuxManagedRepoRequest {
+  /** Source repository working directory the worktree branches from. */
+  readonly path: string;
+  /** Git ref the worktree is created from. */
+  readonly base_ref: string;
+}
+
+/**
  * Request that core synchronously make an existing collaboration target ready.
- * Workspace selection remains dispatcher-local policy; providers supply no
- * repository, cwd, or workspace mode.
+ *
+ * A provider may supply an optional {@link DreamuxManagedRepoRequest} `repo` to
+ * select the source repository and ref for this provision call. When `repo` is
+ * omitted, the existing space binding is used.
  */
 export interface ChannelCollaborationTargetEnsureInput {
   readonly container: ChannelContainer;
   readonly target: ChannelTarget;
   readonly title?: string;
+  readonly repo?: DreamuxManagedRepoRequest;
 }
 
 export type ChannelScopedOperationFailureCode =

--- a/packages/dreamux-types/src/index.ts
+++ b/packages/dreamux-types/src/index.ts
@@ -128,4 +128,5 @@ export type {
   ChannelToolDescriptor,
   ChannelTurnSettledEvent,
   ChannelTurnSubmittedEvent,
+  DreamuxManagedRepoRequest,
 } from './channel.js';

--- a/packages/dreamux-types/tests/root-exports.test.ts
+++ b/packages/dreamux-types/tests/root-exports.test.ts
@@ -110,6 +110,7 @@ const ALLOWLIST = [
   'ChannelTurnSubmittedEvent',
   'DreamuxEnvironment',
   'DreamuxLogger',
+  'DreamuxManagedRepoRequest',
   'InboundAttachment',
   'InboundDeliveryResult',
   'InboundTurnInput',

--- a/packages/dreamux/src/service/channel-service/mcp-descriptors.ts
+++ b/packages/dreamux/src/service/channel-service/mcp-descriptors.ts
@@ -56,7 +56,10 @@ function channelMcpServerDescriptors(input: {
     const tools = provider.tools?.(channel.config);
     if (tools === undefined || tools.length === 0) continue;
     out.push({
-      name: provider.descriptor.id,
+      name:
+        provider.descriptor.ref.source === 'builtin'
+          ? provider.descriptor.id
+          : channel.id,
       command: dreamuxBinPath(),
       args: [
         'channel-mcp',

--- a/packages/dreamux/src/service/collaboration-space/target-lifecycle.ts
+++ b/packages/dreamux/src/service/collaboration-space/target-lifecycle.ts
@@ -431,23 +431,23 @@ export class CollaborationTargetLifecycle {
       if (record.phase === 'claimed') {
         if (!(await this.opts.teams.isOpenTeam(record.team_name))) {
           this.assertNotShuttingDown();
+          const repo = input.repo !== undefined
+            ? { ...input.repo, cleanup: 'delete-on-close' as const }
+            : binding.repo_cwd !== null && binding.worktree.mode === 'managed'
+              ? { path: binding.repo_cwd, ...binding.worktree } : null;
           await this.opts.teams.create({
             name: record.team_name,
             nameClaimToken: routeClaimIdForTarget(record),
             leaderAgentRuntime: binding.leader_agent_runtime,
             intent: targetIntent(target, record),
             ...(binding.identity !== null ? { identity: binding.identity } : {}),
-            ...(binding.repo_cwd !== null && binding.worktree.mode === 'managed'
+            ...(repo !== null
               ? {
-                  repoCwd: binding.repo_cwd,
-                  worktree: {
-                    mode: 'managed' as const,
-                    slug: record.worktree_slug,
+                  repoCwd: repo.path, worktree: {
+                    mode: 'managed' as const, slug: record.worktree_slug,
                     branch: record.team_name,
-                    ...(binding.worktree.base_ref !== null
-                      ? { base_ref: binding.worktree.base_ref }
-                      : {}),
-                    cleanup: binding.worktree.cleanup,
+                    ...(repo.base_ref !== null ? { base_ref: repo.base_ref } : {}),
+                    cleanup: repo.cleanup,
                   },
                 }
               : {}),

--- a/packages/dreamux/src/service/collaboration-space/types.ts
+++ b/packages/dreamux/src/service/collaboration-space/types.ts
@@ -1,6 +1,7 @@
 import type {
   ChannelContainer,
   ChannelTarget,
+  DreamuxManagedRepoRequest,
 } from '@excitedjs/dreamux-types';
 
 export const COLLABORATION_SPACE_RECORD_VERSION = 1;
@@ -154,6 +155,12 @@ export interface CollaborationSpaceProvisionInput {
   container: ChannelContainer;
   target: ChannelTarget;
   title?: string;
+  /**
+   * Optional managed repo for this target's Team. When present, core creates
+   * the Team in a managed worktree branched from `repo.base_ref` instead of the
+   * space binding's workspace. When omitted, the space-binding behavior is used.
+   */
+  repo?: DreamuxManagedRepoRequest;
   eventId?: string;
 }
 

--- a/packages/dreamux/src/service/dispatcher-service/collaboration-routing.ts
+++ b/packages/dreamux/src/service/dispatcher-service/collaboration-routing.ts
@@ -9,6 +9,7 @@ import type {
   ChannelScopedOperationFailureCode,
   ChannelTargetLifecycleEvent,
   DreamuxLogger,
+  DreamuxManagedRepoRequest,
   InboundTurnInput,
 } from '@excitedjs/dreamux-types';
 
@@ -21,6 +22,7 @@ import { validateTeamId } from '../team-collection/types.js';
 const ROUTE_IDENTITY_MAX = 512;
 const DISPLAY_TEXT_MAX = 4_096;
 const SOURCE_ID_MAX = 1_024;
+const REPO_PATH_MAX = 4_096;
 
 export async function handleCollaborationTargetLifecycle(input: {
   dispatcherId: string;
@@ -126,6 +128,7 @@ export async function ensureCollaborationTarget(input: {
         container: request.container,
         target: request.target,
         ...(request.title !== undefined ? { title: request.title } : {}),
+        ...(request.repo !== undefined ? { repo: request.repo } : {}),
         channels: input.channels,
       }),
       {
@@ -407,6 +410,7 @@ function provisionInputForTarget(input: {
   container: ChannelInboundEnvelope['container'];
   target: ChannelInboundEnvelope['target'];
   title?: string;
+  repo?: DreamuxManagedRepoRequest;
   eventId?: string;
 }) {
   if (input.container === undefined) {
@@ -418,6 +422,7 @@ function provisionInputForTarget(input: {
     container: input.container,
     target: input.target,
     ...(input.title !== undefined ? { title: input.title } : {}),
+    ...(input.repo !== undefined ? { repo: input.repo } : {}),
     ...(input.eventId !== undefined ? { eventId: input.eventId } : {}),
   };
 }
@@ -449,12 +454,32 @@ function normalizeEnsureInput(
   input: ChannelCollaborationTargetEnsureInput,
 ): ChannelCollaborationTargetEnsureInput {
   if (!isRecord(input)) throw new TypeError('ensure input must be an object');
+  const repo =
+    input.repo !== undefined ? normalizeManagedRepoRequest(input.repo) : undefined;
   return {
     container: normalizeContainer(input.container),
     target: normalizeStrictTarget(input.target),
     ...(input.title !== undefined
       ? { title: boundedString(input.title, DISPLAY_TEXT_MAX, true) }
       : {}),
+    ...(repo !== undefined ? { repo } : {}),
+  };
+}
+
+/**
+ * Validate the optional repo request: nonblank bounded `path` and `base_ref`
+ * selecting the source repository and ref for this provision call. A small
+ * local validator is intentional — this is the only place the Channel seam
+ * parses the request. Throws on any violation so `ensureCollaborationTarget`
+ * maps it to `invalid_input`.
+ */
+function normalizeManagedRepoRequest(
+  repo: DreamuxManagedRepoRequest,
+): DreamuxManagedRepoRequest {
+  if (!isRecord(repo)) throw new TypeError('repo must be an object');
+  return {
+    path: boundedString(repo.path, REPO_PATH_MAX),
+    base_ref: boundedString(repo.base_ref, ROUTE_IDENTITY_MAX),
   };
 }
 

--- a/packages/dreamux/tests/channel-service.test.ts
+++ b/packages/dreamux/tests/channel-service.test.ts
@@ -13,7 +13,10 @@ import type {
 
 import { ChannelProviderCatalog } from '../src/channel/catalog.js';
 import { resetRuntimeConfig } from '../src/platform/paths.js';
-import { createBuiltinProviderRegistry } from '../src/registry/index.js';
+import {
+  createBuiltinProviderRegistry,
+  parseProviderRef,
+} from '../src/registry/index.js';
 import { ChannelService } from '../src/service/channel-service/index.js';
 import { ChannelSessions } from '../src/service/channel-service/channel-sessions.js';
 import { testDispatcherConfig, testDreamuxConfig } from './helpers/config.js';
@@ -425,6 +428,47 @@ describe('ChannelService binding ownership', () => {
       expect.objectContaining({ marker: 'dispatcher-a' }),
     ]);
     expect(service.live().size).toBe(0);
+  });
+
+  it('uses the channel id as the MCP server name for an npm channel provider', () => {
+    const providerRef = 'npm:@example/dreamux-channel';
+    const descriptor: ChannelProviderDescriptor = {
+      id: providerRef,
+      kind: 'channel',
+      ref: parseProviderRef(providerRef),
+    };
+    const registry = createBuiltinProviderRegistry();
+    registry.register(descriptor);
+    registry.registerImplementation(descriptor.id, {
+      ref: providerRef,
+      descriptor,
+      tools: () => [{ name: 'repository_report' }],
+      createSession: () => {
+        throw new Error('not used');
+      },
+    } satisfies ChannelProvider);
+    const service = new ChannelService({
+      dispatcherId: 'dispatcher-a',
+      config: testDreamuxConfig([
+        testDispatcherConfig({
+          id: 'dispatcher-a',
+          channelId: 'flowx',
+          channelProvider: providerRef,
+        }),
+      ]),
+      channelProviders: new ChannelProviderCatalog({ registry }),
+      channelLoggerFactory: () => ({}) as never,
+      adminSocketPath: '/tmp/dreamux-admin.sock',
+    });
+
+    expect(
+      service.channelMcpServerDescriptorsForCaller({ callerKind: 'dispatcher' }),
+    ).toEqual([
+      expect.objectContaining({
+        name: 'flowx',
+        args: expect.arrayContaining(['--provider', providerRef]),
+      }),
+    ]);
   });
 
   it('detaches closing sessions before await so an older close cannot clear a restart', async () => {

--- a/packages/dreamux/tests/collaboration-space-repo-close.test.ts
+++ b/packages/dreamux/tests/collaboration-space-repo-close.test.ts
@@ -1,7 +1,13 @@
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { execFile } from 'node:child_process';
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
-import { existsSync } from 'node:fs';
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  realpathSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { promisify } from 'node:util';
@@ -61,8 +67,9 @@ describe('collaboration target per-target repo close cleanup', () => {
 
   it('dissolves the Team and removes the managed worktree on owner target-close', async () => {
     // A real source repo so the managed worktree is a real `git worktree`.
-    const sourceRepo = join(root, 'source');
-    mkdirSync(sourceRepo, { recursive: true });
+    const sourceRepoPath = join(root, 'source');
+    mkdirSync(sourceRepoPath, { recursive: true });
+    const sourceRepo = realpathSync(sourceRepoPath);
     const git = async (args: string[]): Promise<string> => {
       const { stdout } = await execFileAsync('git', args, { cwd: sourceRepo });
       return stdout;

--- a/packages/dreamux/tests/collaboration-space-repo-close.test.ts
+++ b/packages/dreamux/tests/collaboration-space-repo-close.test.ts
@@ -1,0 +1,167 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { execFile } from 'node:child_process';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { existsSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { promisify } from 'node:util';
+
+import { CollaborationSpaceService } from '../src/service/collaboration-space/index.js';
+import { CollaborationSpaceStore } from '../src/service/collaboration-space/store.js';
+import { TeamCollection } from '../src/service/team-collection/index.js';
+import { WorktreeManager } from '../src/service/worktree/manager.js';
+import { AgentIdentityStore } from '../src/service/agent-entity/identity-store.js';
+import { AgentTurnsStore } from '../src/service/agent-entity/turns-store.js';
+import { CompletionRouter } from '../src/service/completion-router/index.js';
+import { resetRuntimeConfig } from '../src/platform/paths.js';
+import { testDispatcherConfig, testDreamuxConfig } from './helpers/config.js';
+import { fakeChannels, log } from './helpers/collaboration-space.js';
+import { FAKE_RUNTIME_REF, fakeRuntimeCatalog } from './helpers/fake-runtime.js';
+
+const execFileAsync = promisify(execFile);
+
+const CONTAINER = {
+  container_type: 'topic_group',
+  container_key: 'container-1',
+} as const;
+
+const TARGET = {
+  target_type: 'topic',
+  target_key: 'topic-1',
+  bindable: true,
+  display: 'Fix Login',
+} as const;
+
+/**
+ * Prove the per-target `repo` creates a real managed worktree and that the
+ * OWNER target-close path removes it — not space dissolve or harness teardown.
+ * This drives a REAL `TeamCollection` + `WorktreeManager` against a REAL source
+ * Git repo so the managed worktree is a genuine `git worktree`. `closeTarget`
+ * (owner path) must dissolve the Team, remove the managed worktree directory,
+ * and de-register it from `git worktree list`.
+ */
+describe('collaboration target per-target repo close cleanup', () => {
+  let root: string;
+  let previousHome: string | undefined;
+
+  beforeEach(() => {
+    root = mkdtempSync(join(tmpdir(), 'dreamux-repo-close-'));
+    previousHome = process.env['HOME'];
+    process.env['HOME'] = join(root, 'home');
+    mkdirSync(process.env['HOME'], { recursive: true });
+    resetRuntimeConfig();
+  });
+
+  afterEach(() => {
+    if (previousHome === undefined) delete process.env['HOME'];
+    else process.env['HOME'] = previousHome;
+    resetRuntimeConfig();
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  it('dissolves the Team and removes the managed worktree on owner target-close', async () => {
+    // A real source repo so the managed worktree is a real `git worktree`.
+    const sourceRepo = join(root, 'source');
+    mkdirSync(sourceRepo, { recursive: true });
+    const git = async (args: string[]): Promise<string> => {
+      const { stdout } = await execFileAsync('git', args, { cwd: sourceRepo });
+      return stdout;
+    };
+    await git(['init', '-q']);
+    await git(['config', 'user.email', 'test@example.com']);
+    await git(['config', 'user.name', 'Test']);
+    writeFileSync(join(sourceRepo, 'README.md'), '# source\n');
+    await git(['add', '.']);
+    await git(['commit', '-qm', 'init']);
+    const listWorktrees = async (): Promise<string[]> =>
+      (await git(['worktree', 'list', '--porcelain']))
+        .split('\n')
+        .filter((line) => line.startsWith('worktree '))
+        .map((line) => line.slice('worktree '.length));
+
+    // A real, operator-owned dispatcher workspace so managed worktrees resolve.
+    const workspace = join(root, 'workspace');
+    mkdirSync(workspace, { recursive: true });
+    const config = testDreamuxConfig([
+      testDispatcherConfig({
+        id: 'flow',
+        cwd: workspace,
+        agentRuntime: 'agent-a',
+        runtimeProvider: FAKE_RUNTIME_REF,
+      }),
+    ]);
+
+    const teams = new TeamCollection({
+      dispatcherId: 'flow',
+      config,
+      agentRuntimeProviders: fakeRuntimeCatalog(),
+      worktrees: new WorktreeManager(),
+      identities: new AgentIdentityStore(log as never),
+      turnsStore: new AgentTurnsStore(log as never),
+      router: new CompletionRouter({ dispatcherId: 'flow', log: log as never }),
+      initiatorFor: async () => null,
+      isShuttingDown: () => false,
+      adminSocketPath: join(root, 'admin.sock'),
+      leaderChannelDescriptors: () => [],
+      log: log as never,
+    });
+    const channels = fakeChannels();
+    const store = new CollaborationSpaceStore();
+    const service = new CollaborationSpaceService({
+      dispatcherId: 'flow',
+      config,
+      teams,
+      channels: channels.service,
+      store,
+      log: log as never,
+      isShuttingDown: () => false,
+    });
+
+    // Bind the space repo-less: the only managed repo comes from the target's
+    // own per-target `repo`, exercising the per-target seam.
+    await service.bind({
+      spaceName: 'space-close',
+      container: CONTAINER,
+      leaderAgentRuntime: 'agent-a',
+    });
+
+    const provisioned = await service.provisionTarget({
+      channelId: 'primary',
+      provider: 'builtin:test',
+      container: CONTAINER,
+      target: TARGET,
+      repo: {
+        path: sourceRepo,
+        base_ref: 'HEAD',
+      },
+    });
+    expect(provisioned).toMatchObject({ lifecycle_status: 'active' });
+    const teamName = provisioned!.team_name;
+
+    // The managed worktree is a real, additional `git worktree` of the source.
+    const worktreesWhileActive = await listWorktrees();
+    expect(worktreesWhileActive).toHaveLength(2);
+    const managedPath = worktreesWhileActive.find((path) => path !== sourceRepo)!;
+    expect(managedPath).toBeDefined();
+    expect(existsSync(managedPath)).toBe(true);
+    expect(await teams.isOpenTeam(teamName)).toBe(true);
+
+    // The OWNER close path: dissolve the Team and delete its worktree.
+    const closed = await service.closeTarget({
+      channelId: 'primary',
+      provider: 'builtin:test',
+      container: CONTAINER,
+      target: TARGET,
+    });
+    expect(closed.closed).toBe(true);
+    expect(closed.target?.lifecycle_status).toBe('closed');
+
+    // Team dissolved.
+    expect(await teams.isOpenTeam(teamName)).toBe(false);
+    // Managed worktree directory gone from disk.
+    expect(existsSync(managedPath)).toBe(false);
+    // git worktree registration gone: only the source repo remains.
+    const worktreesAfterClose = await listWorktrees();
+    expect(worktreesAfterClose).toEqual([sourceRepo]);
+  });
+});

--- a/packages/dreamux/tests/helpers/fake-runtime.ts
+++ b/packages/dreamux/tests/helpers/fake-runtime.ts
@@ -1,0 +1,126 @@
+/**
+ * A minimal in-memory {@link AgentRuntime} + catalog for tests that need a REAL
+ * {@link TeamCollection} (and therefore a real leader runtime) without spinning
+ * up the heavyweight codex/claude-code providers. It mirrors the local fake in
+ * `team-collection-read-path.test.ts`: a runtime that starts/stops cleanly and
+ * records submitted turns, exposed through an `AgentRuntimeProviderCatalog` keyed
+ * by {@link FAKE_RUNTIME_REF}. Use it when the assertion is about the surrounding
+ * lifecycle (managed worktrees, dissolve/close) rather than runtime behavior.
+ */
+import type {
+  AgentRuntime,
+  AgentRuntimeCapabilities,
+  AgentRuntimeCreateContext,
+  AgentRuntimeLastResult,
+  AgentRuntimeProvider,
+  AgentRuntimeStatus,
+  AgentRuntimeTextInput,
+  AgentRuntimeTurnResult,
+  InboundTurnInput,
+  TurnSettledSignal,
+} from '@excitedjs/dreamux-types';
+
+import type { AgentRuntimeProviderCatalog } from '../../src/agent-runtime/index.js';
+
+export const FAKE_RUNTIME_REF = 'test:runtime';
+
+const CAPABILITIES: AgentRuntimeCapabilities = {
+  resume: { supported: false },
+};
+
+export class FakeRuntime implements AgentRuntime {
+  readonly providerRef = FAKE_RUNTIME_REF;
+  readonly submitted: InboundTurnInput[] = [];
+  stopAttempts = 0;
+  private status: AgentRuntimeStatus = 'declared';
+  private onTurnSettled: ((settled: TurnSettledSignal) => void) | undefined;
+
+  setOnTurnSettled(onTurnSettled: (settled: TurnSettledSignal) => void): void {
+    this.onTurnSettled = onTurnSettled;
+  }
+
+  async start(): Promise<void> {
+    this.status = 'ready';
+  }
+
+  async resume(): Promise<void> {
+    this.status = 'ready';
+  }
+
+  async stop(): Promise<void> {
+    this.stopAttempts += 1;
+    this.status = 'stopped';
+  }
+
+  async channelInput(input: InboundTurnInput): Promise<AgentRuntimeTurnResult> {
+    this.submitted.push(input);
+    const turnId = `turn-${this.submitted.length}`;
+    queueMicrotask(() =>
+      this.onTurnSettled?.({ turnId, status: 'completed', result: { text: null } }),
+    );
+    return { status: 'submitted', turnId };
+  }
+
+  async completionInput(
+    input: AgentRuntimeTextInput,
+  ): Promise<AgentRuntimeTurnResult> {
+    this.submitted.push({ sourceId: input.sourceId ?? '', text: input.text });
+    return { status: 'submitted', turnId: `turn-${this.submitted.length}` };
+  }
+
+  getStatus(): AgentRuntimeStatus {
+    return this.status;
+  }
+
+  getCheckpoint(): { id: string } | null {
+    return { id: 'thread-fake' };
+  }
+
+  wasCheckpointResumed(): boolean {
+    return false;
+  }
+
+  async getLast(): Promise<AgentRuntimeLastResult> {
+    return { text: 'fake last' };
+  }
+
+  async getContext(): Promise<null> {
+    return null;
+  }
+
+  getCapabilities(): AgentRuntimeCapabilities {
+    return CAPABILITIES;
+  }
+}
+
+/** An `AgentRuntimeProviderCatalog` that hands out {@link FakeRuntime}s. */
+export function fakeRuntimeCatalog(
+  runtimes: FakeRuntime[] = [],
+): AgentRuntimeProviderCatalog {
+  const provider: AgentRuntimeProvider = {
+    ref: FAKE_RUNTIME_REF,
+    descriptor: {
+      id: 'test-runtime',
+      kind: 'agentRuntime',
+      ref: { source: 'builtin', id: 'test-runtime', raw: FAKE_RUNTIME_REF },
+    },
+    getCapabilities: () => CAPABILITIES,
+    createRuntime(context: AgentRuntimeCreateContext) {
+      const runtime = new FakeRuntime();
+      if (context.onTurnSettled !== undefined) {
+        runtime.setOnTurnSettled(context.onTurnSettled);
+      }
+      runtimes.push(runtime);
+      return runtime;
+    },
+  };
+  return {
+    list: () => [provider],
+    resolve(ref: string) {
+      if (ref !== FAKE_RUNTIME_REF) {
+        throw new Error(`unexpected runtime provider ${JSON.stringify(ref)}`);
+      }
+      return provider;
+    },
+  } as AgentRuntimeProviderCatalog;
+}

--- a/packages/dreamux/tests/team-scheduler.test.ts
+++ b/packages/dreamux/tests/team-scheduler.test.ts
@@ -419,6 +419,8 @@ describe('TeamLeader cron scheduler lifecycle', () => {
       text: 'scheduled alpha',
       sourceId: expect.stringMatching(/^scheduled:job-/),
     });
+    restarted.stopSchedulers();
+    await restarted.stopAll();
   });
 
   it('startSchedulers reuses cached Team services', async () => {


### PR DESCRIPTION
## What changed

- add the public `DreamuxManagedRepoRequest { path, base_ref }` contract and optional per-target `repo` input
- pass that input through the existing collaboration target provisioning path
- create the Team in Dreamux's existing managed-worktree path with `delete-on-close`
- keep the existing collaboration-space binding behavior when `repo` is omitted
- amend the Channel collaboration ADR and add the Rush changesets
- add a real Git/worktree target-close test that proves Team dissolution, worktree deletion, and Git worktree deregistration

## Why

FlowX now lets an operator select an edge-reported repository for each task. Dreamux needs a small target-level input so the normal collaboration-space Team creation path can create that task's managed worktree from the selected repository and default ref.

This intentionally keeps the implementation narrow: no compatibility framework, new state machine, specialized error taxonomy, or duplicate repo abstraction.

## Validation

- alpha release workflow run `30229131766` passed Rush install/build, built CLI smoke, tarball audit, and OIDC publish
- published `@excitedjs/dreamux@0.21.0-alpha.g0d223d76aab1`
- published `@excitedjs/dreamux-types@0.7.0-alpha.g0d223d76aab1`
- focused real target-close worktree test passed
- Dreamux and dreamux-types typecheck/lint/package tests passed during implementation
