### PR TITLE
fix(codex): adapt portable output schemas

### DIFF
--- a/.agents/archive/proposals/README.md
+++ b/.agents/archive/proposals/README.md
@@ -5,6 +5,7 @@ implementation guidance; use the linked decisions and reference docs first.
 
 | Proposal | Current pointer |
 |---|---|
+| [Codex portable output schema adapter](codex-portable-output-schema.md) | Implemented in `@excitedjs/agent-runtime-codex`; see [Provider Runtime](../../domains/provider-runtime.md#codex-portable-output-schema) and the [Codex package README](../../../packages/agent-runtime/codex/README.md#portable-structured-output) |
 | [Concrete entity name suffix length](concrete-name-suffix-length.md) | [Current architecture](../../reference/current-architecture.md), [Dispatcher orchestration](../../domains/dispatcher-orchestration.md), [Service topology](../../reference/service-topology.md) |
 | [Dynamic Workflow 编排](dynamic-workflow.md) | Implemented in PR #312 (`feat(workflow): Dynamic Workflow MVP`); see bundled skill `workflow` and `service/workflow-service/` |
 | [Workflow ultracode dialect parity](workflow-ultracode-dialect-parity.md) | Implemented issue #318 requests 1-4; see [Dynamic Workflow usage](../../reference/dynamic-workflow-usage.md), [Current architecture](../../reference/current-architecture.md), and bundled skill `workflow` |

--- a/.agents/archive/proposals/codex-portable-output-schema.md
+++ b/.agents/archive/proposals/codex-portable-output-schema.md
@@ -1,6 +1,9 @@
 # Codex portable output schema adapter
 
-- **Status:** Draft for review
+- **Status:** Implemented historical proposal; current behavior is documented in
+  [Provider Runtime](../../domains/provider-runtime.md#codex-portable-output-schema)
+  and the
+  [Codex package README](../../../packages/agent-runtime/codex/README.md#portable-structured-output)
 - **Date:** 2026-08-09
 - **Affects:** `@excitedjs/agent-runtime-codex`, Workflow schema portability,
   Codex `turn/start.outputSchema`, runtime contract tests
@@ -72,7 +75,7 @@ structured-output surface:
 - `description`;
 - `properties`, `required`, `additionalProperties: false`;
 - one schema-valued `items`;
-- `enum`;
+- primitive-value `enum`;
 - numeric `minimum` and `maximum`, which the current Codex app-server live
   boundary accepts and existing Workflow score schemas use.
 

--- a/.agents/archive/proposals/codex-portable-output-schema.md
+++ b/.agents/archive/proposals/codex-portable-output-schema.md
@@ -154,9 +154,6 @@ The codec is in-memory execution state only. It is never persisted.
 - Runtime teardown/restart discards all in-memory codecs together with the old
   `TurnManager`. Interrupted turns settle stopped through the existing teardown
   path. A new process never restores a result from the old client.
-- A currently pending structured turn without its expected codec is an internal
-  contract failure and settles failed; it is never passed through as
-  unstructured text.
 
 ## Active-turn folding
 

--- a/.agents/domains/provider-runtime.md
+++ b/.agents/domains/provider-runtime.md
@@ -161,9 +161,9 @@ exact native turn id.
 Restoration runs once, behind the existing pending-turn mutual-exclusion guard,
 before `onTurnCompleted`. A successful restoration is the only structured text
 seen by `CodexRuntime.recordCollectedTurn()`, so `lastResult` and completed
-settlement use the neutral restored JSON. Parse, shape, or missing-codec failure
-does not call `onTurnCompleted` or mutate `lastResult`; it emits one ordinary
-failed `TurnSettledSignal` with `text: null`. Submission failure, stop, app-server
+settlement use the neutral restored JSON. Parse or shape restoration failure does
+not call `onTurnCompleted` or mutate `lastResult`; it emits one ordinary failed
+`TurnSettledSignal` with `text: null`. Submission failure, stop, app-server
 teardown/restart, and late completion clear or discard in-memory codecs through
 the same turn lifecycle and never restore or settle twice.
 

--- a/.agents/domains/provider-runtime.md
+++ b/.agents/domains/provider-runtime.md
@@ -123,6 +123,60 @@ Source:
 - `/packages/dreamux/src/service/teammate-service/factory.ts`
 - `/packages/dreamux/tests/package-boundary-guards.test.ts`
 
+## Codex Portable Output Schema
+
+Dreamux core passes the neutral `AgentRuntimeTextInput.outputSchema` unchanged.
+`@excitedjs/agent-runtime-codex` privately compiles it for Codex strict
+structured output; no Codex branch, retry loop, or schema validator exists in
+core.
+
+The accepted portable vocabulary is intentionally narrow:
+
+- one non-null closed root object;
+- nested closed object schemas and arrays with exactly one `items` schema;
+- `object`, `array`, `string`, `number`, `integer`, `boolean`, and `null`;
+- exactly `[T, "null"]` for nullable values, with no other unions;
+- `description`, primitive-value `enum`, and numeric `minimum` / `maximum`.
+
+Every object property is required on the Codex wire schema. An originally
+optional non-nullable property gains `null` in its wire type (and enum when
+present). The private restoration plan recursively removes only those optional
+`null` placeholders. Required nullable fields remain present as `null`.
+
+Compilation validates and clones the input. Open objects, schema-valued
+`additionalProperties`, optional-nullable properties, tuples, missing or
+ambiguous types, non-null unions, references/composition/conditionals,
+unsupported bounds, unknown keywords, and other unsupported shapes return
+`UnsupportedAgentRuntimeFeatureError` with `feature: "outputSchema"` before
+pending submission accounting or `turn/start`. Errors include the schema path;
+constraints are never silently dropped.
+
+Each active Codex turn slot owns either no codec or one authoritative private
+codec. Its fingerprint canonically covers both the wire schema and restoration
+plan. Compatible structured followers may fold into the active turn; a different
+fingerprint or structured/unstructured mixing fails before another
+`turn/start`. After Codex accepts the primary turn, the codec is bound to that
+exact native turn id.
+
+Restoration runs once, behind the existing pending-turn mutual-exclusion guard,
+before `onTurnCompleted`. A successful restoration is the only structured text
+seen by `CodexRuntime.recordCollectedTurn()`, so `lastResult` and completed
+settlement use the neutral restored JSON. Parse, shape, or missing-codec failure
+does not call `onTurnCompleted` or mutate `lastResult`; it emits one ordinary
+failed `TurnSettledSignal` with `text: null`. Submission failure, stop, app-server
+teardown/restart, and late completion clear or discard in-memory codecs through
+the same turn lifecycle and never restore or settle twice.
+
+Source:
+
+- `/packages/agent-runtime/codex/src/output-schema-codec.ts`
+- `/packages/agent-runtime/codex/src/turn-manager.ts`
+- `/packages/agent-runtime/codex/src/runtime.ts`
+- `/packages/agent-runtime/codex/tests/output-schema-codec.test.ts`
+- `/packages/agent-runtime/codex/tests/turn-manager.test.ts`
+- `/packages/agent-runtime/codex/tests/runtime-output-schema.test.ts`
+- `/packages/dreamux/tests/codex-live.test.ts`
+
 ## Bundled Skills
 
 Dreamux ships bundled skills under `/packages/dreamux/skills/`, but it does not

--- a/.agents/proposals/codex-portable-output-schema.md
+++ b/.agents/proposals/codex-portable-output-schema.md
@@ -1,0 +1,228 @@
+# Codex portable output schema adapter
+
+- **Status:** Draft for review
+- **Date:** 2026-08-09
+- **Affects:** `@excitedjs/agent-runtime-codex`, Workflow schema portability,
+  Codex `turn/start.outputSchema`, runtime contract tests
+
+## Intent
+
+Allow provider-neutral Workflow JSON Schemas with ordinary optional object
+properties to run through Codex strict structured output without requiring
+script authors to rewrite every optional field as required.
+
+The fix belongs to `@excitedjs/agent-runtime-codex`. Dreamux core continues to
+pass the neutral `outputSchema` unchanged and trust a runtime's completed
+structured-output claim.
+
+## Observed failure
+
+A live `codex-medium` Workflow accepted a strict scoping schema, then rejected
+all four search turns before model execution:
+
+```text
+400 invalid_json_schema:
+properties.sources.items.required must include every property;
+missing "why"
+```
+
+OpenAI strict structured output requires every declared object property to
+appear in `required`. The neutral Workflow schema intentionally allowed `why`
+to be absent. Manually adding `why` and the later `quote` field to `required`
+made the same top-level ultracode Workflow complete 48/48 Codex turns with
+`max_concurrency: 8`.
+
+## Ownership and boundaries
+
+- `@excitedjs/agent-runtime-codex` owns the Codex-specific schema compiler and
+  result restoration.
+- `@excitedjs/dreamux-types` keeps the existing provider-neutral
+  `AgentRuntimeTextInput.outputSchema` ABI.
+- Dreamux Workflow core does not gain a Codex schema validator, retry loop, or
+  provider-specific branch.
+- Other runtimes receive the original schema unchanged.
+- Codex app-server remains the owner of native constrained decoding and
+  schema-mismatch retry after it accepts the compiled strict schema.
+
+## Compilation contract
+
+Before `turn/start`, the Codex adapter compiles the neutral schema into the
+strict subset accepted by Codex:
+
+1. Require one closed root object schema, then recursively validate and clone
+   its supported object, array, and primitive child schemas.
+2. Every object must be closed with `additionalProperties: false`. An open
+   object cannot be made strict without changing its accepted values and is
+   rejected locally.
+3. Every property is added to the wire `required` array.
+4. A property that was optional in the neutral schema is made nullable in the
+   wire schema. Its existing type is extended with `"null"`; an enum also gains
+   `null`.
+5. Required properties retain their original type and constraints.
+6. Nested objects and array items follow the same rules.
+
+The first implementation supports the schema vocabulary already used by
+Dreamux Workflow examples and fixtures and accepted by the Codex strict
+structured-output surface:
+
+- a root with `type: "object"`, an object-valued `properties`, and
+  `additionalProperties: false`;
+- `type` with one supported JSON primitive/object/array type; or exactly two
+  distinct members where one is `"null"` and the other is one supported type;
+- `description`;
+- `properties`, `required`, `additionalProperties: false`;
+- one schema-valued `items`;
+- `enum`;
+- numeric `minimum` and `maximum`, which the current Codex app-server live
+  boundary accepts and existing Workflow score schemas use.
+
+Unsupported or ambiguous shapes fail locally before `turn/start`, including:
+
+- open objects or schema-valued `additionalProperties`;
+- root nullable, array, or primitive schemas;
+- optional properties whose original schema already accepts `null`, because
+  `null` cannot distinguish "absent" from an explicit value during restoration;
+- missing/ambiguous property types and every non-null type union;
+- tuple arrays;
+- `$ref`, `$defs`, `definitions`, `allOf`, `anyOf`, `oneOf`, `not`,
+  conditionals, unsupported string/number/array bound keywords, and other
+  unimplemented keywords.
+
+The error identifies the schema path and unsupported reason. The adapter does
+not silently drop constraints or pass a known-incompatible schema to Codex.
+Schema compilation and active-slot compatibility rejection return a structural
+`UnsupportedAgentRuntimeFeatureError` with `feature: 'outputSchema'`. This
+reuses the neutral unsupported-capability path: a directly awaited Workflow
+`agent()` rejects, while helper containment remains explicit at the script
+layer.
+
+## Result restoration
+
+The compiler returns one private per-turn codec:
+
+- `wireSchema`: the strict schema sent to Codex;
+- `fingerprint`: a canonical structural identity covering both the wire schema
+  and the restoration plan;
+- `restore(text)`: parse the schema-validated JSON text, recursively remove
+  `null` placeholders only for properties that were optional and non-nullable
+  in the neutral schema, and serialize the restored value.
+
+Required fields and originally nullable fields are never stripped.
+
+The codec is first owned by the claimed `ActiveTurnSlot`. After Codex accepts
+`turn/start`, `activateTurnSlot()` binds that slot and codec to the exact native
+`turnId` returned by Codex. `trackTurn()` captures that turn id plus codec;
+restoration runs only when the collected turn carries the same id.
+
+For structured turns, restoration runs before `onTurnCompleted` is called.
+`CodexRuntime.recordCollectedTurn()` therefore sees only restored text. It
+updates `lastResult` and publishes the completed `onTurnSettled` signal only
+after restoration succeeds.
+
+Parsing or restoration failure:
+
+- does not call `onTurnCompleted`;
+- does not change `lastResult`;
+- emits one `onTurnSettled` signal with `status: 'failed'`, `text: null`, and
+  the restoration error;
+- releases the existing slot/pending-turn state through the same terminal path
+  as another collected-turn failure.
+
+This is an ordinary runtime turn failure, not an unsupported-capability error.
+The current teammate completion envelope intentionally does not project runtime
+errors, so Workflow observes its existing ordinary failed-turn result (`null`,
+including helper containment). This slice does not widen the neutral completion
+ABI solely to turn post-execution restoration failure into a direct
+`agent()` rejection.
+
+The codec is in-memory execution state only. It is never persisted.
+
+## Codec lifecycle
+
+- Compilation or compatibility-check failure happens before
+  `pendingSubmissions` is incremented and before `turn/start`.
+- If `turn/start` submission fails, the submission owns no native turn. Its
+  candidate codec is discarded immediately. If it was the primary submission
+  and no compatible candidate turn can activate the shared slot, the slot codec
+  is discarded when `recordTurnStartFailure()` releases that slot.
+- `stop()` settles pending native turns as stopped and clears their slots/codecs.
+  A late completion is dropped by the existing pending-turn mutual-exclusion
+  guard; restoration is not attempted and the turn is not settled twice.
+- Runtime teardown/restart discards all in-memory codecs together with the old
+  `TurnManager`. Interrupted turns settle stopped through the existing teardown
+  path. A new process never restores a result from the old client.
+- A currently pending structured turn without its expected codec is an internal
+  contract failure and settles failed; it is never passed through as
+  unstructured text.
+
+## Active-turn folding
+
+Codex may fold concurrent `turn/start` submissions into one active turn. One
+native final result cannot satisfy multiple distinct output schemas.
+
+- The primary submission that claims a fresh slot stores its codec on the slot.
+- A follower compiles a candidate codec only to validate its schema and compare
+  compatibility. The slot's primary codec remains authoritative and the
+  follower candidate is discarded after the check.
+- While that slot is active, another structured input is accepted only when
+  its codec fingerprint is identical to the slot fingerprint. Comparing only
+  the wire schema is insufficient: an optional non-nullable string and a
+  required nullable string can compile to the same wire schema but require
+  different restoration.
+- A structured input cannot join an active unstructured slot, and an
+  unstructured input cannot join an active structured slot.
+- Incompatible folding fails locally before incrementing `pendingSubmissions`,
+  before awaiting the shared `turnIdPromise`, and before another `turn/start`.
+
+Compatible submissions receive the same accepted native turn-id receipt through
+the existing shared slot. Restoration runs exactly once on the single collected
+native result before the existing single `onTurnCompleted` / `onTurnSettled`
+publication. Workflow-owned TeamMates normally submit one turn, but this rule
+keeps the general runtime contract deterministic.
+
+## Acceptance
+
+- The live failure schema with optional `why` and nested optional `quote`
+  compiles to a Codex strict schema whose object `required` arrays include all
+  properties.
+- A Codex result containing `why: null` / `quote: null` is restored to the
+  neutral result with those keys absent.
+- Optional nested objects and array-item objects restore recursively.
+- Required nullable fields remain present as `null`.
+- A non-null type union fails before `turn/start` with its schema path.
+- A non-object root fails before `turn/start` with the root schema path.
+- Open objects, optional-nullable fields, tuple arrays, unsupported composition
+  keywords, and unknown schema keywords fail before `turn/start` with a path.
+- Existing already-strict schemas are passed as equivalent clones and their
+  results are unchanged.
+- Plain text turns remain unchanged.
+- A `turn/start` submission failure leaves no codec that can affect a later
+  turn.
+- Stop/restart discards codecs and never restores or double-settles a late
+  completion.
+- Restoration precedes `lastResult` mutation and completed settlement; a
+  restoration failure preserves the prior last result and settles failed.
+- Compatible active-turn folding (same wire schema and restoration plan)
+  restores and settles once; incompatible structured folding submits no second
+  `turn/start`.
+- Codex adapter tests cover compiler, restoration, submission, settlement,
+  dedupe/stop behavior, and failure containment without weakening existing
+  lifecycle assertions.
+- The opt-in live Codex model gate submits the optional-field schema through the
+  real Codex app-server and covers the compiled nullable wire form, enum, and
+  numeric `minimum` / `maximum`; missing Codex still follows the repository's
+  fail-loud rule.
+- `@excitedjs/agent-runtime-codex` receives a patch Rush change and its README
+  documents the supported portable subset and fail-loud boundary.
+- `.agents/domains/provider-runtime.md` is the single current KB owner for the
+  Codex schema compilation/restoration/folding contract. Other current docs
+  link to that owner rather than duplicating the subset.
+
+## Out of scope
+
+- Changing OpenAI/Codex's strict JSON Schema subset.
+- Adding a generic JSON Schema compiler to Dreamux core or
+  `@excitedjs/dreamux-types`.
+- Emulating model retry in Dreamux.
+- Changing Claude Code or Traex structured-output behavior.
+- Supporting every JSON Schema draft keyword in this slice.

--- a/.agents/root.md
+++ b/.agents/root.md
@@ -111,10 +111,6 @@ history and rationale; when you need current behavior, pair them with
 - [Non-blocking dispatcher inbound](domains/non-blocking-dispatcher-inbound.md)
 
 ## Active Proposals
-
-- [Codex portable output schema adapter](proposals/codex-portable-output-schema.md)
-  — compile the neutral Workflow schema subset into Codex strict structured
-  output and restore optional-field semantics inside the Codex runtime package.
 - [AgentRuntime input surface cleanup](proposals/agent-runtime-input-surface-cleanup.md)
   — draft technical design for narrowing the provider-facing runtime input
   surface: plain text `completionInput` for non-channel turns, `channelInput`
@@ -187,6 +183,10 @@ history still matters.
 
 ## Archive
 
+- [Codex portable output schema adapter](archive/proposals/codex-portable-output-schema.md)
+  — implemented private Codex schema compilation, result restoration, and
+  active-turn compatibility; current behavior is documented in
+  [Provider Runtime](domains/provider-runtime.md#codex-portable-output-schema).
 - [Workflow ultracode dialect parity](archive/proposals/workflow-ultracode-dialect-parity.md)
   — implemented issue #318 requests 1-4; current behavior is documented in
   [Dynamic Workflow usage](reference/dynamic-workflow-usage.md) and

--- a/.agents/root.md
+++ b/.agents/root.md
@@ -112,6 +112,9 @@ history and rationale; when you need current behavior, pair them with
 
 ## Active Proposals
 
+- [Codex portable output schema adapter](proposals/codex-portable-output-schema.md)
+  — compile the neutral Workflow schema subset into Codex strict structured
+  output and restore optional-field semantics inside the Codex runtime package.
 - [AgentRuntime input surface cleanup](proposals/agent-runtime-input-surface-cleanup.md)
   — draft technical design for narrowing the provider-facing runtime input
   surface: plain text `completionInput` for non-channel turns, `channelInput`

--- a/common/changes/@excitedjs/agent-runtime-codex/codex-portable-output-schema_2026-08-09-21-04.json
+++ b/common/changes/@excitedjs/agent-runtime-codex/codex-portable-output-schema_2026-08-09-21-04.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@excitedjs/agent-runtime-codex",
+      "comment": "Compile the supported provider-neutral outputSchema subset into Codex strict schemas, restore optional-field semantics on completed JSON, and reject incompatible schemas or active-turn folding before submission.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@excitedjs/agent-runtime-codex"
+}

--- a/common/changes/@excitedjs/dreamux/fix-codex-portable-output-schema_2026-08-09-13-53.json
+++ b/common/changes/@excitedjs/dreamux/fix-codex-portable-output-schema_2026-08-09-13-53.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Add a real Codex model gate for portable structured-output schema admission and restoration, plus isolated live-test diagnostics; test-only, no Dreamux release change.",
+      "type": "none",
+      "packageName": "@excitedjs/dreamux"
+    }
+  ],
+  "packageName": "@excitedjs/dreamux",
+  "email": "15624809+YourWildDad@users.noreply.github.com"
+}

