### PR TITLE
skill(workflow): port max-effort review mechanics into the code-review reference

### DIFF
--- a/common/changes/@excitedjs/dreamux/skill-code-review-max-port_2026-08-11-00-00.json
+++ b/common/changes/@excitedjs/dreamux/skill-code-review-max-port_2026-08-11-00-00.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@excitedjs/dreamux",
+      "comment": "Extend the bundled workflow code-review reference with effort-level presets (quick/standard/max), repeat-until-dry find/verify rounds with seen-key deduplication, a cumulative range mode with a cross-change finder lens and range-scoped false-positive rule, finder severity estimates, and a severity-grouped report format. Documentation-only bundled skill content; no runtime behavior change.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@excitedjs/dreamux"
+}

--- a/common/changes/@excitedjs/dreamux/skill-code-review-max-port_2026-08-11-00-00.json
+++ b/common/changes/@excitedjs/dreamux/skill-code-review-max-port_2026-08-11-00-00.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@excitedjs/dreamux",
-      "comment": "Extend the bundled workflow code-review reference with effort-level presets (quick/standard/max) validated fail-loud, repeat-until-dry find/verify rounds with cross-lens seen-key deduplication, an in-script range resolver plus cross-change finder lens for cumulative range mode, all-conditions verifier prompts with distinct emphases, a required concrete failure scenario per finding, required enum severity feeding a severity-grouped report, a labeled plausible tier at max effort, and coverage facts distinguishing convergence from round-cap stops; add an ultracode orchestration techniques reference (archetypes, scouting, run chaining, worked compositions). Documentation-only bundled skill content; no runtime behavior change.",
+      "comment": "Rework the bundled workflow code-review reference into a method-first recipe (flow, verbatim scoring rubric, false-positive discipline, effort scaling, cumulative-range guidance) with a compact adaptation sketch instead of a paste-ready script, and add an ultracode orchestration techniques reference (archetypes, scouting, run chaining, compact worked compositions). Documentation-only bundled skill content; no runtime behavior change.",
       "type": "patch"
     }
   ],

--- a/common/changes/@excitedjs/dreamux/skill-code-review-max-port_2026-08-11-00-00.json
+++ b/common/changes/@excitedjs/dreamux/skill-code-review-max-port_2026-08-11-00-00.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@excitedjs/dreamux",
-      "comment": "Extend the bundled workflow code-review reference with effort-level presets (quick/standard/max), repeat-until-dry find/verify rounds with seen-key deduplication, a cumulative range mode with a cross-change finder lens and range-scoped false-positive rule, finder severity estimates, and a severity-grouped report format. Documentation-only bundled skill content; no runtime behavior change.",
+      "comment": "Extend the bundled workflow code-review reference with effort-level presets (quick/standard/max) validated fail-loud, repeat-until-dry find/verify rounds with cross-lens seen-key deduplication, an in-script range resolver plus cross-change finder lens for cumulative range mode, all-conditions verifier prompts with distinct emphases, required enum severity feeding a severity-grouped report, and coverage facts distinguishing convergence from round-cap stops; add an ultracode orchestration techniques reference (archetypes, scouting, run chaining, worked compositions). Documentation-only bundled skill content; no runtime behavior change.",
       "type": "patch"
     }
   ],

--- a/common/changes/@excitedjs/dreamux/skill-code-review-max-port_2026-08-11-00-00.json
+++ b/common/changes/@excitedjs/dreamux/skill-code-review-max-port_2026-08-11-00-00.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@excitedjs/dreamux",
-      "comment": "Extend the bundled workflow code-review reference with effort-level presets (quick/standard/max) validated fail-loud, repeat-until-dry find/verify rounds with cross-lens seen-key deduplication, an in-script range resolver plus cross-change finder lens for cumulative range mode, all-conditions verifier prompts with distinct emphases, required enum severity feeding a severity-grouped report, and coverage facts distinguishing convergence from round-cap stops; add an ultracode orchestration techniques reference (archetypes, scouting, run chaining, worked compositions). Documentation-only bundled skill content; no runtime behavior change.",
+      "comment": "Extend the bundled workflow code-review reference with effort-level presets (quick/standard/max) validated fail-loud, repeat-until-dry find/verify rounds with cross-lens seen-key deduplication, an in-script range resolver plus cross-change finder lens for cumulative range mode, all-conditions verifier prompts with distinct emphases, a required concrete failure scenario per finding, required enum severity feeding a severity-grouped report, a labeled plausible tier at max effort, and coverage facts distinguishing convergence from round-cap stops; add an ultracode orchestration techniques reference (archetypes, scouting, run chaining, worked compositions). Documentation-only bundled skill content; no runtime behavior change.",
       "type": "patch"
     }
   ],

--- a/packages/dreamux/skills/shared/workflow/SKILL.md
+++ b/packages/dreamux/skills/shared/workflow/SKILL.md
@@ -161,3 +161,4 @@ unavailable so orchestration stays deterministic.
 | --- | --- | --- |
 | Code review run | Carrying a change review (pull/merge request, git range, or working-tree diff) as one workflow run: eligibility gate, multi-lens finders, confidence-scored verification, one synthesized report. | [Code review](references/code-review.md) |
 | Orchestration and prompt patterns | Writing TeamMate prompts inside scripts, choosing `pipeline` versus `parallel`, and applying quality patterns: adversarial verify, judge panel, loop-until-dry, multi-modal sweep, completeness critic. | [Orchestration patterns](references/orchestration-patterns.md) |
+| Ultracode orchestration techniques | Shaping a whole task as workflows: the five archetypes (understand/design/review/research/migrate), scouting before fan-out, chaining runs with the TeamLeader in the loop, worked compositions, novel harness shapes. | [Ultracode techniques](references/ultracode.md) |

--- a/packages/dreamux/skills/shared/workflow/references/code-review.md
+++ b/packages/dreamux/skills/shared/workflow/references/code-review.md
@@ -2,16 +2,19 @@
 
 `../SKILL.md` owns the run tools and the script API. This reference owns one
 recipe: carrying a full code review as a single `workflow_run` — an eligibility
