### PR TITLE
ci(release): push protected branches with the release deploy key

### DIFF
--- a/.agents/reference/release-process.md
+++ b/.agents/reference/release-process.md
@@ -33,14 +33,36 @@ debug dump; see [Promotion step](#4-promotion-stable) below.
 
 | Branch | Purpose | Lifetime | Protected |
 |---|---|---|---|
-| `main` | Stable npm `latest` head; one commit per release plus `[skip ci]` version bumps | permanent | push restricted to `github-actions[bot]` only |
-| `next` | Default PR base; beta channel head | permanent | squash-merge only via PR; bot allowed to fast-forward on release |
+| `main` | Stable npm `latest` head; one commit per release plus `[skip ci]` version bumps | permanent | ruleset PR gate; only the release deploy key pushes directly |
+| `next` | Default PR base; beta channel head | permanent | squash-merge only via PR (1 approval); release deploy key may fast-forward on release |
 | `feature/<slug>` | In-progress work for one PR | lives from branch-off to PR merge; PR squash merge deletes it | no |
 | `team/<slug>` | Reserved for TeamMate team integration branches; merged via PR | same as feature | no |
 
 PRs target `next`, never `main`. The GitHub repo default branch is
 `next`. Hotfixes, like every other change, land on `next` first and
 ship through the normal promote path.
+
+## Branch protection model
+
+Two layers guard `main` and `next`:
+
+- **Classic branch protection** on each branch blocks force pushes and
+  deletions and applies to administrators (`enforce_admins`). It carries
+  no pull-request rule.
+- **Repository ruleset `release-branch-pr-gate`** (targets
+  `refs/heads/main` and `refs/heads/next`) requires a pull request with
+  1 approving review for every ordinary actor — including
+  administrators and `github-actions[bot]` — and lists **deploy keys**
+  as its only bypass actor.
+
+The bypass exists because GitHub cannot exempt the Actions app from a
+pull-request rule (neither classic protection nor rulesets accept it as
+a bypass actor). The release pipeline therefore pushes over SSH with the
+repository's read-write deploy key `release-pipeline`; its private half
+lives in the Actions secret `RELEASE_DEPLOY_KEY`, and both pushing
+workflows fail loudly when the secret is missing. Rotating the key means:
+generate a new keypair, replace the deploy key and the secret — no
+workflow change.
 
 ## The four-step path
 
@@ -179,28 +201,23 @@ Pipeline steps:
    main already equals next (nothing to promote); the remaining steps
    below all skip on `noop`.
 
-5. **Push `main` to origin.**
-   Uses the workflow `GITHUB_TOKEN` (not a PAT) as the
-   `github-actions[bot]` identity. Main branch protection must allow
-   this identity.
-
-   *Known GitHub behavior:* A `git push` performed with the default
-   workflow `GITHUB_TOKEN` does **not** re-trigger `on.push.main` in
-   release.yml. This is GitHub's documented anti-infinite-loop guard.
-   The next step therefore nudges release.yml explicitly.
-
-6. **Dispatch release.yml on the freshly pushed main.**
-   `gh workflow run release.yml --ref main`, using the same
-   `GITHUB_TOKEN` (this is why promote-next declares
-   `permissions.actions: write`). Prints the newest release run URL
-   back into the promote-next log so the operator can follow along.
+5. **Push `main` to origin with the release deploy key.**
+   The push authenticates over SSH as the repository's release deploy
+   key — the `release-branch-pr-gate` ruleset's bypass actor (see
+   [Branch protection model](#branch-protection-model)); `GITHUB_TOKEN`
+   stays `contents: read`. A deploy-key push is an ordinary push, so
+   `on.push.main` in release.yml fires by itself and no dispatch step
+   exists. If the promoted HEAD commit message ever contains
+   `[skip ci]`, or the triggered run must be retried, dispatch
+   release.yml against `main` by hand — manual dispatch remains the
+   retry hook.
 
 Source reference: promote-next.yml header comments document this
-six-step shape and the known coupling to release.yml.
+five-step shape and the push-triggered coupling to release.yml.
 
-### 5. Stable version + publish (chained off promote-next step 6)
+### 5. Stable version + publish (triggered by the promote push)
 
-The dispatch from promote-next lands on release.yml targeting `main`.
+The deploy-key push of `main` fires release.yml's `on.push` trigger.
 Two jobs run in sequence; the `prerelease` job for stable branches is
 intentionally skipped.
 
@@ -212,9 +229,10 @@ intentionally skipped.
   If no change files are present, `should_publish=false` and both the
   version bump and the subsequent publish step short-circuit.
 - Produces one commit on main:
-  `chore(release): version packages [skip ci]`. The `[skip ci]` footer
-  prevents the push from re-triggering release.yml if someone later
-  adds a push-based trigger to main again.
+  `chore(release): version packages [skip ci]`, pushed with the release
+  deploy key. The `[skip ci]` footer is load-bearing: deploy-key pushes
+  are visible to `on.push`, and this footer is what stops the bump push
+  (and its next-sync below) from retriggering release.yml.
 - **Critical invariant repair step — `sync next onto the freshly bumped main`.**
   Immediately after pushing the version commit to main, the version
   job fetches `next`, compares its SHA to `HEAD^` (the pre-bump main
@@ -260,9 +278,10 @@ Related decision:
 | Failure | Where caught | Recovery |
 |---|---|---|
 | Topology violation: main is not an ancestor of next | promote-next step 3 | Read the divergence-dump section of the log. (a) If main shows only `chore(release)` commits from a prior release, re-anchor next: cherry-pick the `[skip ci]` bump onto next or force-align next to main at the release SHA, then re-run promote. (b) If main shows a non-release commit, that is a process bug — remove/revert it from main and land the change through the normal PR→next path instead. |
-| GITHUB_TOKEN push of main did not trigger release.yml | promote-next logs; absence of a new release run URL | Built-in to promote-next V2: the dispatch step (step 6) is the explicit workaround. If this ever appears to regress, re-check that `permissions.actions: write` is still declared and that `gh` still ships on `ubuntu-latest`. |
+| Promote push of main did not trigger release.yml | Actions tab: no new release run on main after promote | Check whether the promoted HEAD commit message contains `[skip ci]` (workflows are skipped for it). Recovery either way: `Actions → release.yml → Run workflow → main` — manual dispatch is the designed retry hook. |
+| Pipeline push rejected (GH013 rule violations) or deploy-key auth failed | promote-next push step / release.yml version job logs | Verify the `release-branch-pr-gate` ruleset still lists deploy keys as bypass actors, the `release-pipeline` deploy key still exists with write access, and the `RELEASE_DEPLOY_KEY` secret matches it. The setup steps already fail loudly when the secret is absent. |
 | version job produced the bump commit, but publish failed mid-upload | release.yml publish job logs | Re-run the workflow with the same commit via `Actions → release.yml → Run workflow → main`. The version job detects the bump commit has already been produced (change files consumed, no diff in `packages/` and `common/changes/`) and short-circuits with `should_publish=true` on `workflow_dispatch` so only the publish job re-runs. Do not push a new commit just to re-trigger CI. |
-| Version bump was pushed but sync-next step failed | release.yml version step | Verify next branch protection allows the `github-actions[bot]` identity to push. If `next` moved between the bump and the sync, the step logs "Skipping next sync" intentionally; the next PR merged into next will land on top of the pre-release state from the prior beta, and promote-next will still fast-forward because the beta branch is a descendant of main. |
+| Version bump was pushed but sync-next step failed | release.yml version step | Verify the deploy-key bypass (previous row) is intact for `next`. If `next` moved between the bump and the sync, the step logs "Skipping next sync" intentionally; the next PR merged into next will land on top of the pre-release state from the prior beta, and promote-next will still fast-forward because the beta branch is a descendant of main. |
 | Author email fails commit-metadata CI gate | PR CI, or pre-commit hook locally | Fix with `git config user.email <your-github-email>`. Privacy addresses (`*@users.noreply.github.com`) are explicitly allowed. Local pre-commit hook mirrors the CI check; run `rush update` (or `rush install`) to ensure the hook is wired. |
 | Rush change verify fails on a workflow-only PR | PR CI `rush-change-status` job | Generate a `type: none` change file for the package whose workflow or surface is being altered. Workflow-only changes still need a paper trail in the CHANGELOG. |
 

--- a/.github/workflows/promote-next.yml
+++ b/.github/workflows/promote-next.yml
@@ -19,30 +19,33 @@
 #      rebase, and true merge commits all rewrite commit metadata on
 #      main and would drop the link between a beta.<run_number> publish
 #      and the exact commit that shipped as stable.
-#   4. Push the fast-forwarded main back to origin.
-#   5. Dispatch release.yml against the freshly pushed main via
-#      `gh workflow run release.yml --ref main`. The explicit dispatch is
-#      required because step (4) uses the built-in GITHUB_TOKEN, and
-#      GitHub's documented anti-infinite-loop guard prevents a
-#      GITHUB_TOKEN-originated `git push` from re-triggering other
-#      workflows. `on.push.main` in release.yml therefore does NOT fire
-#      automatically; coupling is still git-topology-based (the ref to be
-#      released is `main` at its newly fast-forwarded SHA), we just nudge
-#      the other workflow ourselves.
+#   4. Push the fast-forwarded main back to origin over SSH with the
+#      release deploy key. The `release-branch-pr-gate` repository ruleset
+#      requires pull requests on main/next for every ordinary actor and
+#      GitHub cannot grant the Actions app a bypass, so the ruleset lists
+#      deploy keys as its bypass actor and this push authenticates as the
+#      repository's release deploy key instead of GITHUB_TOKEN.
+#   5. A deploy-key push is an ordinary push, so `on.push.main` in
+#      release.yml fires by itself — no explicit dispatch step. (The old
+#      GITHUB_TOKEN push was invisible to other workflows under GitHub's
+#      anti-infinite-loop guard and needed a manual `gh workflow run`
+#      nudge.) If the promoted HEAD commit message ever contains
+#      [skip ci], or the auto-triggered run must be retried, dispatch
+#      release.yml against main by hand — manual dispatch remains the
+#      documented retry hook.
 #
-# Permissions:
-#   contents:write  — push the fast-forwarded main back.
-#   actions:write   — dispatch the release.yml workflow after the push.
-#   Using the workflow GITHUB_TOKEN (not a PAT) keeps this workflow
-#   self-contained. The main branch protection must allow the
-#   `github-actions[bot]` identity to bypass or satisfy push rules,
-#   exactly as the release.yml version job already requires.
+# Push identity:
+#   The Actions secret RELEASE_DEPLOY_KEY holds the private half of the
+#   read-write repository deploy key "release-pipeline"; its public half
+#   is registered on this repository and the ruleset lists deploy keys as
+#   bypass actors. The workflow fails loudly when the secret is missing.
+#   GITHUB_TOKEN stays contents:read — nothing here pushes with it.
 #
 # Operator usage:
 #   Actions → promote-next → Run workflow → Run (no inputs).
 #   A single click drives the whole stable-release path:
-#     topo guard → ff merge → push main → dispatch release.yml →
-#     release.yml version job → release.yml publish → npm `latest`.
+#     topo guard → ff merge → deploy-key push main → release.yml
+#     on.push → version job → publish → npm `latest`.
 
 name: promote-next
 
@@ -54,8 +57,7 @@ concurrency:
   cancel-in-progress: false
 
 permissions:
-  contents: write
-  actions: write
+  contents: read
 
 jobs:
   promote:
@@ -131,43 +133,30 @@ jobs:
             echo "noop=false" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: push main to origin
+      - name: set up release deploy key (ruleset bypass push identity)
         if: steps.ff.outputs.noop != 'true'
         env:
-          GITHUB_TOKEN: ${{ github.token }}
+          RELEASE_DEPLOY_KEY: ${{ secrets.RELEASE_DEPLOY_KEY }}
         run: |
           set -euo pipefail
-          git config user.name  'github-actions[bot]'
-          git config user.email 'github-actions[bot]@users.noreply.github.com'
-          git remote set-url origin \
-            "https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
-          git push origin main
-          echo "Pushed main → origin."
-          echo "Next step dispatches release.yml on the new main explicitly."
-
-      - name: dispatch release.yml on main (stable publish)
-        if: steps.ff.outputs.noop != 'true'
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
-        run: |
-          set -euo pipefail
-          # Required because GitHub deliberately prevents a `git push` made
-          # with the default GITHUB_TOKEN from triggering new workflow runs
-          # (anti-infinite-loop guard). Without this explicit dispatch, the
-          # on.push.main trigger in release.yml would silently not fire.
-          # `gh` is preinstalled on ubuntu-latest.
-          gh workflow run release.yml --ref main
-          sleep 5
-          # Print the newest release.yml run URL for convenience (best-effort)
-          run_url=$(gh run list \
-            --workflow release.yml \
-            --branch main \
-            --limit 1 \
-            --json url \
-            --jq '.[0].url' \
-            || true)
-          if [ -n "$run_url" ]; then
-            echo "release.yml run: $run_url"
-          else
-            echo "release.yml was dispatched; check Actions tab for the latest main run."
+          if [ -z "${RELEASE_DEPLOY_KEY}" ]; then
+            echo "::error::RELEASE_DEPLOY_KEY secret is missing; the ruleset-protected main branch cannot be pushed without the release deploy key."
+            exit 1
           fi
+          mkdir -p ~/.ssh
+          printf '%s\n' "${RELEASE_DEPLOY_KEY}" > ~/.ssh/release_deploy_key
+          chmod 600 ~/.ssh/release_deploy_key
+          # Pin GitHub's SSH host keys from the meta API instead of trusting
+          # first use.
+          curl -fsS https://api.github.com/meta \
+            | jq -r '.ssh_keys[] | "github.com " + .' > ~/.ssh/release_known_hosts
+
+      - name: push main to origin (deploy key)
+        if: steps.ff.outputs.noop != 'true'
+        env:
+          GIT_SSH_COMMAND: ssh -i ~/.ssh/release_deploy_key -o IdentitiesOnly=yes -o UserKnownHostsFile=~/.ssh/release_known_hosts
+        run: |
+          set -euo pipefail
+          git push "git@github.com:${GITHUB_REPOSITORY}.git" main
+          echo "Pushed main → origin via the release deploy key."
+          echo "release.yml triggers on this push by itself (deploy-key pushes are visible to on.push)."

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,10 +34,16 @@
 # Manual dispatch against main is a retry hook for stable only; stable npm
 # publishes must not come from feature branches.
 #
-# When a version bump is needed, the release job pushes the generated
-# package.json / CHANGELOG commit back to main with the workflow GITHUB_TOKEN.
-# This repository's main protection must continue to allow that bot push, or a
-# future stricter protection rule must grant github-actions[bot] a bypass.
+# When a version bump is needed, the version job pushes the generated
+# package.json / CHANGELOG commit back to main (and re-syncs next) over SSH
+# with the release deploy key (Actions secret RELEASE_DEPLOY_KEY, public half
+# registered as the read-write deploy key "release-pipeline"). The
+# `release-branch-pr-gate` repository ruleset requires pull requests on
+# main/next for every ordinary actor — GitHub cannot exempt the Actions app —
+# and lists deploy keys as its bypass actor, so the deploy key is the only
+# push identity available to this pipeline. The job fails loudly when the
+# secret is missing. The bump commit carries [skip ci], so its deploy-key
+# push does not retrigger this workflow.
 #
 # Prerelease channels reuse this same file (and therefore the same npm
 # trusted-publisher entry, Workflow: release.yml). Pushes to `next` publish
@@ -62,8 +68,7 @@ concurrency:
   cancel-in-progress: false
 
 permissions:
-  contents: write
-  id-token: write
+  contents: read
 
 jobs:
   version:
@@ -72,7 +77,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     permissions:
-      contents: write
+      contents: read
     outputs:
       should_publish: ${{ steps.version.outputs.should_publish }}
     steps:
@@ -84,6 +89,25 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: '22.x'
+
+      - name: Set up release deploy key (ruleset bypass push identity)
+        # Unconditional and fail-loud: a release run that cannot push the
+        # version bump must die here, not after change files were applied.
+        env:
+          RELEASE_DEPLOY_KEY: ${{ secrets.RELEASE_DEPLOY_KEY }}
+        run: |
+          set -euo pipefail
+          if [ -z "${RELEASE_DEPLOY_KEY}" ]; then
+            echo "::error::RELEASE_DEPLOY_KEY secret is missing; the ruleset-protected main/next branches cannot be pushed without the release deploy key."
+            exit 1
+          fi
+          mkdir -p ~/.ssh
+          printf '%s\n' "${RELEASE_DEPLOY_KEY}" > ~/.ssh/release_deploy_key
+          chmod 600 ~/.ssh/release_deploy_key
+          # Pin GitHub's SSH host keys from the meta API instead of trusting
+          # first use.
+          curl -fsS https://api.github.com/meta \
+            | jq -r '.ssh_keys[] | "github.com " + .' > ~/.ssh/release_known_hosts
 
       - name: Apply pending change files (rush)
         id: version
@@ -127,15 +151,14 @@ jobs:
       - name: Push version bump
         if: steps.version.outputs.changed == 'true'
         env:
-          GITHUB_TOKEN: ${{ github.token }}
+          GIT_SSH_COMMAND: ssh -i ~/.ssh/release_deploy_key -o IdentitiesOnly=yes -o UserKnownHostsFile=~/.ssh/release_known_hosts
         run: |
           set -euo pipefail
           git config user.name 'github-actions[bot]'
           git config user.email 'github-actions[bot]@users.noreply.github.com'
           git add packages common/changes
           git commit -m "chore(release): version packages [skip ci]"
-          git remote set-url origin "https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
-          git push origin HEAD:"${GITHUB_REF_NAME}"
+          git push "git@github.com:${GITHUB_REPOSITORY}.git" HEAD:"${GITHUB_REF_NAME}"
 
       - name: sync next onto the freshly bumped main (topology invariant)
         # The long-lived fast-forward contract between next and main is:
@@ -160,7 +183,7 @@ jobs:
         # refused to run earlier).
         if: github.ref == 'refs/heads/main' && steps.version.outputs.changed == 'true'
         env:
-          GITHUB_TOKEN: ${{ github.token }}
+          GIT_SSH_COMMAND: ssh -i ~/.ssh/release_deploy_key -o IdentitiesOnly=yes -o UserKnownHostsFile=~/.ssh/release_known_hosts
         run: |
           set -euo pipefail
           git fetch origin next
@@ -172,7 +195,7 @@ jobs:
           # normal fast-forward path.
           pre_bump_sha=$(git rev-parse HEAD^)
           if [ "$old_next_sha" = "$pre_bump_sha" ]; then
-            git push origin "refs/heads/main:refs/heads/next"
+            git push "git@github.com:${GITHUB_REPOSITORY}.git" "refs/heads/main:refs/heads/next"
             echo "Sync next ${old_next_sha} → ${new_main_sha} (release bump only)."
           else
             echo "Skipping next sync: next already moved (${old_next_sha}) past pre-bump (${pre_bump_sha})."

--- a/common/changes/@excitedjs/dreamux/release-deploy-key-pipeline_2026-08-25-20-10.json
+++ b/common/changes/@excitedjs/dreamux/release-deploy-key-pipeline_2026-08-25-20-10.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@excitedjs/dreamux",
+      "comment": "Release pipeline pushes to the protected main/next branches now authenticate with the repository release deploy key under the release-branch-pr-gate ruleset; promote-next relies on the push-triggered release run instead of an explicit dispatch. No package behavior or version change.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@excitedjs/dreamux"
+}


### PR DESCRIPTION
## Problem

Stable releases were blocked by branch protection: the `promote-next` push of `main` and the release version job's bump/next-sync pushes all run as `github-actions[bot]`, and GitHub offers no way to exempt the Actions app from a pull-request rule — classic protection silently drops it from `bypass_pull_request_allowances`, and rulesets reject it as a bypass actor (422). The operator had to lift protection by hand for every release; the 2026-08-16 release broke the main-ancestor-of-next invariant exactly this way when its next-sync push was rejected.

## Repository settings (already applied and verified)

- Read-write deploy key **release-pipeline** registered; private half stored as Actions secret **RELEASE_DEPLOY_KEY**.
- New repository ruleset **release-branch-pr-gate**: requires a PR with 1 approving review on `main` and `next` for every ordinary actor (including admins and the bot), with **deploy keys** as the only bypass actor.
- Classic protection on both branches keeps force-push/deletion blocks and `enforce_admins`, but no longer carries the PR rule (the ruleset owns it).
- Empirically verified on a scratch ruleset-covered branch: ordinary-credential push → rejected with GH013; deploy-key push → accepted.

## Workflow changes

- `promote-next.yml`: the `main` push authenticates over SSH with the deploy key (host keys pinned from the GitHub meta API; fail-loud when the secret is missing). Because a deploy-key push is an ordinary push, `on.push.main` fires release.yml by itself — the explicit `gh workflow run` dispatch step (the GITHUB_TOKEN anti-loop workaround) is removed, and permissions shrink to `contents: read`.
- `release.yml`: the version job's bump push and next-sync push use the same deploy-key SSH identity; the bump commit's `[skip ci]` footer becomes the load-bearing guard against retriggering. Top-level and version-job permissions shrink to `contents: read` (publish jobs keep their own `id-token: write`).
- `.agents/reference/release-process.md`: documents the two-layer protection model, the five-step promote shape, the push-triggered coupling, and updated failure/recovery rows. KB gate green.
- `type: none` change file for the paper trail; no package behavior or version change.

## Notes for review

- The next stable release is the first end-to-end exercise of the new push path; the deploy-key bypass itself is already proven against the ruleset.
- Key rotation = replace the deploy key + secret; no workflow change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)