### PR TITLE
feat(workflow): Dynamic Workflow MVP + Claude Code outputSchema support

### DIFF
--- a/common/changes/@excitedjs/agent-runtime-claude-code/feat-output-schema-flag_2026-08-03-13-57.json
+++ b/common/changes/@excitedjs/agent-runtime-claude-code/feat-output-schema-flag_2026-08-03-13-57.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@excitedjs/agent-runtime-claude-code",
+      "comment": "Pass --json-schema at resident session creation so structured_output is enforced for the session lifetime. Prefer structured_output over free-form result text, fail loud when a schema session returns none, and cache lastResult only after all validation passes so failed turns never leak unvalidated text.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@excitedjs/agent-runtime-claude-code"
+}

--- a/common/changes/@excitedjs/dreamux/feat-scriptpath-and-review-fixes_2026-08-03-13-57.json
+++ b/common/changes/@excitedjs/dreamux/feat-scriptpath-and-review-fixes_2026-08-03-13-57.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@excitedjs/dreamux",
+      "comment": "Add scriptPath support to workflow_run so scripts can be loaded from files instead of inline. Validate workflow meta before exposing agent() to top-level code, and propagate spawnOwned unsupported-capability errors back to the workflow as failed agent results.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@excitedjs/dreamux"
+}

--- a/packages/agent-runtime/claude-code/src/runtime.ts
+++ b/packages/agent-runtime/claude-code/src/runtime.ts
@@ -630,7 +630,6 @@ export class ClaudeCodeRuntime implements AgentRuntime {
     }
     const resultText =
       outcome.isError || outcome.text === '' ? null : outcome.text;
-    if (resultText !== null) this.lastResult = { text: resultText };
     if (outcome.isError) {
       const detail =
         outcome.errors.length > 0
@@ -638,6 +637,17 @@ export class ClaudeCodeRuntime implements AgentRuntime {
           : (outcome.subtype ?? 'unknown error');
       throw new Error(`claude turn ${turnId} returned an error result: ${detail}`);
     }
+    // When --json-schema was requested, Claude must return a validated
+    // `structured_output`; fail loud rather than surfacing free-form text.
+    if (this.deps.outputSchema !== undefined && !outcome.hasStructuredOutput) {
+      throw new Error(
+        `claude turn ${turnId} did not return structured_output for a ` +
+          `--json-schema session`,
+      );
+    }
+    // Only cache the result once all validation passes, so a failed schema turn
+    // never leaks its unvalidated free-form text through getLast().
+    if (resultText !== null) this.lastResult = { text: resultText };
     this.log('info', `claude-code turn ${turnId} completed`);
     return resultText;
   }

--- a/packages/agent-runtime/claude-code/src/stream.ts
+++ b/packages/agent-runtime/claude-code/src/stream.ts
@@ -113,12 +113,24 @@ function parseResult(o: JsonObject): ResultEnvelope {
   } else {
     isError = o['is_error'] === true || errors.length > 0;
   }
+  // In --json-schema mode Claude Code surfaces the validated object in
+  // `structured_output`; prefer it over the free-form `result` text so the
+  // workflow always receives clean, schema-conformant JSON to parse.
+  //
+  // Presence is checked by key, not by nullish: a JSON Schema `null` root type
+  // is a valid structured output, so an explicit `structured_output: null` must
+  // serialize to the JSON text `"null"` rather than falling back to `result`.
+  const hasStructuredOutput = 'structured_output' in o;
+  const text = hasStructuredOutput
+    ? JSON.stringify(o['structured_output'])
+    : str(o['result']);
   return {
     subtype,
     isError,
-    text: str(o['result']),
+    text,
     sessionId: str(o['session_id']),
     errors,
+    hasStructuredOutput,
   };
 }
 
@@ -309,6 +321,7 @@ export class TurnAggregator {
       sessionId: r.sessionId ?? this.initSessionId,
       subtype: r.subtype,
       errors: r.errors,
+      hasStructuredOutput: r.hasStructuredOutput,
     };
   }
 }

--- a/packages/agent-runtime/claude-code/src/types.ts
+++ b/packages/agent-runtime/claude-code/src/types.ts
@@ -53,6 +53,13 @@ export interface ResultEnvelope {
   readonly sessionId: string | null;
   /** Error subtypes may carry a message list; empty otherwise. */
   readonly errors: readonly string[];
+  /**
+   * Whether the `result` envelope carried a `structured_output` field (even if
+   * its value is `null`, which is a valid JSON Schema root type). The runtime
+   * uses this to fail loud when `--json-schema` was requested but Claude did
+   * not return a validated structured object.
+   */
+  readonly hasStructuredOutput: boolean;
 }
 
 /**
@@ -80,6 +87,13 @@ export interface TurnOutcome {
   readonly sessionId: string | null;
   readonly subtype: string | null;
   readonly errors: readonly string[];
+  /**
+   * Whether the turn's `result` envelope carried a `structured_output` field.
+   * Propagated from {@link ResultEnvelope.hasStructuredOutput} so the runtime
+   * can fail loud when `--json-schema` was requested but no validated object
+   * was returned.
+   */
+  readonly hasStructuredOutput: boolean;
 }
 
 /** Everything needed to spawn one resident `claude` stream-json child. */

--- a/packages/agent-runtime/claude-code/tests/runtime-activity.test.ts
+++ b/packages/agent-runtime/claude-code/tests/runtime-activity.test.ts
@@ -115,6 +115,7 @@ function okOutcome(): TurnOutcome {
     sessionId: 'sess-1',
     subtype: 'success',
     errors: [],
+    hasStructuredOutput: false,
   };
 }
 

--- a/packages/agent-runtime/claude-code/tests/stream.test.ts
+++ b/packages/agent-runtime/claude-code/tests/stream.test.ts
@@ -84,6 +84,56 @@ describe('parseLine', () => {
     }
   });
 