-gate, context collection, independent multi-lens finders, per-finding
-confidence scoring, and one synthesized report.
+gate, context collection, independent multi-lens finders repeated until dry,
+per-finding confidence scoring, and one severity-ordered synthesized report.
 
 ## Contents
 
 - [Stage design](#stage-design) — the five stages and their failure accounting
+- [Effort levels](#effort-levels) — quick / standard / max presets
+- [Cumulative range mode](#cumulative-range-mode) — reviewing many merged
+  changes as one diff
 - [Prompt discipline](#prompt-discipline) — output contract, rejection
   semantics, self-contained prompts
 - [TeamMate budget](#teammate-budget) — cost arithmetic against the run caps
-- [Script](#script) — the complete runnable module
+- [Script](#script) — the complete runnable script
 - [Invocation](#invocation) — call shape and result fields
 
 The review target is any change the Team workspace can read: a GitHub pull
@@ -42,24 +45,70 @@ instead.
    barrier is justified: deduplication needs every lens's output at once —
    and it is where coverage is accounted: lens results are index-aligned with
    the lens list, so a failed lens is recorded as missing coverage instead of
-   being silently dropped by `.filter(Boolean)`.
-4. **Verify** — each unique finding is scored by three TeamMates with distinct
-   focus questions (does it reproduce on the changed lines; is it pre-existing
-   rather than introduced; does the cited guidance actually say that), using a
-   fixed 0-100 rubric. Findings advance through `pipeline` independently of
-   one another: each finding's vote aggregation follows its own three votes
-   without waiting for the other findings. A finding that keeps fewer than two
-   settled votes is returned as `unverified` — verifier failure must not
-   silently launder a finding into a clean report.
-5. **Report** — findings that keep at least two settled votes and average 80 or
-   higher survive; one TeamMate formats the final review comment, noting
-   incomplete coverage and unverified findings when there are any.
+   being silently dropped by `.filter(Boolean)`. At max effort the find/verify
+   pair repeats as rounds: each round's prompts carry every already-seen
+   finding key, and the loop stops after two consecutive rounds produce
+   nothing fresh (or at the round cap). Fixed single passes miss the tail of
+   an unknown-size finding population; deduplicate each round against
+   everything SEEN, never against the accepted list, or judge-rejected
+   findings reappear every round and the loop never converges.
+4. **Verify** — each fresh finding is scored by verifier TeamMates with
+   distinct focus questions (does it reproduce on the changed lines; is it
+   pre-existing rather than introduced; does the cited guidance actually say
+   that), using a fixed 0-100 rubric. Findings advance through `pipeline`
+   independently of one another: each finding's vote aggregation follows its
+   own votes without waiting for the other findings. A finding that keeps
+   fewer than two settled votes is returned as `unverified` — verifier
+   failure must not silently launder a finding into a clean report.
+5. **Report** — findings that keep at least two settled votes and average 80
+   or higher survive; one TeamMate writes the final review comment with a
+   one-paragraph verdict first, then issues grouped by severity, then an
+   Unverified section, then exact coverage gaps.
 
 The run returns the report plus `coverage` and `unverified` records; the
-caller decides where the report goes. When a channel reply tool is available, post it there; or
-have a follow-up `send` to the reporter TeamMate publish it with the forge's
-own tooling (for example `gh` for GitHub or `glab` for GitLab) once the
-operator confirms.
+caller decides where the report goes. When a channel reply tool is available,
+post it there; or have a follow-up `send` to the reporter TeamMate publish it
+with the forge's own tooling (for example `gh` for GitHub or `glab` for
+GitLab) once the operator confirms.
+
+## Effort levels
+
+Match fan-out to what the operator asked for; the script takes an
+`args.effort` preset:
+
+| Preset | Rounds | Verifier votes | Use when |
+| --- | --- | --- | --- |
+| `quick` | 1 | 2 | a fast sanity pass; both votes must settle, so flakes surface as `unverified` rather than confirmations |
+| `standard` (default) | 1 | 3 | a normal pull-request review |
+| `max` | up to 3, stop after 2 dry | 3 | "thoroughly audit this", release gates, cumulative range reviews |
+
+The confirmation bar is constant across presets — at least two settled votes
+and an average of 80 — so a lower effort level produces fewer, not weaker,
+findings. Raising effort widens coverage (more rounds, more lenses in range
+mode); it never lowers the evidence standard.
+
+## Cumulative range mode
+
+Reviewing many merged changes as one diff (a release window, "everything since
+tag X") differs from a single change request in two ways, both handled by
+`args.rangeMode`:
+
+- **Resolve first.** When the target is a description like "PRs #312 through
+  head" rather than an exact range, add a resolve TeamMate ahead of the gate
+  that turns it into `<baseSha>..<headSha>` inside the repository (find the
+  named squash commit; fall back to the earliest merge at or after the named
+  number, since PR numbers are not contiguous; base is that commit's first
+  parent). Pass the resolved range through returned values — later prompts
+  must be self-contained.
+- **The cross-change lens.** A range contains changes that evolved the same
+  subsystems in sequence, so range mode adds a seventh finder lens looking
+  specifically for bad interactions BETWEEN the changes: a later change
+  silently invalidating an earlier one's assumption, dead code or docs left
+  behind by a superseding change, contradictory contracts between commits,
+  deleted-then-still-referenced symbols, and stale statements that only made
+  sense mid-range. The false-positive list also shifts: behavior an earlier
+  change introduced and a later change in the same range deliberately replaced
+  is not a finding.
 
 ## Prompt discipline
 
@@ -73,8 +122,9 @@ Failure semantics drive the script structure:
 - An ordinary failed turn settles the `agent()` call to `null`. `parallel`
   and `pipeline` contain per-item failures as `null` entries and keep results
   index-aligned with their inputs — account required coverage positionally
-  first (which lens failed, which finding lost its verifiers), then drop
-  nulls with `.filter(Boolean)` only where item identity no longer matters.
+  first (which lens failed in which round, which finding lost its verifiers),
+  then drop nulls with `.filter(Boolean)` only where item identity no longer
+  matters.
 - A schema call rejects — it does not return `null` — when the runtime cannot
   provide structured output or reports success with an empty or invalid JSON
   result. A directly awaited rejection fails the whole run; that is the right
@@ -92,14 +142,19 @@ by a guidance file; issues explicitly silenced in code; intentional behavior
 changes related to the broader change; and real issues on lines the change did
 not modify.
 
+Ask finders for a severity estimate (`high` / `medium` / `low`) alongside each
+finding. Severity is the finder's input for the report's grouping; the
+verifiers' confidence score stays the only acceptance gate, so a "high
+severity" label never rescues a low-confidence finding.
+
 ## TeamMate budget
 
-One round costs `1 (gate) + 2 (context) + 6 (find) + 3 × findings (verify) +
-1 (report)` TeamMates. The 1000-TeamMate lifetime cap per run leaves ample
-headroom for a single round (hundreds of findings) and comfortably supports
-repeat-until-dry rounds for exhaustive coverage; still count
-`6 finders + 3 × fresh findings` per extra round before choosing round
-counts, and match fan-out to what the operator asked for.
+One round costs `1 (gate) + 2 (context) + L (find) + votes × findings
+(verify) + 1 (report)` TeamMates, where `L` is 6 lenses (7 in range mode).
+The 1000-TeamMate lifetime cap per run leaves ample headroom for a single
+round (hundreds of findings) and comfortably supports max-effort rounds; still
+count `L finders + votes × fresh findings` per extra round before choosing
+round counts, and match fan-out to what the operator asked for.
 
 ## Script
 
@@ -116,18 +171,31 @@ export const meta = {
   phases: [
     { title: 'gate', detail: 'eligibility check with early exit' },
     { title: 'context', detail: 'guidance discovery and change summary' },
-    { title: 'find', detail: 'six independent finder lenses' },
-    { title: 'verify', detail: 'three-vote confidence scoring per finding' },
-    { title: 'report', detail: 'synthesized review comment' },
+    { title: 'find', detail: 'independent finder lenses, repeated until dry at max effort' },
+    { title: 'verify', detail: 'confidence scoring per finding' },
+    { title: 'report', detail: 'severity-ordered synthesized review comment' },
   ],
 };
+
+const input = args || {};
+const target = input.target;
+if (!target) {
+  return { error: 'args.target is required: a PR/MR URL or number, a git range, or a working-tree description' };
+}
+const EFFORT = input.effort || 'standard'; // quick | standard | max
+const MAX_ROUNDS = input.maxRounds || (EFFORT === 'max' ? 3 : 1);
+const VOTES = EFFORT === 'quick' ? 2 : 3;
+const RANGE_MODE = Boolean(input.rangeMode);
 
 const FALSE_POSITIVES =
   'Treat as false positives: pre-existing issues; code that looks buggy but is not; ' +
   'pedantic nitpicks; anything a linter, typechecker, or CI would catch; general ' +
   'quality concerns (coverage, docs) unless a guidance file (CLAUDE.md, AGENTS.md) ' +
   'requires them; issues explicitly silenced in code; intentional behavior changes ' +
-  'related to the broader change; real issues on unmodified lines.';
+  'related to the broader change; real issues on unmodified lines.' +
+  (RANGE_MODE
+    ? ' Behavior an earlier change introduced and a later change in this same range deliberately replaced is not a finding.'
+    : '');
 
 const RUBRIC =
   '0: Not confident at all. False positive that does not stand up to light scrutiny, or a pre-existing issue.\n' +
@@ -150,8 +218,9 @@ const FINDINGS_SCHEMA = {
           detail: { type: 'string' },
           reason: {
             type: 'string',
-            description: 'guidance | bug | history | prior-review | comment | security',
+            description: 'guidance | bug | history | prior-review | cross-change | comment | security',
           },
+          severity: { type: 'string', description: 'high | medium | low' },
         },
         required: ['file', 'title', 'detail', 'reason'],
         additionalProperties: false,
@@ -174,11 +243,6 @@ const SCORE_SCHEMA = {
 
 function findingKey(f) {
   return `${f.file}:${f.line || 0}:${f.title.toLowerCase().replace(/\s+/g, ' ').trim()}`;
-}
-
-const target = args && args.target;
-if (!target) {
-  return { error: 'args.target is required: a PR/MR URL or number, a git range, or a working-tree description' };
 }
 
 phase('gate');
@@ -240,125 +304,134 @@ const lenses = [
   { key: 'code-comments', prompt: 'Read code comments in the modified files; flag violations of guidance stated in those comments.' },
   { key: 'security', prompt: 'Review the changed code for concrete, exploitable security issues introduced by this change (injection, authorization gaps, secret handling). No generic hardening advice.' },
 ];
-
-phase('find');
+if (RANGE_MODE) {
+  lenses.push({
+    key: 'cross-change',
+    prompt:
+      'This target is a cumulative range of many merged changes evolving the same ' +
+      'subsystems. Look specifically for bad interactions BETWEEN the changes: a later ' +
+      'change silently invalidating an earlier one\'s assumption, dead code or docs ' +
+      'left behind by a superseding change, contradictory contracts between commits, ' +
+      'deleted-then-still-referenced symbols, and stale statements that only made ' +
+      'sense mid-range.',
+  });
+}
 // without discovered guidance files the guidance lens has nothing real to
 // audit — skip it and record the gap instead of auditing an empty list
 const activeLenses = guidanceFailed
   ? lenses.filter((lens) => lens.key !== 'guidance')
   : lenses;
-// parallel() preserves order, so a null entry identifies the failed lens
-const lensResults = await parallel(activeLenses.map((lens) => () =>
-  agent(
-    `Code review this change through one lens: ${target}\n${lens.prompt}\n` +
-    `${FALSE_POSITIVES}\nChange summary:\n${summary}`,
-    {
-      label: `find-${lens.key}`,
-      phase: 'find',
-      intent: `Finder lens: ${lens.key}`,
-      schema: FINDINGS_SCHEMA,
-    },
-  ),
-));
-const failedLenses = [
-  ...(guidanceFailed ? ['guidance'] : []),
-  ...activeLenses.filter((lens, i) => !lensResults[i]).map((lens) => lens.key),
-];
-if (failedLenses.length === lenses.length) {
-  return { error: 'every finder lens failed; the change was not reviewed', failedLenses };
-}
-if (failedLenses.length) {
-  log(`coverage incomplete: failed lenses ${failedLenses.join(', ')}`);
-}
-const found = lensResults.filter(Boolean).flatMap((r) => r.findings);
 
-const seen = new Set();
-const unique = [];
-for (const f of found) {
-  const key = findingKey(f);
-  if (!seen.has(key)) { seen.add(key); unique.push(f); }
-}
-log(`${found.length} raw findings, ${unique.length} unique`);
-
-const checkedLenses = lenses
-  .filter((lens) => !failedLenses.includes(lens.key))
-  .map((lens) => lens.key);
-function coverageRecord(unverifiedCount) {
-  return {
-    complete: failedLenses.length === 0 && unverifiedCount === 0,
-    failedLenses,
-    unverifiedFindings: unverifiedCount,
-  };
-}
-const noIssuesReport = failedLenses.length === 0
-  ? 'No issues found. Checked for bugs, security, history, and guidance-file compliance.'
-  : `No issues found by the lenses that completed (${checkedLenses.join(', ')}). ` +
-    `Coverage is incomplete: ${failedLenses.join(', ')} failed.`;
-if (!unique.length) {
-  return { issues: [], unverified: [], coverage: coverageRecord(0), report: noIssuesReport };
-}
-
-phase('verify');
 const focusQuestions = [
   'does it reproduce on the changed lines',
   'is it pre-existing rather than introduced by this change',
   'does the cited guidance file or code comment actually say that',
-];
-const judged = await pipeline(
-  unique,
-  (finding) => parallel(focusQuestions.map((focus) => () =>
+].slice(0, VOTES);
+
+const seen = new Set();
+const confirmed = [];
+const unverified = [];
+const roundFailures = [];
+let dry = 0;
+for (let round = 1; round <= MAX_ROUNDS && dry < 2; round++) {
+  phase('find');
+  // parallel() preserves order, so a null entry identifies the failed lens
+  const lensResults = await parallel(activeLenses.map((lens) => () =>
     agent(
-      `Confidence-score this code review finding for the change: ${target}\n` +
-      `Finding: ${JSON.stringify(finding)}\n` +
-      `Guidance files: ${JSON.stringify(guidancePaths)}\n` +
-      `Focus question: ${focus}.\n${FALSE_POSITIVES}\n` +
-      `Score with this rubric verbatim:\n${RUBRIC}`,
-      { phase: 'verify', intent: 'Finding verifier', schema: SCORE_SCHEMA },
+      `Code review this change through one lens: ${target}\n${lens.prompt}\n` +
+      `${FALSE_POSITIVES}\nChange summary:\n${summary}\n` +
+      `Estimate severity (high/medium/low) for each finding.\n` +
+      `Known findings, do NOT repeat any of these keys:\n${JSON.stringify([...seen])}\n` +
+      `Round ${round}: dig where earlier rounds have not.`,
+      {
+        label: `find-${lens.key}-r${round}`,
+        phase: 'find',
+        intent: `Finder lens: ${lens.key}`,
+        schema: FINDINGS_SCHEMA,
+      },
     ),
-  )),
-  (votes, finding, index) => {
-    const settled = (votes || []).filter(Boolean);
-    const average = settled.length
-      ? settled.reduce((sum, vote) => sum + vote.score, 0) / settled.length
-      : 0;
-    return { ...finding, confidence: Math.round(average), votes: settled.length, index };
-  },
-);
-// pipeline() results are index-aligned with `unique`: a null entry or a
-// finding with fewer than two settled votes is unverified, not clean
-const unverified = unique.filter((f, i) => {
-  const j = judged[i];
-  return !j || j.votes < 2;
-});
-const confirmed = judged
-  .filter(Boolean)
-  .filter((f) => f.votes >= 2 && f.confidence >= 80);
-const coverage = coverageRecord(unverified.length);
-log(`${confirmed.length} findings at >=80 confidence, ${unverified.length} unverified`);
+  ));
+  const failedLenses = [
+    ...(guidanceFailed ? ['guidance'] : []),
+    ...activeLenses.filter((lens, i) => !lensResults[i]).map((lens) => lens.key),
+  ];
+  if (failedLenses.length === lenses.length) {
+    return { error: 'every finder lens failed; the change was not reviewed', failedLenses };
+  }
+  if (failedLenses.length) roundFailures.push({ round, failedLenses });
+  const found = lensResults.filter(Boolean).flatMap((r) => r.findings)
+    .filter((f) => f && typeof f.file === 'string' && typeof f.title === 'string');
+  // dedupe against everything SEEN, not against the accepted list, or
+  // judge-rejected findings reappear every round and the loop never converges
+  const fresh = found.filter((f) => !seen.has(findingKey(f)));
+  if (!fresh.length) {
+    dry += 1;
+    log(`round ${round}: no fresh findings (dry ${dry}/2)`);
+    continue;
+  }
+  dry = 0;
+  fresh.forEach((f) => seen.add(findingKey(f)));
+  log(`round ${round}: ${fresh.length} fresh findings`);
+
+  phase('verify');
+  const judged = await pipeline(
+    fresh,
+    (finding) => parallel(focusQuestions.map((focus) => () =>
+      agent(
+        `Confidence-score this code review finding for the change: ${target}\n` +
+        `Finding: ${JSON.stringify(finding)}\n` +
+        `Guidance files: ${JSON.stringify(guidancePaths)}\n` +
+        `Focus question: ${focus}.\n${FALSE_POSITIVES}\n` +
+        `Score with this rubric verbatim:\n${RUBRIC}`,
+        { phase: 'verify', intent: 'Finding verifier', schema: SCORE_SCHEMA },
+      ),
+    )),
+    (votes, finding, index) => {
+      const settled = (votes || []).filter((v) => v && typeof v.score === 'number');
+      const average = settled.length
+        ? settled.reduce((sum, vote) => sum + vote.score, 0) / settled.length
+        : 0;
+      return { ...finding, confidence: Math.round(average), votes: settled.length, index };
+    },
+  );
+  // pipeline() results are index-aligned with `fresh`: a null entry or a
+  // finding with fewer than two settled votes is unverified, not clean
+  for (let i = 0; i < fresh.length; i++) {
+    const j = judged[i];
+    if (!j || j.votes < 2) unverified.push(fresh[i]);
+    else if (j.confidence >= 80) confirmed.push(j);
+  }
+  log(`round ${round}: ${confirmed.length} confirmed total, ${unverified.length} unverified total`);
+}
+
+const coverage = {
+  complete: !guidanceFailed && roundFailures.length === 0 && unverified.length === 0,
+  guidanceDiscoveryFailed: guidanceFailed,
+  roundFailures,
+  unverifiedFindings: unverified.length,
+};
 
 phase('report');
-const unverifiedNote = unverified.length
-  ? ` ${unverified.length} finding(s) could not be verified (verifier failures) ` +
-    `and are returned in \`unverified\` for manual triage.`
-  : '';
 if (!confirmed.length) {
-  const reportText = unverified.length
-    ? `No issues confirmed.${unverifiedNote}`
-    : noIssuesReport;
-  return { issues: [], unverified, coverage, report: reportText };
+  const report = unverified.length
+    ? `No issues confirmed. ${unverified.length} finding(s) could not be verified (verifier failures) and are returned in \`unverified\` for manual triage.`
+    : 'No issues found. Checked all lenses across all rounds.';
+  return { issues: [], unverified, coverage, report };
 }
 const report = await agent(
   `Write the final code review comment for the change: ${target}\n` +
   `Confirmed issues (JSON): ${JSON.stringify(confirmed)}\n` +
   `Unverified findings — verifiers failed, no confidence claim (JSON): ${JSON.stringify(unverified)}\n` +
   `Coverage (JSON): ${JSON.stringify(coverage)}\n` +
-  `Format: a "### Code review" heading, "Found N issues:", then a numbered list; ` +
-  `each item is a brief description with the flag reason in parentheses and a ` +
-  `citation on the next line — file#line when the finding carries a line number, ` +
-  `the file path alone otherwise; never invent a line number. If there are ` +
-  `unverified findings, add a short "Unverified" section listing them without ` +
-  `confidence claims. If coverage is incomplete, end with one line naming the ` +
-  `failed lenses. Brief, no emojis. Return markdown only.`,
+  `Structure: a "### Code review" heading; a one-paragraph verdict on the change ` +
+  `as a whole; then issues grouped by severity (high, then medium, then low) as ` +
+  `numbered items, each with the flag reason in parentheses and a citation on ` +
+  `the next line — file#line when the finding carries a line number, the file ` +
+  `path alone otherwise; never invent a line number. If there are unverified ` +
+  `findings, add a short "Unverified" section listing them without confidence ` +
+  `claims. End with one line stating coverage gaps exactly (failed lenses per ` +
+  `round, guidance discovery, unverified count). Brief, no emojis. ` +
+  `Return markdown only.`,
   { label: 'report', phase: 'report', intent: 'Review report writer' },
 );
 return { issues: confirmed, unverified, coverage, report };
@@ -385,10 +458,17 @@ Team workspace:
 - a local git range (`'main...feature'`);
 - a working-tree description (`'the uncommitted diff in the workspace'`).
 
+The other `args` fields are optional: `effort` (`'quick'` / `'standard'` /
+`'max'`), `maxRounds` (overrides the preset's round cap), and `rangeMode`
+(adds the cross-change lens and the range-scoped false-positive rule; pair it
+with a resolve step per [Cumulative range mode](#cumulative-range-mode) when
+the target is not yet an exact range). `agentType` follows the runtime default
+unless each call is given one explicitly.
+
 `max_concurrency` defaults to 16; lower it only when the workspace or runtime
 provider needs gentler fan-out. After the terminal completion, read `issues`
 for the confirmed findings, `unverified` for findings whose verifiers failed,
-`coverage` for whether every finder lens ran and every finding was verified,
-and `report` for the formatted comment; use the reporter TeamMate's concrete
-name with `send` for follow-ups such as posting the comment through the
-forge's tooling or re-checking one finding interactively.
+`coverage` for whether every lens ran in every round and every finding was
+verified, and `report` for the formatted comment; use the reporter TeamMate's
+concrete name with `send` for follow-ups such as posting the comment through
+the forge's tooling or re-checking one finding interactively.

--- a/packages/dreamux/skills/shared/workflow/references/code-review.md
+++ b/packages/dreamux/skills/shared/workflow/references/code-review.md
@@ -98,6 +98,11 @@ Match fan-out to what the operator asked for; the script takes an
 | `standard` (default) | 1 | 3 | a normal pull-request review |
 | `max` | up to 3, stop after 2 dry | 3 | "thoroughly audit this", release gates, cumulative range reviews; additionally reports plausible findings (50-79) in a separate, clearly labeled section |
 
+A single-pass preset (`quick`, `standard`) fulfils its coverage promise with
+one completed pass; only multi-round runs are held to two-dry-round
+convergence, and `coverage.stoppedAtRoundCap` records a multi-round run that
+exited any other way.
+
 The evidence standard for CONFIRMATION is constant across presets: every
 verifier checks all acceptance conditions, and a confirmed finding always
 needs at least two settled votes averaging 80. A lower effort level reduces
@@ -329,8 +334,12 @@ if (RANGE_MODE) {
       },
     },
   );
-  if (!resolved || typeof resolved.range !== 'string' || !resolved.range.trim()) {
-    throw new Error(`range resolution failed for ${target}; no exact range produced`);
+  if (
+    !resolved ||
+    typeof resolved.range !== 'string' ||
+    !/^\S+\.\.\S+$/.test(resolved.range.trim())
+  ) {
+    throw new Error(`range resolution failed for ${target}; expected an exact <base>..<head> range`);
   }
   resolvedRange = resolved;
   reviewTarget = resolved.repoPath
@@ -506,8 +515,9 @@ for (let round = 1; round <= MAX_ROUNDS && dry < 2; round++) {
       const average = settled.length
         ? settled.reduce((sum, vote) => sum + vote.score, 0) / settled.length
         : 0;
-      // tier on the raw mean; round only the displayed confidence, so 79.67
-      // never rounds its way into confirmed
+      // tier on the raw mean; display at one decimal so the shown confidence
+      // never crosses a tier boundary (79.67 tiers plausible and shows 79.7,
+      // not 80 — integer votes make one-decimal display tier-safe)
       const tier = settled.length < 2
         ? 'unverified'
         : average >= 80
@@ -515,7 +525,7 @@ for (let round = 1; round <= MAX_ROUNDS && dry < 2; round++) {
           : PLAUSIBLE_TIER && average >= 50
             ? 'plausible'
             : 'rejected';
-      return { ...finding, confidence: Math.round(average), votes: settled.length, tier, index };
+      return { ...finding, confidence: Math.round(average * 10) / 10, votes: settled.length, tier, index };
     },
   );
   // pipeline() results are index-aligned with `fresh`: a null entry or a
@@ -529,10 +539,11 @@ for (let round = 1; round <= MAX_ROUNDS && dry < 2; round++) {
   log(`round ${round}: ${confirmed.length} confirmed, ${plausible.length} plausible, ${unverified.length} unverified total`);
 }
 
-// convergence means two consecutive dry rounds; exiting for any other
-// reason (round cap, single-pass preset, a failed round) is a different
-// coverage fact even when the final round happened to be dry
-const stoppedAtRoundCap = dry < 2;
+// a single-pass preset fulfils its coverage promise in one completed pass;
+// only multi-round runs require two consecutive dry rounds, and exiting a
+// multi-round run any other way (round cap, a failed round) is recorded even
+// when the final round happened to be dry
+const stoppedAtRoundCap = MAX_ROUNDS > 1 && dry < 2;
 const coverage = {
   complete: !guidanceFailed && roundFailures.length === 0 &&
     unverified.length === 0 && !stoppedAtRoundCap,

--- a/packages/dreamux/skills/shared/workflow/references/code-review.md
+++ b/packages/dreamux/skills/shared/workflow/references/code-review.md
@@ -1,642 +1,143 @@
 # Code Review Workflow
 
-`../SKILL.md` owns the run tools and the script API. This reference owns one
-recipe: carrying a full code review as a single `workflow_run` — an eligibility
-gate, context collection, independent multi-lens finders repeated until dry,
-per-finding confidence scoring, and one severity-ordered synthesized report.
-
-## Contents
-
-- [Stage design](#stage-design) — the stages and their failure accounting
-- [Effort levels](#effort-levels) — quick / standard / max presets
-- [Cumulative range mode](#cumulative-range-mode) — reviewing many merged
-  changes as one diff
-- [Prompt discipline](#prompt-discipline) — output contract, rejection
-  semantics, self-contained prompts
-- [TeamMate budget](#teammate-budget) — cost arithmetic against the run caps
-- [Script](#script) — the complete runnable script
-- [Invocation](#invocation) — call shape and result fields
+`../SKILL.md` owns the run tools and the script API. This reference teaches
+the method for carrying a code review as one `workflow_run`: the stages, the
+scoring rubric, and the false-positive discipline. Write the script for the
+task at hand — the sketch at the end shows the shape, it is not a template to
+paste.
 
 The review target is any change the Team workspace can read: a GitHub pull
 request, a GitLab merge request, a local branch or commit range, or an
-uncommitted working-tree diff. Use this recipe when the operator wants one
-terminal result for such a change. For interactive review — where the next
+uncommitted working-tree diff. For interactive review — where the next
 instruction depends on reading the previous finding — use `spawn` and `send`
 instead.
 
-## Stage design
+## The flow
 
-1. **Resolve** (range mode only) — one TeamMate pins a fuzzy cumulative target
-   ("changes #312 through head") to one exact `base..head` range inside the
-   repository; every later prompt receives the resolved target, never the
-   fuzzy description. The call is awaited bare: an unresolvable target must
-   fail the run, not fan out agents against a guess.
-2. **Gate** — one TeamMate checks eligibility and the run exits early when
-   review is not needed: the change is closed or a draft, is automated or
-   trivially safe, or already carries a review from this Team.
-3. **Context** — two TeamMates in parallel: one lists the file paths (not
-   contents) of the repository's agent guidance files (`CLAUDE.md`,
-   `AGENTS.md`) at the root and in directories the change touches; one
-   summarizes the change (intent, scope, risk areas). Both results feed every
-   later prompt. When guidance discovery fails, the guidance lens is skipped
-   and recorded as missing coverage — it must not audit against a silently
-   empty list. A missing summary is tolerable: finders read the change
-   themselves, and the placeholder is visible in their prompts.
-4. **Find** — independent finder lenses run in parallel, each blind to the
-   others: guidance-file compliance, a shallow bug scan limited to the changed
-   hunks, git history and blame context, review comments on prior change
-   requests touching the same files, guidance stated in code comments of the
-   modified files, and concrete security issues introduced by the change. The
-   barrier is justified: deduplication needs every lens's output at once —
-   and it is where coverage is accounted: lens results are index-aligned with
-   the lens list, so a failed lens is recorded as missing coverage instead of
-   being silently dropped by `.filter(Boolean)`. Deduplication is by finding
-   key against everything SEEN — including the other lenses of the same round,
-   so six lenses reporting one defect yield one finding, not six — and never
-   against the accepted list, or judge-rejected findings reappear every round
-   and the loop never converges. At max effort the find/verify pair repeats as
-   rounds: each round's prompts carry every already-seen finding key, and the
-   loop records whether it CONVERGED (two consecutive dry rounds) or STOPPED
-   AT THE ROUND CAP while findings were still arriving — the two are different
-   coverage facts. A round in which every finder fails is recorded and ends
-   the loop with the results already accumulated; the hard error is reserved
-   for a run that never produced any review output.
-5. **Verify** — each fresh finding is scored by verifier TeamMates. Every
-   verifier checks ALL acceptance conditions — reproduces on the changed
-   lines, introduced by this change rather than pre-existing, and any cited
-   guidance or comment actually says what the finding claims — against a
-   fixed 0-100 rubric; each verifier additionally carries a distinct emphasis
-   so the votes stay diverse. Focus emphasis adds attention; it never removes
-   required evidence. Findings advance through `pipeline` independently of
-   one another. A finding that keeps fewer than two settled votes is returned
-   as `unverified` — verifier failure must not silently launder a finding
-   into a clean report. At `max` effort, findings that verify into the 50-79
-   band with two settled votes survive as a separate PLAUSIBLE tier instead
-   of being silently dropped — broader coverage, explicitly labeled.
-6. **Report** — findings that keep at least two settled votes and average 80
-   or higher survive; one TeamMate writes the final review comment with a
-   one-paragraph verdict first, then confirmed issues grouped by severity,
-   then (at max effort) a clearly labeled Plausible section, then an
-   Unverified section, then exact coverage gaps. The no-findings message is
-   generated from the coverage record — a run with failed lenses or rounds
-   never claims "checked all lenses".
+1. **Gate.** One TeamMate checks eligibility; exit early when review is not
+   needed: the change is closed or a draft, is automated or trivially safe,
+   or already carries a review from this Team.
+2. **Context.** In parallel: list the file paths (not contents) of the
+   repository's agent guidance files (`CLAUDE.md`, `AGENTS.md`) at the root
+   and in directories the change touches; summarize the change (intent,
+   scope, risk areas). Feed both into every later prompt.
+3. **Find.** Independent finder lenses in parallel, each blind to the others:
+   - guidance-file compliance (read the discovered files; not every writing
+     instruction applies at review time);
+   - a shallow bug scan limited to the changed hunks;
+   - git blame and history of the modified code;
+   - review comments on prior change requests touching the same files;
+   - guidance stated in code comments of the modified files;
+   - concrete security issues introduced by the change.
+   Deduplicate across lenses by file, line, and title. For an exhaustive
+   audit, repeat find/verify rounds until two consecutive rounds surface
+   nothing new, carrying already-seen findings in each round's prompts.
+4. **Verify.** Score each finding with parallel verifier TeamMates (three
+   votes normally; two for a quick pass), each given the finding, the
+   guidance paths, the false-positive list, and this rubric verbatim:
+   - 0: Not confident at all. False positive that does not stand up to light
+     scrutiny, or a pre-existing issue.
+   - 25: Somewhat confident. Might be real, might be a false positive; could
+     not verify. If stylistic, it is not explicitly called out in a relevant
+     guidance file.
+   - 50: Moderately confident. Verified real, but may be a nitpick or rare in
+     practice; not very important relative to the rest of the change.
+   - 75: Highly confident. Double checked; very likely real and will be hit
+     in practice; directly impacts functionality or is directly mentioned in
+     a guidance file.
+   - 100: Absolutely certain. Double checked and confirmed; will happen
+     frequently; evidence directly confirms it.
+   Keep findings that average 80 or higher. At max effort, findings in the
+   50-79 band may be reported too — in their own clearly labeled section,
+   never as confirmed issues.
+5. **Report.** One TeamMate writes the review comment: a short verdict, then
+   numbered issues (grouped by severity when findings carry one), each with
+   the flag reason in parentheses and a file#line citation — file path alone
+   when no line is known; never invent a line number. Brief, no emojis. Post
+   the returned report through the channel reply tool, or have a follow-up
+   `send` to the reporter publish it with the forge's tooling (`gh`, `glab`)
+   once the operator confirms.
 
-The run returns the report plus `coverage` and `unverified` records; the
-caller decides where the report goes. When a channel reply tool is available,
-post it there; or have a follow-up `send` to the reporter TeamMate publish it
-with the forge's own tooling (for example `gh` for GitHub or `glab` for
-GitLab) once the operator confirms.
-
-## Effort levels
-
-Match fan-out to what the operator asked for; the script takes an
-`args.effort` preset and fails loudly on any other value:
-
-| Preset | Rounds | Verifier votes | Use when |
-| --- | --- | --- | --- |
-| `quick` | 1 | 2 | a fast sanity pass; both votes must settle, so flakes surface as `unverified` rather than confirmations |
-| `standard` (default) | 1 | 3 | a normal pull-request review |
-| `max` | up to 3, stop after 2 dry | 3 | "thoroughly audit this", release gates, cumulative range reviews; additionally reports plausible findings (50-79) in a separate, clearly labeled section |
-
-A single-pass preset (`quick`, `standard`) fulfils its coverage promise with
-one completed pass; only multi-round runs are held to two-dry-round
-convergence, and `coverage.stoppedAtRoundCap` records a multi-round run that
-exited any other way.
-
-The evidence standard for CONFIRMATION is constant across presets: every
-verifier checks all acceptance conditions, and a confirmed finding always
-needs at least two settled votes averaging 80. A lower effort level reduces
-vote redundancy and round count — fewer, not weaker, findings. Raising effort
-widens coverage: more rounds, more lenses in range mode, and at `max` a
-second, clearly labeled PLAUSIBLE tier — findings with two settled votes
-averaging 50-79 are returned in `plausible` and reported under their own
-heading, never mixed with confirmed issues. Widening reporting to
-labeled-uncertain findings is how max broadens coverage without ever
-relabeling uncertainty as confirmation.
-
-## Cumulative range mode
-
-Reviewing many merged changes as one diff (a release window, "everything since
-tag X") differs from a single change request in two ways, both handled by
-`args.rangeMode`:
-
-- **Resolve first.** The script's resolve stage turns a fuzzy target into
-  `<baseSha>..<headSha>` inside the repository before any other agent starts
-  (find the named squash commit; fall back to the earliest merge at or after
-  the named number, since change numbers are not contiguous; base is that
-  commit's first parent; an already-exact two-dot range passes through
-  unchanged, and three-dot syntax is normalized to the equivalent
-  merge-base two-dot range — the validated output form is exactly one
-  `..` between two endpoints). The resolved target is threaded into every
-  later prompt — prompts stay self-contained and no agent ever receives the
-  fuzzy description.
-- **The cross-change lens.** A range contains changes that evolved the same
-  subsystems in sequence, so range mode adds a seventh finder lens looking
-  specifically for bad interactions BETWEEN the changes: a later change
-  silently invalidating an earlier one's assumption, dead code or docs left
-  behind by a superseding change, contradictory contracts between commits,
-  deleted-then-still-referenced symbols, and stale statements that only made
-  sense mid-range. The false-positive list also shifts: behavior an earlier
-  change introduced and a later change in the same range deliberately replaced
-  is not a finding.
-
-## Prompt discipline
-
-Every workflow TeamMate receives the workflow output contract: its final
-response is the value `agent()` returns, not a human-facing message. Prompts
-can therefore ask for data directly, without output-format boilerplate. With
-`schema`, the runtime's native structured-output mechanism enforces the shape.
-
-Failure semantics drive the script structure:
-
-- An ordinary failed turn settles the `agent()` call to `null`. `parallel`
-  and `pipeline` contain per-item failures as `null` entries and keep results
-  index-aligned with their inputs — account required coverage positionally
-  first (which lens failed in which round, which finding lost its verifiers),
-  then drop nulls with `.filter(Boolean)` only where item identity no longer
-  matters.
-- A schema call rejects — it does not return `null` — when the runtime cannot
-  provide structured output or reports success with an empty or invalid JSON
-  result. A directly awaited rejection fails the whole run; that is the right
-  outcome for load-bearing calls like the resolver and the gate, and the
-  reason both are awaited bare while per-finding work runs inside helpers.
-
-Keep prompts self-contained: a finder must not depend on another finder's
-output, and everything a verifier needs (the finding, the rubric, the
-false-positive list) is embedded in its prompt.
+## False positives
 
 Instruct finders and verifiers to treat these as false positives: pre-existing
 issues; code that looks buggy but is not; pedantic nitpicks; anything a
 linter, typechecker, or CI would catch; general quality concerns not required
 by a guidance file; issues explicitly silenced in code; intentional behavior
-changes related to the broader change; and real issues on lines the change did
-not modify.
+changes related to the broader change; and real issues on lines the change
+did not modify. When reviewing a cumulative range, add: behavior an earlier
+change introduced and a later change in the same range deliberately replaced.
 
-Every finding must carry a concrete failure scenario — the specific inputs or
-state that produce the wrong outcome or crash. A defect that cannot be stated
-as a scenario is not reportable; this single requirement kills most
-plausible-but-vague findings before verification spends votes on them, and
-gives verifiers a concrete claim to check instead of a vibe.
+## Scaling and range reviews
 
-Ask finders for a severity estimate (`high` / `medium` / `low`) alongside each
-finding — the field is required and enum-constrained, because the report's
-grouping depends on it. Severity is the finder's input for grouping only; the
-verifiers' confidence score stays the only acceptance gate, so a "high
-severity" label never rescues a low-confidence finding.
+Match fan-out to the ask: a quick pass is one round with two votes; a normal
+review is one round with three; "thoroughly audit this" repeats rounds until
+dry. The confirmation bar stays the same throughout — effort widens coverage,
+never the evidence standard.
 
-## TeamMate budget
+For a cumulative range ("everything since X"), resolve the fuzzy description
+into one exact `base..head` first — as the opening stage when it takes
+repository work — and add a cross-change lens: a later change silently
+invalidating an earlier one's assumption, dead code or docs left behind by a
+superseding change, contradictory contracts between commits.
 
-One round costs `1 (gate) + 2 (context) + L (find) + votes × findings
-(verify) + 1 (report)` TeamMates, plus one resolver in range mode, where `L`
-is 6 lenses (7 in range mode). The 1000-TeamMate lifetime cap per run leaves
-ample headroom for a single round (hundreds of findings) and comfortably
-supports max-effort rounds; still count `L finders + votes × fresh findings`
-per extra round before choosing round counts, and match fan-out to what the
-operator asked for.
+## Failure semantics worth remembering
 
-## Script
+`agent()` settles to `null` on a failed turn, and helper results stay
+index-aligned with their inputs — note which lens or verifier failed before
+filtering nulls, and say so in the report instead of presenting partial
+coverage as clean. A directly awaited schema call rejects on a
+structured-output contract breach, which is the right outcome for
+load-bearing calls like the gate. The pattern language lives in
+[orchestration-patterns.md](orchestration-patterns.md).
 
-The script uses the top-level entry: the body follows `export const meta`
-directly, and `await` and early `return` work at top level. Constants and helper
-functions remain in the same private async execution scope, so normal function
-hoisting applies exactly as written.
+## Sketch
+
+The shape, compressed — adapt lenses, schemas, rounds, and report format to
+the actual task:
 
 ```js
 export const meta = {
   name: 'code-review',
-  description: 'Multi-lens code review with confidence-scored findings and one report',
-  whenToUse: 'One-shot review of a change request, git range, or working-tree diff.',
+  description: 'Multi-lens code review with confidence-scored findings',
   phases: [
-    { title: 'resolve', detail: 'range mode: pin a fuzzy target to one exact base..head' },
-    { title: 'gate', detail: 'eligibility check with early exit' },
-    { title: 'context', detail: 'guidance discovery and change summary' },
-    { title: 'find', detail: 'independent finder lenses, repeated until dry at max effort' },
-    { title: 'verify', detail: 'confidence scoring per finding' },
-    { title: 'report', detail: 'severity-ordered synthesized review comment' },
+    { title: 'gate' }, { title: 'context' }, { title: 'find' },
+    { title: 'verify' }, { title: 'report' },
   ],
 };
 
-const input = args || {};
-const target = input.target;
-// fail-loud paths throw: a normal return settles the run as completed, which
-// would make invalid input look like a successful review to automated callers
-if (!target) {
-  throw new Error('args.target is required: a PR/MR URL or number, a git range, or a working-tree description');
-}
-const EFFORT = input.effort === undefined ? 'standard' : input.effort;
-if (!['quick', 'standard', 'max'].includes(EFFORT)) {
-  throw new Error(`invalid effort ${JSON.stringify(EFFORT)}: use quick, standard, or max`);
-}
-const MAX_ROUNDS = input.maxRounds === undefined
-  ? (EFFORT === 'max' ? 3 : 1)
-  : input.maxRounds;
-if (!Number.isInteger(MAX_ROUNDS) || MAX_ROUNDS < 1 || MAX_ROUNDS > 10) {
-  throw new Error(`invalid maxRounds ${JSON.stringify(input.maxRounds)}: use an integer from 1 to 10`);
-}
-const VOTES = EFFORT === 'quick' ? 2 : 3;
-const PLAUSIBLE_TIER = EFFORT === 'max';
-const RANGE_MODE = Boolean(input.rangeMode);
-
-const FALSE_POSITIVES =
-  'Treat as false positives: pre-existing issues; code that looks buggy but is not; ' +
-  'pedantic nitpicks; anything a linter, typechecker, or CI would catch; general ' +
-  'quality concerns (coverage, docs) unless a guidance file (CLAUDE.md, AGENTS.md) ' +
-  'requires them; issues explicitly silenced in code; intentional behavior changes ' +
-  'related to the broader change; real issues on unmodified lines.' +
-  (RANGE_MODE
-    ? ' Behavior an earlier change introduced and a later change in this same range deliberately replaced is not a finding.'
-    : '');
-
-const RUBRIC =
-  '0: Not confident at all. False positive that does not stand up to light scrutiny, or a pre-existing issue.\n' +
-  '25: Somewhat confident. Might be real, might be a false positive; could not verify. If stylistic, it is not explicitly called out in a relevant guidance file (CLAUDE.md, AGENTS.md).\n' +
-  '50: Moderately confident. Verified real, but may be a nitpick or rare in practice; not very important relative to the rest of the change.\n' +
-  '75: Highly confident. Double checked; very likely real and will be hit in practice; directly impacts functionality or is directly mentioned in a guidance file.\n' +
-  '100: Absolutely certain. Double checked and confirmed; will happen frequently; evidence directly confirms it.';
-
-const ACCEPTANCE_CONDITIONS =
-  'Check ALL acceptance conditions before scoring: (1) the defect reproduces on ' +
-  'the changed lines of this exact target; (2) it is introduced by this change, ' +
-  'not pre-existing; (3) any guidance file or code comment the finding cites ' +
-  'actually says what the finding claims; (4) the stated failure scenario is ' +
-  'concrete and actually leads to the claimed wrong outcome. A finding failing ' +
-  'any condition scores low.';
-
-const FINDINGS_SCHEMA = {
-  type: 'object',
-  properties: {
-    findings: {
-      type: 'array',
-      items: {
-        type: 'object',
-        properties: {
-          file: { type: 'string' },
-          line: { type: 'integer' },
-          title: { type: 'string' },
-          detail: { type: 'string' },
-          failureScenario: {
-            type: 'string',
-            description: 'concrete inputs or state that produce the wrong outcome or crash',
-          },
-          reason: {
-            type: 'string',
-            description: 'guidance | bug | history | prior-review | cross-change | comment | security',
-          },
-          severity: { type: 'string', enum: ['high', 'medium', 'low'] },
-        },
-        required: ['file', 'title', 'detail', 'failureScenario', 'reason', 'severity'],
-        additionalProperties: false,
-      },
-    },
-  },
-  required: ['findings'],
-  additionalProperties: false,
-};
-
-const SCORE_SCHEMA = {
-  type: 'object',
-  properties: {
-    score: { type: 'integer', minimum: 0, maximum: 100 },
-    reasoning: { type: 'string' },
-  },
-  required: ['score', 'reasoning'],
-  additionalProperties: false,
-};
-
-function findingKey(f) {
-  return `${f.file}:${f.line || 0}:${f.title.toLowerCase().replace(/\s+/g, ' ').trim()}`;
-}
-
-let reviewTarget = target;
-let resolvedRange = null;
-if (RANGE_MODE) {
-  phase('resolve');
-  // awaited bare: an unresolvable target must fail the run, not fan out
-  // agents against a guess
-  const resolved = await agent(
-    `In the repository this workspace can read, resolve this review target into ` +
-    `one exact git range:\n${target}\n` +
-    `If it names a change number ("changes #312 through head"), find that squash ` +
-    `commit; if no commit carries that number, use the earliest merge at or after ` +
-    `it (change numbers are not contiguous). The base is that commit's first ` +
-    `parent and the head is the branch tip. If the target is already an exact ` +
-    `two-dot range, return it unchanged; if it uses three-dot syntax ` +
-    `(a...b), resolve the merge base and return the equivalent ` +
-    `"<mergeBase>..<head>" two-dot range. Return the range expression ` +
-    `"<baseSha>..<headSha>" and the repository path.`,
-    {
-      label: 'resolve',
-      phase: 'resolve',
-      intent: 'Range resolver',
-      schema: {
-        type: 'object',
-        properties: {
-          range: { type: 'string' },
-          repoPath: { type: 'string' },
-        },
-        required: ['range'],
-        additionalProperties: false,
-      },
-    },
-  );
-  // exactly two endpoints around one '..': endpoints may contain single dots
-  // (tags like v1.2.3) but a '..'-split must yield two clean parts, which
-  // also rejects 'a..b..c' and the three-dot 'a...b' form the resolver is
-  // required to normalize away
-  const rangeParts = resolved && typeof resolved.range === 'string'
-    ? resolved.range.trim().split('..')
-    : [];
-  const exactRange = rangeParts.length === 2 && rangeParts.every((part) =>
-    part.length > 0 && !part.startsWith('.') && !part.endsWith('.') && !/\s/.test(part));
-  if (!exactRange) {
-    throw new Error(`range resolution failed for ${target}; expected an exact <base>..<head> range`);
-  }
-  resolvedRange = resolved;
-  reviewTarget = resolved.repoPath
-    ? `the git range ${resolved.range} in the repository at ${resolved.repoPath}`
-    : `the git range ${resolved.range}`;
-  log(`resolved target: ${reviewTarget}`);
-}
-
 phase('gate');
-const gate = await agent(
-  `Inspect this change: ${reviewTarget}. Decide whether it should be code reviewed. ` +
-  `Ineligible if: closed; a draft; an automated or trivial change that is ` +
-  `obviously fine; or it already has a review comment from this Team.`,
-  {
-    label: 'gate',
-    phase: 'gate',
-    intent: 'Review eligibility gate',
-    schema: {
-      type: 'object',
-      properties: { eligible: { type: 'boolean' }, reason: { type: 'string' } },
-      required: ['eligible', 'reason'],
-      additionalProperties: false,
-    },
-  },
-);
-if (!gate || !gate.eligible) {
-  return { skipped: true, reason: gate ? gate.reason : 'gate TeamMate failed' };
-}
+const gate = await agent(`Should ${args.target} be reviewed? ...`, {
+  phase: 'gate', schema: GATE_SCHEMA,
+});
+if (!gate?.eligible) return { skipped: true, reason: gate?.reason };
 
 phase('context');
-const ctx = await parallel([
-  () => agent(
-    `For this change: ${reviewTarget}. List the file paths (NOT contents) of the ` +
-    `repository's agent guidance files — CLAUDE.md and AGENTS.md — at the ` +
-    `repository root and in directories whose files the change modifies.`,
-    {
-      label: 'guidance',
-      phase: 'context',
-      intent: 'Guidance file discovery',
-      schema: {
-        type: 'object',
-        properties: { paths: { type: 'array', items: { type: 'string' } } },
-        required: ['paths'],
-        additionalProperties: false,
-      },
-    },
-  ),
-  () => agent(
-    `View this change: ${reviewTarget}. Summarize it: intent, scope, key files, risk ` +
-    `areas. Concise prose only.`,
-    { label: 'summary', phase: 'context', intent: 'Change summarizer' },
-  ),
+const [guidance, summary] = await parallel([
+  () => agent(`List guidance files relevant to ${args.target}.`, { phase: 'context' }),
+  () => agent(`Summarize ${args.target}.`, { phase: 'context' }),
 ]);
-// a null discovery result is a coverage gap, distinct from a successful
-// empty list (a repo that simply has no guidance files)
-const guidanceFailed = !ctx[0];
-const guidancePaths = guidanceFailed ? [] : ctx[0].paths;
-const summary = ctx[1] || '(summary unavailable)';
 
-const lenses = [
-  { key: 'guidance', prompt: `Audit the change for compliance with these guidance files (read them): ${JSON.stringify(guidancePaths)}. Guidance files direct code writing, so not every instruction applies at review time.` },
-  { key: 'shallow-bugs', prompt: 'Read only the changed hunks and scan for obvious large bugs. Do not read extra context. Skip small issues and nitpicks.' },
-  { key: 'git-history', prompt: 'Read git blame and history of the modified code; flag bugs visible only in light of that historical context, such as reintroduced bugs or violated invariants.' },
-  { key: 'prior-reviews', prompt: 'Find previous change requests (pull/merge requests) touching these files; check review comments on them that also apply to this change.' },
-  { key: 'code-comments', prompt: 'Read code comments in the modified files; flag violations of guidance stated in those comments.' },
-  { key: 'security', prompt: 'Review the changed code for concrete, exploitable security issues introduced by this change (injection, authorization gaps, secret handling). No generic hardening advice.' },
-];
-if (RANGE_MODE) {
-  lenses.push({
-    key: 'cross-change',
-    prompt:
-      'This target is a cumulative range of many merged changes evolving the same ' +
-      'subsystems. Look specifically for bad interactions BETWEEN the changes: a later ' +
-      'change silently invalidating an earlier one\'s assumption, dead code or docs ' +
-      'left behind by a superseding change, contradictory contracts between commits, ' +
-      'deleted-then-still-referenced symbols, and stale statements that only made ' +
-      'sense mid-range.',
-  });
-}
-// without discovered guidance files the guidance lens has nothing real to
-// audit — skip it and record the gap instead of auditing an empty list
-const activeLenses = guidanceFailed
-  ? lenses.filter((lens) => lens.key !== 'guidance')
-  : lenses;
+phase('find');
+const findings = dedupe((await parallel(LENSES.map((lens) => () =>
+  agent(finderPrompt(lens, args.target, guidance, summary), {
+    phase: 'find', schema: FINDINGS_SCHEMA,
+  }),
+))).filter(Boolean).flatMap((r) => r.findings));
 
-const emphases = [
-  'reproduction on the changed lines',
-  'whether it is pre-existing rather than introduced',
-  'whether the cited guidance or comment actually says that',
-].slice(0, VOTES);
-
-const seen = new Set();
-const confirmed = [];
-const plausible = [];
-const unverified = [];
-const roundFailures = [];
-let dry = 0;
-let completedFinderRounds = 0;
-for (let round = 1; round <= MAX_ROUNDS && dry < 2; round++) {
-  phase('find');
-  // parallel() preserves order, so a null entry identifies the failed lens
-  const lensResults = await parallel(activeLenses.map((lens) => () =>
-    agent(
-      `Code review this change through one lens: ${reviewTarget}\n${lens.prompt}\n` +
-      `${FALSE_POSITIVES}\nChange summary:\n${summary}\n` +
-      `Every finding must state a concrete failure scenario: the specific inputs ` +
-      `or state that produce the wrong outcome or crash. A defect you cannot state ` +
-      `as a scenario is not reportable.\n` +
-      `Give each finding a severity: high, medium, or low.\n` +
-      `Known findings, do NOT repeat any of these keys:\n${JSON.stringify([...seen])}\n` +
-      `Round ${round}: dig where earlier rounds have not.`,
-      {
-        label: `find-${lens.key}-r${round}`,
-        phase: 'find',
-        intent: `Finder lens: ${lens.key}`,
-        schema: FINDINGS_SCHEMA,
-      },
-    ),
-  ));
-  const failedLenses = [
-    ...(guidanceFailed ? ['guidance'] : []),
-    ...activeLenses.filter((lens, i) => !lensResults[i]).map((lens) => lens.key),
-  ];
-  if (failedLenses.length) roundFailures.push({ round, failedLenses });
-  if (failedLenses.length === lenses.length) {
-    // reserve the hard error for a run in which no finder round ever
-    // completed; a clean earlier round is review output worth keeping
-    if (completedFinderRounds === 0) {
-      throw new Error(`every finder lens failed in round ${round}; the change was not reviewed`);
-    }
-    log(`round ${round}: every lens failed; stopping with accumulated results`);
-    break;
-  }
-  completedFinderRounds += 1;
-  const found = lensResults.filter(Boolean).flatMap((r) => r.findings)
-    .filter((f) => f && typeof f.file === 'string' && typeof f.title === 'string');
-  // dedupe against everything SEEN — including this round's other lenses, so
-  // one defect reported by six lenses becomes one finding — and never against
-  // the accepted list, or judge-rejected findings reappear every round and
-  // the loop never converges
-  const fresh = [];
-  for (const f of found) {
-    const key = findingKey(f);
-    if (!seen.has(key)) {
-      seen.add(key);
-      fresh.push(f);
-    }
-  }
-  if (!fresh.length) {
-    dry += 1;
-    log(`round ${round}: no fresh findings (dry ${dry}/2)`);
-    continue;
-  }
-  dry = 0;
-  log(`round ${round}: ${fresh.length} fresh findings`);
-
-  phase('verify');
-  const judged = await pipeline(
-    fresh,
-    (finding) => parallel(emphases.map((emphasis) => () =>
-      agent(
-        `Confidence-score this code review finding for the change: ${reviewTarget}\n` +
-        `Finding: ${JSON.stringify(finding)}\n` +
-        `Guidance files: ${JSON.stringify(guidancePaths)}\n` +
-        `${ACCEPTANCE_CONDITIONS}\n` +
-        `Your particular emphasis: ${emphasis}.\n${FALSE_POSITIVES}\n` +
-        `Score with this rubric verbatim:\n${RUBRIC}`,
-        { phase: 'verify', intent: 'Finding verifier', schema: SCORE_SCHEMA },
-      ),
-    )),
-    (votes, finding, index) => {
-      const settled = (votes || []).filter((v) => v && typeof v.score === 'number');
-      const average = settled.length
-        ? settled.reduce((sum, vote) => sum + vote.score, 0) / settled.length
-        : 0;
-      // tier on the raw mean; display at one decimal so the shown confidence
-      // never crosses a tier boundary (79.67 tiers plausible and shows 79.7,
-      // not 80 — integer votes make one-decimal display tier-safe)
-      const tier = settled.length < 2
-        ? 'unverified'
-        : average >= 80
-          ? 'confirmed'
-          : PLAUSIBLE_TIER && average >= 50
-            ? 'plausible'
-            : 'rejected';
-      return { ...finding, confidence: Math.round(average * 10) / 10, votes: settled.length, tier, index };
-    },
-  );
-  // pipeline() results are index-aligned with `fresh`: a null entry or a
-  // finding with fewer than two settled votes is unverified, not clean
-  for (let i = 0; i < fresh.length; i++) {
-    const j = judged[i];
-    if (!j || j.tier === 'unverified') unverified.push(fresh[i]);
-    else if (j.tier === 'confirmed') confirmed.push(j);
-    else if (j.tier === 'plausible') plausible.push(j);
-  }
-  log(`round ${round}: ${confirmed.length} confirmed, ${plausible.length} plausible, ${unverified.length} unverified total`);
-}
-
-// a single-pass preset fulfils its coverage promise in one completed pass;
-// only multi-round runs require two consecutive dry rounds, and exiting a
-// multi-round run any other way (round cap, a failed round) is recorded even
-// when the final round happened to be dry
-const stoppedAtRoundCap = MAX_ROUNDS > 1 && dry < 2;
-const coverage = {
-  complete: !guidanceFailed && roundFailures.length === 0 &&
-    unverified.length === 0 && !stoppedAtRoundCap,
-  guidanceDiscoveryFailed: guidanceFailed,
-  roundFailures,
-  stoppedAtRoundCap,
-  unverifiedFindings: unverified.length,
-};
+phase('verify');
+const scored = await pipeline(
+  findings,
+  (f) => parallel([0, 1, 2].map(() => () =>
+    agent(rubricPrompt(f), { phase: 'verify', schema: SCORE_SCHEMA }))),
+  (votes, f) => ({ ...f, votes: (votes || []).filter(Boolean) }),
+);
+const confirmed = scored.filter(Boolean)
+  .filter((f) => f.votes.length >= 2 && average(f.votes) >= 80);
 
 phase('report');
-if (!confirmed.length && !plausible.length) {
-  const gaps = [];
-  if (guidanceFailed) gaps.push('guidance discovery failed');
-  if (roundFailures.length) {
-    gaps.push(`lens failures: ${roundFailures.map((r) => `round ${r.round} (${r.failedLenses.join(', ')})`).join('; ')}`);
-  }
-  if (stoppedAtRoundCap) gaps.push('stopped before two-dry-round convergence');
-  if (unverified.length) gaps.push(`${unverified.length} finding(s) unverified after verifier failures`);
-  const report = gaps.length
-    ? `No issues confirmed. ${gaps.join('; ')}. See coverage and unverified for details.`
-    : 'No issues found. Checked all lenses across all rounds.';
-  return { issues: [], plausible, unverified, coverage, resolvedRange, report };
-}
-const report = await agent(
-  `Write the final code review comment for the change: ${reviewTarget}\n` +
-  `Confirmed issues (JSON): ${JSON.stringify(confirmed)}\n` +
-  `Plausible findings — two settled votes at 50-79 confidence, unconfirmed (JSON): ${JSON.stringify(plausible)}\n` +
-  `Unverified findings — verifiers failed, no confidence claim (JSON): ${JSON.stringify(unverified)}\n` +
-  `Coverage (JSON): ${JSON.stringify(coverage)}\n` +
-  `Structure: a "### Code review" heading; a one-paragraph verdict on the change ` +
-  `as a whole (when nothing is confirmed, say so plainly); then confirmed issues ` +
-  `grouped by severity (high, then medium, then low) as numbered items, each with ` +
-  `the flag reason in parentheses, its failure scenario, and a citation on the ` +
-  `next line — file#line when the finding carries a line number, the file path ` +
-  `alone otherwise; never invent a line number. If there are plausible findings, ` +
-  `add a "Plausible (unconfirmed)" section after the confirmed issues with the ` +
-  `same per-item detail (title, citation, failure scenario, stated confidence), ` +
-  `never presenting them as confirmed. If there are unverified findings, add a ` +
-  `short "Unverified" section listing them without confidence claims. End with ` +
-  `one line stating coverage gaps exactly (failed lenses per round, guidance ` +
-  `discovery, convergence status, unverified count). Brief, no emojis. ` +
-  `Return markdown only.`,
-  { label: 'report', phase: 'report', intent: 'Review report writer' },
-);
-return { issues: confirmed, plausible, unverified, coverage, resolvedRange, report };
+return {
+  issues: confirmed,
+  report: await agent(reportPrompt(args.target, confirmed), { phase: 'report' }),
+};
 ```
-
-The verify stage shows the three-argument stage signature: stage one returns
-only the vote array, and stage two recovers the finding and its position from
-`(votes, finding, index)` instead of threading them through the return value.
-
-## Invocation
-
-```
-workflow_run({
-  script: <the script above>,
-  args: { target: 'https://github.com/owner/repo/pull/123' },
-})
-```
-
-`args.target` is forge-neutral — pass whatever identifies the change in the
-Team workspace:
-
-- a pull-request or merge-request URL or number
-  (`'https://gitlab.example.com/group/repo/-/merge_requests/45'`, `'#123'`);
-- a local git range (`'main...feature'`);
-- a working-tree description (`'the uncommitted diff in the workspace'`).
-
-The other `args` fields are optional and validated before any agent starts:
-`effort` must be `'quick'`, `'standard'`, or `'max'`; `maxRounds` must be an
-integer from 1 to 10 and overrides the preset's round cap; `rangeMode` runs
-the resolve stage first and adds the cross-change lens plus the range-scoped
-false-positive rule. `agentType` follows the runtime default unless each call
-is given one explicitly.
-
-`max_concurrency` defaults to 16; lower it only when the workspace or runtime
-provider needs gentler fan-out. After the terminal completion, read `issues`
-for the confirmed findings, `plausible` for max-effort findings in the 50-79
-band (labeled, never mixed with confirmed), `unverified` for findings whose
-verifiers failed,
-`coverage` for whether every lens ran in every round, the loop converged
-rather than stopping at the round cap, and every finding was verified,
-`resolvedRange` for the exact range in range mode, and `report` for the
-formatted comment; use the reporter TeamMate's concrete name with `send` for
-follow-ups such as posting the comment through the forge's tooling or
-re-checking one finding interactively.

--- a/packages/dreamux/skills/shared/workflow/references/code-review.md
+++ b/packages/dreamux/skills/shared/workflow/references/code-review.md
@@ -210,18 +210,20 @@ export const meta = {
 
 const input = args || {};
 const target = input.target;
+// fail-loud paths throw: a normal return settles the run as completed, which
+// would make invalid input look like a successful review to automated callers
 if (!target) {
-  return { error: 'args.target is required: a PR/MR URL or number, a git range, or a working-tree description' };
+  throw new Error('args.target is required: a PR/MR URL or number, a git range, or a working-tree description');
 }
 const EFFORT = input.effort === undefined ? 'standard' : input.effort;
 if (!['quick', 'standard', 'max'].includes(EFFORT)) {
-  return { error: `invalid effort ${JSON.stringify(EFFORT)}: use quick, standard, or max` };
+  throw new Error(`invalid effort ${JSON.stringify(EFFORT)}: use quick, standard, or max`);
 }
 const MAX_ROUNDS = input.maxRounds === undefined
   ? (EFFORT === 'max' ? 3 : 1)
   : input.maxRounds;
 if (!Number.isInteger(MAX_ROUNDS) || MAX_ROUNDS < 1 || MAX_ROUNDS > 10) {
-  return { error: `invalid maxRounds ${JSON.stringify(input.maxRounds)}: use an integer from 1 to 10` };
+  throw new Error(`invalid maxRounds ${JSON.stringify(input.maxRounds)}: use an integer from 1 to 10`);
 }
 const VOTES = EFFORT === 'quick' ? 2 : 3;
 const PLAUSIBLE_TIER = EFFORT === 'max';
@@ -328,7 +330,7 @@ if (RANGE_MODE) {
     },
   );
   if (!resolved || typeof resolved.range !== 'string' || !resolved.range.trim()) {
-    return { error: 'range resolution failed; no exact range produced', target };
+    throw new Error(`range resolution failed for ${target}; no exact range produced`);
   }
   resolvedRange = resolved;
   reviewTarget = resolved.repoPath
@@ -426,7 +428,7 @@ const plausible = [];
 const unverified = [];
 const roundFailures = [];
 let dry = 0;
-let lastRoundHadFresh = false;
+let completedFinderRounds = 0;
 for (let round = 1; round <= MAX_ROUNDS && dry < 2; round++) {
   phase('find');
   // parallel() preserves order, so a null entry identifies the failed lens
@@ -454,15 +456,15 @@ for (let round = 1; round <= MAX_ROUNDS && dry < 2; round++) {
   ];
   if (failedLenses.length) roundFailures.push({ round, failedLenses });
   if (failedLenses.length === lenses.length) {
-    // reserve the hard error for a run that never produced any review output;
-    // otherwise keep the accumulated results and report the gap
-    if (!confirmed.length && !unverified.length && seen.size === 0) {
-      return { error: 'every finder lens failed; the change was not reviewed', failedLenses };
+    // reserve the hard error for a run in which no finder round ever
+    // completed; a clean earlier round is review output worth keeping
+    if (completedFinderRounds === 0) {
+      throw new Error(`every finder lens failed in round ${round}; the change was not reviewed`);
     }
     log(`round ${round}: every lens failed; stopping with accumulated results`);
-    lastRoundHadFresh = false;
     break;
   }
+  completedFinderRounds += 1;
   const found = lensResults.filter(Boolean).flatMap((r) => r.findings)
     .filter((f) => f && typeof f.file === 'string' && typeof f.title === 'string');
   // dedupe against everything SEEN — including this round's other lenses, so
@@ -477,7 +479,6 @@ for (let round = 1; round <= MAX_ROUNDS && dry < 2; round++) {
       fresh.push(f);
     }
   }
-  lastRoundHadFresh = fresh.length > 0;
   if (!fresh.length) {
     dry += 1;
     log(`round ${round}: no fresh findings (dry ${dry}/2)`);
@@ -505,23 +506,33 @@ for (let round = 1; round <= MAX_ROUNDS && dry < 2; round++) {
       const average = settled.length
         ? settled.reduce((sum, vote) => sum + vote.score, 0) / settled.length
         : 0;
-      return { ...finding, confidence: Math.round(average), votes: settled.length, index };
+      // tier on the raw mean; round only the displayed confidence, so 79.67
+      // never rounds its way into confirmed
+      const tier = settled.length < 2
+        ? 'unverified'
+        : average >= 80
+          ? 'confirmed'
+          : PLAUSIBLE_TIER && average >= 50
+            ? 'plausible'
+            : 'rejected';
+      return { ...finding, confidence: Math.round(average), votes: settled.length, tier, index };
     },
   );
   // pipeline() results are index-aligned with `fresh`: a null entry or a
   // finding with fewer than two settled votes is unverified, not clean
   for (let i = 0; i < fresh.length; i++) {
     const j = judged[i];
-    if (!j || j.votes < 2) unverified.push(fresh[i]);
-    else if (j.confidence >= 80) confirmed.push(j);
-    else if (PLAUSIBLE_TIER && j.confidence >= 50) plausible.push(j);
+    if (!j || j.tier === 'unverified') unverified.push(fresh[i]);
+    else if (j.tier === 'confirmed') confirmed.push(j);
+    else if (j.tier === 'plausible') plausible.push(j);
   }
   log(`round ${round}: ${confirmed.length} confirmed, ${plausible.length} plausible, ${unverified.length} unverified total`);
 }
 
-// stopping at the round cap while findings were still arriving is a
-// different coverage fact from converging on two dry rounds
-const stoppedAtRoundCap = MAX_ROUNDS > 1 && dry < 2 && lastRoundHadFresh;
+// convergence means two consecutive dry rounds; exiting for any other
+// reason (round cap, single-pass preset, a failed round) is a different
+// coverage fact even when the final round happened to be dry
+const stoppedAtRoundCap = dry < 2;
 const coverage = {
   complete: !guidanceFailed && roundFailures.length === 0 &&
     unverified.length === 0 && !stoppedAtRoundCap,
@@ -532,19 +543,16 @@ const coverage = {
 };
 
 phase('report');
-if (!confirmed.length) {
+if (!confirmed.length && !plausible.length) {
   const gaps = [];
   if (guidanceFailed) gaps.push('guidance discovery failed');
   if (roundFailures.length) {
     gaps.push(`lens failures: ${roundFailures.map((r) => `round ${r.round} (${r.failedLenses.join(', ')})`).join('; ')}`);
   }
-  if (stoppedAtRoundCap) gaps.push('stopped at the round cap while findings were still arriving');
+  if (stoppedAtRoundCap) gaps.push('stopped before two-dry-round convergence');
   if (unverified.length) gaps.push(`${unverified.length} finding(s) unverified after verifier failures`);
-  if (plausible.length) {
-    gaps.push(`${plausible.length} plausible (unconfirmed) finding(s) at max effort`);
-  }
   const report = gaps.length
-    ? `No issues confirmed. ${gaps.join('; ')}. See coverage, plausible, and unverified for details.`
+    ? `No issues confirmed. ${gaps.join('; ')}. See coverage and unverified for details.`
     : 'No issues found. Checked all lenses across all rounds.';
   return { issues: [], plausible, unverified, coverage, resolvedRange, report };
 }
@@ -555,16 +563,18 @@ const report = await agent(
   `Unverified findings — verifiers failed, no confidence claim (JSON): ${JSON.stringify(unverified)}\n` +
   `Coverage (JSON): ${JSON.stringify(coverage)}\n` +
   `Structure: a "### Code review" heading; a one-paragraph verdict on the change ` +
-  `as a whole; then issues grouped by severity (high, then medium, then low) as ` +
-  `numbered items, each with the flag reason in parentheses and a citation on ` +
-  `the next line — file#line when the finding carries a line number, the file ` +
-  `path alone otherwise; never invent a line number. If there are plausible ` +
-  `findings, add a "Plausible (unconfirmed)" section after the confirmed issues, ` +
-  `stating each one's confidence and never presenting it as confirmed. If there ` +
-  `are unverified findings, add a short "Unverified" section listing them without ` +
-  `confidence claims. End with one line stating coverage gaps exactly (failed ` +
-  `lenses per round, guidance discovery, round-cap stop, unverified count). ` +
-  `Brief, no emojis. Return markdown only.`,
+  `as a whole (when nothing is confirmed, say so plainly); then confirmed issues ` +
+  `grouped by severity (high, then medium, then low) as numbered items, each with ` +
+  `the flag reason in parentheses, its failure scenario, and a citation on the ` +
+  `next line — file#line when the finding carries a line number, the file path ` +
+  `alone otherwise; never invent a line number. If there are plausible findings, ` +
+  `add a "Plausible (unconfirmed)" section after the confirmed issues with the ` +
+  `same per-item detail (title, citation, failure scenario, stated confidence), ` +
+  `never presenting them as confirmed. If there are unverified findings, add a ` +
+  `short "Unverified" section listing them without confidence claims. End with ` +
+  `one line stating coverage gaps exactly (failed lenses per round, guidance ` +
+  `discovery, convergence status, unverified count). Brief, no emojis. ` +
+  `Return markdown only.`,
   { label: 'report', phase: 'report', intent: 'Review report writer' },
 );
 return { issues: confirmed, plausible, unverified, coverage, resolvedRange, report };

--- a/packages/dreamux/skills/shared/workflow/references/code-review.md
+++ b/packages/dreamux/skills/shared/workflow/references/code-review.md
@@ -124,9 +124,12 @@ tag X") differs from a single change request in two ways, both handled by
   `<baseSha>..<headSha>` inside the repository before any other agent starts
   (find the named squash commit; fall back to the earliest merge at or after
   the named number, since change numbers are not contiguous; base is that
-  commit's first parent; an already-exact range passes through unchanged).
-  The resolved target is threaded into every later prompt — prompts stay
-  self-contained and no agent ever receives the fuzzy description.
+  commit's first parent; an already-exact two-dot range passes through
+  unchanged, and three-dot syntax is normalized to the equivalent
+  merge-base two-dot range — the validated output form is exactly one
+  `..` between two endpoints). The resolved target is threaded into every
+  later prompt — prompts stay self-contained and no agent ever receives the
+  fuzzy description.
 - **The cross-change lens.** A range contains changes that evolved the same
   subsystems in sequence, so range mode adds a seventh finder lens looking
   specifically for bad interactions BETWEEN the changes: a later change
@@ -317,8 +320,10 @@ if (RANGE_MODE) {
     `commit; if no commit carries that number, use the earliest merge at or after ` +
     `it (change numbers are not contiguous). The base is that commit's first ` +
     `parent and the head is the branch tip. If the target is already an exact ` +
-    `range, return it unchanged. Return the range expression "<baseSha>..<headSha>" ` +
-    `and the repository path.`,
+    `two-dot range, return it unchanged; if it uses three-dot syntax ` +
+    `(a...b), resolve the merge base and return the equivalent ` +
+    `"<mergeBase>..<head>" two-dot range. Return the range expression ` +
+    `"<baseSha>..<headSha>" and the repository path.`,
     {
       label: 'resolve',
       phase: 'resolve',
@@ -334,11 +339,16 @@ if (RANGE_MODE) {
       },
     },
   );
-  if (
-    !resolved ||
-    typeof resolved.range !== 'string' ||
-    !/^\S+\.\.\S+$/.test(resolved.range.trim())
-  ) {
+  // exactly two endpoints around one '..': endpoints may contain single dots
+  // (tags like v1.2.3) but a '..'-split must yield two clean parts, which
+  // also rejects 'a..b..c' and the three-dot 'a...b' form the resolver is
+  // required to normalize away
+  const rangeParts = resolved && typeof resolved.range === 'string'
+    ? resolved.range.trim().split('..')
+    : [];
+  const exactRange = rangeParts.length === 2 && rangeParts.every((part) =>
+    part.length > 0 && !part.startsWith('.') && !part.endsWith('.') && !/\s/.test(part));
+  if (!exactRange) {
     throw new Error(`range resolution failed for ${target}; expected an exact <base>..<head> range`);
   }
   resolvedRange = resolved;

--- a/packages/dreamux/skills/shared/workflow/references/code-review.md
+++ b/packages/dreamux/skills/shared/workflow/references/code-review.md
@@ -7,7 +7,7 @@ per-finding confidence scoring, and one severity-ordered synthesized report.
 
 ## Contents
 
-- [Stage design](#stage-design) — the five stages and their failure accounting
+- [Stage design](#stage-design) — the stages and their failure accounting
 - [Effort levels](#effort-levels) — quick / standard / max presets
 - [Cumulative range mode](#cumulative-range-mode) — reviewing many merged
   changes as one diff
@@ -26,10 +26,15 @@ instead.
 
 ## Stage design
 
-1. **Gate** — one TeamMate checks eligibility and the run exits early when
+1. **Resolve** (range mode only) — one TeamMate pins a fuzzy cumulative target
+   ("changes #312 through head") to one exact `base..head` range inside the
+   repository; every later prompt receives the resolved target, never the
+   fuzzy description. The call is awaited bare: an unresolvable target must
+   fail the run, not fan out agents against a guess.
+2. **Gate** — one TeamMate checks eligibility and the run exits early when
    review is not needed: the change is closed or a draft, is automated or
    trivially safe, or already carries a review from this Team.
-2. **Context** — two TeamMates in parallel: one lists the file paths (not
+3. **Context** — two TeamMates in parallel: one lists the file paths (not
    contents) of the repository's agent guidance files (`CLAUDE.md`,
    `AGENTS.md`) at the root and in directories the change touches; one
    summarizes the change (intent, scope, risk areas). Both results feed every
@@ -37,7 +42,7 @@ instead.
    and recorded as missing coverage — it must not audit against a silently
    empty list. A missing summary is tolerable: finders read the change
    themselves, and the placeholder is visible in their prompts.
-3. **Find** — independent finder lenses run in parallel, each blind to the
+4. **Find** — independent finder lenses run in parallel, each blind to the
    others: guidance-file compliance, a shallow bug scan limited to the changed
    hunks, git history and blame context, review comments on prior change
    requests touching the same files, guidance stated in code comments of the
@@ -45,25 +50,33 @@ instead.
    barrier is justified: deduplication needs every lens's output at once —
    and it is where coverage is accounted: lens results are index-aligned with
    the lens list, so a failed lens is recorded as missing coverage instead of
-   being silently dropped by `.filter(Boolean)`. At max effort the find/verify
-   pair repeats as rounds: each round's prompts carry every already-seen
-   finding key, and the loop stops after two consecutive rounds produce
-   nothing fresh (or at the round cap). Fixed single passes miss the tail of
-   an unknown-size finding population; deduplicate each round against
-   everything SEEN, never against the accepted list, or judge-rejected
-   findings reappear every round and the loop never converges.
-4. **Verify** — each fresh finding is scored by verifier TeamMates with
-   distinct focus questions (does it reproduce on the changed lines; is it
-   pre-existing rather than introduced; does the cited guidance actually say
-   that), using a fixed 0-100 rubric. Findings advance through `pipeline`
-   independently of one another: each finding's vote aggregation follows its
-   own votes without waiting for the other findings. A finding that keeps
-   fewer than two settled votes is returned as `unverified` — verifier
-   failure must not silently launder a finding into a clean report.
-5. **Report** — findings that keep at least two settled votes and average 80
+   being silently dropped by `.filter(Boolean)`. Deduplication is by finding
+   key against everything SEEN — including the other lenses of the same round,
+   so six lenses reporting one defect yield one finding, not six — and never
+   against the accepted list, or judge-rejected findings reappear every round
+   and the loop never converges. At max effort the find/verify pair repeats as
+   rounds: each round's prompts carry every already-seen finding key, and the
+   loop records whether it CONVERGED (two consecutive dry rounds) or STOPPED
+   AT THE ROUND CAP while findings were still arriving — the two are different
+   coverage facts. A round in which every finder fails is recorded and ends
+   the loop with the results already accumulated; the hard error is reserved
+   for a run that never produced any review output.
+5. **Verify** — each fresh finding is scored by verifier TeamMates. Every
+   verifier checks ALL acceptance conditions — reproduces on the changed
+   lines, introduced by this change rather than pre-existing, and any cited
+   guidance or comment actually says what the finding claims — against a
+   fixed 0-100 rubric; each verifier additionally carries a distinct emphasis
+   so the votes stay diverse. Focus emphasis adds attention; it never removes
+   required evidence. Findings advance through `pipeline` independently of
+   one another. A finding that keeps fewer than two settled votes is returned
+   as `unverified` — verifier failure must not silently launder a finding
+   into a clean report.
+6. **Report** — findings that keep at least two settled votes and average 80
    or higher survive; one TeamMate writes the final review comment with a
    one-paragraph verdict first, then issues grouped by severity, then an
-   Unverified section, then exact coverage gaps.
+   Unverified section, then exact coverage gaps. The no-findings message is
+   generated from the coverage record — a run with failed lenses or rounds
+   never claims "checked all lenses".
 
 The run returns the report plus `coverage` and `unverified` records; the
 caller decides where the report goes. When a channel reply tool is available,
@@ -74,7 +87,7 @@ GitLab) once the operator confirms.
 ## Effort levels
 
 Match fan-out to what the operator asked for; the script takes an
-`args.effort` preset:
+`args.effort` preset and fails loudly on any other value:
 
 | Preset | Rounds | Verifier votes | Use when |
 | --- | --- | --- | --- |
@@ -82,10 +95,11 @@ Match fan-out to what the operator asked for; the script takes an
 | `standard` (default) | 1 | 3 | a normal pull-request review |
 | `max` | up to 3, stop after 2 dry | 3 | "thoroughly audit this", release gates, cumulative range reviews |
 
-The confirmation bar is constant across presets — at least two settled votes
-and an average of 80 — so a lower effort level produces fewer, not weaker,
-findings. Raising effort widens coverage (more rounds, more lenses in range
-mode); it never lowers the evidence standard.
+The evidence standard is constant across presets: every verifier checks all
+acceptance conditions, and confirmation always needs at least two settled
+votes averaging 80. A lower effort level reduces vote redundancy and round
+count — fewer, not weaker, findings. Raising effort widens coverage (more
+rounds, more lenses in range mode); it never changes what counts as evidence.
 
 ## Cumulative range mode
 
@@ -93,13 +107,13 @@ Reviewing many merged changes as one diff (a release window, "everything since
 tag X") differs from a single change request in two ways, both handled by
 `args.rangeMode`:
 
-- **Resolve first.** When the target is a description like "PRs #312 through
-  head" rather than an exact range, add a resolve TeamMate ahead of the gate
-  that turns it into `<baseSha>..<headSha>` inside the repository (find the
-  named squash commit; fall back to the earliest merge at or after the named
-  number, since PR numbers are not contiguous; base is that commit's first
-  parent). Pass the resolved range through returned values — later prompts
-  must be self-contained.
+- **Resolve first.** The script's resolve stage turns a fuzzy target into
+  `<baseSha>..<headSha>` inside the repository before any other agent starts
+  (find the named squash commit; fall back to the earliest merge at or after
+  the named number, since change numbers are not contiguous; base is that
+  commit's first parent; an already-exact range passes through unchanged).
+  The resolved target is threaded into every later prompt — prompts stay
+  self-contained and no agent ever receives the fuzzy description.
 - **The cross-change lens.** A range contains changes that evolved the same
   subsystems in sequence, so range mode adds a seventh finder lens looking
   specifically for bad interactions BETWEEN the changes: a later change
@@ -128,8 +142,8 @@ Failure semantics drive the script structure:
 - A schema call rejects — it does not return `null` — when the runtime cannot
   provide structured output or reports success with an empty or invalid JSON
   result. A directly awaited rejection fails the whole run; that is the right
-  outcome for load-bearing calls like the gate, and the reason the gate below
-  is awaited bare while per-finding work runs inside helpers.
+  outcome for load-bearing calls like the resolver and the gate, and the
+  reason both are awaited bare while per-finding work runs inside helpers.
 
 Keep prompts self-contained: a finder must not depend on another finder's
 output, and everything a verifier needs (the finding, the rubric, the
@@ -143,18 +157,20 @@ changes related to the broader change; and real issues on lines the change did
 not modify.
 
 Ask finders for a severity estimate (`high` / `medium` / `low`) alongside each
-finding. Severity is the finder's input for the report's grouping; the
+finding — the field is required and enum-constrained, because the report's
+grouping depends on it. Severity is the finder's input for grouping only; the
 verifiers' confidence score stays the only acceptance gate, so a "high
 severity" label never rescues a low-confidence finding.
 
 ## TeamMate budget
 
 One round costs `1 (gate) + 2 (context) + L (find) + votes × findings
-(verify) + 1 (report)` TeamMates, where `L` is 6 lenses (7 in range mode).
-The 1000-TeamMate lifetime cap per run leaves ample headroom for a single
-round (hundreds of findings) and comfortably supports max-effort rounds; still
-count `L finders + votes × fresh findings` per extra round before choosing
-round counts, and match fan-out to what the operator asked for.
+(verify) + 1 (report)` TeamMates, plus one resolver in range mode, where `L`
+is 6 lenses (7 in range mode). The 1000-TeamMate lifetime cap per run leaves
+ample headroom for a single round (hundreds of findings) and comfortably
+supports max-effort rounds; still count `L finders + votes × fresh findings`
+per extra round before choosing round counts, and match fan-out to what the
+operator asked for.
 
 ## Script
 
@@ -169,6 +185,7 @@ export const meta = {
   description: 'Multi-lens code review with confidence-scored findings and one report',
   whenToUse: 'One-shot review of a change request, git range, or working-tree diff.',
   phases: [
+    { title: 'resolve', detail: 'range mode: pin a fuzzy target to one exact base..head' },
     { title: 'gate', detail: 'eligibility check with early exit' },
     { title: 'context', detail: 'guidance discovery and change summary' },
     { title: 'find', detail: 'independent finder lenses, repeated until dry at max effort' },
@@ -182,8 +199,16 @@ const target = input.target;
 if (!target) {
   return { error: 'args.target is required: a PR/MR URL or number, a git range, or a working-tree description' };
 }
-const EFFORT = input.effort || 'standard'; // quick | standard | max
-const MAX_ROUNDS = input.maxRounds || (EFFORT === 'max' ? 3 : 1);
+const EFFORT = input.effort === undefined ? 'standard' : input.effort;
+if (!['quick', 'standard', 'max'].includes(EFFORT)) {
+  return { error: `invalid effort ${JSON.stringify(EFFORT)}: use quick, standard, or max` };
+}
+const MAX_ROUNDS = input.maxRounds === undefined
+  ? (EFFORT === 'max' ? 3 : 1)
+  : input.maxRounds;
+if (!Number.isInteger(MAX_ROUNDS) || MAX_ROUNDS < 1 || MAX_ROUNDS > 10) {
+  return { error: `invalid maxRounds ${JSON.stringify(input.maxRounds)}: use an integer from 1 to 10` };
+}
 const VOTES = EFFORT === 'quick' ? 2 : 3;
 const RANGE_MODE = Boolean(input.rangeMode);
 
@@ -204,6 +229,12 @@ const RUBRIC =
   '75: Highly confident. Double checked; very likely real and will be hit in practice; directly impacts functionality or is directly mentioned in a guidance file.\n' +
   '100: Absolutely certain. Double checked and confirmed; will happen frequently; evidence directly confirms it.';
 
+const ACCEPTANCE_CONDITIONS =
+  'Check ALL acceptance conditions before scoring: (1) the defect reproduces on ' +
+  'the changed lines of this exact target; (2) it is introduced by this change, ' +
+  'not pre-existing; (3) any guidance file or code comment the finding cites ' +
+  'actually says what the finding claims. A finding failing any condition scores low.';
+
 const FINDINGS_SCHEMA = {
   type: 'object',
   properties: {
@@ -220,9 +251,9 @@ const FINDINGS_SCHEMA = {
             type: 'string',
             description: 'guidance | bug | history | prior-review | cross-change | comment | security',
           },
-          severity: { type: 'string', description: 'high | medium | low' },
+          severity: { type: 'string', enum: ['high', 'medium', 'low'] },
         },
-        required: ['file', 'title', 'detail', 'reason'],
+        required: ['file', 'title', 'detail', 'reason', 'severity'],
         additionalProperties: false,
       },
     },
@@ -245,9 +276,49 @@ function findingKey(f) {
   return `${f.file}:${f.line || 0}:${f.title.toLowerCase().replace(/\s+/g, ' ').trim()}`;
 }
 
+let reviewTarget = target;
+let resolvedRange = null;
+if (RANGE_MODE) {
+  phase('resolve');
+  // awaited bare: an unresolvable target must fail the run, not fan out
+  // agents against a guess
+  const resolved = await agent(
+    `In the repository this workspace can read, resolve this review target into ` +
+    `one exact git range:\n${target}\n` +
+    `If it names a change number ("changes #312 through head"), find that squash ` +
+    `commit; if no commit carries that number, use the earliest merge at or after ` +
+    `it (change numbers are not contiguous). The base is that commit's first ` +
+    `parent and the head is the branch tip. If the target is already an exact ` +
+    `range, return it unchanged. Return the range expression "<baseSha>..<headSha>" ` +
+    `and the repository path.`,
+    {
+      label: 'resolve',
+      phase: 'resolve',
+      intent: 'Range resolver',
+      schema: {
+        type: 'object',
+        properties: {
+          range: { type: 'string' },
+          repoPath: { type: 'string' },
+        },
+        required: ['range'],
+        additionalProperties: false,
+      },
+    },
+  );
+  if (!resolved || typeof resolved.range !== 'string' || !resolved.range.trim()) {
+    return { error: 'range resolution failed; no exact range produced', target };
+  }
+  resolvedRange = resolved;
+  reviewTarget = resolved.repoPath
+    ? `the git range ${resolved.range} in the repository at ${resolved.repoPath}`
+    : `the git range ${resolved.range}`;
+  log(`resolved target: ${reviewTarget}`);
+}
+
 phase('gate');
 const gate = await agent(
-  `Inspect this change: ${target}. Decide whether it should be code reviewed. ` +
+  `Inspect this change: ${reviewTarget}. Decide whether it should be code reviewed. ` +
   `Ineligible if: closed; a draft; an automated or trivial change that is ` +
   `obviously fine; or it already has a review comment from this Team.`,
   {
@@ -269,7 +340,7 @@ if (!gate || !gate.eligible) {
 phase('context');
 const ctx = await parallel([
   () => agent(
-    `For this change: ${target}. List the file paths (NOT contents) of the ` +
+    `For this change: ${reviewTarget}. List the file paths (NOT contents) of the ` +
     `repository's agent guidance files — CLAUDE.md and AGENTS.md — at the ` +
     `repository root and in directories whose files the change modifies.`,
     {
@@ -285,7 +356,7 @@ const ctx = await parallel([
     },
   ),
   () => agent(
-    `View this change: ${target}. Summarize it: intent, scope, key files, risk ` +
+    `View this change: ${reviewTarget}. Summarize it: intent, scope, key files, risk ` +
     `areas. Concise prose only.`,
     { label: 'summary', phase: 'context', intent: 'Change summarizer' },
   ),
@@ -322,10 +393,10 @@ const activeLenses = guidanceFailed
   ? lenses.filter((lens) => lens.key !== 'guidance')
   : lenses;
 
-const focusQuestions = [
-  'does it reproduce on the changed lines',
-  'is it pre-existing rather than introduced by this change',
-  'does the cited guidance file or code comment actually say that',
+const emphases = [
+  'reproduction on the changed lines',
+  'whether it is pre-existing rather than introduced',
+  'whether the cited guidance or comment actually says that',
 ].slice(0, VOTES);
 
 const seen = new Set();
@@ -333,14 +404,15 @@ const confirmed = [];
 const unverified = [];
 const roundFailures = [];
 let dry = 0;
+let lastRoundHadFresh = false;
 for (let round = 1; round <= MAX_ROUNDS && dry < 2; round++) {
   phase('find');
   // parallel() preserves order, so a null entry identifies the failed lens
   const lensResults = await parallel(activeLenses.map((lens) => () =>
     agent(
-      `Code review this change through one lens: ${target}\n${lens.prompt}\n` +
+      `Code review this change through one lens: ${reviewTarget}\n${lens.prompt}\n` +
       `${FALSE_POSITIVES}\nChange summary:\n${summary}\n` +
-      `Estimate severity (high/medium/low) for each finding.\n` +
+      `Give each finding a severity: high, medium, or low.\n` +
       `Known findings, do NOT repeat any of these keys:\n${JSON.stringify([...seen])}\n` +
       `Round ${round}: dig where earlier rounds have not.`,
       {
@@ -355,33 +427,50 @@ for (let round = 1; round <= MAX_ROUNDS && dry < 2; round++) {
     ...(guidanceFailed ? ['guidance'] : []),
     ...activeLenses.filter((lens, i) => !lensResults[i]).map((lens) => lens.key),
   ];
-  if (failedLenses.length === lenses.length) {
-    return { error: 'every finder lens failed; the change was not reviewed', failedLenses };
-  }
   if (failedLenses.length) roundFailures.push({ round, failedLenses });
+  if (failedLenses.length === lenses.length) {
+    // reserve the hard error for a run that never produced any review output;
+    // otherwise keep the accumulated results and report the gap
+    if (!confirmed.length && !unverified.length && seen.size === 0) {
+      return { error: 'every finder lens failed; the change was not reviewed', failedLenses };
+    }
+    log(`round ${round}: every lens failed; stopping with accumulated results`);
+    lastRoundHadFresh = false;
+    break;
+  }
   const found = lensResults.filter(Boolean).flatMap((r) => r.findings)
     .filter((f) => f && typeof f.file === 'string' && typeof f.title === 'string');
-  // dedupe against everything SEEN, not against the accepted list, or
-  // judge-rejected findings reappear every round and the loop never converges
-  const fresh = found.filter((f) => !seen.has(findingKey(f)));
+  // dedupe against everything SEEN — including this round's other lenses, so
+  // one defect reported by six lenses becomes one finding — and never against
+  // the accepted list, or judge-rejected findings reappear every round and
+  // the loop never converges
+  const fresh = [];
+  for (const f of found) {
+    const key = findingKey(f);
+    if (!seen.has(key)) {
+      seen.add(key);
+      fresh.push(f);
+    }
+  }
+  lastRoundHadFresh = fresh.length > 0;
   if (!fresh.length) {
     dry += 1;
     log(`round ${round}: no fresh findings (dry ${dry}/2)`);
     continue;
   }
   dry = 0;
-  fresh.forEach((f) => seen.add(findingKey(f)));
   log(`round ${round}: ${fresh.length} fresh findings`);
 
   phase('verify');
   const judged = await pipeline(
     fresh,
-    (finding) => parallel(focusQuestions.map((focus) => () =>
+    (finding) => parallel(emphases.map((emphasis) => () =>
       agent(
-        `Confidence-score this code review finding for the change: ${target}\n` +
+        `Confidence-score this code review finding for the change: ${reviewTarget}\n` +
         `Finding: ${JSON.stringify(finding)}\n` +
         `Guidance files: ${JSON.stringify(guidancePaths)}\n` +
-        `Focus question: ${focus}.\n${FALSE_POSITIVES}\n` +
+        `${ACCEPTANCE_CONDITIONS}\n` +
+        `Your particular emphasis: ${emphasis}.\n${FALSE_POSITIVES}\n` +
         `Score with this rubric verbatim:\n${RUBRIC}`,
         { phase: 'verify', intent: 'Finding verifier', schema: SCORE_SCHEMA },
       ),
@@ -404,22 +493,34 @@ for (let round = 1; round <= MAX_ROUNDS && dry < 2; round++) {
   log(`round ${round}: ${confirmed.length} confirmed total, ${unverified.length} unverified total`);
 }
 
+// stopping at the round cap while findings were still arriving is a
+// different coverage fact from converging on two dry rounds
+const stoppedAtRoundCap = MAX_ROUNDS > 1 && dry < 2 && lastRoundHadFresh;
 const coverage = {
-  complete: !guidanceFailed && roundFailures.length === 0 && unverified.length === 0,
+  complete: !guidanceFailed && roundFailures.length === 0 &&
+    unverified.length === 0 && !stoppedAtRoundCap,
   guidanceDiscoveryFailed: guidanceFailed,
   roundFailures,
+  stoppedAtRoundCap,
   unverifiedFindings: unverified.length,
 };
 
 phase('report');
 if (!confirmed.length) {
-  const report = unverified.length
-    ? `No issues confirmed. ${unverified.length} finding(s) could not be verified (verifier failures) and are returned in \`unverified\` for manual triage.`
+  const gaps = [];
+  if (guidanceFailed) gaps.push('guidance discovery failed');
+  if (roundFailures.length) {
+    gaps.push(`lens failures: ${roundFailures.map((r) => `round ${r.round} (${r.failedLenses.join(', ')})`).join('; ')}`);
+  }
+  if (stoppedAtRoundCap) gaps.push('stopped at the round cap while findings were still arriving');
+  if (unverified.length) gaps.push(`${unverified.length} finding(s) unverified after verifier failures`);
+  const report = gaps.length
+    ? `No issues confirmed. Coverage is incomplete: ${gaps.join('; ')}. See coverage and unverified for details.`
     : 'No issues found. Checked all lenses across all rounds.';
-  return { issues: [], unverified, coverage, report };
+  return { issues: [], unverified, coverage, resolvedRange, report };
 }
 const report = await agent(
-  `Write the final code review comment for the change: ${target}\n` +
+  `Write the final code review comment for the change: ${reviewTarget}\n` +
   `Confirmed issues (JSON): ${JSON.stringify(confirmed)}\n` +
   `Unverified findings — verifiers failed, no confidence claim (JSON): ${JSON.stringify(unverified)}\n` +
   `Coverage (JSON): ${JSON.stringify(coverage)}\n` +
@@ -430,11 +531,11 @@ const report = await agent(
   `path alone otherwise; never invent a line number. If there are unverified ` +
   `findings, add a short "Unverified" section listing them without confidence ` +
   `claims. End with one line stating coverage gaps exactly (failed lenses per ` +
-  `round, guidance discovery, unverified count). Brief, no emojis. ` +
-  `Return markdown only.`,
+  `round, guidance discovery, round-cap stop, unverified count). Brief, no ` +
+  `emojis. Return markdown only.`,
   { label: 'report', phase: 'report', intent: 'Review report writer' },
 );
-return { issues: confirmed, unverified, coverage, report };
+return { issues: confirmed, unverified, coverage, resolvedRange, report };
 ```
 
 The verify stage shows the three-argument stage signature: stage one returns
@@ -458,17 +559,19 @@ Team workspace:
 - a local git range (`'main...feature'`);
 - a working-tree description (`'the uncommitted diff in the workspace'`).
 
-The other `args` fields are optional: `effort` (`'quick'` / `'standard'` /
-`'max'`), `maxRounds` (overrides the preset's round cap), and `rangeMode`
-(adds the cross-change lens and the range-scoped false-positive rule; pair it
-with a resolve step per [Cumulative range mode](#cumulative-range-mode) when
-the target is not yet an exact range). `agentType` follows the runtime default
-unless each call is given one explicitly.
+The other `args` fields are optional and validated before any agent starts:
+`effort` must be `'quick'`, `'standard'`, or `'max'`; `maxRounds` must be an
+integer from 1 to 10 and overrides the preset's round cap; `rangeMode` runs
+the resolve stage first and adds the cross-change lens plus the range-scoped
+false-positive rule. `agentType` follows the runtime default unless each call
+is given one explicitly.
 
 `max_concurrency` defaults to 16; lower it only when the workspace or runtime
 provider needs gentler fan-out. After the terminal completion, read `issues`
 for the confirmed findings, `unverified` for findings whose verifiers failed,
-`coverage` for whether every lens ran in every round and every finding was
-verified, and `report` for the formatted comment; use the reporter TeamMate's
-concrete name with `send` for follow-ups such as posting the comment through
-the forge's tooling or re-checking one finding interactively.
+`coverage` for whether every lens ran in every round, the loop converged
+rather than stopping at the round cap, and every finding was verified,
+`resolvedRange` for the exact range in range mode, and `report` for the
+formatted comment; use the reporter TeamMate's concrete name with `send` for
+follow-ups such as posting the comment through the forge's tooling or
+re-checking one finding interactively.

--- a/packages/dreamux/skills/shared/workflow/references/code-review.md
+++ b/packages/dreamux/skills/shared/workflow/references/code-review.md
@@ -29,9 +29,12 @@ instead.
    - review comments on prior change requests touching the same files;
    - guidance stated in code comments of the modified files;
    - concrete security issues introduced by the change.
-   Deduplicate across lenses by file, line, and title. For an exhaustive
-   audit, repeat find/verify rounds until two consecutive rounds surface
-   nothing new, carrying already-seen findings in each round's prompts.
+   Every finding must state a concrete failure scenario — the specific
+   inputs or state that produce the wrong outcome; a defect that cannot be
+   stated as a scenario is not reportable. Deduplicate across lenses by
+   file, line, and title. For an exhaustive audit, repeat find/verify rounds
+   until two consecutive rounds surface nothing new, carrying already-seen
+   findings in each round's prompts.
 4. **Verify.** Score each finding with parallel verifier TeamMates (three
    votes normally; two for a quick pass), each given the finding, the
    guidance paths, the false-positive list, and this rubric verbatim:
@@ -47,16 +50,18 @@ instead.
      a guidance file.
    - 100: Absolutely certain. Double checked and confirmed; will happen
      frequently; evidence directly confirms it.
-   Keep findings that average 80 or higher. At max effort, findings in the
-   50-79 band may be reported too — in their own clearly labeled section,
-   never as confirmed issues.
+   Verifiers also check that the stated failure scenario is concrete and
+   actually leads to the claimed outcome. Keep findings that average 80 or
+   higher. At max effort, findings in the 50-79 band may be reported too —
+   in their own clearly labeled section, never as confirmed issues.
 5. **Report.** One TeamMate writes the review comment: a short verdict, then
    numbered issues (grouped by severity when findings carry one), each with
    the flag reason in parentheses and a file#line citation — file path alone
-   when no line is known; never invent a line number. Brief, no emojis. Post
-   the returned report through the channel reply tool, or have a follow-up
-   `send` to the reporter publish it with the forge's tooling (`gh`, `glab`)
-   once the operator confirms.
+   when no line is known; never invent a line number. Brief, no emojis. When a
+   channel reply tool is available, post the returned report through it;
+   otherwise return the report for the caller, or have a follow-up `send` to
+   the reporter publish it with the forge's tooling (`gh`, `glab`) once the
+   operator confirms.
 
 ## False positives
 

--- a/packages/dreamux/skills/shared/workflow/references/code-review.md
+++ b/packages/dreamux/skills/shared/workflow/references/code-review.md
@@ -70,10 +70,13 @@ instead.
    required evidence. Findings advance through `pipeline` independently of
    one another. A finding that keeps fewer than two settled votes is returned
    as `unverified` — verifier failure must not silently launder a finding
-   into a clean report.
+   into a clean report. At `max` effort, findings that verify into the 50-79
+   band with two settled votes survive as a separate PLAUSIBLE tier instead
+   of being silently dropped — broader coverage, explicitly labeled.
 6. **Report** — findings that keep at least two settled votes and average 80
    or higher survive; one TeamMate writes the final review comment with a
-   one-paragraph verdict first, then issues grouped by severity, then an
+   one-paragraph verdict first, then confirmed issues grouped by severity,
+   then (at max effort) a clearly labeled Plausible section, then an
    Unverified section, then exact coverage gaps. The no-findings message is
    generated from the coverage record — a run with failed lenses or rounds
    never claims "checked all lenses".
@@ -93,13 +96,18 @@ Match fan-out to what the operator asked for; the script takes an
 | --- | --- | --- | --- |
 | `quick` | 1 | 2 | a fast sanity pass; both votes must settle, so flakes surface as `unverified` rather than confirmations |
 | `standard` (default) | 1 | 3 | a normal pull-request review |
-| `max` | up to 3, stop after 2 dry | 3 | "thoroughly audit this", release gates, cumulative range reviews |
+| `max` | up to 3, stop after 2 dry | 3 | "thoroughly audit this", release gates, cumulative range reviews; additionally reports plausible findings (50-79) in a separate, clearly labeled section |
 
-The evidence standard is constant across presets: every verifier checks all
-acceptance conditions, and confirmation always needs at least two settled
-votes averaging 80. A lower effort level reduces vote redundancy and round
-count — fewer, not weaker, findings. Raising effort widens coverage (more
-rounds, more lenses in range mode); it never changes what counts as evidence.
+The evidence standard for CONFIRMATION is constant across presets: every
+verifier checks all acceptance conditions, and a confirmed finding always
+needs at least two settled votes averaging 80. A lower effort level reduces
+vote redundancy and round count — fewer, not weaker, findings. Raising effort
+widens coverage: more rounds, more lenses in range mode, and at `max` a
+second, clearly labeled PLAUSIBLE tier — findings with two settled votes
+averaging 50-79 are returned in `plausible` and reported under their own
+heading, never mixed with confirmed issues. Widening reporting to
+labeled-uncertain findings is how max broadens coverage without ever
+relabeling uncertainty as confirmation.
 
 ## Cumulative range mode
 
@@ -156,6 +164,12 @@ by a guidance file; issues explicitly silenced in code; intentional behavior
 changes related to the broader change; and real issues on lines the change did
 not modify.
 
+Every finding must carry a concrete failure scenario — the specific inputs or
+state that produce the wrong outcome or crash. A defect that cannot be stated
+as a scenario is not reportable; this single requirement kills most
+plausible-but-vague findings before verification spends votes on them, and
+gives verifiers a concrete claim to check instead of a vibe.
+
 Ask finders for a severity estimate (`high` / `medium` / `low`) alongside each
 finding — the field is required and enum-constrained, because the report's
 grouping depends on it. Severity is the finder's input for grouping only; the
@@ -210,6 +224,7 @@ if (!Number.isInteger(MAX_ROUNDS) || MAX_ROUNDS < 1 || MAX_ROUNDS > 10) {
   return { error: `invalid maxRounds ${JSON.stringify(input.maxRounds)}: use an integer from 1 to 10` };
 }
 const VOTES = EFFORT === 'quick' ? 2 : 3;
+const PLAUSIBLE_TIER = EFFORT === 'max';
 const RANGE_MODE = Boolean(input.rangeMode);
 
 const FALSE_POSITIVES =
@@ -233,7 +248,9 @@ const ACCEPTANCE_CONDITIONS =
   'Check ALL acceptance conditions before scoring: (1) the defect reproduces on ' +
   'the changed lines of this exact target; (2) it is introduced by this change, ' +
   'not pre-existing; (3) any guidance file or code comment the finding cites ' +
-  'actually says what the finding claims. A finding failing any condition scores low.';
+  'actually says what the finding claims; (4) the stated failure scenario is ' +
+  'concrete and actually leads to the claimed wrong outcome. A finding failing ' +
+  'any condition scores low.';
 
 const FINDINGS_SCHEMA = {
   type: 'object',
@@ -247,13 +264,17 @@ const FINDINGS_SCHEMA = {
           line: { type: 'integer' },
           title: { type: 'string' },
           detail: { type: 'string' },
+          failureScenario: {
+            type: 'string',
+            description: 'concrete inputs or state that produce the wrong outcome or crash',
+          },
           reason: {
             type: 'string',
             description: 'guidance | bug | history | prior-review | cross-change | comment | security',
           },
           severity: { type: 'string', enum: ['high', 'medium', 'low'] },
         },
-        required: ['file', 'title', 'detail', 'reason', 'severity'],
+        required: ['file', 'title', 'detail', 'failureScenario', 'reason', 'severity'],
         additionalProperties: false,
       },
     },
@@ -401,6 +422,7 @@ const emphases = [
 
 const seen = new Set();
 const confirmed = [];
+const plausible = [];
 const unverified = [];
 const roundFailures = [];
 let dry = 0;
@@ -412,6 +434,9 @@ for (let round = 1; round <= MAX_ROUNDS && dry < 2; round++) {
     agent(
       `Code review this change through one lens: ${reviewTarget}\n${lens.prompt}\n` +
       `${FALSE_POSITIVES}\nChange summary:\n${summary}\n` +
+      `Every finding must state a concrete failure scenario: the specific inputs ` +
+      `or state that produce the wrong outcome or crash. A defect you cannot state ` +
+      `as a scenario is not reportable.\n` +
       `Give each finding a severity: high, medium, or low.\n` +
       `Known findings, do NOT repeat any of these keys:\n${JSON.stringify([...seen])}\n` +
       `Round ${round}: dig where earlier rounds have not.`,
@@ -489,8 +514,9 @@ for (let round = 1; round <= MAX_ROUNDS && dry < 2; round++) {
     const j = judged[i];
     if (!j || j.votes < 2) unverified.push(fresh[i]);
     else if (j.confidence >= 80) confirmed.push(j);
+    else if (PLAUSIBLE_TIER && j.confidence >= 50) plausible.push(j);
   }
-  log(`round ${round}: ${confirmed.length} confirmed total, ${unverified.length} unverified total`);
+  log(`round ${round}: ${confirmed.length} confirmed, ${plausible.length} plausible, ${unverified.length} unverified total`);
 }
 
 // stopping at the round cap while findings were still arriving is a
@@ -514,28 +540,34 @@ if (!confirmed.length) {
   }
   if (stoppedAtRoundCap) gaps.push('stopped at the round cap while findings were still arriving');
   if (unverified.length) gaps.push(`${unverified.length} finding(s) unverified after verifier failures`);
+  if (plausible.length) {
+    gaps.push(`${plausible.length} plausible (unconfirmed) finding(s) at max effort`);
+  }
   const report = gaps.length
-    ? `No issues confirmed. Coverage is incomplete: ${gaps.join('; ')}. See coverage and unverified for details.`
+    ? `No issues confirmed. ${gaps.join('; ')}. See coverage, plausible, and unverified for details.`
     : 'No issues found. Checked all lenses across all rounds.';
-  return { issues: [], unverified, coverage, resolvedRange, report };
+  return { issues: [], plausible, unverified, coverage, resolvedRange, report };
 }
 const report = await agent(
   `Write the final code review comment for the change: ${reviewTarget}\n` +
   `Confirmed issues (JSON): ${JSON.stringify(confirmed)}\n` +
+  `Plausible findings — two settled votes at 50-79 confidence, unconfirmed (JSON): ${JSON.stringify(plausible)}\n` +
   `Unverified findings — verifiers failed, no confidence claim (JSON): ${JSON.stringify(unverified)}\n` +
   `Coverage (JSON): ${JSON.stringify(coverage)}\n` +
   `Structure: a "### Code review" heading; a one-paragraph verdict on the change ` +
   `as a whole; then issues grouped by severity (high, then medium, then low) as ` +
   `numbered items, each with the flag reason in parentheses and a citation on ` +
   `the next line — file#line when the finding carries a line number, the file ` +
-  `path alone otherwise; never invent a line number. If there are unverified ` +
-  `findings, add a short "Unverified" section listing them without confidence ` +
-  `claims. End with one line stating coverage gaps exactly (failed lenses per ` +
-  `round, guidance discovery, round-cap stop, unverified count). Brief, no ` +
-  `emojis. Return markdown only.`,
+  `path alone otherwise; never invent a line number. If there are plausible ` +
+  `findings, add a "Plausible (unconfirmed)" section after the confirmed issues, ` +
+  `stating each one's confidence and never presenting it as confirmed. If there ` +
+  `are unverified findings, add a short "Unverified" section listing them without ` +
+  `confidence claims. End with one line stating coverage gaps exactly (failed ` +
+  `lenses per round, guidance discovery, round-cap stop, unverified count). ` +
+  `Brief, no emojis. Return markdown only.`,
   { label: 'report', phase: 'report', intent: 'Review report writer' },
 );
-return { issues: confirmed, unverified, coverage, resolvedRange, report };
+return { issues: confirmed, plausible, unverified, coverage, resolvedRange, report };
 ```
 
 The verify stage shows the three-argument stage signature: stage one returns
@@ -568,7 +600,9 @@ is given one explicitly.
 
 `max_concurrency` defaults to 16; lower it only when the workspace or runtime
 provider needs gentler fan-out. After the terminal completion, read `issues`
-for the confirmed findings, `unverified` for findings whose verifiers failed,
+for the confirmed findings, `plausible` for max-effort findings in the 50-79
+band (labeled, never mixed with confirmed), `unverified` for findings whose
+verifiers failed,
 `coverage` for whether every lens ran in every round, the loop converged
 rather than stopping at the round cap, and every finding was verified,
 `resolvedRange` for the exact range in range mode, and `report` for the

--- a/packages/dreamux/skills/shared/workflow/references/code-review.md
+++ b/packages/dreamux/skills/shared/workflow/references/code-review.md
@@ -35,9 +35,14 @@ instead.
    file, line, and title. For an exhaustive audit, repeat find/verify rounds
    until two consecutive rounds surface nothing new, carrying already-seen
    findings in each round's prompts.
-4. **Verify.** Score each finding with parallel verifier TeamMates (three
-   votes normally; two for a quick pass), each given the finding, the
-   guidance paths, the false-positive list, and this rubric verbatim:
+4. **Verify.** Score each finding with parallel verifier TeamMates — three
+   normally, two for a quick pass — but give each verifier a *distinct focus
+   question* rather than re-asking the same one: does the defect reproduce on
+   the changed lines; is it pre-existing rather than introduced by this change;
+   does the cited guidance file or code comment actually say that. Diverse
+   focus catches failure modes that identical skeptics miss. Each verifier
+   receives the finding, the guidance paths, the false-positive list, its
+   focus question, and this rubric verbatim:
    - 0: Not confident at all. False positive that does not stand up to light
      scrutiny, or a pre-existing issue.
    - 25: Somewhat confident. Might be real, might be a false positive; could
@@ -51,9 +56,13 @@ instead.
    - 100: Absolutely certain. Double checked and confirmed; will happen
      frequently; evidence directly confirms it.
    Verifiers also check that the stated failure scenario is concrete and
-   actually leads to the claimed outcome. Keep findings that average 80 or
-   higher. At max effort, findings in the 50-79 band may be reported too —
-   in their own clearly labeled section, never as confirmed issues.
+   actually leads to the claimed outcome. Score toward the low end when you
+   cannot independently corroborate the finding — an uncorroborated finding is
+   a 0 or 25, not a hopeful 50. Keep a finding only when at least two verifiers
+   settled a vote and those votes average 80 or higher; fewer than two settled
+   votes is unverified coverage, not a pass. At
+   max effort, findings in the 50-79 band may be reported too — in their own
+   clearly labeled section, never as confirmed issues.
 5. **Report.** One TeamMate writes the review comment: a short verdict, then
    numbered issues (grouped by severity when findings carry one), each with
    the flag reason in parentheses and a file#line citation — file path alone
@@ -133,8 +142,8 @@ const findings = dedupe((await parallel(LENSES.map((lens) => () =>
 phase('verify');
 const scored = await pipeline(
   findings,
-  (f) => parallel([0, 1, 2].map(() => () =>
-    agent(rubricPrompt(f), { phase: 'verify', schema: SCORE_SCHEMA }))),
+  (f) => parallel(FOCUS_QUESTIONS.map((focus) => () =>
+    agent(rubricPrompt(f, focus), { phase: 'verify', schema: SCORE_SCHEMA }))),
   (votes, f) => ({ ...f, votes: (votes || []).filter(Boolean) }),
 );
 const confirmed = scored.filter(Boolean)

--- a/packages/dreamux/skills/shared/workflow/references/orchestration-patterns.md
+++ b/packages/dreamux/skills/shared/workflow/references/orchestration-patterns.md
@@ -125,25 +125,19 @@ Compose these freely; pick by task.
   ```js
   const seen = new Set();
   let dry = 0;
-  for (let round = 1; round <= MAX_ROUNDS && dry < 2; round++) {
-    const thunks = finderThunks(seen);
-    const results = await parallel(thunks);
-    if (results.every((r) => !r)) break; // an outage is not a dry round
-    const fresh = [];
-    for (const f of results.filter(Boolean).flatMap((r) => r.findings)) {
-      // add to seen INSIDE the loop: the same finding from several
-      // concurrent finders must collapse to one entry
-      if (!seen.has(key(f))) { seen.add(key(f)); fresh.push(f); }
-    }
-    if (!fresh.length) { dry += 1; continue; }
+  while (dry < 2) {
+    const found = (await parallel(finderThunks(seen))).filter(Boolean)
+      .flatMap((r) => r.findings)
+      .filter((f) => !seen.has(key(f)));
+    if (!found.length) { dry += 1; continue; }
     dry = 0;
+    found.forEach((f) => seen.add(key(f)));
     // ...verify and accept...
   }
   ```
 
-  Bound the loop with an explicit round cap and report whether it converged
-  (two dry rounds) or stopped early. Budget first: rounds multiply TeamMate
-  count, and a run stops at 1000 TeamMates total.
+  Budget first: rounds multiply TeamMate count, and a run stops at 1000
+  TeamMates total.
 - **Multi-modal sweep.** Run parallel searchers that each look a different
   way (by file structure, by content, by naming convention, by history),
   each blind to the others. One search angle rarely finds everything.

--- a/packages/dreamux/skills/shared/workflow/references/orchestration-patterns.md
+++ b/packages/dreamux/skills/shared/workflow/references/orchestration-patterns.md
@@ -125,19 +125,25 @@ Compose these freely; pick by task.
   ```js
   const seen = new Set();
   let dry = 0;
-  while (dry < 2) {
-    const found = (await parallel(finderThunks(seen))).filter(Boolean)
-      .flatMap((r) => r.findings)
-      .filter((f) => !seen.has(key(f)));
-    if (!found.length) { dry += 1; continue; }
+  for (let round = 1; round <= MAX_ROUNDS && dry < 2; round++) {
+    const thunks = finderThunks(seen);
+    const results = await parallel(thunks);
+    if (results.every((r) => !r)) break; // an outage is not a dry round
+    const fresh = [];
+    for (const f of results.filter(Boolean).flatMap((r) => r.findings)) {
+      // add to seen INSIDE the loop: the same finding from several
+      // concurrent finders must collapse to one entry
+      if (!seen.has(key(f))) { seen.add(key(f)); fresh.push(f); }
+    }
+    if (!fresh.length) { dry += 1; continue; }
     dry = 0;
-    found.forEach((f) => seen.add(key(f)));
     // ...verify and accept...
   }
   ```
 
-  Budget first: rounds multiply TeamMate count, and a run stops at 1000
-  TeamMates total.
+  Bound the loop with an explicit round cap and report whether it converged
+  (two dry rounds) or stopped early. Budget first: rounds multiply TeamMate
+  count, and a run stops at 1000 TeamMates total.
 - **Multi-modal sweep.** Run parallel searchers that each look a different
   way (by file structure, by content, by naming convention, by history),
   each blind to the others. One search angle rarely finds everything.

--- a/packages/dreamux/skills/shared/workflow/references/ultracode.md
+++ b/packages/dreamux/skills/shared/workflow/references/ultracode.md
@@ -96,18 +96,7 @@ set before expensive downstream work:
 ```js
 const all = await parallel(angles.map((a) => () =>
   agent(searchPrompt(a), { phase: 'search', schema: SOURCES_SCHEMA })));
-// account failures positionally BEFORE dropping nulls — a failed angle is
-// missing coverage, not an angle that found nothing
-const failedAngles = angles.filter((a, i) => !all[i]).map((a) => a.name);
-if (failedAngles.length) log(`failed angles: ${failedAngles.join(', ')}`);
-const seen = new Set();
-const sources = [];
-for (const result of all.filter(Boolean)) {
-  for (const s of result.sources) {
-    const key = s.url.replace(/[#?].*$/, '');
-    if (!seen.has(key)) { seen.add(key); sources.push(s); }
-  }
-}
+const sources = dedupeByUrl(all.filter(Boolean).flatMap((r) => r.sources));
 // only now fan out the expensive per-source work
 const reports = await pipeline(sources, fetchStage, verifyStage);
 ```
@@ -115,57 +104,31 @@ const reports = await pipeline(sources, fetchStage, verifyStage);
 The barrier earns its latency because the dedup needs every angle's output at
 once; the per-source work that follows goes back to `pipeline`.
 
-**The exhaustive-discovery loop** — finders → dedup vs SEEN → diverse
-verification → repeat until dry, the composition behind every "audit
-everything" request:
+**The exhaustive-discovery loop** — finders → dedup vs SEEN → verification →
+repeat until dry, the composition behind every "audit everything" request:
 
 ```js
 const seen = new Set();
 const accepted = [];
-const unverified = [];
-const roundFailures = [];
 let dry = 0;
-for (let round = 1; round <= MAX_ROUNDS && dry < 2; round++) {
-  const thunks = finderThunks(seen);
-  const results = await parallel(thunks);
-  const failed = results.filter((r) => !r).length;
-  if (failed) roundFailures.push({ round, failed });
-  if (failed === thunks.length) {
-    log(`round ${round}: every finder failed`); // an outage is not convergence
-    break;
-  }
-  const found = results.filter(Boolean).flatMap((r) => r.findings);
-  const fresh = [];
-  for (const f of found) {
-    if (!seen.has(key(f))) { seen.add(key(f)); fresh.push(f); }
-  }
-  if (!fresh.length) { dry += 1; continue; }
+while (dry < 2) {
+  const found = (await parallel(finderThunks(seen))).filter(Boolean)
+    .flatMap((r) => r.findings)
+    .filter((f) => !seen.has(key(f)));
+  if (!found.length) { dry += 1; continue; }
   dry = 0;
-  const judged = await pipeline(fresh, verifyStage, aggregateStage);
-  for (let i = 0; i < fresh.length; i++) {
-    if (!judged[i]) unverified.push(fresh[i]); // verifier outage, not rejection
-    else if (judged[i].accepted) accepted.push(judged[i]);
-  }
+  found.forEach((f) => seen.add(key(f)));
+  const judged = await pipeline(found, verifyStage, aggregateStage);
+  accepted.push(...judged.filter(Boolean).filter((f) => f.accepted));
 }
-const converged = dry >= 2;
-// report roundFailures, unverified, and converged with the results — exiting
-// at the cap, an outage, or unverified findings are coverage facts, not a
-// clean finish
 ```
 
-Four load-bearing details, all learned the hard way: dedupe against SEEN (not
-against `accepted`, or judge-rejected findings reappear every round and the
-loop never converges); dedupe INSIDE the fresh-collection loop (not with a
-plain `filter` against the pre-round set, or the same finding from several
-concurrent finders enters the round several times); account failed finders
-positionally before `.filter(Boolean)` and treat an all-finder outage as an
-outage, never as a dry round — otherwise two rounds of failures read as
-convergence; bound the loop with an explicit round cap, reporting whether
-it converged or stopped at the cap; and route verifier-failed findings into
-an unverified record positionally instead of `.filter(Boolean)`-ing them
-away — a run must not display converged while silently missing verdicts. The complete accounting contract lives in
-[code-review.md](code-review.md); this sketch stays minimal but must not
-contradict it.
+Dedupe against SEEN, not against `accepted` — otherwise judge-rejected
+findings reappear every round and the loop never converges. When adapting the
+sketch, remember the standing failure-plumbing rules from
+[orchestration-patterns.md](orchestration-patterns.md): note failed positions
+before filtering nulls, and bound loops when the finding population may not
+converge.
 
 ## Loop-until-count
 

--- a/packages/dreamux/skills/shared/workflow/references/ultracode.md
+++ b/packages/dreamux/skills/shared/workflow/references/ultracode.md
@@ -144,6 +144,7 @@ while (bugs.length < 10) {
   bugs.push(...result.bugs);
   log(`${bugs.length}/10 found`);
 }
+if (bugs.length < 10) log(`stopped short: ${bugs.length}/10 — no more found`);
 ```
 
 Always pair the target with a dry-pass exit and `log()` the shortfall — a
@@ -160,9 +161,17 @@ shapes when the task calls for it:
   to a fixer → re-check, bounded by attempts, with every iteration logged;
 - **staged escalation** — a cheap pass filters the easy majority, and only
   survivors reach the expensive treatment (the confidence-gated verify stage
-  in [code-review.md](code-review.md) is this shape).
+  in [code-review.md](code-review.md) is this shape);
+- **completeness critic** — after synthesis, one agent asks "what is missing —
+  an angle never searched, a claim left unverified, a source unread?" What it
+  surfaces becomes the next round's work or is reported as a known gap. Pair it
+  with loop-until-dry: the loop proves discovery is exhausted, the critic proves
+  verification and coverage are.
 
 Whatever the shape, the standing rules from
 [orchestration-patterns.md](orchestration-patterns.md) still bind: positional
 coverage accounting before `.filter(Boolean)`, no silent caps, self-contained
 prompts, and budget arithmetic against the run limits before choosing sizes.
+And because scripts run in the deterministic sandbox, `Date.now()`,
+`Math.random()`, and argless `new Date()` throw — derive variation from an
+item's index, and take any timestamp from `args` instead of reading the clock.

--- a/packages/dreamux/skills/shared/workflow/references/ultracode.md
+++ b/packages/dreamux/skills/shared/workflow/references/ultracode.md
@@ -75,8 +75,13 @@ decisions between phases (is the map good enough? which design won? is the
 implementation ready for review?) are exactly the parts that should stay with
 the TeamLeader, interactive and revisable.
 
-Two practical consequences:
+Three practical consequences:
 
+- `workflow_run` returns only `{ run_id }` immediately — a durable acceptance
+  receipt, not the result. Save the id, wait for the terminal completion that
+  Dreamux pushes, and build the next run's `args` from that completion's
+  `result`; feeding the receipt into the next run is the classic mistake.
+  `workflow_status(run_id)` is for explicit recovery, not a polling loop.
 - return STRUCTURED results (not just prose) from each run so the next run's
   `args` can be built from them mechanically;
 - after a run, follow up interactively with a recorded concrete TeamMate name
@@ -91,6 +96,10 @@ set before expensive downstream work:
 ```js
 const all = await parallel(angles.map((a) => () =>
   agent(searchPrompt(a), { phase: 'search', schema: SOURCES_SCHEMA })));
+// account failures positionally BEFORE dropping nulls — a failed angle is
+// missing coverage, not an angle that found nothing
+const failedAngles = angles.filter((a, i) => !all[i]).map((a) => a.name);
+if (failedAngles.length) log(`failed angles: ${failedAngles.join(', ')}`);
 const seen = new Set();
 const sources = [];
 for (const result of all.filter(Boolean)) {
@@ -113,10 +122,18 @@ everything" request:
 ```js
 const seen = new Set();
 const accepted = [];
+const roundFailures = [];
 let dry = 0;
-while (dry < 2) {
-  const found = (await parallel(finderThunks(seen))).filter(Boolean)
-    .flatMap((r) => r.findings);
+for (let round = 1; round <= MAX_ROUNDS && dry < 2; round++) {
+  const thunks = finderThunks(seen);
+  const results = await parallel(thunks);
+  const failed = results.filter((r) => !r).length;
+  if (failed) roundFailures.push({ round, failed });
+  if (failed === thunks.length) {
+    log(`round ${round}: every finder failed`); // an outage is not convergence
+    break;
+  }
+  const found = results.filter(Boolean).flatMap((r) => r.findings);
   const fresh = [];
   for (const f of found) {
     if (!seen.has(key(f))) { seen.add(key(f)); fresh.push(f); }
@@ -126,13 +143,22 @@ while (dry < 2) {
   const judged = await pipeline(fresh, verifyStage, aggregateStage);
   accepted.push(...judged.filter(Boolean).filter((f) => f.accepted));
 }
+const converged = dry >= 2;
+// report roundFailures and converged with the results — exiting at the cap
+// or on an outage is a coverage fact, not a clean finish
 ```
 
-Two load-bearing details, both learned the hard way: dedupe against SEEN (not
+Four load-bearing details, all learned the hard way: dedupe against SEEN (not
 against `accepted`, or judge-rejected findings reappear every round and the
-loop never converges), and dedupe INSIDE the fresh-collection loop (not with a
+loop never converges); dedupe INSIDE the fresh-collection loop (not with a
 plain `filter` against the pre-round set, or the same finding from several
-concurrent finders enters the round several times).
+concurrent finders enters the round several times); account failed finders
+positionally before `.filter(Boolean)` and treat an all-finder outage as an
+outage, never as a dry round — otherwise two rounds of failures read as
+convergence; and bound the loop with an explicit round cap, reporting whether
+it converged or stopped at the cap. The complete accounting contract lives in
+[code-review.md](code-review.md); this sketch stays minimal but must not
+contradict it.
 
 ## Loop-until-count
 

--- a/packages/dreamux/skills/shared/workflow/references/ultracode.md
+++ b/packages/dreamux/skills/shared/workflow/references/ultracode.md
@@ -1,0 +1,172 @@
+# Ultracode Orchestration Techniques
+
+`../SKILL.md` owns the run tools and the script API;
+[orchestration-patterns.md](orchestration-patterns.md) owns prompt discipline,
+the `pipeline`-versus-`parallel` rules, and the individual quality patterns.
+This reference owns the level above: how to shape a whole task as ultracode
+workflows — choosing an archetype, scouting before orchestrating, chaining
+runs, and composing the quality patterns into complete harnesses.
+
+## Contents
+
+- [Workflow archetypes](#workflow-archetypes) — five reusable single-run
+  shapes
+- [Scout before you orchestrate](#scout-before-you-orchestrate) — discover
+  the work-list first
+- [Chain runs, stay in the loop](#chain-runs-stay-in-the-loop) — multi-phase
+  work as a sequence of runs
+- [Worked compositions](#worked-compositions) — barrier-when-justified and
+  the exhaustive-discovery loop
+- [Loop-until-count](#loop-until-count) — accumulate to a target
+- [Novel harnesses](#novel-harnesses) — beyond the named patterns
+
+## Workflow archetypes
+
+Most tasks that deserve a workflow fit one of five single-run shapes. Name the
+shape first; the script structure follows from it.
+
+- **Understand** — parallel readers over relevant subsystems, one structured
+  map out. Fan out one `agent()` per subsystem with a shared schema, then one
+  synthesis agent merges the maps. Use when the question is "how does this
+  system work" and no single context can hold it all.
+- **Design** — a judge panel over N independent approaches. Generate attempts
+  from deliberately different angles (smallest-change-first, risk-first,
+  user-first), score them with parallel judges against explicit criteria,
+  synthesize from the winner while grafting the runners-up's best ideas. Use
+  when the solution space is wide and one-attempt-iterated would anchor early.
+- **Review** — dimensions → find → adversarially verify. The complete recipe
+  lives in [code-review.md](code-review.md); the shape generalizes to any
+  audit: independent finder lenses, confidence-gated verification, one
+  severity-ordered report.
+- **Research** — multi-modal sweep → deep-read → verify → synthesize: search
+  agents per angle, URL dedup at a justified barrier, per-source claim
+  extraction, adversarial claim verification, one cited report with honest
+  coverage caveats.
+- **Migrate** — discover sites → transform each → verify each. Scout the
+  work-list first (see below), then `pipeline` items through
+  transform-then-verify stages. Keep concurrent edits on clearly independent
+  paths, or serialize the write stage — workflow TeamMates share the Team
+  workspace.
+
+## Scout before you orchestrate
+
+The coordination graph must be known before the orchestration step — not
+before the task. When the work-list is unknown ("migrate every call site",
+"review whatever changed"), scout first and fan out second:
+
+- cheap scouting (one `git diff --stat`, one directory listing) belongs in
+  the TeamLeader's own turn before `workflow_run`, with the result passed in
+  as `args`;
+- scouting that itself needs an agent (resolving a fuzzy range, inventorying
+  a subsystem) belongs as the script's first stage, awaited bare so an
+  unresolvable work-list fails the run before any fan-out — the resolve stage
+  in [code-review.md](code-review.md)'s range mode is this technique.
+
+Never fan out against a guess: every downstream prompt should receive the
+resolved work-list, not the fuzzy description.
+
+## Chain runs, stay in the loop
+
+A workflow is one well-scoped fan-out with a deterministic graph. Larger work
+— understand, then design, then implement, then review — is a SEQUENCE of
+workflows with the TeamLeader reading each terminal result before shaping the
+next run. Resist packing multi-phase judgment into one mega-script: the
+decisions between phases (is the map good enough? which design won? is the
+implementation ready for review?) are exactly the parts that should stay with
+the TeamLeader, interactive and revisable.
+
+Two practical consequences:
+
+- return STRUCTURED results (not just prose) from each run so the next run's
+  `args` can be built from them mechanically;
+- after a run, follow up interactively with a recorded concrete TeamMate name
+  via `send` when one result needs a clarification — reshaping and re-running
+  the whole workflow is for when the graph itself was wrong.
+
+## Worked compositions
+
+**A barrier when it is genuinely justified** — dedup across the full result
+set before expensive downstream work:
+
+```js
+const all = await parallel(angles.map((a) => () =>
+  agent(searchPrompt(a), { phase: 'search', schema: SOURCES_SCHEMA })));
+const seen = new Set();
+const sources = [];
+for (const result of all.filter(Boolean)) {
+  for (const s of result.sources) {
+    const key = s.url.replace(/[#?].*$/, '');
+    if (!seen.has(key)) { seen.add(key); sources.push(s); }
+  }
+}
+// only now fan out the expensive per-source work
+const reports = await pipeline(sources, fetchStage, verifyStage);
+```
+
+The barrier earns its latency because the dedup needs every angle's output at
+once; the per-source work that follows goes back to `pipeline`.
+
+**The exhaustive-discovery loop** — finders → dedup vs SEEN → diverse
+verification → repeat until dry, the composition behind every "audit
+everything" request:
+
+```js
+const seen = new Set();
+const accepted = [];
+let dry = 0;
+while (dry < 2) {
+  const found = (await parallel(finderThunks(seen))).filter(Boolean)
+    .flatMap((r) => r.findings);
+  const fresh = [];
+  for (const f of found) {
+    if (!seen.has(key(f))) { seen.add(key(f)); fresh.push(f); }
+  }
+  if (!fresh.length) { dry += 1; continue; }
+  dry = 0;
+  const judged = await pipeline(fresh, verifyStage, aggregateStage);
+  accepted.push(...judged.filter(Boolean).filter((f) => f.accepted));
+}
+```
+
+Two load-bearing details, both learned the hard way: dedupe against SEEN (not
+against `accepted`, or judge-rejected findings reappear every round and the
+loop never converges), and dedupe INSIDE the fresh-collection loop (not with a
+plain `filter` against the pre-round set, or the same finding from several
+concurrent finders enters the round several times).
+
+## Loop-until-count
+
+For "give me N of X" requests, accumulate to the target instead of guessing
+the fan-out size:
+
+```js
+const bugs = [];
+while (bugs.length < 10) {
+  const result = await agent('Find bugs not in this list: ' +
+    JSON.stringify(bugs.map((b) => b.title)), { schema: BUGS_SCHEMA });
+  if (!result || !result.bugs.length) break; // a dry pass ends the hunt honestly
+  bugs.push(...result.bugs);
+  log(`${bugs.length}/10 found`);
+}
+```
+
+Always pair the target with a dry-pass exit and `log()` the shortfall — a
+loop that cannot reach N must say so, not spin against the agent cap.
+
+## Novel harnesses
+
+The named patterns are a vocabulary, not a ceiling. Compose new harness
+shapes when the task calls for it:
+
+- **tournament** — pair candidates, judge each pair, advance winners; better
+  than one big judge panel when candidates are too many to compare at once;
+- **self-repair loop** — generate → check → feed the checker's findings back
+  to a fixer → re-check, bounded by attempts, with every iteration logged;
+- **staged escalation** — a cheap pass filters the easy majority, and only
+  survivors reach the expensive treatment (the confidence-gated verify stage
+  in [code-review.md](code-review.md) is this shape).
+
+Whatever the shape, the standing rules from
+[orchestration-patterns.md](orchestration-patterns.md) still bind: positional
+coverage accounting before `.filter(Boolean)`, no silent caps, self-contained
+prompts, and budget arithmetic against the run limits before choosing sizes.

--- a/packages/dreamux/skills/shared/workflow/references/ultracode.md
+++ b/packages/dreamux/skills/shared/workflow/references/ultracode.md
@@ -122,6 +122,7 @@ everything" request:
 ```js
 const seen = new Set();
 const accepted = [];
+const unverified = [];
 const roundFailures = [];
 let dry = 0;
 for (let round = 1; round <= MAX_ROUNDS && dry < 2; round++) {
@@ -141,11 +142,15 @@ for (let round = 1; round <= MAX_ROUNDS && dry < 2; round++) {
   if (!fresh.length) { dry += 1; continue; }
   dry = 0;
   const judged = await pipeline(fresh, verifyStage, aggregateStage);
-  accepted.push(...judged.filter(Boolean).filter((f) => f.accepted));
+  for (let i = 0; i < fresh.length; i++) {
+    if (!judged[i]) unverified.push(fresh[i]); // verifier outage, not rejection
+    else if (judged[i].accepted) accepted.push(judged[i]);
+  }
 }
 const converged = dry >= 2;
-// report roundFailures and converged with the results — exiting at the cap
-// or on an outage is a coverage fact, not a clean finish
+// report roundFailures, unverified, and converged with the results — exiting
+// at the cap, an outage, or unverified findings are coverage facts, not a
+// clean finish
 ```
 
 Four load-bearing details, all learned the hard way: dedupe against SEEN (not
@@ -155,8 +160,10 @@ plain `filter` against the pre-round set, or the same finding from several
 concurrent finders enters the round several times); account failed finders
 positionally before `.filter(Boolean)` and treat an all-finder outage as an
 outage, never as a dry round — otherwise two rounds of failures read as
-convergence; and bound the loop with an explicit round cap, reporting whether
-it converged or stopped at the cap. The complete accounting contract lives in
+convergence; bound the loop with an explicit round cap, reporting whether
+it converged or stopped at the cap; and route verifier-failed findings into
+an unverified record positionally instead of `.filter(Boolean)`-ing them
+away — a run must not display converged while silently missing verdicts. The complete accounting contract lives in
 [code-review.md](code-review.md); this sketch stays minimal but must not
 contradict it.
 

--- a/packages/dreamux/skills/shared/workflow/references/ultracode.md
+++ b/packages/dreamux/skills/shared/workflow/references/ultracode.md
@@ -81,7 +81,7 @@ Three practical consequences:
   receipt, not the result. Save the id, wait for the terminal completion that
   Dreamux pushes, and build the next run's `args` from that completion's
   `result`; feeding the receipt into the next run is the classic mistake.
-  `workflow_status(run_id)` is for explicit recovery, not a polling loop.
+  `workflow_status({ run_id })` is for explicit recovery, not a polling loop.
 - return STRUCTURED results (not just prose) from each run so the next run's
   `args` can be built from them mechanically;
 - after a run, follow up interactively with a recorded concrete TeamMate name


### PR DESCRIPTION
## What

Extends the bundled `workflow` skill's `references/code-review.md` with the mechanics that make a mature max-effort review practice work, so a TeamLeader loading the skill gets them without re-deriving:

- **Effort presets** (`quick` / `standard` / `max`): rounds and verifier-vote counts scale with the ask; the confirmation bar (≥2 settled votes, average ≥80) is constant, so lower effort yields fewer findings, never weaker ones.
- **Repeat-until-dry rounds** at max effort: find/verify pairs loop until two consecutive dry rounds (or the round cap), each round's prompts carrying every seen finding key; dedupe is against SEEN, not against the accepted list, with the non-convergence rationale documented.
- **Cumulative range mode** (`args.rangeMode`): resolve-first guidance for fuzzy targets ("PRs #N through head" → exact `base..head`), a seventh cross-change lens hunting bad interactions BETWEEN changes in the range (later change invalidating an earlier assumption, superseded leftovers, contradictory contracts, mid-range-only statements), and a range-scoped false-positive rule (intra-range deliberate replacement is not a finding).
- **Severity-grouped reporting**: finders estimate high/medium/low; the report leads with a verdict paragraph and groups issues by severity — with the explicit rule that severity labels never rescue low-confidence findings.

All previously landed hardening is preserved: positional lens-coverage accounting (now per-round), guidance-discovery failure handling, unverified-findings routing, citation discipline, bare-await gate semantics.

## Why

The recipe shipped in #319 covered one standard pass. Real review requests split into "quick sanity check", "normal PR review", and "audit everything since X" — the presets, dry-loop, and range mode are exactly the parts of that spectrum a script author gets wrong first (fixed passes miss the tail; naive dedupe never converges; cumulative ranges need the cross-change lens to be worth running as one diff).

## Notes

- Documentation-only bundled skill content; no runtime code touched.
- The embedded script uses the single top-level dialect (post-#324) and re-passes a syntax check under compiler-equivalent strict wrapping.
- Rush change file included (patch, bundled skill content).

Refs #319, #324

🤖 Generated with [Claude Code](https://claude.com/claude-code)
