### PR TITLE
fix(codex): dispose turn collectors

### DIFF
--- a/.agents/domains/provider-runtime.md
+++ b/.agents/domains/provider-runtime.md
@@ -167,9 +167,17 @@ not call `onTurnCompleted` or mutate `lastResult`; it emits one ordinary failed
 teardown/restart, and late completion clear or discard in-memory codecs through
 the same turn lifecycle and never restore or settle twice.
 
+Each collector owns and unregisters exactly one Codex notification handler.
+Normal completion and terminal failure close it automatically; rejected
+`turn/start`, runtime stop, and direct `runTurn` cleanup dispose it explicitly.
+An abandoned collector therefore cannot buffer a later turn or accumulate
+handlers on the resident Codex client.
+
 Source:
 
 - `/packages/agent-runtime/codex/src/output-schema-codec.ts`
+- `/packages/agent-runtime/codex/src/events.ts`
+- `/packages/agent-runtime/codex/src/rpc.ts`
 - `/packages/agent-runtime/codex/src/turn-manager.ts`
 - `/packages/agent-runtime/codex/src/runtime.ts`
 - `/packages/agent-runtime/codex/tests/output-schema-codec.test.ts`

--- a/common/changes/@excitedjs/agent-runtime-codex/fix-codex-collector-dispose_2026-08-09-15-14.json
+++ b/common/changes/@excitedjs/agent-runtime-codex/fix-codex-collector-dispose_2026-08-09-15-14.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Unsubscribe Codex turn collectors after completion, failure, rejected turn/start, direct-run cleanup, and runtime stop so stale collectors cannot observe later turns.",
+      "type": "patch",
+      "packageName": "@excitedjs/agent-runtime-codex"
+    }
+  ],
+  "packageName": "@excitedjs/agent-runtime-codex",
+  "email": "053700@gmail.com"
+}

--- a/packages/agent-runtime/codex/README.md
+++ b/packages/agent-runtime/codex/README.md
@@ -73,6 +73,11 @@ structured with the same compiled wire schema and restoration plan, or both are
 unstructured. Structured/unstructured mixing and incompatible schemas fail
 before another `turn/start`.
 