+  it('prefers structured_output over result text in --json-schema mode', () => {
+    const line = parseLine(
+      JSON.stringify({
+        type: 'result',
+        subtype: 'success',
+        result: 'unvalidated free text that must be ignored',
+        structured_output: { answer: 4 },
+        session_id: 's1',
+      }),
+    );
+    expect(line.kind).toBe('result');
+    if (line.kind === 'result') {
+      expect(line.outcome.text).toBe('{"answer":4}');
+      expect(line.outcome.hasStructuredOutput).toBe(true);
+    }
+  });
+
+  it('serializes an explicit structured_output: null as JSON null', () => {
+    const line = parseLine(
+      JSON.stringify({
+        type: 'result',
+        subtype: 'success',
+        result: 'fallback text that must not be used',
+        structured_output: null,
+        session_id: 's1',
+      }),
+    );
+    expect(line.kind).toBe('result');
+    if (line.kind === 'result') {
+      expect(line.outcome.text).toBe('null');
+      expect(line.outcome.hasStructuredOutput).toBe(true);
+    }
+  });
+
+  it('falls back to result text when structured_output is absent', () => {
+    const line = parseLine(
+      JSON.stringify({
+        type: 'result',
+        subtype: 'success',
+        result: 'plain text answer',
+        session_id: 's1',
+      }),
+    );
+    expect(line.kind).toBe('result');
+    if (line.kind === 'result') {
+      expect(line.outcome.text).toBe('plain text answer');
+      expect(line.outcome.hasStructuredOutput).toBe(false);
+    }
+  });
+
   it('treats any non-success result subtype as an error', () => {
     const line = parseLine(
       JSON.stringify({
@@ -214,6 +264,7 @@ describe('TurnAggregator', () => {
       sessionId: 's1',
       subtype: 'success',
       errors: [],
+      hasStructuredOutput: false,
     });
   });
 

--- a/packages/dreamux/src/admin/methods.ts
+++ b/packages/dreamux/src/admin/methods.ts
@@ -264,8 +264,14 @@ export const adminMethods: Record<string, AdminHandler> = {
 
   'workflow.run': async (server, params) => {
     const maxConcurrency = optionalInteger(params, 'max_concurrency');
+    const script = optionalNonBlankString(params, 'script');
+    const scriptPath = optionalNonBlankString(params, 'scriptPath');
+    if (script === null && scriptPath === null) {
+      throw new AdminError('BAD_REQUEST', 'workflow.run requires either script or scriptPath');
+    }
     return (await teammateTargetFor(server, params)).service.workflows.run({
-      script: mustNonEmptyString(params, 'script'),
+      ...(script !== null ? { script } : {}),
+      ...(scriptPath !== null ? { scriptPath } : {}),
       ...(params !== undefined && Object.hasOwn(params, 'args')
         ? { args: params['args'] }
         : {}),

--- a/packages/dreamux/src/mcp/teammate-mcp.ts
+++ b/packages/dreamux/src/mcp/teammate-mcp.ts
@@ -183,13 +183,14 @@ export function teammateTools(callerKind: TeamMateMcpCallerKind): Array<Record<s
   const workflowTools = [
     tool(
       'workflow_run',
-      'Load the bundled `workflow` skill before use. Start a deterministic multi-agent workflow from an inline module script and return { run_id } immediately; Dreamux pushes one terminal completion when the run finishes.',
+      'Load the bundled `workflow` skill before use. Start a deterministic multi-agent workflow from an inline module script (`script`) or a local file path (`scriptPath`) and return { run_id } immediately; Dreamux pushes one terminal completion when the run finishes.',
       {
         script: { type: 'string', minLength: 1 },
+        scriptPath: { type: 'string', minLength: 1 },
         args: {},
         max_concurrency: { type: 'integer', minimum: 1, maximum: 8 },
       },
-      ['script'],
+      [],
     ),
     tool(
       'workflow_status',
@@ -325,8 +326,14 @@ function mapToolCall(
 function workflowRunArgs(value: unknown): Record<string, unknown> {
   const obj = asRecord(value, 'workflow_run arguments');
   const maxConcurrency = optionalInteger(obj, 'max_concurrency');
+  const script = optionalString(obj, 'script');
+  const scriptPath = optionalString(obj, 'scriptPath');
+  if ((script === null || script.trim() === '') && (scriptPath === null || scriptPath.trim() === '')) {
+    throw new Error('workflow_run requires either script or scriptPath');
+  }
   return {
-    script: requireString(obj, 'script'),
+    ...(script !== null && script.trim() !== '' ? { script } : {}),
+    ...(scriptPath !== null && scriptPath.trim() !== '' ? { scriptPath } : {}),
     ...(Object.hasOwn(obj, 'args') ? { args: obj['args'] } : {}),
     ...(maxConcurrency !== null ? { max_concurrency: maxConcurrency } : {}),
   };

--- a/packages/dreamux/src/platform/paths.ts
+++ b/packages/dreamux/src/platform/paths.ts
@@ -85,14 +85,14 @@ export function getRuntimeConfig(): DreamuxConfig {
 }
 
 /**
- * The dreamux home root. Overridable via `DREAMUX_ROOT` (tests isolate state
- * into a temp dir). Reads `process.env.HOME` directly instead of `os.homedir()`
- * for reliable, platform-independent test isolation.
+ * The dreamux home root. Overridable via the `DREAMUX_ROOT` environment variable
+ * so tests (or custom deployments) can redirect durable state into an isolated
+ * directory without hijacking `process.env.HOME`.
  */
 export function dreamuxRoot(): string {
   const override = process.env['DREAMUX_ROOT'];
   if (override !== undefined && override !== '') return override;
-  return join(process.env['HOME'] ?? homedir(), '.dreamux');
+  return join(homedir(), '.dreamux');
 }
 
 /** Lexical containment: is `candidate` at or under `root` (both resolved)? */

--- a/packages/dreamux/src/platform/paths.ts
+++ b/packages/dreamux/src/platform/paths.ts
@@ -84,8 +84,15 @@ export function getRuntimeConfig(): DreamuxConfig {
   return currentConfig;
 }
 
+/**
+ * The dreamux home root. Overridable via `DREAMUX_ROOT` (tests isolate state
+ * into a temp dir). Reads `process.env.HOME` directly instead of `os.homedir()`
+ * for reliable, platform-independent test isolation.
+ */
 export function dreamuxRoot(): string {
-  return join(homedir(), '.dreamux');
+  const override = process.env['DREAMUX_ROOT'];
+  if (override !== undefined && override !== '') return override;
+  return join(process.env['HOME'] ?? homedir(), '.dreamux');
 }
 
 /** Lexical containment: is `candidate` at or under `root` (both resolved)? */
@@ -95,13 +102,10 @@ function pathIsAtOrUnder(root: string, candidate: string): boolean {
 }
 
 /**
- * True when `path` resolves to, or inside, the dreamux home root
- * (`~/.dreamux`). Lexical only — a path that *symlinks* into `~/.dreamux` is not
- * caught here; use {@link isRealPathUnderDreamuxRoot} for the placement guard.
- * Managed worktree creation must fail loud rather than place a worktree under
- * Dreamux's own state/run/cache tree (issue #182 PR-4): a dispatcher workspace
- * must be a real operator project directory, never the retired state-dir
- * fallback or any other path inside `~/.dreamux`.
+ * True when `path` resolves to, or inside, the dreamux home root (`~/.dreamux`).
+ * Lexical only — symlinks are not caught; use {@link isRealPathUnderDreamuxRoot}
+ * for the placement guard. Managed worktree creation must fail loud rather than
+ * place a worktree under Dreamux's own state/run/cache tree (issue #182 PR-4).
  */
 export function isUnderDreamuxRoot(path: string): boolean {
   return pathIsAtOrUnder(dreamuxRoot(), path);
@@ -117,12 +121,9 @@ async function canonicalPath(path: string): Promise<string> {
 }
 
 /**
- * Symlink-safe variant of {@link isUnderDreamuxRoot} (issue #182 PR-4, PR #186
- * review P1): canonicalizes BOTH the dreamux root and `path` with `realpath`
- * before the containment check, so a workspace path that lives outside
- * `~/.dreamux` lexically but symlinks into it is still rejected. This is the
- * authoritative guard for managed-worktree placement, where a bypass would put
- * worktrees physically under Dreamux home.
+ * Symlink-safe variant of {@link isUnderDreamuxRoot} (issue #182 PR-4, #186):
+ * canonicalizes both the root and `path` with `realpath` before the containment
+ * check, so a workspace that symlinks into `~/.dreamux` is still rejected.
  */
 export async function isRealPathUnderDreamuxRoot(path: string): Promise<boolean> {
   const [realRoot, realPath] = await Promise.all([

--- a/packages/dreamux/src/service/workflow-service/index.ts
+++ b/packages/dreamux/src/service/workflow-service/index.ts
@@ -1,4 +1,5 @@
 import { createHash, randomUUID } from 'node:crypto';
+import { readFile, stat } from 'node:fs/promises';
 
 import type { DreamuxLogger } from '@excitedjs/dreamux-types';
 
@@ -36,6 +37,7 @@ import type {
 const DEFAULT_MAX_CONCURRENCY = 8;
 const MIN_MAX_CONCURRENCY = 1;
 const MAX_MAX_CONCURRENCY = 8;
+const MAX_SCRIPT_BYTES = 1024 * 1024;
 
 export interface WorkflowServiceOptions extends WorkflowScopePathInput {
   callerKind: WorkflowCallerKind;
@@ -108,7 +110,8 @@ export class WorkflowService implements WorkflowOps {
   private async createRun(input: WorkflowRunInput): Promise<WorkflowRunAccepted> {
     await this.initialize();
     if (!this.accepting) throw new Error('workflow admission is closed');
-    if (typeof input.script !== 'string' || input.script.trim() === '') {
+    const script = await resolveWorkflowScript(input);
+    if (script.trim() === '') {
       throw new Error('workflow script must be non-empty');
     }
 
@@ -123,7 +126,7 @@ export class WorkflowService implements WorkflowOps {
       dispatcher_id: this.scope.dispatcherId,
       team_id: this.scope.teamId,
       caller_kind: this.opts.callerKind,
-      script_hash: createHash('sha256').update(input.script).digest('hex'),
+      script_hash: createHash('sha256').update(script).digest('hex'),
       status: 'running',
       max_concurrency: clampMaxConcurrency(input.max_concurrency),
       phase: null,
@@ -169,7 +172,7 @@ export class WorkflowService implements WorkflowOps {
       },
       'workflow run created',
     );
-    await run.start(input.script, input.args);
+    await run.start(script, input.args);
     return { run_id: runId };
   }
 
@@ -289,4 +292,24 @@ function clampMaxConcurrency(value: number | undefined): number {
     MAX_MAX_CONCURRENCY,
     Math.max(MIN_MAX_CONCURRENCY, Math.trunc(value)),
   );
+}
+
+async function resolveWorkflowScript(input: WorkflowRunInput): Promise<string> {
+  const hasScript = typeof input.script === 'string' && input.script.trim() !== '';
+  const hasScriptPath = typeof input.scriptPath === 'string' && input.scriptPath.trim() !== '';
+  if (!hasScript && !hasScriptPath) {
+    throw new Error('workflow script or scriptPath must be provided');
+  }
+  if (hasScript) return input.script as string;
+  const path = input.scriptPath as string;
+  const fileStat = await stat(path);
+  if (!fileStat.isFile()) {
+    throw new Error(`workflow scriptPath is not a regular file: ${path}`);
+  }
+  if (fileStat.size > MAX_SCRIPT_BYTES) {
+    throw new Error(
+      `workflow scriptPath exceeds ${MAX_SCRIPT_BYTES} bytes: ${path}`,
+    );
+  }
+  return await readFile(path, 'utf8');
 }

--- a/packages/dreamux/src/service/workflow-service/run.ts
+++ b/packages/dreamux/src/service/workflow-service/run.ts
@@ -405,10 +405,15 @@ export class WorkflowRun {
       }
       if (!call.completed) {
         const stopped = this.terminal.requested === 'stopped';
+        const runnerError =
+          !stopped && isUnsupportedFeatureError(error, 'outputSchema')
+            ? errorMessage(error)
+            : undefined;
         await this.completeAgent(
           call,
           stopped ? 'stopped' : 'failed',
           null,
+          runnerError,
         ).catch((persistenceError: unknown) => {
           this.terminal.observe(
             'failed',

--- a/packages/dreamux/src/service/workflow-service/runner.ts
+++ b/packages/dreamux/src/service/workflow-service/runner.ts
@@ -59,6 +59,9 @@ async function runWorkflow(script: string, args: unknown): Promise<void> {
     await module.link((specifier) => {
       throw new Error(`workflow imports are disabled: ${specifier}`);
     });
+    // Evaluate top-level code (meta declaration + entrypoint definition) without
+    // exposing agent/parallel/pipeline, so an invalid script cannot spawn agents
+    // before its metadata is validated.
     await module.evaluate();
 
     const namespace = module.namespace as Record<string, unknown>;
@@ -67,6 +70,9 @@ async function runWorkflow(script: string, args: unknown): Promise<void> {
     if (typeof entrypoint !== 'function') {
       throw new Error('workflow script must export a default run function');
     }
+
+    // Metadata is valid; now expose the orchestration primitives and run.
+    installWorkflowPrimitives(context);
 
     const result: unknown = await Reflect.apply(entrypoint, undefined, []);
     if (aborted) throw new Error('workflow aborted');
@@ -86,13 +92,22 @@ async function runWorkflow(script: string, args: unknown): Promise<void> {
 function createWorkflowContext(args: unknown): Context {
   return createContext({
     args,
-    agent: startAgent,
-    parallel,
-    pipeline,
     phase: (message: unknown): void => emit('phase', message),
     log: (message: unknown): void => emit('log', message),
     console: undefined,
   });
+}
+
+/** Expose orchestration primitives after metadata validation succeeds. */
+function installWorkflowPrimitives(context: Context): void {
+  const sandbox = context as Context & {
+    agent?: typeof startAgent;
+    parallel?: typeof parallel;
+    pipeline?: typeof pipeline;
+  };
+  sandbox.agent = startAgent;
+  sandbox.parallel = parallel;
+  sandbox.pipeline = pipeline;
 }
 
 async function installDeterministicIntrinsics(context: Context): Promise<void> {

--- a/packages/dreamux/src/service/workflow-service/types.ts
+++ b/packages/dreamux/src/service/workflow-service/types.ts
@@ -42,7 +42,8 @@ export interface WorkflowRunRecord {
 }
 
 export interface WorkflowRunInput {
-  script: string;
+  script?: string;
+  scriptPath?: string;
   args?: unknown;
   max_concurrency?: number;
 }

--- a/packages/dreamux/tests/architecture-ownership-gate.test.ts
+++ b/packages/dreamux/tests/architecture-ownership-gate.test.ts
@@ -170,6 +170,7 @@ describe('architecture ownership gate (#233)', () => {
     root = await mkdtemp(join(tmpdir(), 'dreamux-ownership-gate-'));
     previousHome = process.env['HOME'];
     process.env['HOME'] = join(root, 'home');
+    process.env['DREAMUX_ROOT'] = join(root, 'dreamux');
     await mkdir(process.env['HOME'], { recursive: true });
     resetRuntimeConfig();
   });
@@ -177,6 +178,7 @@ describe('architecture ownership gate (#233)', () => {
   afterEach(async () => {
     if (previousHome === undefined) delete process.env['HOME'];
     else process.env['HOME'] = previousHome;
+    delete process.env['DREAMUX_ROOT'];
     resetRuntimeConfig();
     await rm(root, { recursive: true, force: true });
   });

--- a/packages/dreamux/tests/channel-binding-store.test.ts
+++ b/packages/dreamux/tests/channel-binding-store.test.ts
@@ -47,12 +47,14 @@ describe('ChannelBindingStore v3', () => {
     root = mkdtempSync(join(tmpdir(), 'dreamux-binding-v3-'));
     previousHome = process.env['HOME'];
     process.env['HOME'] = join(root, 'home');
+    process.env['DREAMUX_ROOT'] = join(root, 'dreamux');
     resetRuntimeConfig();
   });
 
   afterEach(() => {
     if (previousHome === undefined) delete process.env['HOME'];
     else process.env['HOME'] = previousHome;
+    delete process.env['DREAMUX_ROOT'];
     resetRuntimeConfig();
     rmSync(root, { recursive: true, force: true });
   });

--- a/packages/dreamux/tests/channel-service-feishu-topic-auth.test.ts
+++ b/packages/dreamux/tests/channel-service-feishu-topic-auth.test.ts
@@ -72,6 +72,7 @@ describe('ChannelService Feishu topic authorization', () => {
     root = mkdtempSync(join(tmpdir(), 'dreamux-feishu-topic-auth-'));
     previousHome = process.env['HOME'];
     process.env['HOME'] = join(root, 'home');
+    process.env['DREAMUX_ROOT'] = join(root, 'dreamux');
     mkdirSync(process.env['HOME'], { recursive: true });
     resetRuntimeConfig();
   });
@@ -79,6 +80,7 @@ describe('ChannelService Feishu topic authorization', () => {
   afterEach(() => {
     if (previousHome === undefined) delete process.env['HOME'];
     else process.env['HOME'] = previousHome;
+    delete process.env['DREAMUX_ROOT'];
     resetRuntimeConfig();
     rmSync(root, { recursive: true, force: true });
   });

--- a/packages/dreamux/tests/channel-service.test.ts
+++ b/packages/dreamux/tests/channel-service.test.ts
@@ -101,12 +101,14 @@ describe('ChannelService binding ownership', () => {
     root = mkdtempSync(join(tmpdir(), 'dreamux-channel-service-'));
     previousHome = process.env['HOME'];
     process.env['HOME'] = join(root, 'home');
+    process.env['DREAMUX_ROOT'] = join(root, 'dreamux');
     resetRuntimeConfig();
   });
 
   afterEach(() => {
     if (previousHome === undefined) delete process.env['HOME'];
     else process.env['HOME'] = previousHome;
+    delete process.env['DREAMUX_ROOT'];
     resetRuntimeConfig();
     rmSync(root, { recursive: true, force: true });
   });

--- a/packages/dreamux/tests/claude-code-live.test.ts
+++ b/packages/dreamux/tests/claude-code-live.test.ts
@@ -85,11 +85,13 @@ describe('claude-code live integration (opt-in)', () => {
     home = mkdtempSync(join(tmpdir(), 'dreamux-cc-live-'));
     previousHome = process.env['HOME'];
     process.env['HOME'] = home;
+    process.env['DREAMUX_ROOT'] = home;
   });
 
   afterEach(() => {
     if (previousHome === undefined) delete process.env['HOME'];
     else process.env['HOME'] = previousHome;
+    delete process.env['DREAMUX_ROOT'];
     rmSync(home, { recursive: true, force: true });
   });
 

--- a/packages/dreamux/tests/claude-code-runtime.test.ts
+++ b/packages/dreamux/tests/claude-code-runtime.test.ts
@@ -391,12 +391,14 @@ describe('ClaudeCodeRuntime resident lifecycle (fake session)', () => {
     home = mkdtempSync(join(tmpdir(), 'dreamux-cc-'));
     previousHome = process.env['HOME'];
     process.env['HOME'] = home;
+    process.env['DREAMUX_ROOT'] = home;
   });
 
   afterEach(async () => {
     await Promise.all(runtimes.map((runtime) => runtime.stop().catch(() => undefined)));
     if (previousHome === undefined) delete process.env['HOME'];
     else process.env['HOME'] = previousHome;
+    delete process.env['DREAMUX_ROOT'];
     rmSync(home, { recursive: true, force: true });
   });
 

--- a/packages/dreamux/tests/claude-code-runtime.test.ts
+++ b/packages/dreamux/tests/claude-code-runtime.test.ts
@@ -95,7 +95,7 @@ function claudeDispatcher(
 }
 
 function okOutcome(sessionId: string | null = 'session-abc'): TurnOutcome {
-  return { isError: false, text: 'done', sessionId, subtype: 'success', errors: [] };
+  return { isError: false, text: 'done', sessionId, subtype: 'success', errors: [], hasStructuredOutput: false };
 }
 
 /** A fake resident session: records turns, plays a scripted outcome sequence. */
@@ -1216,7 +1216,7 @@ describe('ClaudeCodeRuntime resident lifecycle (fake session)', () => {
 
   it('surfaces an error result envelope as a degraded turn', async () => {
     const fleet = fakeFleet([
-      { isError: true, text: '', sessionId: 'session-abc', subtype: 'error_during_execution', errors: ['model overloaded'] },
+      { isError: true, text: '', sessionId: 'session-abc', subtype: 'error_during_execution', errors: ['model overloaded'], hasStructuredOutput: false },
     ]);
     const { runtime, store } = await makeRuntime(fleet);
     await runtime.start();

--- a/packages/dreamux/tests/codex-live.test.ts
+++ b/packages/dreamux/tests/codex-live.test.ts
@@ -510,6 +510,7 @@ describe('codex live integration', () => {
 
       mkdirSync(dispatcherCwd, { recursive: true });
       process.env['HOME'] = runtimeHome;
+    process.env['DREAMUX_ROOT'] = runtimeHome;
       process.env['CODEX_HOME'] = isolatedCodexHome;
       // Onboard the live sender onto the global allow-user list so the folded
       // group messages are delivered (empty `allow_users` authorizes nobody
@@ -634,6 +635,7 @@ describe('codex live integration', () => {
         await server?.shutdown();
         if (previousHome === undefined) delete process.env['HOME'];
         else process.env['HOME'] = previousHome;
+    delete process.env['DREAMUX_ROOT'];
         if (previousCodexHome === undefined) delete process.env['CODEX_HOME'];
         else process.env['CODEX_HOME'] = previousCodexHome;
         rmSync(dir, { recursive: true, force: true });

--- a/packages/dreamux/tests/collaboration-space-race.test.ts
+++ b/packages/dreamux/tests/collaboration-space-race.test.ts
@@ -45,12 +45,14 @@ describe('CollaborationSpaceService race regressions', () => {
     root = mkdtempSync(join(tmpdir(), 'dreamux-collab-race-'));
     previousHome = process.env['HOME'];
     process.env['HOME'] = join(root, 'home');
+    process.env['DREAMUX_ROOT'] = join(root, 'dreamux');
     resetRuntimeConfig();
   });
 
   afterEach(() => {
     if (previousHome === undefined) delete process.env['HOME'];
     else process.env['HOME'] = previousHome;
+    delete process.env['DREAMUX_ROOT'];
     resetRuntimeConfig();
     rmSync(root, { recursive: true, force: true });
   });

--- a/packages/dreamux/tests/collaboration-space-repo-close.test.ts
+++ b/packages/dreamux/tests/collaboration-space-repo-close.test.ts
@@ -54,6 +54,7 @@ describe('collaboration target per-target repo close cleanup', () => {
     root = mkdtempSync(join(tmpdir(), 'dreamux-repo-close-'));
     previousHome = process.env['HOME'];
     process.env['HOME'] = join(root, 'home');
+    process.env['DREAMUX_ROOT'] = join(root, 'dreamux');
     mkdirSync(process.env['HOME'], { recursive: true });
     resetRuntimeConfig();
   });
@@ -61,6 +62,7 @@ describe('collaboration target per-target repo close cleanup', () => {
   afterEach(() => {
     if (previousHome === undefined) delete process.env['HOME'];
     else process.env['HOME'] = previousHome;
+    delete process.env['DREAMUX_ROOT'];
     resetRuntimeConfig();
     rmSync(root, { recursive: true, force: true });
   });

--- a/packages/dreamux/tests/collaboration-space-service.test.ts
+++ b/packages/dreamux/tests/collaboration-space-service.test.ts
@@ -34,12 +34,14 @@ describe('CollaborationSpaceService', () => {
     root = mkdtempSync(join(tmpdir(), 'dreamux-collab-space-'));
     previousHome = process.env['HOME'];
     process.env['HOME'] = join(root, 'home');
+    process.env['DREAMUX_ROOT'] = join(root, 'dreamux');
     resetRuntimeConfig();
   });
 
   afterEach(() => {
     if (previousHome === undefined) delete process.env['HOME'];
     else process.env['HOME'] = previousHome;
+    delete process.env['DREAMUX_ROOT'];
     resetRuntimeConfig();
     rmSync(root, { recursive: true, force: true });
   });

--- a/packages/dreamux/tests/core-event-owner-publishers.test.ts
+++ b/packages/dreamux/tests/core-event-owner-publishers.test.ts
@@ -39,6 +39,7 @@ describe('core event owner publishers', () => {
     root = realpathSync(mkdtempSync(join('/tmp', 'dx-core-events-')));
     previousHome = process.env['HOME'];
     process.env['HOME'] = join(root, 'home');
+    process.env['DREAMUX_ROOT'] = join(root, 'dreamux');
     mkdirSync(process.env['HOME'], { recursive: true });
     resetRuntimeConfig();
   });
@@ -46,6 +47,7 @@ describe('core event owner publishers', () => {
   afterEach(() => {
     if (previousHome === undefined) delete process.env['HOME'];
     else process.env['HOME'] = previousHome;
+    delete process.env['DREAMUX_ROOT'];
     resetRuntimeConfig();
     rmSync(root, { recursive: true, force: true });
   });
@@ -309,6 +311,7 @@ describe('core event owner publishers', () => {
     const blockedHome = join(root, 'blocked-home');
     writeFileSync(blockedHome, 'not a directory');
     process.env['HOME'] = blockedHome;
+    process.env['DREAMUX_ROOT'] = blockedHome;
     resetRuntimeConfig();
 
     const log = noopLogger();

--- a/packages/dreamux/tests/daemon.test.ts
+++ b/packages/dreamux/tests/daemon.test.ts
@@ -219,6 +219,7 @@ describe('managed service working directory ownership', () => {
     oldHome = process.env['HOME'];
     oldConfigDir = process.env['DREAMUX_CONFIG_DIR'];
     process.env['HOME'] = join(root, 'home');
+    process.env['DREAMUX_ROOT'] = join(root, 'dreamux');
     process.env['DREAMUX_CONFIG_DIR'] = join(root, 'config');
     writeInstallConfig(join(root, 'config'));
   });
@@ -304,6 +305,7 @@ describe('daemon install (stable service Node, issue #83)', () => {
     oldHome = process.env['HOME'];
     oldConfigDir = process.env['DREAMUX_CONFIG_DIR'];
     process.env['HOME'] = join(root, 'home');
+    process.env['DREAMUX_ROOT'] = join(root, 'dreamux');
     process.env['DREAMUX_CONFIG_DIR'] = join(root, 'config');
     writeInstallConfig(join(root, 'config'));
   });
@@ -607,11 +609,13 @@ describe('provider binary resolution from captured session PATH', () => {
     oldHome = process.env['HOME'];
     oldPath = process.env['PATH'];
     process.env['HOME'] = join(root, 'home');
+    process.env['DREAMUX_ROOT'] = join(root, 'dreamux');
   });
 
   afterEach(() => {
     if (oldHome === undefined) delete process.env['HOME'];
     else process.env['HOME'] = oldHome;
+    delete process.env['DREAMUX_ROOT'];
     if (oldPath === undefined) delete process.env['PATH'];
     else process.env['PATH'] = oldPath;
     resetRuntimeConfig();
@@ -730,6 +734,7 @@ describe('re-running daemon install refreshes the persisted service PATH', () =>
     oldConfigDir = process.env['DREAMUX_CONFIG_DIR'];
     oldPath = process.env['PATH'];
     process.env['HOME'] = join(root, 'home');
+    process.env['DREAMUX_ROOT'] = join(root, 'dreamux');
     process.env['DREAMUX_CONFIG_DIR'] = join(root, 'config');
     writeInstallConfig(join(root, 'config'));
   });
@@ -853,6 +858,7 @@ describe('normal CLI invocation captures ambient process.env PATH (options.env o
     oldPath = process.env['PATH'];
     oldCodexBin = process.env['CODEX_HOST_CODEX_BIN'];
     process.env['HOME'] = join(root, 'home');
+    process.env['DREAMUX_ROOT'] = join(root, 'dreamux');
     process.env['DREAMUX_CONFIG_DIR'] = join(root, 'config');
     // Normal CLI use: the host codex binary is in the ambient environment.
     process.env['CODEX_HOST_CODEX_BIN'] = process.execPath;
@@ -970,12 +976,14 @@ describe('daemon install resolves bare provider bins and includes them in the se
     oldConfigDir = process.env['DREAMUX_CONFIG_DIR'];
     oldPath = process.env['PATH'];
     process.env['HOME'] = join(root, 'home');
+    process.env['DREAMUX_ROOT'] = join(root, 'dreamux');
     process.env['DREAMUX_CONFIG_DIR'] = join(root, 'config');
   });
 
   afterEach(() => {
     if (oldHome === undefined) delete process.env['HOME'];
     else process.env['HOME'] = oldHome;
+    delete process.env['DREAMUX_ROOT'];
     if (oldConfigDir === undefined) delete process.env['DREAMUX_CONFIG_DIR'];
     else process.env['DREAMUX_CONFIG_DIR'] = oldConfigDir;
     if (oldPath === undefined) delete process.env['PATH'];

--- a/packages/dreamux/tests/dispatcher-codex-home.test.ts
+++ b/packages/dreamux/tests/dispatcher-codex-home.test.ts
@@ -28,12 +28,14 @@ describe('global Codex home doctor', () => {
     runtimeDir = mkdtempSync(join(homedir(), '.dreamux-test-'));
     previousHome = process.env['HOME'];
     process.env['HOME'] = join(runtimeDir, 'home');
+    process.env['DREAMUX_ROOT'] = join(runtimeDir, 'dreamux');
     setRuntimeConfig(BUILT_IN_DEFAULTS);
   });
 
   afterEach(() => {
     if (previousHome === undefined) delete process.env['HOME'];
     else process.env['HOME'] = previousHome;
+    delete process.env['DREAMUX_ROOT'];
     resetRuntimeConfig();
     rmSync(runtimeDir, { recursive: true, force: true });
   });
@@ -139,9 +141,9 @@ describe('global Codex home doctor', () => {
   it('uses the private OS temp dir for deep home dirs when XDG is absent (#182 macOS gate)', async () => {
     const previousXdg = process.env['XDG_RUNTIME_DIR'];
     const previousTmpdir = process.env['TMPDIR'];
-    // The macOS CI shape: long $HOME, no $XDG_RUNTIME_DIR, but a short PRIVATE
-    // $TMPDIR keeps the Codex socket within budget instead of failing loudly.
-    process.env['HOME'] = join(runtimeDir, 'h'.repeat(120));
+    // The macOS CI shape: long DREAMUX_ROOT, no $XDG_RUNTIME_DIR, but a short
+    // PRIVATE $TMPDIR keeps the Codex socket within budget instead of failing loudly.
+    process.env['DREAMUX_ROOT'] = join(runtimeDir, 'h'.repeat(120));
     delete process.env['XDG_RUNTIME_DIR'];
     process.env['TMPDIR'] = join(runtimeDir, 't');
 
@@ -159,7 +161,7 @@ describe('global Codex home doctor', () => {
 
   it('uses the private XDG runtime root for deep home dirs instead of failing', async () => {
     const previousXdg = process.env['XDG_RUNTIME_DIR'];
-    process.env['HOME'] = join(runtimeDir, 'h'.repeat(120));
+    process.env['DREAMUX_ROOT'] = join(runtimeDir, 'h'.repeat(120));
     process.env['XDG_RUNTIME_DIR'] = join(runtimeDir, 'xdg');
 
     try {

--- a/packages/dreamux/tests/dispatcher-collaboration-space.test.ts
+++ b/packages/dreamux/tests/dispatcher-collaboration-space.test.ts
@@ -329,6 +329,7 @@ describe('DispatcherService collaboration-space routing', () => {
     root = realpathSync(mkdtempSync(join('/tmp', 'dx-')));
     previousHome = process.env['HOME'];
     process.env['HOME'] = join(root, 'home');
+    process.env['DREAMUX_ROOT'] = join(root, 'dreamux');
     mkdirSync(process.env['HOME'], { recursive: true });
     resetRuntimeConfig();
   });
@@ -336,6 +337,7 @@ describe('DispatcherService collaboration-space routing', () => {
   afterEach(() => {
     if (previousHome === undefined) delete process.env['HOME'];
     else process.env['HOME'] = previousHome;
+    delete process.env['DREAMUX_ROOT'];
     resetRuntimeConfig();
     rmSync(root, { recursive: true, force: true });
   });

--- a/packages/dreamux/tests/dispatcher-store.test.ts
+++ b/packages/dreamux/tests/dispatcher-store.test.ts
@@ -43,12 +43,14 @@ describe('dispatcher config projection store', () => {
     root = mkdtempSync(join(tmpdir(), 'dreamux-store-'));
     previousHome = process.env['HOME'];
     process.env['HOME'] = join(root, 'home');
+    process.env['DREAMUX_ROOT'] = join(root, 'dreamux');
     resetRuntimeConfig();
   });
 
   afterEach(() => {
     if (previousHome === undefined) delete process.env['HOME'];
     else process.env['HOME'] = previousHome;
+    delete process.env['DREAMUX_ROOT'];
     resetRuntimeConfig();
     rmSync(root, { recursive: true, force: true });
   });
@@ -97,12 +99,14 @@ describe('dispatcher root identity authority', () => {
     root = mkdtempSync(join(tmpdir(), 'dreamux-dispatcher-identity-'));
     previousHome = process.env['HOME'];
     process.env['HOME'] = join(root, 'home');
+    process.env['DREAMUX_ROOT'] = join(root, 'dreamux');
     resetRuntimeConfig();
   });
 
   afterEach(() => {
     if (previousHome === undefined) delete process.env['HOME'];
     else process.env['HOME'] = previousHome;
+    delete process.env['DREAMUX_ROOT'];
     resetRuntimeConfig();
     rmSync(root, { recursive: true, force: true });
   });

--- a/packages/dreamux/tests/dispatcher-workspace.test.ts
+++ b/packages/dreamux/tests/dispatcher-workspace.test.ts
@@ -59,12 +59,14 @@ describe('dispatcher workspace cwd contract (issue #182 PR-4)', () => {
     root = mkdtempSync(join(tmpdir(), 'dreamux-workspace-'));
     previousHome = process.env['HOME'];
     process.env['HOME'] = join(root, 'home');
+    process.env['DREAMUX_ROOT'] = join(root, 'dreamux');
     resetRuntimeConfig();
   });
 
   afterEach(() => {
     if (previousHome === undefined) delete process.env['HOME'];
     else process.env['HOME'] = previousHome;
+    delete process.env['DREAMUX_ROOT'];
     resetRuntimeConfig();
     rmSync(root, { recursive: true, force: true });
   });

--- a/packages/dreamux/tests/doctor.test.ts
+++ b/packages/dreamux/tests/doctor.test.ts
@@ -111,6 +111,7 @@ describe('dreamux doctor command', () => {
     process.env['DREAMUX_CONFIG_DIR'] = join(root, 'config');
     process.env['DREAMUX_BIN'] = '/usr/local/bin/dreamux';
     process.env['HOME'] = join(root, 'home');
+    process.env['DREAMUX_ROOT'] = join(root, 'dreamux');
   });
 
   afterEach(() => {

--- a/packages/dreamux/tests/e2e.test.ts
+++ b/packages/dreamux/tests/e2e.test.ts
@@ -252,6 +252,7 @@ describe('dreamux cross-module e2e', () => {
     runtimeDir = mkdtempSync(join(tmpdir(), 'dreamux-e2e-'));
     previousHome = process.env['HOME'];
     process.env['HOME'] = join(runtimeDir, 'home');
+    process.env['DREAMUX_ROOT'] = join(runtimeDir, 'dreamux');
     writeReadyDispatcherWorkspace('flow');
     // Onboard the canonical sender onto the global allow-user list so a
     // mentioned group message is delivered (empty `allow_users` authorizes
@@ -283,6 +284,7 @@ describe('dreamux cross-module e2e', () => {
     await fake?.close();
     if (previousHome === undefined) delete process.env['HOME'];
     else process.env['HOME'] = previousHome;
+    delete process.env['DREAMUX_ROOT'];
     rmSync(runtimeDir, { recursive: true, force: true });
   });
 

--- a/packages/dreamux/tests/external-runtime-parity.test.ts
+++ b/packages/dreamux/tests/external-runtime-parity.test.ts
@@ -140,6 +140,7 @@ describe('external runtime production parity', () => {
     root = await mkdtemp(join(tmpdir(), 'dreamux-external-runtime-parity-'));
     previousHome = process.env['HOME'];
     process.env['HOME'] = join(root, 'home');
+    process.env['DREAMUX_ROOT'] = join(root, 'dreamux');
     await mkdir(process.env['HOME'], { recursive: true });
     resetRuntimeConfig();
     externalRuntimeModule.resetExternalRuntimeFixture();
@@ -148,6 +149,7 @@ describe('external runtime production parity', () => {
   afterEach(async () => {
     if (previousHome === undefined) delete process.env['HOME'];
     else process.env['HOME'] = previousHome;
+    delete process.env['DREAMUX_ROOT'];
     resetRuntimeConfig();
     await rm(root, { recursive: true, force: true });
     externalRuntimeModule.resetExternalRuntimeFixture();

--- a/packages/dreamux/tests/legacy-state-fail-loud.test.ts
+++ b/packages/dreamux/tests/legacy-state-fail-loud.test.ts
@@ -55,12 +55,14 @@ describe('issue #199 Slice 5 — pre-#199 local state fails loud', () => {
     root = mkdtempSync(join(tmpdir(), 'dreamux-legacy-'));
     previousHome = process.env['HOME'];
     process.env['HOME'] = join(root, 'home');
+    process.env['DREAMUX_ROOT'] = join(root, 'dreamux');
     resetRuntimeConfig();
   });
 
   afterEach(() => {
     if (previousHome === undefined) delete process.env['HOME'];
     else process.env['HOME'] = previousHome;
+    delete process.env['DREAMUX_ROOT'];
     resetRuntimeConfig();
     rmSync(root, { recursive: true, force: true });
   });

--- a/packages/dreamux/tests/onboard.test.ts
+++ b/packages/dreamux/tests/onboard.test.ts
@@ -140,11 +140,13 @@ describe('dreamux onboard', () => {
     root = mkdtempSync(join(homedir(), '.dreamux-onboard-'));
     previousHome = process.env['HOME'];
     process.env['HOME'] = join(root, 'home');
+    process.env['DREAMUX_ROOT'] = join(root, 'dreamux');
   });
 
   afterEach(() => {
     if (previousHome === undefined) delete process.env['HOME'];
     else process.env['HOME'] = previousHome;
+    delete process.env['DREAMUX_ROOT'];
     resetRuntimeConfig();
     rmSync(root, { recursive: true, force: true });
   });

--- a/packages/dreamux/tests/runtime-paths.test.ts
+++ b/packages/dreamux/tests/runtime-paths.test.ts
@@ -230,7 +230,7 @@ describe('runtime paths', () => {
       unixSocketPathFitsBudget('x'.repeat(DREAMUX_UNIX_SOCKET_PATH_MAX_BYTES + 1)),
     ).toBe(false);
 
-    process.env['HOME'] = join(root, 'h'.repeat(90));
+    process.env['DREAMUX_ROOT'] = join(root, 'h'.repeat(90));
     expect(() => adminSocketPath()).toThrow(/too long for Unix sockets/);
   });
 

--- a/packages/dreamux/tests/runtime-sockets.test.ts
+++ b/packages/dreamux/tests/runtime-sockets.test.ts
@@ -31,6 +31,7 @@ describe('runtime socket allocation', () => {
     previousXdg = process.env['XDG_RUNTIME_DIR'];
     previousTmpdir = process.env['TMPDIR'];
     process.env['HOME'] = join(root, 'home');
+    process.env['DREAMUX_ROOT'] = join(root, 'dreamux');
     delete process.env['XDG_RUNTIME_DIR'];
     // Pin TMPDIR to a shared-tmp value so the private-OS-temp candidate is
     // excluded by default; tests that exercise it set TMPDIR explicitly. This
@@ -43,6 +44,7 @@ describe('runtime socket allocation', () => {
   afterEach(() => {
     if (previousHome === undefined) delete process.env['HOME'];
     else process.env['HOME'] = previousHome;
+    delete process.env['DREAMUX_ROOT'];
     if (previousXdg === undefined) delete process.env['XDG_RUNTIME_DIR'];
     else process.env['XDG_RUNTIME_DIR'] = previousXdg;
     if (previousTmpdir === undefined) delete process.env['TMPDIR'];
@@ -95,11 +97,11 @@ describe('runtime socket allocation', () => {
   });
 
   it('uses a private OS temp dir when XDG is absent and the run root is over budget (#182 macOS gate)', () => {
-    // Reproduce the macOS CI failure: no XDG_RUNTIME_DIR and a long per-run HOME
+    // Reproduce the macOS CI failure: no XDG_RUNTIME_DIR and a long DREAMUX_ROOT
     // push ~/.dreamux/run/sockets over the sun_path budget. A short, PRIVATE
     // TMPDIR (the macOS $TMPDIR analog) must keep the socket within budget
-    // without touching shared /tmp or depending on the long durable HOME.
-    process.env['HOME'] = join(root, 'h'.repeat(120));
+    // without touching shared /tmp or depending on the long durable root.
+    process.env['DREAMUX_ROOT'] = join(root, 'h'.repeat(120));
     resetRuntimeConfig();
     const privateTmp = join(root, 't'); // short, under the real (short) home
     const path = allocateRuntimeSocketPath('test socket', { TMPDIR: privateTmp });
@@ -125,7 +127,7 @@ describe('runtime socket allocation', () => {
   });
 
   it('fails loudly when even the dreamux-owned fallback is over budget', () => {
-    process.env['HOME'] = join(root, 'h'.repeat(120));
+    process.env['DREAMUX_ROOT'] = join(root, 'h'.repeat(120));
     // TMPDIR pinned to shared /tmp (beforeEach) is excluded, so no private-temp
     // candidate rescues an over-budget run root here.
     expect(() => allocateRuntimeSocketPath('test socket', {})).toThrow(

--- a/packages/dreamux/tests/scheduler.test.ts
+++ b/packages/dreamux/tests/scheduler.test.ts
@@ -31,12 +31,14 @@ describe('CronJobStore', () => {
     root = mkdtempSync(join(tmpdir(), 'dreamux-scheduler-'));
     previousHome = process.env['HOME'];
     process.env['HOME'] = join(root, 'home');
+    process.env['DREAMUX_ROOT'] = join(root, 'dreamux');
     resetRuntimeConfig();
   });
 
   afterEach(() => {
     if (previousHome === undefined) delete process.env['HOME'];
     else process.env['HOME'] = previousHome;
+    delete process.env['DREAMUX_ROOT'];
     resetRuntimeConfig();
     rmSync(root, { recursive: true, force: true });
   });
@@ -128,12 +130,14 @@ describe('SchedulerService dispatch', () => {
     root = mkdtempSync(join(tmpdir(), 'dreamux-scheduler-'));
     previousHome = process.env['HOME'];
     process.env['HOME'] = join(root, 'home');
+    process.env['DREAMUX_ROOT'] = join(root, 'dreamux');
     resetRuntimeConfig();
   });
 
   afterEach(() => {
     if (previousHome === undefined) delete process.env['HOME'];
     else process.env['HOME'] = previousHome;
+    delete process.env['DREAMUX_ROOT'];
     resetRuntimeConfig();
     rmSync(root, { recursive: true, force: true });
   });

--- a/packages/dreamux/tests/team-collection-read-path.test.ts
+++ b/packages/dreamux/tests/team-collection-read-path.test.ts
@@ -250,12 +250,14 @@ describe('TeamCollection read path (issue #233 R4)', () => {
     root = mkdtempSync(join(tmpdir(), 'dreamux-team-collection-'));
     previousHome = process.env['HOME'];
     process.env['HOME'] = join(root, 'home');
+    process.env['DREAMUX_ROOT'] = join(root, 'dreamux');
     mkdirSync(process.env['HOME'], { recursive: true });
   });
 
   afterEach(() => {
     if (previousHome === undefined) delete process.env['HOME'];
     else process.env['HOME'] = previousHome;
+    delete process.env['DREAMUX_ROOT'];
     rmSync(root, { recursive: true, force: true });
   });
 
@@ -390,12 +392,14 @@ describe('exclusively owned TeamMate submission', () => {
     root = mkdtempSync(join(tmpdir(), 'dreamux-owned-teammate-'));
     previousHome = process.env['HOME'];
     process.env['HOME'] = join(root, 'home');
+    process.env['DREAMUX_ROOT'] = join(root, 'dreamux');
     mkdirSync(process.env['HOME'], { recursive: true });
   });
 
   afterEach(() => {
     if (previousHome === undefined) delete process.env['HOME'];
     else process.env['HOME'] = previousHome;
+    delete process.env['DREAMUX_ROOT'];
     rmSync(root, { recursive: true, force: true });
   });
 
@@ -961,12 +965,14 @@ describe('TeamCollection route readiness recovery', () => {
     root = mkdtempSync(join(tmpdir(), 'dreamux-team-route-ready-'));
     previousHome = process.env['HOME'];
     process.env['HOME'] = join(root, 'home');
+    process.env['DREAMUX_ROOT'] = join(root, 'dreamux');
     mkdirSync(process.env['HOME'], { recursive: true });
   });
 
   afterEach(() => {
     if (previousHome === undefined) delete process.env['HOME'];
     else process.env['HOME'] = previousHome;
+    delete process.env['DREAMUX_ROOT'];
     rmSync(root, { recursive: true, force: true });
   });
 
@@ -1096,12 +1102,14 @@ describe('TeamCollection create without a prompt fires no leader turn', () => {
     root = mkdtempSync(join(tmpdir(), 'dreamux-team-create-'));
     previousHome = process.env['HOME'];
     process.env['HOME'] = join(root, 'home');
+    process.env['DREAMUX_ROOT'] = join(root, 'dreamux');
     mkdirSync(process.env['HOME'], { recursive: true });
   });
 
   afterEach(() => {
     if (previousHome === undefined) delete process.env['HOME'];
     else process.env['HOME'] = previousHome;
+    delete process.env['DREAMUX_ROOT'];
     rmSync(root, { recursive: true, force: true });
   });
 
@@ -1379,12 +1387,14 @@ describe('TeamCollection identity prompt launch behavior', () => {
     root = mkdtempSync(join(tmpdir(), 'dreamux-team-identity-'));
     previousHome = process.env['HOME'];
     process.env['HOME'] = join(root, 'home');
+    process.env['DREAMUX_ROOT'] = join(root, 'dreamux');
     mkdirSync(process.env['HOME'], { recursive: true });
   });
 
   afterEach(() => {
     if (previousHome === undefined) delete process.env['HOME'];
     else process.env['HOME'] = previousHome;
+    delete process.env['DREAMUX_ROOT'];
     rmSync(root, { recursive: true, force: true });
   });
 
@@ -1511,12 +1521,14 @@ describe('TeamCollection TeamLeader lifecycle and dispatcher send', () => {
     root = mkdtempSync(join(tmpdir(), 'dreamux-team-send-'));
     previousHome = process.env['HOME'];
     process.env['HOME'] = join(root, 'home');
+    process.env['DREAMUX_ROOT'] = join(root, 'dreamux');
     mkdirSync(process.env['HOME'], { recursive: true });
   });
 
   afterEach(() => {
     if (previousHome === undefined) delete process.env['HOME'];
     else process.env['HOME'] = previousHome;
+    delete process.env['DREAMUX_ROOT'];
     rmSync(root, { recursive: true, force: true });
   });
 
@@ -2097,12 +2109,14 @@ describe('closing a team member must not remove the shared team worktree', () =>
     root = mkdtempSync(join(tmpdir(), 'dreamux-team-member-close-'));
     previousHome = process.env['HOME'];
     process.env['HOME'] = join(root, 'home');
+    process.env['DREAMUX_ROOT'] = join(root, 'dreamux');
     mkdirSync(process.env['HOME'], { recursive: true });
   });
 
   afterEach(() => {
     if (previousHome === undefined) delete process.env['HOME'];
     else process.env['HOME'] = previousHome;
+    delete process.env['DREAMUX_ROOT'];
     rmSync(root, { recursive: true, force: true });
   });
 
@@ -2197,12 +2211,14 @@ describe('team dissolve syncs cleanup_state to the leader and members (#237)', (
     root = mkdtempSync(join(tmpdir(), 'dreamux-team-dissolve-state-'));
     previousHome = process.env['HOME'];
     process.env['HOME'] = join(root, 'home');
+    process.env['DREAMUX_ROOT'] = join(root, 'dreamux');
     mkdirSync(process.env['HOME'], { recursive: true });
   });
 
   afterEach(() => {
     if (previousHome === undefined) delete process.env['HOME'];
     else process.env['HOME'] = previousHome;
+    delete process.env['DREAMUX_ROOT'];
     rmSync(root, { recursive: true, force: true });
   });
 

--- a/packages/dreamux/tests/team-scheduler.test.ts
+++ b/packages/dreamux/tests/team-scheduler.test.ts
@@ -325,6 +325,7 @@ describe('TeamLeader cron scheduler lifecycle', () => {
     root = mkdtempSync(join(tmpdir(), 'dreamux-team-scheduler-'));
     previousHome = process.env['HOME'];
     process.env['HOME'] = join(root, 'home');
+    process.env['DREAMUX_ROOT'] = join(root, 'dreamux');
     mkdirSync(process.env['HOME'], { recursive: true });
     resetRuntimeConfig();
   });
@@ -332,6 +333,7 @@ describe('TeamLeader cron scheduler lifecycle', () => {
   afterEach(() => {
     if (previousHome === undefined) delete process.env['HOME'];
     else process.env['HOME'] = previousHome;
+    delete process.env['DREAMUX_ROOT'];
     resetRuntimeConfig();
     rmSync(root, { recursive: true, force: true });
   });

--- a/packages/dreamux/tests/teammate-mcp.test.ts
+++ b/packages/dreamux/tests/teammate-mcp.test.ts
@@ -214,8 +214,12 @@ describe('teammate-mcp stdio shim', () => {
       expect(JSON.stringify(workflowTools)).not.toMatch(/auto-close/i);
 
       const run = workflowTools[0]!;
-      expect(run.inputSchema.required).toEqual(['script']);
+      expect(run.inputSchema.required).toEqual([]);
       expect(run.inputSchema.properties['script']).toMatchObject({
+        type: 'string',
+        minLength: 1,
+      });
+      expect(run.inputSchema.properties['scriptPath']).toMatchObject({
         type: 'string',
         minLength: 1,
       });

--- a/packages/dreamux/tests/teammate-service.test.ts
+++ b/packages/dreamux/tests/teammate-service.test.ts
@@ -226,12 +226,14 @@ describe('TeammateService channel input routing', () => {
     root = mkdtempSync(join(tmpdir(), 'dreamux-teammate-service-'));
     previousHome = process.env['HOME'];
     process.env['HOME'] = join(root, 'home');
+    process.env['DREAMUX_ROOT'] = join(root, 'dreamux');
     mkdirSync(process.env['HOME'], { recursive: true });
   });
 
   afterEach(() => {
     if (previousHome === undefined) delete process.env['HOME'];
     else process.env['HOME'] = previousHome;
+    delete process.env['DREAMUX_ROOT'];
     rmSync(root, { recursive: true, force: true });
   });
 

--- a/packages/dreamux/tests/uninstall.test.ts
+++ b/packages/dreamux/tests/uninstall.test.ts
@@ -48,11 +48,13 @@ describe('dreamux uninstall', () => {
     root = mkdtempSync(join(homedir(), '.dreamux-uninstall-'));
     previousHome = process.env['HOME'];
     process.env['HOME'] = join(root, 'home');
+    process.env['DREAMUX_ROOT'] = join(root, 'dreamux');
   });
 
   afterEach(() => {
     if (previousHome === undefined) delete process.env['HOME'];
     else process.env['HOME'] = previousHome;
+    delete process.env['DREAMUX_ROOT'];
     resetRuntimeConfig();
     rmSync(root, { recursive: true, force: true });
   });
@@ -246,6 +248,7 @@ describe('dreamux uninstall', () => {
       const homeDir = join(caseRoot, 'home');
       const previousCaseHome = process.env['HOME'];
       process.env['HOME'] = homeDir;
+      process.env['DREAMUX_ROOT'] = homeDir;
       const servicePath = join(
         homeDir,
         '.config',

--- a/packages/dreamux/tests/workflow-runner.test.ts
+++ b/packages/dreamux/tests/workflow-runner.test.ts
@@ -227,6 +227,22 @@ describe('workflow runner', () => {
     });
   });
 
+  it('does not spawn agents from top-level code before meta is validated', async () => {
+    const execution = await runScript(`
+      agent('spawn before meta validation');
+      export const meta = { name: 'early-agent', description: 'early agent' };
+      export default async function run() { return null; }
+    `);
+
+    expect(execution.result).toMatchObject({
+      type: 'run_result',
+      status: 'failed',
+    });
+    expect(
+      execution.messages.some((m) => m.type === 'agent_start'),
+    ).toBe(false);
+  });
+
   it('force-stops a workflow that blocks the VM event loop', async () => {
     let resolveReady: (() => void) | undefined;
     const ready = new Promise<void>((resolveReadyPromise) => {

--- a/packages/dreamux/tests/workflow-service.test.ts
+++ b/packages/dreamux/tests/workflow-service.test.ts
@@ -304,6 +304,7 @@ describe('WorkflowService', () => {
     home = await mkdtemp(join(tmpdir(), 'dreamux-workflow-service-'));
     previousHome = process.env['HOME'];
     process.env['HOME'] = home;
+    process.env['DREAMUX_ROOT'] = home;
   });
 
   afterEach(async () => {
@@ -313,6 +314,7 @@ describe('WorkflowService', () => {
     teammateFakes.length = 0;
     if (previousHome === undefined) delete process.env['HOME'];
     else process.env['HOME'] = previousHome;
+    delete process.env['DREAMUX_ROOT'];
     await rm(home, { recursive: true, force: true });
     vi.restoreAllMocks();
   });

--- a/packages/dreamux/tests/workflow-service.test.ts
+++ b/packages/dreamux/tests/workflow-service.test.ts
@@ -863,6 +863,46 @@ describe('WorkflowService', () => {
     ]);
   });
 
+  it('propagates an unsupported outputSchema error thrown by spawnOwned', async () => {
+    const ctx = await context(['run-schema-throw']);
+    const unsupported = Object.assign(
+      new Error('claude-code runtime does not support per-turn outputSchema'),
+      {
+        name: 'UnsupportedAgentRuntimeFeatureError',
+        feature: 'outputSchema',
+      },
+    );
+    ctx.teammates.spawnError = unsupported;
+    await ctx.service.run({ script: validScript() });
+    const runner = ctx.runner.latest();
+
+    runner.emit({
+      type: 'agent_start',
+      index: 0,
+      prompt: 'structured prompt',
+      options: { schema: { type: 'object' } },
+    });
+    await vi.waitFor(() =>
+      expect(agentResults(runner)).toEqual([
+        {
+          type: 'agent_result',
+          index: 0,
+          error: 'claude-code runtime does not support per-turn outputSchema',
+        },
+      ]),
+    );
+    expect(ctx.teammates.spawnAttempts).toBe(1);
+    expect(ctx.teammates.spawns).toHaveLength(0);
+
+    runner.emit({
+      type: 'run_result',
+      status: 'failed',
+      error: 'claude-code runtime does not support per-turn outputSchema',
+    });
+    await vi.waitFor(() => expect(ctx.initiator.received).toHaveLength(1));
+    expect(ctx.initiator.received[0]?.status).toBe('failed');
+  });
+
   it('maps an ordinary outputSchema turn failure to null', async () => {
     const ctx = await context(['run-schema-failed']);
     ctx.teammates.nextTurnStatus = 'failed';


### PR DESCRIPTION
## Summary

This PR lands the Dynamic Workflow MVP and adds structured output (JSON Schema) support to the Claude Code agent runtime.

### Dynamic Workflow
- Workflow runner with `agent()`, `parallel()`, `pipeline()`, `phase()`, `log()` script API
- Deterministic VM sandbox: no Date.now/Math.random/new Date(), no imports, no host process/fs/network/timer access
- `workflow_run` / `workflow_status` / `workflow_list` / `workflow_stop` MCP methods
- `scriptPath` support to load workflow scripts from files
- Fail-loud on unsupported capabilities (e.g. outputSchema on a runtime that can't provide it)

### Claude Code outputSchema
- `--json-schema` flag passed to `claude` binary at session creation
- `structured_output` field preferred over free-form `result` text in schema mode
- Fail-loud when a schema session does not return `structured_output` (no silent degradation)
- `lastResult` cached only after all validation passes, so failed turns never leak unvalidated text

### Review history
This branch went through 4 review rounds. All must-fix findings are resolved:
- Meta validated before `agent`/primitives exposed to top-level code
- `spawnOwned()` throw path propagates unsupported capability errors back to the workflow
- `hasStructuredOutput` presence flag distinguishes explicit null from absent field
- Test fixtures synced with the required `TurnOutcome.hasStructuredOutput` field
- `lastResult` assignment moved after error + schema checks

## Verification
- `rush build`: green
- `tsc -p tsconfig.tests.json --noEmit`: clean (exit 0)
- Claude Code tests: 6 files / 50 tests passed
- Dreamux workflow tests: 2 files / 36 tests passed
- `rush lint`: passes (max-lines, no-sync-IO, import boundaries)