### PR TITLE
fix(workflow): discourage status polling after run

### DIFF
--- a/common/changes/@excitedjs/dreamux/fix-workflow-run-reminder_2026-08-12-05-21.json
+++ b/common/changes/@excitedjs/dreamux/fix-workflow-run-reminder_2026-08-12-05-21.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Tell agents in successful workflow_run results to await Dreamux's automatic completion push instead of polling workflow status.",
+      "type": "patch",
+      "packageName": "@excitedjs/dreamux"
+    }
+  ],
+  "packageName": "@excitedjs/dreamux",
+  "email": "053700@gmail.com"
+}

--- a/packages/dreamux/src/mcp/task-dispatch-reminder.ts
+++ b/packages/dreamux/src/mcp/task-dispatch-reminder.ts
@@ -51,20 +51,17 @@ function taskDispatchSuccessReminder(
 }
 
 function hasNonEmptyRunId(result: unknown): boolean {
-  if (result === null || typeof result !== 'object' || Array.isArray(result)) {
-    return false;
-  }
-  const runId = (result as Record<string, unknown>)['run_id'];
+  if (!isRecord(result)) return false;
+  const runId = result['run_id'];
   return typeof runId === 'string' && runId.trim() !== '';
 }
 
 function hasSubmittedTurn(result: unknown): boolean {
-  if (result === null || typeof result !== 'object' || Array.isArray(result)) {
-    return false;
-  }
-  const turn = (result as Record<string, unknown>)['turn'];
-  if (turn === null || typeof turn !== 'object' || Array.isArray(turn)) {
-    return false;
-  }
-  return (turn as Record<string, unknown>)['status'] === 'submitted';
+  if (!isRecord(result)) return false;
+  const turn = result['turn'];
+  return isRecord(turn) && turn['status'] === 'submitted';
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
 }

--- a/packages/dreamux/src/mcp/task-dispatch-reminder.ts
+++ b/packages/dreamux/src/mcp/task-dispatch-reminder.ts
@@ -4,26 +4,58 @@ export const TEAM_DISPATCH_SUCCESS_REMINDER =
 export const TEAMMATE_DISPATCH_SUCCESS_REMINDER =
   'Reminder: The TeamMate task was submitted successfully. Dreamux core will automatically push the TeamMate completion back when it finishes. Do not poll last or other read tools for completion; if you have no other work, you may end this turn naturally.';
 
+export const WORKFLOW_RUN_SUCCESS_REMINDER =
+  'Reminder: The workflow runs in the background. When it finishes, Dreamux automatically pushes the terminal completion into the caller\'s current context. Unless the user explicitly asks for a status check, do not call or poll workflow_status or other status/read tools; wait for the system push. If there is no other work, the turn may end naturally.';
+
 export function appendTaskDispatchSuccessReminder(
   text: string,
   result: unknown,
-  reminder: string,
+  method: string,
+  taskDispatchReminder: string,
 ): string {
-  return hasSubmittedTurn(result)
-    ? `${text}\n\n${reminder}`
-    : text;
+  const reminder = taskDispatchSuccessReminder(
+    method,
+    result,
+    taskDispatchReminder,
+  );
+  return reminder === null ? text : `${text}\n\n${reminder}`;
 }
 
 export function appendStructuredTaskDispatchSuccessReminder(
   result: unknown,
-  reminder: string,
+  method: string,
+  taskDispatchReminder: string,
 ): unknown {
-  return hasSubmittedTurn(result)
-    ? {
+  const reminder = taskDispatchSuccessReminder(
+    method,
+    result,
+    taskDispatchReminder,
+  );
+  return reminder === null
+    ? result
+    : {
         ...(result as Record<string, unknown>),
         reminder,
-      }
-    : result;
+      };
+}
+
+function taskDispatchSuccessReminder(
+  method: string,
+  result: unknown,
+  taskDispatchReminder: string,
+): string | null {
+  if (method === 'workflow.run' && hasNonEmptyRunId(result)) {
+    return WORKFLOW_RUN_SUCCESS_REMINDER;
+  }
+  return hasSubmittedTurn(result) ? taskDispatchReminder : null;
+}
+
+function hasNonEmptyRunId(result: unknown): boolean {
+  if (result === null || typeof result !== 'object' || Array.isArray(result)) {
+    return false;
+  }
+  const runId = (result as Record<string, unknown>)['run_id'];
+  return typeof runId === 'string' && runId.trim() !== '';
 }
 
 function hasSubmittedTurn(result: unknown): boolean {

--- a/packages/dreamux/src/mcp/team-mcp.ts
+++ b/packages/dreamux/src/mcp/team-mcp.ts
@@ -242,11 +242,13 @@ async function callTool(
         text: appendTaskDispatchSuccessReminder(
           `${call.name} forwarded to dreamux serve`,
           result,
+          mapped.method,
           TEAM_DISPATCH_SUCCESS_REMINDER,
         ),
       }],
       structuredContent: appendStructuredTaskDispatchSuccessReminder(
         result,
+        mapped.method,
         TEAM_DISPATCH_SUCCESS_REMINDER,
       ),
     };