--- a/packages/agent-runtime/codex/README.md
+++ b/packages/agent-runtime/codex/README.md
@@ -12,13 +12,14 @@ completion delivery, and Codex doctor diagnostics.
 
 ## Boundary
 
-This package depends on `@excitedjs/dreamux-types` **only**. It never imports
-`@excitedjs/dreamux` core. Everything host-specific — per-dispatcher paths, the
-volatile rendezvous-socket root, the durable state sink, the process `PATH`
-seeded from the host package bins, and bundled-skill installation — is supplied
-by the Dreamux host through the neutral `AgentRuntimeCreateContext` and the
-provider factory options. The package owns only Codex-engine mechanics and its
-own `~/.codex` home/config paths.
+This package depends only on the neutral `@excitedjs/dreamux-types` contracts
+and shared `@excitedjs/dreamux-utils`; it never imports `@excitedjs/dreamux`
+core. Everything host-specific — per-dispatcher paths, the volatile
+rendezvous-socket root, the durable state sink, the process `PATH` seeded from
+the host package bins, and bundled-skill installation — is supplied by the
+Dreamux host through the neutral `AgentRuntimeCreateContext` and provider
+factory options. The package owns only Codex-engine mechanics and its own
+`~/.codex` home/config paths.
 
 The host resolves `builtin:codex` to this package and wraps it with a
 core-owned adapter that maps its private dispatcher objects onto the neutral
@@ -42,3 +43,36 @@ import { createCodexAgentRuntimeProvider } from '@excitedjs/agent-runtime-codex'
 The factory accepts the neutral create context plus optional host hooks
 (socket allocator, base process env, workspace skill preparation, and test
 factories for the Codex process / WS client / home doctor).