+Each turn collector owns one notification subscription. It unsubscribes on
+normal completion, terminal failure, explicit disposal, or runtime stop. A
+rejected `turn/start` therefore cannot leave a stale collector observing or
+buffering notifications from a later turn.
+
 See
 [Provider Runtime](../../../.agents/domains/provider-runtime.md#codex-portable-output-schema)
 for the complete current lifecycle and failure contract.

--- a/packages/agent-runtime/codex/src/events.ts
+++ b/packages/agent-runtime/codex/src/events.ts
@@ -25,6 +25,7 @@ export interface CollectedTurn {
 
 export interface TurnCollector {
   awaitTurn(turnId?: string): Promise<CollectedTurn>;
+  dispose(): void;
 }
 
 /**
@@ -83,6 +84,7 @@ export function subscribeTurnCollection(
   let firstFailure: Error | null = null;
   let unscopedFailure: Error | null = null;
   let closed = false;
+  let unsubscribe = (): void => {};
   let awaiting:
     | {
         turnId: string | null;
@@ -93,8 +95,12 @@ export function subscribeTurnCollection(
     | null = null;
 
   const closeCollector = (): void => {
+    if (closed) return;
     closed = true;
     itemsByTurn.clear();
+    completedByTurn.clear();
+    failuresByTurn.clear();
+    unsubscribe();
   };
 
   const resolveAwaiting = (): void => {
@@ -135,7 +141,7 @@ export function subscribeTurnCollection(
     }
   };
 
-  client.onNotification((notif) => {
+  unsubscribe = client.onNotification((notif) => {
     const p = (notif.params ?? {}) as Record<string, unknown>;
     const nThreadId = typeof p['threadId'] === 'string' ? (p['threadId'] as string) : null;
     const matches = acceptAnyThread || nThreadId === threadId;
@@ -226,6 +232,13 @@ export function subscribeTurnCollection(
       };
       return promise;
     },
+    dispose(): void {
+      if (awaiting !== null) {
+        awaiting.reject(new Error('codex turn collector disposed'));
+        awaiting = null;
+      }
+      closeCollector();
+    },
   };
 }
 
@@ -272,8 +285,12 @@ export async function runTurn(
   cwd: string | null,
 ): Promise<CollectedTurn> {
   const collector = subscribeTurnCollection(client, threadId);
-  const res = await submitTurnStart(client, threadId, prompt, cwd);
-  return collector.awaitTurn(res.turn.id);
+  try {
+    const res = await submitTurnStart(client, threadId, prompt, cwd);
+    return await collector.awaitTurn(res.turn.id);
+  } finally {
+    collector.dispose();
+  }
 }
 
 /**

--- a/packages/agent-runtime/codex/src/rpc.ts
+++ b/packages/agent-runtime/codex/src/rpc.ts
@@ -45,7 +45,7 @@ export class CodexWsClient {
     number,
     { resolve: (v: unknown) => void; reject: (e: Error) => void }
   >();
-  private readonly notifHandlers: NotificationHandler[] = [];
+  private readonly notifHandlers = new Set<NotificationHandler>();
   private readonly closeHandlers: CloseHandler[] = [];
   private serverReqHandler: ServerRequestHandler = async () => {
     throw new Error(
@@ -93,8 +93,11 @@ export class CodexWsClient {
     return this.opened;
   }
 
-  onNotification(handler: NotificationHandler): void {
-    this.notifHandlers.push(handler);
+  onNotification(handler: NotificationHandler): () => void {
+    this.notifHandlers.add(handler);
+    return () => {
+      this.notifHandlers.delete(handler);
+    };
   }
 
   /**

--- a/packages/agent-runtime/codex/src/turn-manager.ts
+++ b/packages/agent-runtime/codex/src/turn-manager.ts
@@ -250,7 +250,10 @@ export class TurnManager {
     this.stopped = true;
     const activeSlot = this.activeTurnSlot;
     this.activeTurnSlot = null;
-    if (activeSlot !== null) activeSlot.codec = null;
+    if (activeSlot !== null) {
+      activeSlot.collector.dispose();
+      activeSlot.codec = null;
+    }
     if (activeSlot !== null && activeSlot.turnId === null) {
       activeSlot.rejectTurnId(new Error('codex turn stopped before acceptance'));
     }
@@ -340,6 +343,7 @@ export class TurnManager {
     }
     if (slot.primaryFailed && slot.pendingSubmissions === 0) {
       if (this.activeTurnSlot === slot) this.activeTurnSlot = null;
+      slot.collector.dispose();
       slot.codec = null;
       slot.rejectTurnId(error);
       this.resolveIdleWaitersIfIdle();

--- a/packages/agent-runtime/codex/tests/codex-events.test.ts
+++ b/packages/agent-runtime/codex/tests/codex-events.test.ts
@@ -14,6 +14,7 @@
 import { describe, expect, it } from 'vitest';
 
 import {
+  runTurn,
   subscribeTurnCollection,
   type TurnTraceEvent,
 } from '../src/events.js';
@@ -22,15 +23,29 @@ import type { CodexWsClient } from '../src/rpc.js';
 /** Minimal CodexWsClient stub exposing only the onNotification seam + emit. */
 function fakeClient(): {
   client: CodexWsClient;
-  emit: (notif: { method: string; params: unknown }) => void;
+  emit: (notification: { method: string; params: unknown }) => void;
+  handlerCount: () => number;
 } {
-  let handler: ((n: { method: string; params: unknown }) => void) | null = null;
+  const handlers = new Set<
+    (notification: { method: string; params: unknown }) => void
+  >();
   const client = {
-    onNotification(h: (n: { method: string; params: unknown }) => void): void {
-      handler = h;
+    onNotification(
+      handler: (notification: { method: string; params: unknown }) => void,
+    ): () => void {
+      handlers.add(handler);
+      return () => {
+        handlers.delete(handler);
+      };
     },
   } as unknown as CodexWsClient;
-  return { client, emit: (notif) => handler?.(notif) };
+  return {
+    client,
+    emit: (notification) => {
+      for (const handler of handlers) handler(notification);
+    },
+    handlerCount: () => handlers.size,
+  };
 }
 
 describe('subscribeTurnCollection (issue #126 PR8)', () => {
@@ -74,7 +89,7 @@ describe('subscribeTurnCollection (issue #126 PR8)', () => {
   });
 
   it('acceptAnyThread resolves on a turn/completed with a mismatched threadId', async () => {
-    const { client, emit } = fakeClient();
+    const { client, emit, handlerCount } = fakeClient();
     const collector = subscribeTurnCollection(client, 'thread-A', {
       acceptAnyThread: true,
     });
@@ -98,5 +113,31 @@ describe('subscribeTurnCollection (issue #126 PR8)', () => {
     const turn = await collector.awaitTurn();
     expect(turn.turnId).toBe('t1');
     expect(turn.items.map((i) => i.type)).toEqual(['agentMessage']);
+    expect(handlerCount()).toBe(0);
+  });
+
+  it('disposes a pending collector and unsubscribes idempotently', async () => {
+    const { client, handlerCount } = fakeClient();
+    const collector = subscribeTurnCollection(client, 'thread-A');
+    const pending = collector.awaitTurn('turn-never-accepted');
+
+    expect(handlerCount()).toBe(1);
+    collector.dispose();
+    collector.dispose();
+
+    await expect(pending).rejects.toThrow('codex turn collector disposed');
+    expect(handlerCount()).toBe(0);
+  });
+
+  it('unsubscribes runTurn when turn/start is rejected', async () => {
+    const { client, handlerCount } = fakeClient();
+    client.request = async () => {
+      throw new Error('turn/start rejected');
+    };
+
+    await expect(
+      runTurn(client, 'thread-A', 'work', null),
+    ).rejects.toThrow('turn/start rejected');
+    expect(handlerCount()).toBe(0);
   });
 });

--- a/packages/agent-runtime/codex/tests/runtime-output-schema.test.ts
+++ b/packages/agent-runtime/codex/tests/runtime-output-schema.test.ts
@@ -128,7 +128,7 @@ describe('CodexRuntime portable output schema settlement', () => {
 });
 
 class RuntimeFakeClient {
-  private readonly notificationHandlers: NotificationHandler[] = [];
+  private readonly notificationHandlers = new Set<NotificationHandler>();
   private readonly closeHandlers: Array<(reason: Error) => void> = [];
   private nextTurnId = 1;
 
@@ -139,8 +139,11 @@ class RuntimeFakeClient {
   onClose(handler: (reason: Error) => void): void {
     this.closeHandlers.push(handler);
   }
-  onNotification(handler: NotificationHandler): void {
-    this.notificationHandlers.push(handler);
+  onNotification(handler: NotificationHandler): () => void {
+    this.notificationHandlers.add(handler);
+    return () => {
+      this.notificationHandlers.delete(handler);
+    };
   }
   setServerRequestHandler(): void {}
   async ready(): Promise<void> {}

--- a/packages/agent-runtime/codex/tests/skill-extra-roots.test.ts
+++ b/packages/agent-runtime/codex/tests/skill-extra-roots.test.ts
@@ -34,15 +34,18 @@ class FakeClient {
   readonly threadResumeCalls: unknown[] = [];
   readonly turnStartCalls: unknown[] = [];
   threadResumeError: Error | null = null;
-  private readonly handlers: Array<(notification: unknown) => void> = [];
+  private readonly handlers = new Set<(notification: unknown) => void>();
   private nextTurnId = 1;
   failExtraRoots = false;
   /** When set, `skills/extraRoots/set` rejects with this error instead. */
   extraRootsError: Error | null = null;
 
   onClose(): void {}
-  onNotification(handler: (notification: unknown) => void): void {
-    this.handlers.push(handler);
+  onNotification(handler: (notification: unknown) => void): () => void {
+    this.handlers.add(handler);
+    return () => {
+      this.handlers.delete(handler);
+    };
   }
   setServerRequestHandler(): void {}
   async ready(): Promise<void> {}

--- a/packages/agent-runtime/codex/tests/turn-manager.test.ts
+++ b/packages/agent-runtime/codex/tests/turn-manager.test.ts
@@ -245,6 +245,49 @@ describe('TurnManager text input submission', () => {
       undefined,
     ]);
   });
+
+  it.each([
+    ['plain failure before structured recovery', false],
+    ['structured failure before plain recovery', true],
+  ])('disposes the abandoned collector after %s', async (_label, failedStructured) => {
+    const client = new RecoveringFakeCodexClient();
+    const completed: CollectedTurn[] = [];
+    const manager = new TurnManager({
+      dispatcherId: 'flow',
+      getThreadId: () => 'thread-1',
+      client: client as never,
+      onTurnCompleted: (turn) => completed.push(turn),
+    });
+
+    await expect(manager.submitTextInput(
+      failedStructured
+        ? { text: 'failed structured', outputSchema: optionalValueSchema() }
+        : { text: 'failed plain' },
+    )).resolves.toMatchObject({ status: 'failed' });
+    expect(client.handlerCount).toBe(0);
+
+    await expect(manager.submitTextInput(
+      failedStructured
+        ? { text: 'plain recovery' }
+        : { text: 'structured recovery', outputSchema: optionalValueSchema() },
+    )).resolves.toEqual({ status: 'submitted', turnId: 'turn-2' });
+    expect(client.handlerCount).toBe(1);
+
+    client.emitCompleted(
+      'thread-1',
+      'turn-2',
+      failedStructured ? 'plain result' : '{"value":null}',
+    );
+    await waitFor(() => completed.length === 1);
+
+    expect(completed[0]?.items).toContainEqual(
+      expect.objectContaining({
+        type: 'agentMessage',
+        text: failedStructured ? 'plain result' : '{}',
+      }),
+    );
+    expect(client.handlerCount).toBe(0);
+  });
 });
 
 describe('TurnManager turn settlement', () => {
@@ -560,6 +603,7 @@ describe('TurnManager turn settlement', () => {
     expect(settled).toEqual([
       { turnId: 'turn-1', status: 'stopped', result: { text: null } },
     ]);
+    expect(client.handlerCount).toBe(0);
   });
 
   it('does not re-settle a completed turn as stopped', async () => {
@@ -663,10 +707,18 @@ function requiredNullableValueSchema(): Record<string, unknown> {
 /** A fake client that acks turn/start but never emits turn/completed. */
 class ManualFakeCodexClient {
   readonly inputs: string[] = [];
+  private readonly handlers = new Set<NotificationHandler>();
   private nextTurnId = 1;
 
-  onNotification(_handler: NotificationHandler): void {
-    /* no notifications are ever emitted */
+  get handlerCount(): number {
+    return this.handlers.size;
+  }
+
+  onNotification(handler: NotificationHandler): () => void {
+    this.handlers.add(handler);
+    return () => {
+      this.handlers.delete(handler);
+    };
   }
 
   async request<R>(method: string, params: unknown): Promise<R> {
@@ -681,11 +733,14 @@ class FakeCodexClient {
   readonly inputs: string[] = [];
   readonly methods: string[] = [];
   readonly outputSchemas: Array<Record<string, unknown> | undefined> = [];
-  private readonly handlers: NotificationHandler[] = [];
+  private readonly handlers = new Set<NotificationHandler>();
   private nextTurnId = 1;
 
-  onNotification(handler: NotificationHandler): void {
-    this.handlers.push(handler);
+  onNotification(handler: NotificationHandler): () => void {
+    this.handlers.add(handler);
+    return () => {
+      this.handlers.delete(handler);
+    };
   }
 
   async request<R>(method: string, params: unknown): Promise<R> {
@@ -729,13 +784,16 @@ class FakeCodexClient {
 class FoldingFakeCodexClient {
   readonly inputs: string[] = [];
   readonly outputSchemas: Array<Record<string, unknown> | undefined> = [];
-  private readonly handlers: NotificationHandler[] = [];
+  private readonly handlers = new Set<NotificationHandler>();
   private nextIndex = 0;
 
   constructor(private readonly turnIds: string[]) {}
 
-  onNotification(handler: NotificationHandler): void {
-    this.handlers.push(handler);
+  onNotification(handler: NotificationHandler): () => void {
+    this.handlers.add(handler);
+    return () => {
+      this.handlers.delete(handler);
+    };
   }
 
   async request<R>(method: string, params: unknown): Promise<R> {
@@ -777,11 +835,14 @@ class FoldingFakeCodexClient {
 
 class FailOnceFakeCodexClient {
   readonly outputSchemas: Array<Record<string, unknown> | undefined> = [];
-  private readonly handlers: NotificationHandler[] = [];
+  private readonly handlers = new Set<NotificationHandler>();
   private requests = 0;
 
-  onNotification(handler: NotificationHandler): void {
-    this.handlers.push(handler);
+  onNotification(handler: NotificationHandler): () => void {
+    this.handlers.add(handler);
+    return () => {
+      this.handlers.delete(handler);
+    };
   }
 
   async request<R>(method: string, params: unknown): Promise<R> {
@@ -794,17 +855,66 @@ class FailOnceFakeCodexClient {
   }
 }
 
+class RecoveringFakeCodexClient {
+  private readonly handlers = new Set<NotificationHandler>();
+  private requests = 0;
+
+  get handlerCount(): number {
+    return this.handlers.size;
+  }
+
+  onNotification(handler: NotificationHandler): () => void {
+    this.handlers.add(handler);
+    return () => {
+      this.handlers.delete(handler);
+    };
+  }
+
+  async request<R>(method: string): Promise<R> {
+    if (method !== 'turn/start') throw new Error(`unexpected method ${method}`);
+    this.requests += 1;
+    if (this.requests === 1) throw new Error('turn/start rejected');
+    return { turn: { id: 'turn-2' } } as TurnStartResponse as R;
+  }
+
+  emitCompleted(threadId: string, turnId: string, text: string): void {
+    this.emit({
+      method: 'item/completed',
+      params: {
+        threadId,
+        turnId,
+        completedAtMs: Date.now(),
+        item: { type: 'agentMessage', id: `item-${turnId}`, text },
+      },
+    });
+    this.emit({
+      method: 'turn/completed',
+      params: {
+        threadId,
+        turn: { id: turnId, items: [] },
+      },
+    });
+  }
+
+  private emit(notification: ServerNotification): void {
+    for (const handler of this.handlers) handler(notification);
+  }
+}
+
 class DelayedFakeCodexClient {
   readonly inputs: string[] = [];
-  private readonly handlers: NotificationHandler[] = [];
+  private readonly handlers = new Set<NotificationHandler>();
   private readonly pending: Array<(turnId: string) => void> = [];
 
   get handlerCount(): number {
-    return this.handlers.length;
+    return this.handlers.size;
   }
 
-  onNotification(handler: NotificationHandler): void {
-    this.handlers.push(handler);
+  onNotification(handler: NotificationHandler): () => void {
+    this.handlers.add(handler);
+    return () => {
+      this.handlers.delete(handler);
+    };
   }
 
   request<R>(method: string, params: unknown): Promise<R> {
@@ -856,13 +966,16 @@ class DelayedFakeCodexClient {
  * With willRetry=true (transient) a normal turn/completed follows.
  */
 class ErroringFakeCodexClient {
-  private readonly handlers: NotificationHandler[] = [];
+  private readonly handlers = new Set<NotificationHandler>();
   private nextTurnId = 1;
 
   constructor(private readonly willRetry: boolean) {}
 
-  onNotification(handler: NotificationHandler): void {
-    this.handlers.push(handler);
+  onNotification(handler: NotificationHandler): () => void {
+    this.handlers.add(handler);
+    return () => {
+      this.handlers.delete(handler);
+    };
   }
 
   async request<R>(method: string, params: unknown): Promise<R> {


### PR DESCRIPTION
## Summary

- make Codex notification registrations return an idempotent unsubscribe callback
- let each turn collector own and release its notification subscription on completion, terminal failure, explicit disposal, or direct-run cleanup
- dispose abandoned collectors after rejected `turn/start` submissions and during runtime stop

## Problem

`TurnManager` subscribes a collector before calling `turn/start`. If every submission for that slot is rejected, the slot is cleared but the collector remains registered on the resident Codex client. A later turn on the same thread is then observed by both the stale and current collectors, and repeated failures accumulate handlers and buffered turn data.

## Tests

- `rush build --to @excitedjs/agent-runtime-codex`
- Codex focused tests: 32 passed
- Codex full suite: 74 passed
- Codex source/test typecheck and lint
- `.agents/scripts/check.sh` (92 files reachable)
- `rush change --verify --target-branch origin/next`
- `git diff --check origin/next...HEAD`

The new regressions cover normal completion unsubscription, idempotent explicit disposal, rejected direct `runTurn`, rejected plain-to-structured recovery, rejected structured-to-plain recovery, and runtime stop.