--- a/packages/dreamux/src/mcp/teammate-mcp.ts
+++ b/packages/dreamux/src/mcp/teammate-mcp.ts
@@ -389,11 +389,13 @@ async function forwardToolCall(
         text: appendTaskDispatchSuccessReminder(
           `${label} forwarded to dreamux serve`,
           result,
+          method,
           TEAMMATE_DISPATCH_SUCCESS_REMINDER,
         ),
       }],
       structuredContent: appendStructuredTaskDispatchSuccessReminder(
         result,
+        method,
         TEAMMATE_DISPATCH_SUCCESS_REMINDER,
       ),
     };

--- a/packages/dreamux/tests/teammate-mcp.test.ts
+++ b/packages/dreamux/tests/teammate-mcp.test.ts
@@ -10,6 +10,7 @@ import type { AdminRequest, AdminResponse } from '../src/admin/protocol.js';
 import {
   TEAM_DISPATCH_SUCCESS_REMINDER,
   TEAMMATE_DISPATCH_SUCCESS_REMINDER,
+  WORKFLOW_RUN_SUCCESS_REMINDER,
 } from '../src/mcp/task-dispatch-reminder.js';
 import { runTeamMateMcp } from '../src/mcp/teammate-mcp.js';
 
@@ -248,12 +249,18 @@ describe('teammate-mcp stdio shim', () => {
   });
 
   it('maps workflow tools onto TeamLeader-scoped admin methods', async () => {
+    const workflowResults: Record<string, unknown> = {
+      'workflow.run': { run_id: 'run-1' },
+      'workflow.status': { run_id: 'run-1', status: 'running' },
+      'workflow.stop': { run_id: 'run-1', status: 'stopped' },
+      'workflow.list': {
+        runs: [{ run_id: 'run-1', status: 'running' }],
+      },
+    };
     const admin = await startFakeAdminServer((request) => ({
       id: request.id,
       ok: true,
-      result: request.method === 'workflow.run'
-        ? { run_id: 'run-1' }
-        : { ok: true },
+      result: workflowResults[request.method] ?? {},
     }));
     try {
       const input = new PassThrough();
@@ -282,6 +289,7 @@ describe('teammate-mcp stdio shim', () => {
         { name: 'workflow_stop', arguments: { run_id: 'run-1' } },
         { name: 'workflow_list', arguments: {} },
       ];
+      const responses: unknown[] = [];
 
       for (const [index, call] of calls.entries()) {
         writeJson(input, {
@@ -290,11 +298,57 @@ describe('teammate-mcp stdio shim', () => {
           method: 'tools/call',
           params: call,
         });
-        await expect(reader.next()).resolves.toMatchObject({
+        const response = await reader.next();
+        expect(response).toMatchObject({
           jsonrpc: '2.0',
           id: index + 1,
           result: { structuredContent: expect.any(Object) as object },
         });
+        responses.push(response);
+      }
+
+      const [runResponse, statusResponse, stopResponse, listResponse] = responses;
+      expect(runResponse).toMatchObject({
+        result: {
+          content: [{
+            text: expect.stringContaining(WORKFLOW_RUN_SUCCESS_REMINDER) as string,
+          }],
+          structuredContent: {
+            run_id: 'run-1',
+            reminder: WORKFLOW_RUN_SUCCESS_REMINDER,
+          },
+        },
+      });
+      expect(JSON.stringify(runResponse)).not.toContain(
+        TEAMMATE_DISPATCH_SUCCESS_REMINDER,
+      );
+      expect(statusResponse).toMatchObject({
+        result: {
+          content: [{ text: 'workflow_status forwarded to dreamux serve' }],
+          structuredContent: { run_id: 'run-1', status: 'running' },
+        },
+      });
+      expect(stopResponse).toMatchObject({
+        result: {
+          content: [{ text: 'workflow_stop forwarded to dreamux serve' }],
+          structuredContent: { run_id: 'run-1', status: 'stopped' },
+        },
+      });
+      expect(listResponse).toMatchObject({
+        result: {
+          content: [{ text: 'workflow_list forwarded to dreamux serve' }],
+          structuredContent: {
+            runs: [{ run_id: 'run-1', status: 'running' }],
+          },
+        },
+      });
+      for (const response of [statusResponse, stopResponse, listResponse]) {
+        expect(JSON.stringify(response)).not.toContain(
+          WORKFLOW_RUN_SUCCESS_REMINDER,
+        );
+        expect(JSON.stringify(response)).not.toContain(
+          TEAMMATE_DISPATCH_SUCCESS_REMINDER,
+        );
       }
 
       expect(admin.requests).toEqual([
@@ -341,6 +395,69 @@ describe('teammate-mcp stdio shim', () => {
           },
         },
       ]);
+
+      input.end();
+      await run;
+    } finally {
+      await admin.close();
+    }
+  });
+
+  it('returns a workflow_run admin error without any reminder', async () => {
+    const admin = await startFakeAdminServer((request) => ({
+      id: request.id,
+      ok: false,
+      error: {
+        code: 'WORKFLOW_START_FAILED',
+        message: 'workflow could not start',
+      },
+    }));
+    try {
+      const input = new PassThrough();
+      const output = new PassThrough();
+      const reader = new JsonLineReader(output);
+      const run = runTeamMateMcp({
+        dispatcherId: 'dispatcher-a',
+        callerKind: 'dispatcher',
+        adminSocketPath: admin.socketPath,
+        input,
+        output,
+        log: () => {},
+      });
+
+      writeJson(input, {
+        jsonrpc: '2.0',
+        id: 1,
+        method: 'tools/call',
+        params: {
+          name: 'workflow_run',
+          arguments: {
+            script:
+              'export const meta = { name: "x", description: "x" }; return null;',
+          },
+        },
+      });
+
+      const response = (await reader.next()) as {
+        result: Record<string, unknown>;
+      };
+      expect(response).toMatchObject({
+        jsonrpc: '2.0',
+        id: 1,
+        result: {
+          isError: true,
+          content: [{
+            text: '[WORKFLOW_START_FAILED] workflow could not start',
+          }],
+        },
+      });
+      expect(response.result).not.toHaveProperty('structuredContent');
+      expect(JSON.stringify(response)).not.toContain(
+        WORKFLOW_RUN_SUCCESS_REMINDER,
+      );
+      expect(JSON.stringify(response)).not.toContain(
+        TEAMMATE_DISPATCH_SUCCESS_REMINDER,
+      );
 
       input.end();
       await run;

--- a/packages/dreamux/tests/teammate-mcp.test.ts
+++ b/packages/dreamux/tests/teammate-mcp.test.ts
@@ -319,6 +319,26 @@ describe('teammate-mcp stdio shim', () => {
           },
         },
       });
+      const successfulRunResult = runResponse as {
+        result: {
+          content: Array<{ text: string }>;
+          structuredContent: { reminder: string };
+        };
+      };
+      const structuredReminder =
+        successfulRunResult.result.structuredContent.reminder;
+      expect(structuredReminder).toBe(WORKFLOW_RUN_SUCCESS_REMINDER);
+      expect(structuredReminder).toMatch(/background/i);
+      expect(structuredReminder).toMatch(/automatically pushes/i);
+      expect(structuredReminder).toMatch(/terminal completion/i);
+      expect(structuredReminder).toMatch(/caller'?s current context/i);
+      expect(structuredReminder).toMatch(
+        /unless the user explicitly asks[\s\S]*do not call or poll workflow_status/i,
+      );
+      expect(structuredReminder).toMatch(/wait for the system push/i);
+      expect(successfulRunResult.result.content[0]?.text).toContain(
+        structuredReminder,
+      );
       expect(JSON.stringify(runResponse)).not.toContain(
         TEAMMATE_DISPATCH_SUCCESS_REMINDER,
       );


### PR DESCRIPTION
## Summary

- add a workflow-specific reminder to successful `workflow_run` MCP results
- tell agents that the run continues in the background and its terminal completion is pushed into the current context automatically
- gate the reminder on the mapped `workflow.run` admin method so `workflow_status`, `workflow_stop`, `workflow_list`, and existing Team/TeamMate dispatch responses remain unchanged

## Tests

- `node ../../common/scripts/install-run-rushx.js test tests/teammate-mcp.test.ts tests/team-mcp.test.ts` (28 passed)
- `node common/scripts/install-run-rush.js build`
- `node common/scripts/install-run-rush.js smoke-built-cli`
- `node common/scripts/install-run-rush.js typecheck`
- `node common/scripts/install-run-rush.js typecheck:tests`
- `node common/scripts/install-run-rush.js lint`
- `.agents/scripts/check.sh`
- `node common/scripts/install-run-rush.js change --verify --target-branch origin/next --no-fetch`
- `DREAMUX_SKIP_LIVE_CODEX=1 node common/scripts/install-run-rush.js test`

## Live Codex Boundary

The unskipped full test run reached real Codex 0.147.0 but two existing live tests timed out outside this change's MCP response path:

- portable structured output: Codex emitted `Reconnecting... 2/5` through `5/5` and never settled the turn
- issue #63 inbound gate: the model turn started but never began the expected command execution before the timeout

All non-live workspace tests pass with the repository's explicit `DREAMUX_SKIP_LIVE_CODEX=1` boundary.