+
+## Portable Structured Output
+
+The neutral `AgentRuntimeTextInput.outputSchema` contract accepts ordinary
+optional object properties. Codex strict structured output requires every
+declared property to appear in `required`, so this package privately compiles a
+narrow portable subset before `turn/start`:
+
+- one closed root object (`additionalProperties: false`);
+- nested closed objects and single-schema arrays;
+- `string`, `number`, `integer`, `boolean`, `null`, and nullable
+  `[T, "null"]`;
+- `description`, primitive-value `enum`, and numeric `minimum` / `maximum`.
+
+Every wire property is required. An originally optional non-nullable property is
+made nullable for Codex, then a `null` placeholder is removed from the completed
+JSON before Dreamux observes the result. Required nullable values remain
+present as `null`.
+
+Open objects, optional fields that already accept `null`, tuples, non-null
+unions, composition/reference keywords, unknown keywords, and other unsupported
+constraints fail before `turn/start` with
+`UnsupportedAgentRuntimeFeatureError(feature = "outputSchema")`. The adapter
+does not drop constraints or fall back to unconstrained text.
+
+Concurrent submissions may fold into one active Codex turn only when both are
+structured with the same compiled wire schema and restoration plan, or both are
+unstructured. Structured/unstructured mixing and incompatible schemas fail
+before another `turn/start`.
+
+See
+[Provider Runtime](../../../.agents/domains/provider-runtime.md#codex-portable-output-schema)
+for the complete current lifecycle and failure contract.

--- a/packages/agent-runtime/codex/package.json
+++ b/packages/agent-runtime/codex/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@excitedjs/agent-runtime-codex",
   "version": "0.3.4",
-  "description": "Built-in Codex Agent Runtime provider for Dreamux (alias builtin:codex). Implements the @excitedjs/dreamux-types AgentRuntimeProvider contract against the Codex app-server; depends on @excitedjs/dreamux-types only, never on @excitedjs/dreamux core (issue excitedjs/dreamux#209).",
+  "description": "Built-in Codex Agent Runtime provider for Dreamux (alias builtin:codex). Implements the @excitedjs/dreamux-types AgentRuntimeProvider contract against the Codex app-server; depends only on provider-neutral Dreamux contracts and utilities, never on @excitedjs/dreamux core (issue excitedjs/dreamux#209).",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/packages/agent-runtime/codex/src/output-schema-codec.ts
+++ b/packages/agent-runtime/codex/src/output-schema-codec.ts
@@ -1,0 +1,451 @@
+import { createHash } from 'node:crypto';
+
+import { unsupportedFeatureError } from '@excitedjs/dreamux-utils';
+
+type SupportedType =
+  | 'object'
+  | 'array'
+  | 'string'
+  | 'number'
+  | 'integer'
+  | 'boolean'
+  | 'null';
+
+type JsonPrimitive = null | boolean | number | string;
+
+type JsonValue =
+  | JsonPrimitive
+  | JsonValue[]
+  | { [key: string]: JsonValue };
+
+type RestorationPlan =
+  | { kind: 'value' }
+  | {
+      kind: 'array';
+      acceptsNull: boolean;
+      items: RestorationPlan;
+    }
+  | {
+      kind: 'object';
+      acceptsNull: boolean;
+      properties: Record<
+        string,
+        { omitNull: boolean; plan: RestorationPlan }
+      >;
+    };
+
+interface CompiledSchema {
+  wireSchema: Record<string, unknown>;
+  plan: RestorationPlan;
+  acceptsNull: boolean;
+}
+
+export interface CodexOutputSchemaCodec {
+  wireSchema: Record<string, unknown>;
+  fingerprint: string;
+  restore(text: string): string;
+}
+
+const SUPPORTED_TYPES = new Set<SupportedType>([
+  'object',
+  'array',
+  'string',
+  'number',
+  'integer',
+  'boolean',
+  'null',
+]);
+
+const COMMON_KEYWORDS = new Set(['type', 'description', 'enum']);
+const OBJECT_KEYWORDS = new Set([
+  ...COMMON_KEYWORDS,
+  'properties',
+  'required',
+  'additionalProperties',
+]);
+const ARRAY_KEYWORDS = new Set([...COMMON_KEYWORDS, 'items']);
+const NUMERIC_KEYWORDS = new Set([
+  ...COMMON_KEYWORDS,
+  'minimum',
+  'maximum',
+]);
+
+export function compileCodexOutputSchema(
+  schema: Record<string, unknown>,
+): CodexOutputSchemaCodec {
+  const root = schemaRecord(schema, '$');
+  const rootType = schemaType(root['type'], '$.type');
+  if (rootType.type !== 'object' || rootType.nullable) {
+    fail('$.type', 'root schema must have type "object"');
+  }
+  const compiled = compileSchema(schema, '$', false);
+  const fingerprint = createHash('sha256')
+    .update(canonicalJson({
+      wireSchema: compiled.wireSchema as JsonValue,
+      restorationPlan: compiled.plan as unknown as JsonValue,
+    }))
+    .digest('hex');
+  return {
+    wireSchema: compiled.wireSchema,
+    fingerprint,
+    restore(text) {
+      let parsed: unknown;
+      try {
+        parsed = JSON.parse(text) as unknown;
+      } catch (error) {
+        throw new Error(
+          `codex outputSchema restoration at $: invalid JSON: ${errorMessage(error)}`,
+        );
+      }
+      return JSON.stringify(restoreValue(parsed, compiled.plan, '$'));
+    },
+  };
+}
+
+function compileSchema(
+  value: unknown,
+  path: string,
+  optional: boolean,
+): CompiledSchema {
+  const schema = schemaRecord(value, path);
+  const { type, nullable } = schemaType(schema['type'], `${path}.type`);
+  const enumValues = schemaEnum(schema['enum'], `${path}.enum`);
+  if (enumValues !== undefined) {
+    validateEnumTypes(enumValues, type, nullable, `${path}.enum`);
+  }
+  const acceptsNull = type === 'null' ||
+    (nullable && (enumValues === undefined || enumValues.includes(null)));
+  if (optional && acceptsNull) {
+    fail(path, 'optional property already accepts null');
+  }
+
+  const allowed = type === 'object'
+    ? OBJECT_KEYWORDS
+    : type === 'array'
+      ? ARRAY_KEYWORDS
+      : type === 'number' || type === 'integer'
+        ? NUMERIC_KEYWORDS
+        : COMMON_KEYWORDS;
+  rejectUnknownKeywords(schema, allowed, path);
+
+  const wireSchema: Record<string, unknown> = {
+    type: type === 'null'
+      ? type
+      : optional || nullable
+        ? [type, 'null']
+        : type,
+  };
+  if (schema['description'] !== undefined) {
+    if (typeof schema['description'] !== 'string') {
+      fail(`${path}.description`, 'description must be a string');
+    }
+    wireSchema['description'] = schema['description'];
+  }
+  if (enumValues !== undefined) {
+    const wireEnum = optional && !enumValues.includes(null)
+      ? [...enumValues, null]
+      : enumValues;
+    wireSchema['enum'] = canonicalEnum(wireEnum);
+  }
+
+  if (type === 'object') {
+    return compileObject(schema, path, wireSchema, acceptsNull);
+  }
+  if (type === 'array') {
+    return compileArray(schema, path, wireSchema, acceptsNull);
+  }
+  if (type === 'number' || type === 'integer') {
+    compileNumericBounds(schema, path, wireSchema);
+  }
+  return { wireSchema, plan: { kind: 'value' }, acceptsNull };
+}
+
+function compileObject(
+  schema: Record<string, unknown>,
+  path: string,
+  wireSchema: Record<string, unknown>,
+  acceptsNull: boolean,
+): CompiledSchema {
+  if (schema['additionalProperties'] !== false) {
+    fail(
+      `${path}.additionalProperties`,
+      'object schemas must set additionalProperties to false',
+    );
+  }
+  const properties = schemaRecord(schema['properties'], `${path}.properties`);
+  const required = requiredProperties(
+    schema['required'],
+    properties,
+    `${path}.required`,
+  );
+  const propertyEntries: Array<[string, Record<string, unknown>]> = [];
+  const planEntries: Array<
+    [string, { omitNull: boolean; plan: RestorationPlan }]
+  > = [];
+  const names = Object.keys(properties).sort();
+  for (const name of names) {
+    const propertyPath = schemaPropertyPath(path, name);
+    const optional = !required.has(name);
+    const compiled = compileSchema(properties[name], propertyPath, optional);
+    propertyEntries.push([name, compiled.wireSchema]);
+    planEntries.push([
+      name,
+      { omitNull: optional && !compiled.acceptsNull, plan: compiled.plan },
+    ]);
+  }
+  wireSchema['properties'] = Object.fromEntries(propertyEntries);
+  wireSchema['required'] = names;
+  wireSchema['additionalProperties'] = false;
+  return {
+    wireSchema,
+    plan: {
+      kind: 'object',
+      acceptsNull,
+      properties: Object.fromEntries(planEntries),
+    },
+    acceptsNull,
+  };
+}
+
+function compileArray(
+  schema: Record<string, unknown>,
+  path: string,
+  wireSchema: Record<string, unknown>,
+  acceptsNull: boolean,
+): CompiledSchema {
+  if (Array.isArray(schema['items'])) {
+    fail(`${path}.items`, 'tuple arrays are not supported');
+  }
+  if (schema['items'] === undefined) {
+    fail(`${path}.items`, 'array schemas require one items schema');
+  }
+  const items = compileSchema(schema['items'], `${path}.items`, false);
+  wireSchema['items'] = items.wireSchema;
+  return {
+    wireSchema,
+    plan: { kind: 'array', acceptsNull, items: items.plan },
+    acceptsNull,
+  };
+}
+
+function compileNumericBounds(
+  schema: Record<string, unknown>,
+  path: string,
+  wireSchema: Record<string, unknown>,
+): void {
+  for (const keyword of ['minimum', 'maximum'] as const) {
+    const value = schema[keyword];
+    if (value === undefined) continue;
+    if (typeof value !== 'number' || !Number.isFinite(value)) {
+      fail(`${path}.${keyword}`, `${keyword} must be a finite number`);
+    }
+    wireSchema[keyword] = value;
+  }
+  if (
+    typeof wireSchema['minimum'] === 'number' &&
+    typeof wireSchema['maximum'] === 'number' &&
+    wireSchema['minimum'] > wireSchema['maximum']
+  ) {
+    fail(path, 'minimum must not exceed maximum');
+  }
+}
+
+function schemaType(
+  value: unknown,
+  path: string,
+): { type: SupportedType; nullable: boolean } {
+  if (typeof value === 'string') {
+    if (!SUPPORTED_TYPES.has(value as SupportedType)) {
+      fail(path, `unsupported type ${JSON.stringify(value)}`);
+    }
+    return { type: value as SupportedType, nullable: value === 'null' };
+  }
+  if (!Array.isArray(value)) {
+    fail(path, 'type must be one supported type or [T, "null"]');
+  }
+  if (
+    value.length !== 2 ||
+    new Set(value).size !== 2 ||
+    !value.includes('null')
+  ) {
+    fail(path, 'only nullable [T, "null"] unions are supported');
+  }
+  const nonNull = value.find((entry) => entry !== 'null');
+  if (
+    typeof nonNull !== 'string' ||
+    nonNull === 'null' ||
+    !SUPPORTED_TYPES.has(nonNull as SupportedType)
+  ) {
+    fail(path, 'only nullable [T, "null"] unions are supported');
+  }
+  return { type: nonNull as SupportedType, nullable: true };
+}
+
+function schemaEnum(value: unknown, path: string): JsonPrimitive[] | undefined {
+  if (value === undefined) return undefined;
+  if (!Array.isArray(value) || value.length === 0) {
+    fail(path, 'enum must be a non-empty array of primitive JSON values');
+  }
+  const values = value.map((entry, index) => {
+    if (
+      entry === null ||
+      typeof entry === 'string' ||
+      typeof entry === 'boolean'
+    ) return entry;
+    if (typeof entry === 'number' && Number.isFinite(entry)) return entry;
+    fail(`${path}[${index}]`, 'enum entries must be primitive JSON values');
+  });
+  const canonical = values.map(canonicalJson);
+  if (new Set(canonical).size !== values.length) {
+    fail(path, 'enum values must be unique');
+  }
+  return values;
+}
+
+function validateEnumTypes(
+  values: JsonPrimitive[],
+  type: SupportedType,
+  nullable: boolean,
+  path: string,
+): void {
+  if (type === 'object' || type === 'array') {
+    fail(path, 'enum is supported only on primitive schemas');
+  }
+  for (const [index, value] of values.entries()) {
+    if (value === null && nullable) continue;
+    const valid = type === 'null'
+      ? value === null
+      : type === 'integer'
+        ? typeof value === 'number' && Number.isInteger(value)
+        : typeof value === type;
+    if (!valid) {
+      fail(
+        `${path}[${index}]`,
+        `enum value does not match declared type ${JSON.stringify(type)}`,
+      );
+    }
+  }
+}
+
+function requiredProperties(
+  value: unknown,
+  properties: Record<string, unknown>,
+  path: string,
+): Set<string> {
+  if (value === undefined) return new Set();
+  if (!Array.isArray(value)) fail(path, 'required must be an array of strings');
+  const required = new Set<string>();
+  for (const [index, entry] of value.entries()) {
+    if (typeof entry !== 'string') {
+      fail(`${path}[${index}]`, 'required entries must be strings');
+    }
+    if (!Object.hasOwn(properties, entry)) {
+      fail(`${path}[${index}]`, `unknown required property ${JSON.stringify(entry)}`);
+    }
+    if (required.has(entry)) {
+      fail(`${path}[${index}]`, `duplicate required property ${JSON.stringify(entry)}`);
+    }
+    required.add(entry);
+  }
+  return required;
+}
+
+function rejectUnknownKeywords(
+  schema: Record<string, unknown>,
+  allowed: ReadonlySet<string>,
+  path: string,
+): void {
+  for (const keyword of Object.keys(schema)) {
+    if (!allowed.has(keyword)) {
+      fail(`${path}.${keyword}`, `unsupported keyword ${JSON.stringify(keyword)}`);
+    }
+  }
+}
+
+function restoreValue(
+  value: unknown,
+  plan: RestorationPlan,
+  path: string,
+): unknown {
+  if (plan.kind === 'value') return value;
+  if (value === null && plan.acceptsNull) return null;
+  if (plan.kind === 'array') {
+    if (!Array.isArray(value)) {
+      throw new Error(`codex outputSchema restoration at ${path}: expected array`);
+    }
+    return value.map((entry, index) =>
+      restoreValue(entry, plan.items, `${path}[${index}]`));
+  }
+  if (!isRecord(value)) {
+    throw new Error(`codex outputSchema restoration at ${path}: expected object`);
+  }
+  const restored = { ...value };
+  for (const [name, property] of Object.entries(plan.properties)) {
+    if (!Object.hasOwn(restored, name)) continue;
+    if (property.omitNull && restored[name] === null) {
+      delete restored[name];
+      continue;
+    }
+    restored[name] = restoreValue(
+      restored[name],
+      property.plan,
+      valuePropertyPath(path, name),
+    );
+  }
+  return restored;
+}
+
+function canonicalEnum(values: JsonPrimitive[]): JsonPrimitive[] {
+  return [...values].sort((left, right) =>
+    canonicalJson(left).localeCompare(canonicalJson(right)));
+}
+
+function canonicalJson(value: JsonValue): string {
+  if (Array.isArray(value)) {
+    return `[${value.map(canonicalJson).join(',')}]`;
+  }
+  if (isRecord(value)) {
+    return `{${Object.keys(value).sort().map((key) =>
+      `${JSON.stringify(key)}:${canonicalJson(value[key] as JsonValue)}`,
+    ).join(',')}}`;
+  }
+  return JSON.stringify(value);
+}
+
+function schemaRecord(value: unknown, path: string): Record<string, unknown> {
+  if (!isRecord(value)) fail(path, 'schema must be a plain object');
+  return value;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+    return false;
+  }
+  const prototype = Object.getPrototypeOf(value) as unknown;
+  return prototype === Object.prototype || prototype === null;
+}
+
+function schemaPropertyPath(path: string, name: string): string {
+  return `${path}.properties${pathSegment(name)}`;
+}
+
+function valuePropertyPath(path: string, name: string): string {
+  return `${path}${pathSegment(name)}`;
+}
+
+function pathSegment(name: string): string {
+  return /^[A-Za-z_$][A-Za-z0-9_$]*$/.test(name)
+    ? `.${name}`
+    : `[${JSON.stringify(name)}]`;
+}
+
+function fail(path: string, reason: string): never {
+  throw unsupportedFeatureError(
+    'outputSchema',
+    `codex outputSchema at ${path}: ${reason}`,
+  );
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}

