### PR TITLE
test: isolate collaboration worktree fixture

### DIFF
--- a/common/changes/@excitedjs/dreamux/dreamux-worktree-residue-audit_2026-08-15-05-01.json
+++ b/common/changes/@excitedjs/dreamux/dreamux-worktree-residue-audit_2026-08-15-05-01.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Isolate the collaboration provisioning test Git fixture so repeated runs cannot leave stale worktree registrations in the host checkout.",
+      "type": "none",
+      "packageName": "@excitedjs/dreamux"
+    }
+  ],
+  "packageName": "@excitedjs/dreamux",
+  "email": "15624809+YourWildDad@users.noreply.github.com"
+}

--- a/packages/dreamux/tests/dispatcher-collaboration-space.test.ts
+++ b/packages/dreamux/tests/dispatcher-collaboration-space.test.ts
@@ -1,6 +1,14 @@
+import { execFile } from 'node:child_process';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { mkdirSync, mkdtempSync, realpathSync, rmSync } from 'node:fs';
+import {
+  mkdirSync,
+  mkdtempSync,
+  realpathSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
 import { join } from 'node:path';
+import { promisify } from 'node:util';
 
 import type {
   AgentRuntime,
@@ -49,6 +57,7 @@ import { createFakeFeishuBot } from './helpers/fake-feishu-bot.js';
 
 const RUNTIME_REF = 'test:runtime';
 const CHANNEL_REF = 'test:channel';
+const execFileAsync = promisify(execFile);
 
 const CAPABILITIES: AgentRuntimeCapabilities = {
   resume: { supported: false },
@@ -955,9 +964,18 @@ describe('DispatcherService collaboration-space routing', () => {
   });
 
   it('provisions from neutral inbound container before delivery', async () => {
+    const sourceRepoPath = join(root, 'source');
+    mkdirSync(sourceRepoPath, { recursive: true });
+    const repo = realpathSync(sourceRepoPath);
+    const git = async (args: string[]) => execFileAsync('git', args, { cwd: repo });
+    await git(['init', '--initial-branch=main', '-q']);
+    await git(['config', 'user.email', 'test@example.com']);
+    await git(['config', 'user.name', 'Test']);
+    writeFileSync(join(repo, 'README.md'), '# source\n');
+    await git(['add', '.']);
+    await git(['commit', '-qm', 'init']);
     const workspace = join(root, 'workspace');
     mkdirSync(workspace, { recursive: true });
-    const repo = process.cwd();
     const config = testDreamuxConfig([
       testDispatcherConfig({
         id: 'flow',


### PR DESCRIPTION
## Summary

- isolate the collaboration-space provisioning test from the developer's real Git checkout
- initialize the test source repository inside the existing temporary fixture root
- prevent repeated test runs from leaving prunable worktree registrations in the host repository

## Validation

- `node common/scripts/install-run-rush.js build --to @excitedjs/dreamux`
- `node common/scripts/install-run-rush.js typecheck --to @excitedjs/dreamux`
- `node common/scripts/install-run-rush.js lint --to @excitedjs/dreamux`
- `packages/dreamux/node_modules/.bin/vitest run tests/dispatcher-collaboration-space.test.ts`
- `packages/dreamux/node_modules/.bin/tsc -p packages/dreamux/tsconfig.tests.json --noEmit`
- repeated the focused test twice and confirmed the host repository worktree, matching-branch, and prunable counts remained unchanged

## Limitations

- The full Rush test run reached the changed test successfully, but two unrelated live Codex tests timed out while reconnecting to the external service.