--- a/packages/agent-runtime/codex/src/output-schema-codec.ts
+++ b/packages/agent-runtime/codex/src/output-schema-codec.ts
@@ -273,7 +273,6 @@ function schemaType(
   const nonNull = value.find((entry) => entry !== 'null');
   if (
     typeof nonNull !== 'string' ||
-    nonNull === 'null' ||
     !SUPPORTED_TYPES.has(nonNull as SupportedType)
   ) {
     fail(path, 'only nullable [T, "null"] unions are supported');

--- a/packages/agent-runtime/codex/src/turn-manager.ts
+++ b/packages/agent-runtime/codex/src/turn-manager.ts
@@ -9,13 +9,21 @@
  */
 
 import {
+  extractAssistantText,
   subscribeTurnCollection,
   submitTurnStart,
   type CollectedTurn,
   type TurnCollector,
 } from './events.js';
+import {
+  compileCodexOutputSchema,
+  type CodexOutputSchemaCodec,
+} from './output-schema-codec.js';
 import type { CodexWsClient } from './rpc.js';
-import { DEFAULT_MESSAGE_ID_DEDUPE_WINDOW } from '@excitedjs/dreamux-utils';
+import {
+  DEFAULT_MESSAGE_ID_DEDUPE_WINDOW,
+  unsupportedFeatureError,
+} from '@excitedjs/dreamux-utils';
 import type {
   InboundTurnInput,
   InboundDeliveryResult,
@@ -25,6 +33,8 @@ import type {
 
 interface ActiveTurnSlot {
   collector: TurnCollector;
+  codec: CodexOutputSchemaCodec | null;
+  expectsStructuredOutput: boolean;
   turnId: string | null;
   candidateTurnId: string | null;
   primaryFailed: boolean;
@@ -73,7 +83,13 @@ export class TurnManager {
    * `stop()` each still-pending turn is settled as `stopped` so a teammate turn
    * interrupted by teardown is not lost.
    */
-  private readonly pendingTurnIds = new Set<string>();
+  private readonly pendingTurns = new Map<
+    string,
+    {
+      codec: CodexOutputSchemaCodec | null;
+      expectsStructuredOutput: boolean;
+    }
+  >();
   private idlePromise: Promise<void> | null = null;
   private idleResolve: (() => void) | null = null;
   private readonly log: NonNullable<TurnManagerOptions['log']>;
@@ -92,7 +108,7 @@ export class TurnManager {
   }
 
   isBusy(): boolean {
-    return this.activeTurnSlot !== null || this.pendingTurnIds.size > 0;
+    return this.activeTurnSlot !== null || this.pendingTurns.size > 0;
   }
 
   waitIdle(): Promise<void> {
@@ -123,7 +139,14 @@ export class TurnManager {
       return { status: 'failed', error };
     }
 
-    const activeTurn = this.claimActiveTurnSlot(threadId);
+    let activeTurn: ReturnType<TurnManager['claimActiveTurnSlot']>;
+    try {
+      activeTurn = this.claimActiveTurnSlot(threadId, null);
+    } catch (err) {
+      const error = asError(err);
+      this.log('error', error.message, error);
+      return { status: 'failed', error };
+    }
     activeTurn.slot.pendingSubmissions += 1;
 
     let res: Awaited<ReturnType<typeof submitTurnStart>>;
@@ -176,7 +199,24 @@ export class TurnManager {
       return { status: 'failed', error };
     }
 
-    const activeTurn = this.claimActiveTurnSlot(threadId);
+    let codec: CodexOutputSchemaCodec | null = null;
+    if (input.outputSchema !== undefined) {
+      try {
+        codec = compileCodexOutputSchema(input.outputSchema);
+      } catch (err) {
+        const error = asError(err);
+        this.log('error', error.message, error);
+        return { status: 'failed', error };
+      }
+    }
+    let activeTurn: ReturnType<TurnManager['claimActiveTurnSlot']>;
+    try {
+      activeTurn = this.claimActiveTurnSlot(threadId, codec);
+    } catch (err) {
+      const error = asError(err);
+      this.log('error', error.message, error);
+      return { status: 'failed', error };
+    }
     activeTurn.slot.pendingSubmissions += 1;
 
     let res: Awaited<ReturnType<typeof submitTurnStart>>;
@@ -186,7 +226,7 @@ export class TurnManager {
         threadId,
         input.text,
         this.opts.turnCwd ?? null,
-        input.outputSchema,
+        activeTurn.slot.codec?.wireSchema,
       );
     } catch (err) {
       const error = err instanceof Error ? err : new Error(String(err));
@@ -214,30 +254,37 @@ export class TurnManager {
     this.stopped = true;
     const activeSlot = this.activeTurnSlot;
     this.activeTurnSlot = null;
+    if (activeSlot !== null) activeSlot.codec = null;
     if (activeSlot !== null && activeSlot.turnId === null) {
       activeSlot.rejectTurnId(new Error('codex turn stopped before acceptance'));
     }
     // Any turn still in flight at teardown will never reach `turn/completed`
     // (the WS is closing). Settle each as `stopped` so an interrupted teammate
     // turn is delivered with a status rather than vanishing.
-    for (const turnId of this.pendingTurnIds) {
+    for (const turnId of this.pendingTurns.keys()) {
       this.opts.onTurnSettled?.({
         turnId,
         status: 'stopped',
         result: { text: null },
       });
     }
-    this.pendingTurnIds.clear();
+    this.pendingTurns.clear();
     this.activeTurnId = null;
     this.resolveIdleWaitersIfIdle();
   }
 
-  private claimActiveTurnSlot(threadId: string): {
+  private claimActiveTurnSlot(
+    threadId: string,
+    codec: CodexOutputSchemaCodec | null,
+  ): {
     slot: ActiveTurnSlot;
     primary: boolean;
   } {
     const active = this.activeTurnSlot;
-    if (active !== null) return { slot: active, primary: false };
+    if (active !== null) {
+      assertCompatibleCodec(active.codec, codec);
+      return { slot: active, primary: false };
+    }
 
     let resolveTurnId!: (turnId: string) => void;
     let rejectTurnId!: (err: Error) => void;
@@ -251,6 +298,8 @@ export class TurnManager {
     turnIdPromise.catch(() => undefined);
     const slot: ActiveTurnSlot = {
       collector: subscribeTurnCollection(this.opts.client, threadId),
+      codec,
+      expectsStructuredOutput: codec !== null,
       turnId: null,
       candidateTurnId: null,
       primaryFailed: false,
@@ -296,6 +345,7 @@ export class TurnManager {
     }
     if (slot.primaryFailed && slot.pendingSubmissions === 0) {
       if (this.activeTurnSlot === slot) this.activeTurnSlot = null;
+      slot.codec = null;
       slot.rejectTurnId(error);
       this.resolveIdleWaitersIfIdle();
     }
@@ -320,27 +370,55 @@ export class TurnManager {
   private trackTurn(
     turnId: string,
     collector: TurnCollector,
-    slot?: ActiveTurnSlot,
+    slot: ActiveTurnSlot,
   ): void {
-    if (this.pendingTurnIds.has(turnId)) return;
-    this.pendingTurnIds.add(turnId);
+    if (this.pendingTurns.has(turnId)) return;
+    this.pendingTurns.set(turnId, {
+      codec: slot.codec,
+      expectsStructuredOutput: slot.expectsStructuredOutput,
+    });
     this.activeTurnId = turnId;
     void collector.awaitTurn(turnId).then(
       (turn) => {
         // Only forward completion if this turn was still pending. If `stop()`
         // already settled it as `stopped`, the delete returns false and we drop
         // the late completion so a turn is never settled twice.
-        if (this.pendingTurnIds.delete(turnId)) {
+        const pending = this.pendingTurns.get(turnId);
+        if (pending !== undefined && this.pendingTurns.delete(turnId)) {
           if (this.activeTurnSlot === slot) this.activeTurnSlot = null;
           if (this.activeTurnId === turnId) this.activeTurnId = null;
-          this.opts.onTurnCompleted?.(turn);
+          let completedTurn: CollectedTurn;
+          try {
+            if (
+              pending.expectsStructuredOutput &&
+              pending.codec === null
+            ) {
+              throw new Error(
+                `codex outputSchema restoration for turn ${turnId}: ` +
+                  'structured turn has no codec',
+              );
+            }
+            completedTurn = pending.codec === null
+              ? turn
+              : restoreCollectedTurn(turn, pending.codec);
+          } catch (err) {
+            this.opts.onTurnSettled?.({
+              turnId,
+              status: 'failed',
+              result: { text: null },
+              error: asError(err),
+            });
+            this.resolveIdleWaitersIfIdle();
+            return;
+          }
+          this.opts.onTurnCompleted?.(completedTurn);
           this.resolveIdleWaitersIfIdle();
         }
       },
       (err) => {
         // Same mutual-exclusion guard as the completed path: only settle as
         // `failed` if `stop()` did not already settle it as `stopped`.
-        if (this.pendingTurnIds.delete(turnId)) {
+        if (this.pendingTurns.delete(turnId)) {
           if (this.activeTurnSlot === slot) this.activeTurnSlot = null;
           if (this.activeTurnId === turnId) this.activeTurnId = null;
           this.opts.onTurnSettled?.({
@@ -385,4 +463,57 @@ export class TurnManager {
     this.idleResolve = null;
     resolve?.();
   }
+}
+
+function assertCompatibleCodec(
+  active: CodexOutputSchemaCodec | null,
+  candidate: CodexOutputSchemaCodec | null,
+): void {
+  if (active === null && candidate === null) return;
+  if (active !== null && candidate !== null) {
+    if (active.fingerprint === candidate.fingerprint) return;
+    throw unsupportedFeatureError(
+      'outputSchema',
+      'codex active turn has an incompatible outputSchema',
+    );
+  }
+  throw unsupportedFeatureError(
+    'outputSchema',
+    active === null
+      ? 'codex cannot fold structured output into an active unstructured turn'
+      : 'codex cannot fold unstructured input into an active structured turn',
+  );
+}
+
+function restoreCollectedTurn(
+  turn: CollectedTurn,
+  codec: CodexOutputSchemaCodec,
+): CollectedTurn {
+  const text = extractAssistantText(turn);
+  if (text === null) {
+    throw new Error(
+      `codex outputSchema restoration for turn ${turn.turnId}: ` +
+        'completed turn has no assistant JSON text',
+    );
+  }
+  const restoredText = codec.restore(text);
+  let replaced = false;
+  const items = [...turn.items].reverse().map((item) => {
+    if (replaced || item.type !== 'agentMessage' || item.text !== text) {
+      return item;
+    }
+    replaced = true;
+    return { ...item, text: restoredText };
+  }).reverse();
+  if (!replaced) {
+    throw new Error(
+      `codex outputSchema restoration for turn ${turn.turnId}: ` +
+        'assistant JSON text was not found',
+    );
+  }
+  return { ...turn, items };
+}
+
+function asError(error: unknown): Error {
+  return error instanceof Error ? error : new Error(String(error));
 }

--- a/packages/agent-runtime/codex/src/turn-manager.ts
+++ b/packages/agent-runtime/codex/src/turn-manager.ts
@@ -34,7 +34,6 @@ import type {
 interface ActiveTurnSlot {
   collector: TurnCollector;
   codec: CodexOutputSchemaCodec | null;
-  expectsStructuredOutput: boolean;
   turnId: string | null;
   candidateTurnId: string | null;
   primaryFailed: boolean;
@@ -85,10 +84,7 @@ export class TurnManager {
    */
   private readonly pendingTurns = new Map<
     string,
-    {
-      codec: CodexOutputSchemaCodec | null;
-      expectsStructuredOutput: boolean;
-    }
+    { codec: CodexOutputSchemaCodec | null }
   >();
   private idlePromise: Promise<void> | null = null;
   private idleResolve: (() => void) | null = null;
@@ -299,7 +295,6 @@ export class TurnManager {
     const slot: ActiveTurnSlot = {
       collector: subscribeTurnCollection(this.opts.client, threadId),
       codec,
-      expectsStructuredOutput: codec !== null,
       turnId: null,
       candidateTurnId: null,
       primaryFailed: false,
@@ -373,10 +368,7 @@ export class TurnManager {
     slot: ActiveTurnSlot,
   ): void {
     if (this.pendingTurns.has(turnId)) return;
-    this.pendingTurns.set(turnId, {
-      codec: slot.codec,
-      expectsStructuredOutput: slot.expectsStructuredOutput,
-    });
+    this.pendingTurns.set(turnId, { codec: slot.codec });
     this.activeTurnId = turnId;
     void collector.awaitTurn(turnId).then(
       (turn) => {
@@ -389,15 +381,6 @@ export class TurnManager {
           if (this.activeTurnId === turnId) this.activeTurnId = null;
           let completedTurn: CollectedTurn;
           try {
-            if (
-              pending.expectsStructuredOutput &&
-              pending.codec === null
-            ) {
-              throw new Error(
-                `codex outputSchema restoration for turn ${turnId}: ` +
-                  'structured turn has no codec',
-              );
-            }
             completedTurn = pending.codec === null
               ? turn
               : restoreCollectedTurn(turn, pending.codec);

--- a/packages/agent-runtime/codex/tests/output-schema-codec.test.ts
+++ b/packages/agent-runtime/codex/tests/output-schema-codec.test.ts
@@ -1,0 +1,308 @@
+import { describe, expect, it } from 'vitest';
+
+import { compileCodexOutputSchema } from '../src/output-schema-codec.js';
+
+describe('Codex portable output schema compiler', () => {
+  it('compiles optional nested fields into required nullable wire fields', () => {
+    const schema = {
+      type: 'object',
+      description: 'Research result',
+      properties: {
+        sources: {
+          type: 'array',
+          items: {
+            type: 'object',
+            properties: {
+              title: { type: 'string' },
+              why: {
+                type: 'string',
+                description: 'Optional rationale',
+                enum: ['primary', 'secondary'],
+              },
+              score: {
+                type: 'number',
+                minimum: 0,
+                maximum: 100,
+              },
+            },
+            required: ['title', 'score'],
+            additionalProperties: false,
+          },
+        },
+      },
+      required: ['sources'],
+      additionalProperties: false,
+    };
+    const original = structuredClone(schema);
+
+    const codec = compileCodexOutputSchema(schema);
+
+    expect(schema).toEqual(original);
+    expect(codec.wireSchema).toEqual({
+      type: 'object',
+      description: 'Research result',
+      properties: {
+        sources: {
+          type: 'array',
+          items: {
+            type: 'object',
+            properties: {
+              score: {
+                type: 'number',
+                minimum: 0,
+                maximum: 100,
+              },
+              title: { type: 'string' },
+              why: {
+                type: ['string', 'null'],
+                description: 'Optional rationale',
+                enum: ['primary', 'secondary', null],
+              },
+            },
+            required: ['score', 'title', 'why'],
+            additionalProperties: false,
+          },
+        },
+      },
+      required: ['sources'],
+      additionalProperties: false,
+    });
+  });
+
+  it('restores optional placeholders recursively while retaining required nullable null', () => {
+    const codec = compileCodexOutputSchema({
+      type: 'object',
+      properties: {
+        note: { type: ['string', 'null'] },
+        profile: {
+          type: 'object',
+          properties: {
+            nickname: { type: 'string' },
+            tags: {
+              type: 'array',
+              items: {
+                type: 'object',
+                properties: {
+                  label: { type: 'string' },
+                  detail: { type: 'string' },
+                },
+                required: ['label'],
+                additionalProperties: false,
+              },
+            },
+          },
+          required: ['tags'],
+          additionalProperties: false,
+        },
+        optionalObject: {
+          type: 'object',
+          properties: { value: { type: 'string' } },
+          additionalProperties: false,
+        },
+        nullableObject: {
+          type: ['object', 'null'],
+          properties: { value: { type: 'string' } },
+          additionalProperties: false,
+        },
+      },
+      required: ['note', 'nullableObject', 'profile'],
+      additionalProperties: false,
+    });
+
+    expect(JSON.parse(codec.restore(JSON.stringify({
+      note: null,
+      profile: {
+        nickname: null,
+        tags: [
+          { label: 'one', detail: null },
+          { label: 'two', detail: 'kept' },
+        ],
+      },
+      optionalObject: null,
+      nullableObject: null,
+    })))).toEqual({
+      note: null,
+      nullableObject: null,
+      profile: {
+        tags: [
+          { label: 'one' },
+          { label: 'two', detail: 'kept' },
+        ],
+      },
+    });
+  });
+
+  it('canonicalizes equivalent schemas and includes the restoration plan', () => {
+    const optional = compileCodexOutputSchema({
+      type: 'object',
+      properties: { value: { type: 'string' } },
+      additionalProperties: false,
+    });
+    const equivalentOptional = compileCodexOutputSchema({
+      additionalProperties: false,
+      properties: { value: { type: 'string' } },
+      required: [],
+      type: 'object',
+    });
+    const requiredNullable = compileCodexOutputSchema({
+      type: 'object',
+      properties: { value: { type: ['string', 'null'] } },
+      required: ['value'],
+      additionalProperties: false,
+    });
+
+    expect(equivalentOptional.fingerprint).toBe(optional.fingerprint);
+    expect(requiredNullable.wireSchema).toEqual(optional.wireSchema);
+    expect(requiredNullable.fingerprint).not.toBe(optional.fingerprint);
+  });
+
+  it('preserves a required null-only field without constructing a duplicate union', () => {
+    const codec = compileCodexOutputSchema({
+      type: 'object',
+      properties: { empty: { type: 'null', enum: [null] } },
+      required: ['empty'],
+      additionalProperties: false,
+    });
+
+    expect(codec.wireSchema).toEqual({
+      type: 'object',
+      properties: { empty: { type: 'null', enum: [null] } },
+      required: ['empty'],
+      additionalProperties: false,
+    });
+    expect(JSON.parse(codec.restore('{"empty":null}'))).toEqual({ empty: null });
+  });
+
+  it.each([
+    [
+      { type: 'array', items: { type: 'string' } },
+      '$.type',
+      'root schema must have type "object"',
+    ],
+    [
+      { type: ['object', 'null'], properties: {}, additionalProperties: false },
+      '$.type',
+      'root schema must have type "object"',
+    ],
+    [
+      {
+        type: 'object',
+        properties: { value: { type: ['string', 'number'] } },
+        additionalProperties: false,
+      },
+      '$.properties.value.type',
+      'only nullable [T, "null"] unions are supported',
+    ],
+    [
+      {
+        type: 'object',
+        properties: { value: { type: ['string', 'null'] } },
+        additionalProperties: false,
+      },
+      '$.properties.value',
+      'optional property already accepts null',
+    ],
+    [
+      {
+        type: 'object',
+        properties: {
+          rows: { type: 'array', items: [{ type: 'string' }] },
+        },
+        required: ['rows'],
+        additionalProperties: false,
+      },
+      '$.properties.rows.items',
+      'tuple arrays are not supported',
+    ],
+    [
+      {
+        type: 'object',
+        properties: {
+          nested: { type: 'object', properties: {} },
+        },
+        required: ['nested'],
+        additionalProperties: false,
+      },
+      '$.properties.nested.additionalProperties',
+      'object schemas must set additionalProperties to false',
+    ],
+    [
+      {
+        type: 'object',
+        properties: {},
+        additionalProperties: false,
+        oneOf: [],
+      },
+      '$.oneOf',
+      'unsupported keyword "oneOf"',
+    ],
+    [
+      {
+        type: 'object',
+        properties: { value: { description: 'missing type' } },
+        additionalProperties: false,
+      },
+      '$.properties.value.type',
+      'type must be one supported type or [T, "null"]',
+    ],
+    [
+      {
+        type: 'object',
+        properties: { value: { type: 'string', enum: [1] } },
+        required: ['value'],
+        additionalProperties: false,
+      },
+      '$.properties.value.enum[0]',
+      'enum value does not match declared type "string"',
+    ],
+    [
+      {
+        type: 'object',
+        properties: {
+          value: {
+            type: 'object',
+            properties: {},
+            required: [],
+            additionalProperties: false,
+            enum: [{}],
+          },
+        },
+        required: ['value'],
+        additionalProperties: false,
+      },
+      '$.properties.value.enum[0]',
+      'enum entries must be primitive JSON values',
+    ],
+  ])('rejects incompatible schemas at %s', (schema, path, reason) => {
+    expect(() => compileCodexOutputSchema(
+      schema as Record<string, unknown>,
+    )).toThrowError(
+      expect.objectContaining({
+        name: 'UnsupportedAgentRuntimeFeatureError',
+        feature: 'outputSchema',
+        message: expect.stringContaining(`${path}: ${reason}`),
+      }),
+    );
+  });
+
+  it('reports restoration shape and JSON failures as ordinary errors', () => {
+    const codec = compileCodexOutputSchema({
+      type: 'object',
+      properties: {
+        values: { type: 'array', items: { type: 'string' } },
+      },
+      required: ['values'],
+      additionalProperties: false,
+    });
+
+    expect(() => codec.restore('{')).toThrow(
+      'codex outputSchema restoration at $: invalid JSON',
+    );
+    expect(() => codec.restore('{"values":{}}')).toThrow(
+      'codex outputSchema restoration at $.values: expected array',
+    );
+    expect(() => codec.restore('null')).toThrow(
+      'codex outputSchema restoration at $: expected object',
+    );
+  });
+});

--- a/packages/agent-runtime/codex/tests/runtime-output-schema.test.ts
+++ b/packages/agent-runtime/codex/tests/runtime-output-schema.test.ts
@@ -1,0 +1,238 @@
+import { describe, expect, it } from 'vitest';
+
+import { CodexRuntime } from '../src/runtime.js';
+import type { NotificationHandler } from '../src/rpc.js';
+import type {
+  AgentRuntimePathContext,
+  AgentRuntimeStateCallbacks,
+  TurnSettledSignal,
+} from '@excitedjs/dreamux-types';
+
+describe('CodexRuntime portable output schema settlement', () => {
+  it('preserves lastResult and emits failed settlement when restoration fails', async () => {
+    const client = new RuntimeFakeClient();
+    const settled: TurnSettledSignal[] = [];
+    const runtime = new CodexRuntime(
+      { runtime_id: 'flow', checkpoint_id: null },
+      {
+        cwd: '/fake/cwd',
+        state: noopState(),
+        paths: PATHS,
+        allocateSocketPath: () => '/fake/run/flow.sock',
+        codexProcessFactory: () => new FakeProcess() as never,
+        codexClientFactory: () => client as never,
+        onTurnSettled: (signal) => settled.push(signal),
+      },
+    );
+
+    await runtime.start();
+    try {
+      await expect(runtime.completionInput({
+        text: 'plain',
+        sourceId: 'plain',
+      })).resolves.toMatchObject({ status: 'submitted' });
+      await waitFor(() => settled.length === 1);
+      expect(await runtime.getLast()).toEqual({ text: 'plain result' });
+
+      await expect(runtime.completionInput({
+        text: 'structured',
+        sourceId: 'structured',
+        outputSchema: {
+          type: 'object',
+          properties: {
+            values: { type: 'array', items: { type: 'string' } },
+          },
+          required: ['values'],
+          additionalProperties: false,
+        },
+      })).resolves.toMatchObject({ status: 'submitted' });
+      await waitFor(() => settled.length === 2);
+
+      expect(await runtime.getLast()).toEqual({ text: 'plain result' });
+      expect(settled).toEqual([
+        {
+          turnId: 'turn-1',
+          status: 'completed',
+          result: { text: 'plain result' },
+        },
+        {
+          turnId: 'turn-2',
+          status: 'failed',
+          result: { text: null },
+          error: expect.objectContaining({
+            message: expect.stringContaining('$.values: expected array'),
+          }),
+        },
+      ]);
+    } finally {
+      await runtime.stop();
+    }
+  });
+
+  it('discards the old codec across websocket restart and drops late completion', async () => {
+    const firstClient = new RuntimeFakeClient({ autoComplete: false });
+    const secondClient = new RuntimeFakeClient();
+    const clients = [firstClient, secondClient];
+    const settled: TurnSettledSignal[] = [];
+    const runtime = new CodexRuntime(
+      { runtime_id: 'flow', checkpoint_id: null },
+      {
+        cwd: '/fake/cwd',
+        state: noopState(),
+        paths: PATHS,
+        allocateSocketPath: () => '/fake/run/flow.sock',
+        codexProcessFactory: () => new FakeProcess() as never,
+        codexClientFactory: () => {
+          const client = clients.shift();
+          if (client === undefined) throw new Error('no fake client');
+          return client as never;
+        },
+        onTurnSettled: (signal) => settled.push(signal),
+        restartBackoffBaseMs: 0,
+        restartBackoffMaxMs: 0,
+      },
+    );
+
+    await runtime.start();
+    try {
+      await runtime.completionInput({
+        text: 'old structured turn',
+        outputSchema: {
+          type: 'object',
+          properties: { optional: { type: 'string' } },
+          additionalProperties: false,
+        },
+      });
+      firstClient.emitClose(new Error('restart requested'));
+      await waitFor(() => runtime.getStatus() === 'ready' && clients.length === 0);
+
+      expect(settled).toEqual([
+        { turnId: 'turn-1', status: 'stopped', result: { text: null } },
+      ]);
+      firstClient.emitCompleted('thread-1', 'turn-1', '{"optional":null}');
+      await new Promise((resolve) => setImmediate(resolve));
+      expect(settled).toHaveLength(1);
+
+      await runtime.completionInput({ text: 'new plain turn' });
+      await waitFor(() => settled.length === 2);
+      expect(settled[1]).toEqual({
+        turnId: 'turn-1',
+        status: 'completed',
+        result: { text: 'plain result' },
+      });
+      expect(await runtime.getLast()).toEqual({ text: 'plain result' });
+    } finally {
+      await runtime.stop();
+    }
+  });
+});
+
+class RuntimeFakeClient {
+  private readonly notificationHandlers: NotificationHandler[] = [];
+  private readonly closeHandlers: Array<(reason: Error) => void> = [];
+  private nextTurnId = 1;
+
+  constructor(
+    private readonly options: { autoComplete?: boolean } = {},
+  ) {}
+
+  onClose(handler: (reason: Error) => void): void {
+    this.closeHandlers.push(handler);
+  }
+  onNotification(handler: NotificationHandler): void {
+    this.notificationHandlers.push(handler);
+  }
+  setServerRequestHandler(): void {}
+  async ready(): Promise<void> {}
+  close(): void {}
+  notify(): void {}
+
+  async request<R>(method: string, params: unknown): Promise<R> {
+    if (method === 'initialize') {
+      return {
+        userAgent: 'fake/0.147.0',
+        codexHome: '/fake/home',
+        platformFamily: 'unix',
+        platformOs: 'Linux',
+      } as R;
+    }
+    if (method === 'thread/start') {
+      return { thread: { id: 'thread-1' } } as R;
+    }
+    if (method === 'thread/resume') {
+      return {
+        thread: { id: (params as { threadId: string }).threadId },
+      } as R;
+    }
+    if (method !== 'turn/start') throw new Error(`unexpected method ${method}`);
+
+    const turnId = `turn-${this.nextTurnId++}`;
+    const input = params as {
+      threadId: string;
+      input: Array<{ text: string }>;
+      outputSchema?: Record<string, unknown>;
+    };
+    const result = input.outputSchema === undefined
+      ? 'plain result'
+      : '{"values":{}}';
+    if (this.options.autoComplete !== false) {
+      queueMicrotask(() => this.emitCompleted(input.threadId, turnId, result));
+    }
+    return { turn: { id: turnId } } as R;
+  }
+
+  emitClose(reason: Error): void {
+    for (const handler of this.closeHandlers) handler(reason);
+  }
+
+  emitCompleted(threadId: string, turnId: string, text: string): void {
+    this.emit({
+      method: 'item/completed',
+      params: {
+        threadId,
+        turnId,
+        completedAtMs: Date.now(),
+        item: { type: 'agentMessage', id: `item-${turnId}`, text },
+      },
+    });
+    this.emit({
+      method: 'turn/completed',
+      params: {
+        threadId,
+        turn: { id: turnId, items: [] },
+      },
+    });
+  }
+
+  private emit(notification: Parameters<NotificationHandler>[0]): void {
+    for (const handler of this.notificationHandlers) handler(notification);
+  }
+}
+
+class FakeProcess {
+  onExit(): void {}
+  async start(): Promise<void> {}
+  async reap(): Promise<void> {}
+}
+
+const PATHS: AgentRuntimePathContext = {
+  cacheDir: () => '/fake/cache',
+  logsDir: () => '/fake/logs',
+  runtimeSocketDirs: () => ['/fake/run/sockets'],
+};
+
+function noopState(): AgentRuntimeStateCallbacks {
+  return {
+    async setStatus(): Promise<void> {},
+    async setCheckpoint(): Promise<void> {},
+  };
+}
+
+async function waitFor(predicate: () => boolean): Promise<void> {
+  const deadline = Date.now() + 2_000;
+  while (Date.now() < deadline) {
+    if (predicate()) return;
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+  throw new Error('waitFor timed out');
+}

--- a/packages/agent-runtime/codex/tests/turn-manager.test.ts
+++ b/packages/agent-runtime/codex/tests/turn-manager.test.ts
@@ -162,6 +162,89 @@ describe('TurnManager text input submission', () => {
       },
     ]);
   });
+
+  it('compiles and restores optional output fields before completion', async () => {
+    const client = new FoldingFakeCodexClient(['turn-1']);
+    const completed: CollectedTurn[] = [];
+    const manager = new TurnManager({
+      dispatcherId: 'flow',
+      getThreadId: () => 'thread-1',
+      client: client as never,
+      onTurnCompleted: (turn) => completed.push(turn),
+    });
+    const outputSchema = optionalValueSchema();
+
+    await expect(manager.submitTextInput({
+      text: 'return optional JSON',
+      outputSchema,
+    })).resolves.toEqual({ status: 'submitted', turnId: 'turn-1' });
+
+    expect(client.outputSchemas).toEqual([{
+      type: 'object',
+      properties: {
+        value: { type: ['string', 'null'] },
+      },
+      required: ['value'],
+      additionalProperties: false,
+    }]);
+    expect(client.outputSchemas[0]).not.toBe(outputSchema);
+
+    client.emitCompleted('thread-1', 'turn-1', '{"value":null}');
+    await waitFor(() => completed.length === 1);
+    expect(completed[0]?.items).toContainEqual(
+      expect.objectContaining({ type: 'agentMessage', text: '{}' }),
+    );
+  });
+
+  it('rejects incompatible schemas before turn/start and slot admission', async () => {
+    const client = new DelayedFakeCodexClient();
+    const manager = new TurnManager({
+      dispatcherId: 'flow',
+      getThreadId: () => 'thread-1',
+      client: client as never,
+    });
+
+    await expect(manager.submitTextInput({
+      text: 'invalid schema',
+      outputSchema: {
+        type: 'object',
+        properties: { value: { type: ['string', 'number'] } },
+        additionalProperties: false,
+      },
+    })).resolves.toMatchObject({
+      status: 'failed',
+      error: {
+        name: 'UnsupportedAgentRuntimeFeatureError',
+        feature: 'outputSchema',
+        message: expect.stringContaining('$.properties.value.type'),
+      },
+    });
+    expect(client.inputs).toEqual([]);
+    expect(manager.isBusy()).toBe(false);
+  });
+
+  it('discards a failed submission codec before the next turn', async () => {
+    const client = new FailOnceFakeCodexClient();
+    const manager = new TurnManager({
+      dispatcherId: 'flow',
+      getThreadId: () => 'thread-1',
+      client: client as never,
+    });
+
+    await expect(manager.submitTextInput({
+      text: 'structured failure',
+      outputSchema: optionalValueSchema(),
+    })).resolves.toMatchObject({ status: 'failed' });
+    expect(manager.isBusy()).toBe(false);
+
+    await expect(manager.submitTextInput({
+      text: 'plain successor',
+    })).resolves.toEqual({ status: 'submitted', turnId: 'turn-2' });
+    expect(client.outputSchemas).toEqual([
+      expect.any(Object),
+      undefined,
+    ]);
+  });
 });
 
 describe('TurnManager turn settlement', () => {
@@ -272,6 +355,161 @@ describe('TurnManager turn settlement', () => {
     await flush();
 
     expect(completed.map((turn) => turn.turnId)).toEqual(['turn-1']);
+  });
+
+  it('folds compatible structured submissions and restores exactly once', async () => {
+    const client = new FoldingFakeCodexClient(['turn-1', 'turn-2']);
+    const completed: CollectedTurn[] = [];
+    const settled: TurnSettledSignal[] = [];
+    const manager = new TurnManager({
+      dispatcherId: 'flow',
+      getThreadId: () => 'thread-1',
+      client: client as never,
+      onTurnCompleted: (turn) => completed.push(turn),
+      onTurnSettled: (turn) => settled.push(turn),
+    });
+
+    await expect(manager.submitTextInput({
+      text: 'first',
+      outputSchema: optionalValueSchema(),
+    })).resolves.toEqual({ status: 'submitted', turnId: 'turn-1' });
+    await expect(manager.submitTextInput({
+      text: 'folded',
+      outputSchema: {
+        additionalProperties: false,
+        required: [],
+        properties: { value: { type: 'string' } },
+        type: 'object',
+      },
+    })).resolves.toEqual({ status: 'submitted', turnId: 'turn-1' });
+    expect(client.inputs).toEqual(['first', 'folded']);
+
+    client.emitCompleted('thread-1', 'turn-1', '{"value":null}');
+    client.emitCompleted('thread-1', 'turn-2', '{"value":"ignored"}');
+    await waitFor(() => completed.length === 1);
+    await flush();
+
+    expect(completed[0]?.items).toContainEqual(
+      expect.objectContaining({ text: '{}' }),
+    );
+    expect(settled).toEqual([]);
+  });
+
+  it('rejects incompatible structured folding without another turn/start', async () => {
+    const client = new FoldingFakeCodexClient(['turn-1']);
+    const manager = new TurnManager({
+      dispatcherId: 'flow',
+      getThreadId: () => 'thread-1',
+      client: client as never,
+    });
+
+    await manager.submitTextInput({
+      text: 'optional',
+      outputSchema: optionalValueSchema(),
+    });
+    await expect(manager.submitTextInput({
+      text: 'required nullable',
+      outputSchema: requiredNullableValueSchema(),
+    })).resolves.toMatchObject({
+      status: 'failed',
+      error: {
+        name: 'UnsupportedAgentRuntimeFeatureError',
+        feature: 'outputSchema',
+      },
+    });
+    expect(client.inputs).toEqual(['optional']);
+  });
+
+  it.each([
+    ['structured then plain', true],
+    ['plain then structured', false],
+  ])('rejects active-turn mixing for %s', async (_label, structuredFirst) => {
+    const client = new FoldingFakeCodexClient(['turn-1']);
+    const manager = new TurnManager({
+      dispatcherId: 'flow',
+      getThreadId: () => 'thread-1',
+      client: client as never,
+    });
+    const structured = {
+      text: 'structured',
+      outputSchema: optionalValueSchema(),
+    };
+    const plain = { text: 'plain' };
+
+    await manager.submitTextInput(structuredFirst ? structured : plain);
+    await expect(
+      manager.submitTextInput(structuredFirst ? plain : structured),
+    ).resolves.toMatchObject({
+      status: 'failed',
+      error: {
+        name: 'UnsupportedAgentRuntimeFeatureError',
+        feature: 'outputSchema',
+      },
+    });
+    expect(client.inputs).toHaveLength(1);
+  });
+
+  it('settles restoration failure without forwarding completion', async () => {
+    const client = new FoldingFakeCodexClient(['turn-1']);
+    const completed: CollectedTurn[] = [];
+    const settled: TurnSettledSignal[] = [];
+    const manager = new TurnManager({
+      dispatcherId: 'flow',
+      getThreadId: () => 'thread-1',
+      client: client as never,
+      onTurnCompleted: (turn) => completed.push(turn),
+      onTurnSettled: (turn) => settled.push(turn),
+    });
+
+    await manager.submitTextInput({
+      text: 'invalid restored shape',
+      outputSchema: {
+        type: 'object',
+        properties: {
+          values: { type: 'array', items: { type: 'string' } },
+        },
+        required: ['values'],
+        additionalProperties: false,
+      },
+    });
+    client.emitCompleted('thread-1', 'turn-1', '{"values":{}}');
+    await waitFor(() => settled.length === 1);
+
+    expect(completed).toEqual([]);
+    expect(settled[0]).toMatchObject({
+      turnId: 'turn-1',
+      status: 'failed',
+      result: { text: null },
+      error: {
+        message: expect.stringContaining('$.values: expected array'),
+      },
+    });
+  });
+
+  it('drops structured late completion after stop without restoring twice', async () => {
+    const client = new FoldingFakeCodexClient(['turn-1']);
+    const completed: CollectedTurn[] = [];
+    const settled: TurnSettledSignal[] = [];
+    const manager = new TurnManager({
+      dispatcherId: 'flow',
+      getThreadId: () => 'thread-1',
+      client: client as never,
+      onTurnCompleted: (turn) => completed.push(turn),
+      onTurnSettled: (turn) => settled.push(turn),
+    });
+
+    await manager.submitTextInput({
+      text: 'wait',
+      outputSchema: optionalValueSchema(),
+    });
+    await manager.stop();
+    client.emitCompleted('thread-1', 'turn-1', '{');
+    await flush();
+
+    expect(completed).toEqual([]);
+    expect(settled).toEqual([
+      { turnId: 'turn-1', status: 'stopped', result: { text: null } },
+    ]);
   });
 
   it('starts a fresh subscription for a sequential send after the previous turn completed', async () => {
@@ -405,6 +643,23 @@ function input(messageId: string, text: string) {
   };
 }
 
+function optionalValueSchema(): Record<string, unknown> {
+  return {
+    type: 'object',
+    properties: { value: { type: 'string' } },
+    additionalProperties: false,
+  };
+}
+
+function requiredNullableValueSchema(): Record<string, unknown> {
+  return {
+    type: 'object',
+    properties: { value: { type: ['string', 'null'] } },
+    required: ['value'],
+    additionalProperties: false,
+  };
+}
+
 /** A fake client that acks turn/start but never emits turn/completed. */
 class ManualFakeCodexClient {
   readonly inputs: string[] = [];
@@ -473,6 +728,7 @@ class FakeCodexClient {
 
 class FoldingFakeCodexClient {
   readonly inputs: string[] = [];
+  readonly outputSchemas: Array<Record<string, unknown> | undefined> = [];
   private readonly handlers: NotificationHandler[] = [];
   private nextIndex = 0;
 
@@ -486,8 +742,10 @@ class FoldingFakeCodexClient {
     if (method !== 'turn/start') throw new Error(`unexpected method ${method}`);
     const p = params as {
       input: Array<{ text: string }>;
+      outputSchema?: Record<string, unknown>;
     };
     this.inputs.push(p.input[0]?.text ?? '');
+    this.outputSchemas.push(p.outputSchema);
     const turnId = this.turnIds[this.nextIndex++];
     if (turnId === undefined) throw new Error('no scripted turn id');
     return { turn: { id: turnId } } as TurnStartResponse as R;
@@ -514,6 +772,25 @@ class FoldingFakeCodexClient {
 
   private emit(notification: ServerNotification): void {
     for (const handler of this.handlers) handler(notification);
+  }
+}
+
+class FailOnceFakeCodexClient {
+  readonly outputSchemas: Array<Record<string, unknown> | undefined> = [];
+  private readonly handlers: NotificationHandler[] = [];
+  private requests = 0;
+
+  onNotification(handler: NotificationHandler): void {
+    this.handlers.push(handler);
+  }
+
+  async request<R>(method: string, params: unknown): Promise<R> {
+    if (method !== 'turn/start') throw new Error(`unexpected method ${method}`);
+    this.requests += 1;
+    const p = params as { outputSchema?: Record<string, unknown> };
+    this.outputSchemas.push(p.outputSchema);
+    if (this.requests === 1) throw new Error('turn/start rejected');
+    return { turn: { id: 'turn-2' } } as TurnStartResponse as R;
   }
 }
 

--- a/packages/dreamux/tests/codex-live.test.ts
+++ b/packages/dreamux/tests/codex-live.test.ts
@@ -17,10 +17,10 @@
  * (e.g. dev machines without codex, or pre-merge sandboxes). The skip
  * emits a loud `console.warn` so it's visible in test output.
  *
- * The issue #63 mid-turn model gate needs a usable Codex model login, not just
- * the app-server binary. It runs by default outside CI. CI loud-skips that one
- * gate unless `DREAMUX_RUN_LIVE_MODEL_GATE=1` is set, because public CI cannot
- * assume an operator's interactive Codex auth is available.
+ * The real-model gates need a usable Codex model login, not just the app-server
+ * binary. They run by default outside CI. CI loud-skips them unless
+ * `DREAMUX_RUN_LIVE_MODEL_GATE=1` is set, because public CI cannot assume an
+ * operator's interactive Codex auth is available.
  */
 
 import { describe, it, expect } from 'vitest';
@@ -37,7 +37,10 @@ import {
 import { homedir } from 'node:os';
 import { join } from 'node:path';
 
-import { CodexProcess } from '@excitedjs/agent-runtime-codex';
+import {
+  CodexProcess,
+  CodexRuntime,
+} from '@excitedjs/agent-runtime-codex';
 import { CodexWsClient, type CodexWsClientOptions } from '@excitedjs/agent-runtime-codex';
 import { performInitializeHandshake } from '@excitedjs/agent-runtime-codex';
 import {
@@ -57,6 +60,11 @@ import { codexAgentRuntimeCatalog } from './helpers/fake-agent-runtime.js';
 import { saveDispatcherAccess } from '@excitedjs/feishu-channel';
 import { dispatcherDir } from '../src/platform/paths.js';
 import type { DreamuxConfig } from '../src/config/config.js';
+import type {
+  AgentRuntimePathContext,
+  AgentRuntimeStateCallbacks,
+  TurnSettledSignal,
+} from '@excitedjs/dreamux-types';
 import type {
   ServerNotification,
   ThreadStartResponse,
@@ -247,6 +255,9 @@ function createIsolatedCodexHome(dir: string): string {
       'approval_policy = "never"',
       'sandbox_mode = "danger-full-access"',
       '',
+      '[features]',
+      'apps = false',
+      '',
       '[apps._default]',
       'enabled = false',
       'destructive_enabled = false',
@@ -358,9 +369,9 @@ describe('codex live integration', () => {
   // From here on we know codex is on PATH and reports a parseable version.
   if (!runModelGate) {
     console.warn(
-      `[codex-live] issue #63 mid-turn model gate SKIPPED in CI. ` +
+      `[codex-live] live model gates SKIPPED in CI. ` +
         `Set ${MODEL_GATE_ENV}=1 in an environment with usable Codex model auth ` +
-        `to verify the real model/tool folding path.`,
+        `to verify structured output and model/tool folding paths.`,
     );
   }
 
@@ -485,6 +496,147 @@ describe('codex live integration', () => {
       }
     },
     60_000,
+  );
+
+  (runModelGate ? it : it.skip)(
+    `runs the portable optional-field schema through real codex ${detection.version}`,
+    async () => {
+      const operatorHome = homedir();
+      const previousCodexHome = process.env['CODEX_HOME'];
+      const dir = mkdtempSync(join(operatorHome, '.dreamux-codex-schema-live-'));
+      const isolatedCodexHome = createIsolatedCodexHome(dir);
+      const cwd = join(dir, 'cwd');
+      const socketPath = join(dir, 'codex.sock');
+      const settled: TurnSettledSignal[] = [];
+      let client: RecordingCodexWsClient | null = null;
+      const paths: AgentRuntimePathContext = {
+        cacheDir: () => join(dir, 'cache'),
+        logsDir: () => join(dir, 'logs'),
+        runtimeSocketDirs: () => [dir],
+      };
+      const state: AgentRuntimeStateCallbacks = {
+        async setStatus(): Promise<void> {},
+        async setCheckpoint(): Promise<void> {},
+      };
+      process.env['CODEX_HOME'] = isolatedCodexHome;
+
+      const runtime = new CodexRuntime(
+        { runtime_id: 'schema-live', checkpoint_id: null },
+        {
+          cwd,
+          state,
+          paths,
+          allocateSocketPath: () => socketPath,
+          codexBinPath: 'codex',
+          resolveExtraArgs: () => codexArgsToCli(
+            parseCodexArgs('{"sandboxMode":"danger-full-access"}'),
+          ),
+          codexClientFactory: (path) => {
+            client = new RecordingCodexWsClient({ socketPath: path });
+            return client;
+          },
+          codexHomeDoctor: () => {
+            /* real Codex auth is supplied through the isolated CODEX_HOME */
+          },
+          onTurnSettled: (signal) => settled.push(signal),
+        },
+      );
+
+      try {
+        await runtime.start();
+        const outputSchema = {
+          type: 'object',
+          properties: {
+            kind: {
+              type: 'string',
+              enum: ['portable'],
+            },
+            score: {
+              type: 'integer',
+              minimum: 7,
+              maximum: 7,
+            },
+            nullableFlag: {
+              type: ['boolean', 'null'],
+            },
+            optionalNote: {
+              type: 'string',
+              enum: ['present'],
+            },
+          },
+          required: ['kind', 'score', 'nullableFlag'],
+          additionalProperties: false,
+        };
+        await expect(runtime.completionInput({
+          sourceId: 'portable-output-schema-live',
+          text: [
+            'Return the requested structured result.',
+            'Use kind "portable", score 7, nullableFlag null, and optionalNote null.',
+          ].join(' '),
+          outputSchema,
+        })).resolves.toMatchObject({ status: 'submitted' });
+        try {
+          await waitFor(
+            () => settled.length === 1,
+            120_000,
+            'portable structured-output turn settled',
+          );
+        } catch (err) {
+          const liveClient = client!;
+          const suffix = notificationDebugSummary(liveClient);
+          const turnStart = turnStartRequests(liveClient)[0];
+          throw new Error(
+            `${err instanceof Error ? err.message : String(err)}; ` +
+              `turn/start error=${turnStart?.error ?? 'none'}; ` +
+              `recent notifications: ${suffix}`,
+          );
+        }
+
+        const settledTurn = settled[0];
+        if (settledTurn?.status !== 'completed') {
+          const liveClient = client!;
+          throw new Error(
+            `portable structured-output turn ${settledTurn?.status ?? 'missing'}: ` +
+              `${settledTurn?.error?.message ?? 'no settlement error'}; ` +
+              `recent notifications: ${notificationDebugSummary(liveClient)}`,
+          );
+        }
+        expect(settledTurn).toMatchObject({
+          status: 'completed',
+          result: { text: expect.any(String) as string },
+        });
+        const resultText = settledTurn.result?.text;
+        expect(resultText).not.toBeNull();
+        expect(JSON.parse(resultText ?? '')).toEqual({
+          kind: 'portable',
+          score: 7,
+          nullableFlag: null,
+        });
+        expect(await runtime.getLast()).toEqual({ text: resultText });
+
+        const liveClient = client!;
+        const request = turnStartRequests(liveClient)[0];
+        const params = request?.params as {
+          outputSchema?: Record<string, unknown>;
+        };
+        expect(params.outputSchema).toMatchObject({
+          required: ['kind', 'nullableFlag', 'optionalNote', 'score'],
+          properties: {
+            kind: { enum: ['portable'] },
+            score: { minimum: 7, maximum: 7 },
+            nullableFlag: { type: ['boolean', 'null'] },
+            optionalNote: { type: ['string', 'null'] },
+          },
+          additionalProperties: false,
+        });
+      } finally {
+        await runtime.stop();
+        if (previousCodexHome === undefined) delete process.env['CODEX_HOME'];
+        else process.env['CODEX_HOME'] = previousCodexHome;
+        rmSync(dir, { recursive: true, force: true });
+      }
+    },
+    180_000,
   );
 
   (runModelGate ? it : it.skip)(


### PR DESCRIPTION
## Summary

- compile the provider-neutral structured-output subset into Codex strict schemas before `turn/start`
- restore optional-field semantics before Codex publishes a completed turn, while preserving required nullable values
- bind private codecs to active-turn slots/native turn ids and reject incompatible folding before submission
- document the adapter-owned contract, archive the implemented proposal, and add package-scoped Rush declarations

## Exact head

`0b9d91c0ab77667a0c0a94162f4f15100f7bcb15`

## Validation

- `@excitedjs/agent-runtime-codex`: 70/70 tests; final simplification focused set 42/42
- `@excitedjs/dreamux` CI-mode tests: 916 passed, 5 skipped
- Codex and Dreamux production/test typecheck
- Codex and Dreamux build + lint
- `rush change --verify --target-branch origin/next --no-fetch`
- `.agents/scripts/check.sh`
- `git diff --check`
- GitHub CI: 8/8 jobs passed on Ubuntu/macOS, including full Rush build/typecheck/lint/test, Rush change, KB, shellcheck, commit metadata, and full-history gitleaks
- resident architecture, lifecycle, and complexity reviews: APPROVE on the exact head
- external Devbox review: APPROVED on GitHub

## Live Codex gate

The opt-in real Codex model gate is included. On the current machine, Codex 0.147 accepted the compiled `turn/start.outputSchema` (`turn/start error=none`) and entered the model turn, but the ChatGPT model backend repeatedly reconnected and never produced a terminal result. This is recorded as an environment/model-service blocker rather than reported as a passing end-to-end model gate. CI keeps the existing explicit model-gate opt-in behavior.