### PR TITLE
test: restore Feishu COT contract coverage

### DIFF
--- a/.agents/tasks/architecture/minimize-provider-boundaries/README.md
+++ b/.agents/tasks/architecture/minimize-provider-boundaries/README.md
@@ -623,6 +623,12 @@ architecture merely because it is possible.
   gating, with one in-flight lookup shared by concurrent messages. Scope is the
   Feishu transport implementation, focused tests, and its Rush change note;
   the separate empty-TeamLeader recovery defect is explicitly excluded.
+- Post-merge COT test-coverage correction: Approved by the operator on
+  2026-08-31 for a new PR branched from the merged `next` head. Scope is the
+  test-related portion of issue #352: restore direct behavior-level coverage
+  for the current Feishu COT adapter/session contracts and replace the accepted
+  source-text mirror assertions with behavior-level or proper static-boundary
+  coverage. The canonical-KB portion of #352 is not part of this correction.
 
 ## Delivery
 

--- a/common/changes/@excitedjs/dreamux/test-feishu-cot-coverage_2026-08-31-11-42.json
+++ b/common/changes/@excitedjs/dreamux/test-feishu-cot-coverage_2026-08-31-11-42.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Restore and strengthen test coverage without changing published package behavior.",
+      "type": "none",
+      "packageName": "@excitedjs/dreamux"
+    }
+  ],
+  "packageName": "@excitedjs/dreamux",
+  "email": "15624809+YourWildDad@users.noreply.github.com"
+}

--- a/common/changes/@excitedjs/feishu-channel/test-feishu-cot-coverage_2026-08-31-11-42.json
+++ b/common/changes/@excitedjs/feishu-channel/test-feishu-cot-coverage_2026-08-31-11-42.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Restore and strengthen test coverage without changing published package behavior.",
+      "type": "none",
+      "packageName": "@excitedjs/feishu-channel"
+    }
+  ],
+  "packageName": "@excitedjs/feishu-channel",
+  "email": "15624809+YourWildDad@users.noreply.github.com"
+}

--- a/packages/channel/feishu-channel/tests/feishu-cot-adapter.test.ts
+++ b/packages/channel/feishu-channel/tests/feishu-cot-adapter.test.ts
@@ -1,0 +1,921 @@
+/**
+ * The live COT card state machine (COVERAGE CELL F).
+ *
+ * Everything here is asserted through the *platform* surface: what the adapter
+ * did is exactly the sequence of create / append / complete requests the real
+ * transport would have issued, with each AG-UI event decoded back out of the
+ * wire body. No private field is read and no internal method is called — the
+ * adapter's only inputs are neutral Core turn events plus this Channel's own
+ * anchors and route facts, and its only output is those requests.
+ *
+ * The contracts this pins, per issue #352:
+ *   - reply-anchor lifecycle and routing fences;
+ *   - append batching under the platform budgets;
+ *   - turn-settlement projection;
+ *   - conversation activity bounds;
+ *   - failure isolation and error redaction;
+ *   - close behavior and the state it leaves behind.
+ */
+import { describe, expect, it, vi } from 'vitest';
+
+import { FeishuCotApiError } from '@excitedjs/feishu-transport';
+
+import { createFakeCotClient, settleCot } from './helpers/fake-cot-client.js';
+import {
+  anchor,
+  assistant,
+  DISPATCHER_AGENT,
+  dispatcherAssistant,
+  dispatcherSettled,
+  dispatcherSubmitted,
+  groupTarget,
+  harness,
+  LEADER,
+  openLeaderCard,
+  settled,
+  submitted,
+  TEAM,
+  teamState,
+  threadTarget,
+  toolCall,
+  userMessage,
+  type CotHarness,
+} from './helpers/cot-fixtures.js';
+import { chatTarget } from '../src/routing/target.js';
+
+const RECEIPT = '已收到消息，开始处理。';
+
+function cotIdOf(h: CotHarness, index: number): string {
+  const created = h.cot.createRequests();
+  if (created.length <= index) {
+    throw new Error(`no COT was created at index ${index}`);
+  }
+  return `cot-${index + 1}`;
+}
+
+function textOn(h: CotHarness, cotId: string): string {
+  return h.cot
+    .eventsFor(cotId)
+    .filter((event) => event.eventType === 'TEXT_MESSAGE_CONTENT')
+    .map((event) => String(event.content['delta']))
+    .join('');
+}
+
+function finishStatuses(h: CotHarness, cotId: string): string[] {
+  return h.cot
+    .eventsFor(cotId)
+    .filter((event) => event.eventType === 'RUN_FINISHED')
+    .map((event) => String(event.content['status']));
+}
+
+function originOf(h: CotHarness, index: number): {
+  receiveId: unknown;
+  originMessageId: unknown;
+} {
+  const request = h.cot.createRequests()[index];
+  return {
+    receiveId: request?.data?.['receive_id'],
+    originMessageId: request?.data?.['origin_message_id'],
+  };
+}
+
+async function openSettledLeaderCard(h: CotHarness): Promise<void> {
+  openLeaderCard(h);
+  await settleCot();
+  h.adapter.onTurnSettled(settled());
+  await settleCot();
+}
+
+describe('a card opens under the exact visible message its turn came from', () => {
+  it('creates the card eagerly with a receipt line, on the anchor the session supplied', async () => {
+    const h = harness();
+
+    openLeaderCard(h, { messageId: 'om-inbound-1' });
+    await settleCot();
+
+    expect(h.cot.createRequests()).toHaveLength(1);
+    expect(originOf(h, 0)).toEqual({
+      receiveId: groupTarget().chatId,
+      originMessageId: 'om-inbound-1',
+    });
+    expect(h.cot.eventTypesFor(cotIdOf(h, 0))).toEqual([
+      'RUN_STARTED',
+      'TEXT_MESSAGE_START',
+      'TEXT_MESSAGE_CONTENT',
+      'TEXT_MESSAGE_END',
+    ]);
+    expect(textOn(h, cotIdOf(h, 0))).toBe(RECEIPT);
+    await h.adapter.close();
+  });
+
+  it('creates nothing for a submission whose anchor names no real visible message', async () => {
+    const h = harness();
+
+    h.adapter.onAnchoredSubmission({
+      event: submitted(),
+      anchor: { ...anchor('om-1'), messageId: '' },
+    });
+    // A team_leader event with no Team is not a leader conversation at all.
+    h.adapter.onAnchoredSubmission({
+      event: submitted({ team_name: null }),
+      anchor: anchor('om-2'),
+    });
+    await settleCot();
+
+    expect(h.cot.requests).toHaveLength(0);
+    await h.adapter.close();
+  });
+
+  it('keeps a Reply as the *next* card\'s anchor, leaving the open card where it is', async () => {
+    const h = harness();
+    openLeaderCard(h, { messageId: 'om-inbound-1' });
+    await settleCot();
+
+    // The leader replied; that reply becomes the anchor for the next card only.
+    h.adapter.refreshNextAnchor(TEAM, LEADER, anchor('om-reply-1'));
+    h.adapter.onTurnMessage(assistant({ content: '仍在当前卡片' }));
+    await settleCot();
+
+    expect(h.cot.createRequests()).toHaveLength(1);
+    expect(textOn(h, cotIdOf(h, 0))).toContain('仍在当前卡片');
+
+    // Settle, then let a continuation open the next card: it lands on the reply.
+    h.adapter.onTurnSettled(settled());
+    await settleCot();
+    h.adapter.onTurnSubmitted(
+      submitted({ turn_id: 'turn-2', turn_source: 'task-notification' }),
+    );
+    h.adapter.onTurnMessage(
+      userMessage({ turn_id: 'turn-2', event_id: 'evt-user-2', content: '任务完成' }),
+    );
+    await settleCot();
+
+    expect(h.cot.createRequests()).toHaveLength(2);
+    expect(originOf(h, 1).originMessageId).toBe('om-reply-1');
+    await h.adapter.close();
+  });
+
+  it('ignores a Reply anchor pointing into a different conversation', async () => {
+    const h = harness();
+    openLeaderCard(h, { messageId: 'om-inbound-1' });
+    await settleCot();
+    h.adapter.onTurnSettled(settled());
+    await settleCot();
+
+    h.adapter.refreshNextAnchor(
+      TEAM,
+      LEADER,
+      anchor('om-elsewhere', chatTarget('oc-other', 'group')),
+    );
+    h.adapter.onTurnSubmitted(
+      submitted({ turn_id: 'turn-2', turn_source: 'cron' }),
+    );
+    h.adapter.onTurnMessage(
+      userMessage({ turn_id: 'turn-2', event_id: 'evt-user-2', content: '定时触发' }),
+    );
+    await settleCot();
+
+    // The standing anchor is still the inbound message this Team is watched at.
+    expect(originOf(h, 1).originMessageId).toBe('om-inbound-1');
+    await h.adapter.close();
+  });
+
+  it('never lets a binding fallback anchor displace an anchor the conversation already has', async () => {
+    const h = harness();
+    openLeaderCard(h, { messageId: 'om-inbound-1' });
+    await settleCot();
+    h.adapter.onTurnSettled(settled());
+    await settleCot();
+
+    h.adapter.setFallbackAnchorIfAbsent(TEAM, LEADER, anchor('om-notification-1'));
+    h.adapter.onTurnSubmitted(
+      submitted({ turn_id: 'turn-2', turn_source: 'task-notification' }),
+    );
+    h.adapter.onTurnMessage(
+      userMessage({ turn_id: 'turn-2', event_id: 'evt-user-2', content: '任务完成' }),
+    );
+    await settleCot();
+
+    expect(originOf(h, 1).originMessageId).toBe('om-inbound-1');
+    await h.adapter.close();
+  });
+
+  it('uses a binding fallback anchor when the Team has never been talked to here', async () => {
+    const h = harness();
+
+    h.adapter.setFallbackAnchorIfAbsent(TEAM, LEADER, anchor('om-notification-1'));
+    h.adapter.onTurnSubmitted(
+      submitted({ turn_id: 'turn-2', turn_source: 'task-notification' }),
+    );
+    h.adapter.onTurnMessage(
+      userMessage({ turn_id: 'turn-2', event_id: 'evt-user-2', content: '任务完成' }),
+    );
+    await settleCot();
+
+    expect(h.cot.createRequests()).toHaveLength(1);
+    expect(originOf(h, 0).originMessageId).toBe('om-notification-1');
+    await h.adapter.close();
+  });
+});
+
+describe('which turns a conversation narrates', () => {
+  it('admits a completion or a cron fire onto the standing anchor, but only once its own text arrives', async () => {
+    const h = harness();
+    await openSettledLeaderCard(h);
+    const createdBefore = h.cot.createRequests().length;
+
+    h.adapter.onTurnSubmitted(
+      submitted({ turn_id: 'turn-2', turn_source: 'task-notification' }),
+    );
+    await settleCot();
+    // Nothing was produced yet, so no empty card was opened.
+    expect(h.cot.createRequests()).toHaveLength(createdBefore);
+
+    h.adapter.onTurnMessage(
+      userMessage({ turn_id: 'turn-2', event_id: 'evt-user-2', content: '任务完成' }),
+    );
+    await settleCot();
+
+    expect(h.cot.createRequests()).toHaveLength(createdBefore + 1);
+    expect(textOn(h, cotIdOf(h, 1))).toContain('任务完成');
+    await h.adapter.close();
+  });
+
+  it('never narrates a turn that arrived out of band', async () => {
+    const h = harness();
+    await openSettledLeaderCard(h);
+    const createdBefore = h.cot.createRequests().length;
+
+    for (const source of ['admin', 'mcp', 'unknown', 'feishu']) {
+      h.adapter.onTurnSubmitted(
+        submitted({ turn_id: `turn-${source}`, turn_source: source }),
+      );
+      h.adapter.onTurnMessage(
+        userMessage({
+          turn_id: `turn-${source}`,
+          event_id: `evt-${source}`,
+          content: `来自 ${source}`,
+        }),
+      );
+      h.adapter.onTurnMessage(
+        assistant({ turn_id: `turn-${source}`, event_id: `evt-a-${source}` }),
+      );
+    }
+    await settleCot();
+
+    expect(h.cot.createRequests()).toHaveLength(createdBefore);
+    await h.adapter.close();
+  });
+
+  it('shows only the turn the conversation admitted, never another Agent\'s', async () => {
+    const h = harness();
+    openLeaderCard(h, { turnId: 'turn-1' });
+    await settleCot();
+
+    // A Team member's own turn, and a second leader turn nobody anchored.
+    h.adapter.onTurnMessage(
+      assistant({ role: 'teammate', teammate_name: 'member-1', content: '成员输出' }),
+    );
+    h.adapter.onTurnMessage(
+      assistant({ turn_id: 'turn-9', event_id: 'evt-9', content: '未被接纳的轮次' }),
+    );
+    h.adapter.onTurnToolCall(
+      toolCall({ role: 'teammate', teammate_name: 'member-1', call_id: 'call-m' }),
+    );
+    await settleCot();
+
+    const text = textOn(h, cotIdOf(h, 0));
+    expect(text).not.toContain('成员输出');
+    expect(text).not.toContain('未被接纳的轮次');
+    expect(h.cot.createRequests()).toHaveLength(1);
+    await h.adapter.close();
+  });
+});
+
+describe('settlement projects the run status onto the card', () => {
+  it.each([
+    ['completed', 'done'],
+    ['failed', 'interrupted'],
+    ['stopped', 'interrupted'],
+  ] as const)('maps a %s turn to a %s run', async (status, expected) => {
+    const h = harness();
+    openLeaderCard(h);
+    await settleCot();
+
+    h.adapter.onTurnSettled(settled({ status }));
+    await settleCot();
+
+    expect(finishStatuses(h, cotIdOf(h, 0))).toEqual([expected]);
+    await h.adapter.close();
+  });
+
+  it('ignores a settlement for a turn this card is not showing', async () => {
+    const h = harness();
+    openLeaderCard(h, { turnId: 'turn-1' });
+    await settleCot();
+
+    h.adapter.onTurnSettled(settled({ turn_id: 'turn-stale', status: 'failed' }));
+    await settleCot();
+    expect(finishStatuses(h, cotIdOf(h, 0))).toEqual([]);
+
+    h.adapter.onTurnSettled(settled({ turn_id: 'turn-1' }));
+    await settleCot();
+    expect(finishStatuses(h, cotIdOf(h, 0))).toEqual(['done']);
+    await h.adapter.close();
+  });
+
+  it('finishes a card exactly once, whatever arrives afterwards', async () => {
+    const h = harness();
+    openLeaderCard(h);
+    await settleCot();
+
+    h.adapter.onTurnSettled(settled());
+    h.adapter.onTurnSettled(settled({ status: 'failed' }));
+    await settleCot();
+    h.adapter.onTurnMessage(assistant({ content: '结束后的输出' }));
+    await settleCot();
+
+    expect(finishStatuses(h, cotIdOf(h, 0))).toEqual(['done']);
+    expect(textOn(h, cotIdOf(h, 0))).not.toContain('结束后的输出');
+    await h.adapter.close();
+  });
+});
+
+describe('tool activity is paired, bounded, and generation-scoped', () => {
+  it('opens a tool call and closes it with its own result on the same card', async () => {
+    const h = harness();
+    openLeaderCard(h);
+    await settleCot();
+
+    h.adapter.onTurnToolCall(toolCall({ status: 'started' }));
+    h.adapter.onTurnToolCall(
+      toolCall({
+        status: 'completed',
+        event_id: 'evt-tool-result-1',
+        result_json: 'all green',
+      }),
+    );
+    await settleCot();
+
+    const types = h.cot.eventTypesFor(cotIdOf(h, 0));
+    expect(types).toContain('TOOL_CALL_START');
+    expect(types).toContain('TOOL_CALL_END');
+    expect(types).toContain('TOOL_CALL_RESULT');
+    await h.adapter.close();
+  });
+
+  it('drops a result for a call this card never opened', async () => {
+    const h = harness();
+    openLeaderCard(h);
+    await settleCot();
+
+    h.adapter.onTurnToolCall(
+      toolCall({ status: 'completed', call_id: 'never-started', result_json: 'x' }),
+    );
+    await settleCot();
+
+    expect(h.cot.eventTypesFor(cotIdOf(h, 0))).not.toContain('TOOL_CALL_RESULT');
+    await h.adapter.close();
+  });
+
+  it('does not carry an open call across a new anchor', async () => {
+    const h = harness();
+    openLeaderCard(h, { turnId: 'turn-1', messageId: 'om-inbound-1' });
+    await settleCot();
+    h.adapter.onTurnToolCall(toolCall({ turn_id: 'turn-1', status: 'started' }));
+    await settleCot();
+
+    // A newer inbound message replaces the anchor and the generation with it.
+    openLeaderCard(h, { turnId: 'turn-2', messageId: 'om-inbound-2' });
+    await settleCot();
+    h.adapter.onTurnToolCall(
+      toolCall({
+        turn_id: 'turn-1',
+        status: 'completed',
+        event_id: 'evt-late-result',
+        result_json: '迟到的结果',
+      }),
+    );
+    await settleCot();
+
+    expect(JSON.stringify(h.cot.eventsFor(cotIdOf(h, 1)))).not.toContain('迟到的结果');
+    await h.adapter.close();
+  });
+
+  it('keeps every append inside the platform batch budgets under a burst', async () => {
+    const h = harness();
+    openLeaderCard(h);
+    await settleCot();
+
+    for (let index = 0; index < 40; index += 1) {
+      h.adapter.onTurnMessage(
+        assistant({ event_id: `evt-${index}`, content: `输出 ${index}`.repeat(40) }),
+      );
+    }
+    await settleCot(40);
+
+    const appends = h.cot.appendRequests();
+    expect(appends.length).toBeGreaterThan(1);
+    for (const request of appends) {
+      const events = request.data?.['events'] as readonly unknown[];
+      expect(events.length).toBeGreaterThanOrEqual(1);
+      expect(events.length).toBeLessThanOrEqual(50);
+      expect(Buffer.byteLength(JSON.stringify(request.data), 'utf8'))
+        .toBeLessThanOrEqual(64 * 1_024);
+    }
+    await h.adapter.close();
+  });
+
+  it('coalesces a burst arriving during a slow append into one queued flush', async () => {
+    const h = harness();
+    openLeaderCard(h);
+    await settleCot();
+    const appendsBefore = h.cot.appendRequests().length;
+
+    const release = h.cot.blockNextAppend();
+    h.adapter.onTurnMessage(assistant({ event_id: 'evt-1', content: '第一条' }));
+    await settleCot();
+    for (let index = 2; index <= 10; index += 1) {
+      h.adapter.onTurnMessage(
+        assistant({ event_id: `evt-${index}`, content: `第 ${index} 条` }),
+      );
+    }
+    await settleCot();
+    release();
+    await settleCot(40);
+
+    // One in-flight append plus one drain of everything that queued behind it:
+    // a nine-message burst does not become nine platform calls.
+    expect(h.cot.appendRequests().length - appendsBefore).toBeLessThanOrEqual(2);
+    const text = textOn(h, cotIdOf(h, 0));
+    for (let index = 1; index <= 10; index += 1) {
+      expect(text).toContain(index === 1 ? '第一条' : `第 ${index} 条`);
+    }
+    await h.adapter.close();
+  });
+});
+
+describe('routing fences: where a Team may no longer present', () => {
+  it('interrupts the open card when its Team closes, and opens nothing afterwards', async () => {
+    const h = harness();
+    openLeaderCard(h, { turnId: 'turn-1' });
+    await settleCot();
+
+    h.adapter.onTeamState(teamState({ status: 'closed' }));
+    await settleCot();
+    expect(finishStatuses(h, cotIdOf(h, 0))).toEqual(['interrupted']);
+
+    openLeaderCard(h, { turnId: 'turn-2', messageId: 'om-inbound-2' });
+    await settleCot();
+    expect(h.cot.createRequests()).toHaveLength(1);
+    await h.adapter.close();
+  });
+
+  it('lets the Team present again once it is running', async () => {
+    const h = harness();
+    openLeaderCard(h, { turnId: 'turn-1' });
+    await settleCot();
+    h.adapter.onTeamState(teamState({ status: 'closed' }));
+    await settleCot();
+
+    h.adapter.onTeamState(teamState({ status: 'running' }));
+    openLeaderCard(h, { turnId: 'turn-2', messageId: 'om-inbound-2' });
+    await settleCot();
+
+    expect(h.cot.createRequests()).toHaveLength(2);
+    await h.adapter.close();
+  });
+
+  it('retires the cards anchored in a conversation this Channel unbound, and only those', async () => {
+    const h = harness();
+    const otherTarget = chatTarget('oc-other', 'group');
+    openLeaderCard(h, { turnId: 'turn-1', messageId: 'om-a' });
+    h.adapter.onAnchoredSubmission({
+      event: submitted({ turn_id: 'turn-2', teammate_name: 'leader-b' }),
+      anchor: anchor('om-b', otherTarget),
+    });
+    await settleCot();
+    expect(h.cot.createRequests()).toHaveLength(2);
+
+    h.adapter.onRouteReleased({ teamName: TEAM, target: groupTarget() });
+    await settleCot();
+
+    expect(finishStatuses(h, cotIdOf(h, 0))).toEqual(['interrupted']);
+    // The other conversation's card is untouched.
+    expect(finishStatuses(h, cotIdOf(h, 1))).toEqual([]);
+
+    // And the unbound conversation is closed to new cards until it is re-bound.
+    openLeaderCard(h, { turnId: 'turn-3', messageId: 'om-c' });
+    await settleCot();
+    expect(h.cot.createRequests()).toHaveLength(2);
+
+    h.adapter.onRouteClaimed({ teamName: TEAM, target: groupTarget() });
+    openLeaderCard(h, { turnId: 'turn-4', messageId: 'om-d' });
+    await settleCot();
+    expect(h.cot.createRequests()).toHaveLength(3);
+    await h.adapter.close();
+  });
+
+  it('matches the fence to the exact conversation, not merely the chat it is in', async () => {
+    const h = harness();
+    const topic = threadTarget();
+    openLeaderCard(h, { turnId: 'turn-1', messageId: 'om-topic', target: topic });
+    await settleCot();
+
+    // Unbinding the surrounding group does not retire a topic's own card.
+    h.adapter.onRouteReleased({ teamName: TEAM, target: groupTarget() });
+    await settleCot();
+    expect(finishStatuses(h, cotIdOf(h, 0))).toEqual([]);
+
+    h.adapter.onRouteReleased({ teamName: TEAM, target: topic });
+    await settleCot();
+    expect(finishStatuses(h, cotIdOf(h, 0))).toEqual(['interrupted']);
+    await h.adapter.close();
+  });
+
+  it('fences only the Team whose route moved', async () => {
+    const h = harness();
+    openLeaderCard(h, { turnId: 'turn-1', messageId: 'om-a' });
+    h.adapter.onAnchoredSubmission({
+      event: submitted({ team_name: 'team-beta', turn_id: 'turn-2' }),
+      anchor: anchor('om-b'),
+    });
+    await settleCot();
+
+    h.adapter.onRouteReleased({ teamName: TEAM, target: groupTarget() });
+    await settleCot();
+
+    expect(finishStatuses(h, cotIdOf(h, 0))).toEqual(['interrupted']);
+    expect(finishStatuses(h, cotIdOf(h, 1))).toEqual([]);
+    await h.adapter.close();
+  });
+});
+
+describe('the Dispatcher Agent presents one turn per visible message', () => {
+  it('answers the message it was asked in, without echoing the question back', async () => {
+    const h = harness();
+    const chat = chatTarget('oc-dm-1', 'p2p');
+
+    h.adapter.onAnchoredSubmission({
+      event: dispatcherSubmitted('turn-d1'),
+      anchor: anchor('om-dm-1', chat),
+    });
+    await settleCot();
+    h.adapter.onTurnMessage(
+      dispatcherAssistant('turn-d1', 'evt-d1', { content: '这是回答' }),
+    );
+    // The user's own message is already visible in the chat.
+    h.adapter.onTurnMessage(
+      dispatcherAssistant('turn-d1', 'evt-d1-user', {
+        message_role: 'user',
+        content: '这是提问',
+      }),
+    );
+    await settleCot();
+
+    expect(originOf(h, 0)).toEqual({
+      receiveId: 'oc-dm-1',
+      originMessageId: 'om-dm-1',
+    });
+    const text = textOn(h, cotIdOf(h, 0));
+    expect(text).toContain('这是回答');
+    expect(text).not.toContain('这是提问');
+    await h.adapter.close();
+  });
+
+  it('runs two conversations side by side without either stealing or closing the other', async () => {
+    const h = harness();
+    h.adapter.onAnchoredSubmission({
+      event: dispatcherSubmitted('turn-a'),
+      anchor: anchor('om-a', chatTarget('oc-a', 'p2p')),
+    });
+    h.adapter.onAnchoredSubmission({
+      event: dispatcherSubmitted('turn-b'),
+      anchor: anchor('om-b', chatTarget('oc-b', 'p2p')),
+    });
+    await settleCot();
+
+    h.adapter.onTurnMessage(dispatcherAssistant('turn-a', 'evt-a', { content: 'A 的回答' }));
+    h.adapter.onTurnMessage(dispatcherAssistant('turn-b', 'evt-b', { content: 'B 的回答' }));
+    h.adapter.onTurnSettled(dispatcherSettled('turn-a'));
+    await settleCot();
+
+    expect(textOn(h, cotIdOf(h, 0))).toContain('A 的回答');
+    expect(textOn(h, cotIdOf(h, 0))).not.toContain('B 的回答');
+    expect(finishStatuses(h, cotIdOf(h, 0))).toEqual(['done']);
+    expect(finishStatuses(h, cotIdOf(h, 1))).toEqual([]);
+
+    h.adapter.onTurnSettled(dispatcherSettled('turn-b', { status: 'failed' }));
+    await settleCot();
+    expect(finishStatuses(h, cotIdOf(h, 1))).toEqual(['interrupted']);
+    await h.adapter.close();
+  });
+
+  it('never opens a card for a Dispatcher turn this session did not submit', async () => {
+    const h = harness();
+
+    // No `onAnchoredSubmission`: this turn belongs to another session.
+    h.adapter.onTurnSubmitted(dispatcherSubmitted('turn-foreign'));
+    h.adapter.onTurnMessage(
+      dispatcherAssistant('turn-foreign', 'evt-f', { content: '别的会话' }),
+    );
+    h.adapter.onTurnToolCall(
+      toolCall({ role: 'dispatcher', teammate_name: DISPATCHER_AGENT, turn_id: 'turn-foreign' }),
+    );
+    await settleCot();
+
+    expect(h.cot.requests).toHaveLength(0);
+    await h.adapter.close();
+  });
+
+  it('stops accepting activity for a Dispatcher turn once it settles', async () => {
+    const h = harness();
+    h.adapter.onAnchoredSubmission({
+      event: dispatcherSubmitted('turn-a'),
+      anchor: anchor('om-a', chatTarget('oc-a', 'p2p')),
+    });
+    await settleCot();
+    h.adapter.onTurnSettled(dispatcherSettled('turn-a'));
+    await settleCot();
+
+    h.adapter.onTurnMessage(
+      dispatcherAssistant('turn-a', 'evt-late', { content: '结束后的输出' }),
+    );
+    await settleCot();
+
+    expect(textOn(h, cotIdOf(h, 0))).not.toContain('结束后的输出');
+    await h.adapter.close();
+  });
+});
+
+describe('failure isolation: display never becomes a second failure', () => {
+  it('degrades to no presentation at all when the platform has no COT capability', async () => {
+    const h = harness({ cotClient: () => undefined });
+
+    openLeaderCard(h);
+    h.adapter.onTurnMessage(assistant());
+    h.adapter.onTurnSettled(settled());
+    await settleCot();
+
+    expect(h.cot.requests).toHaveLength(0);
+    expect(h.logs.some((entry) => entry.message.includes('abandoned'))).toBe(true);
+    await h.adapter.close();
+  });
+
+  it('abandons the generation when create fails, and recovers on the next inbound message', async () => {
+    const h = harness();
+    h.cot.failNextCreate(new FeishuCotApiError(230_002, 'no permission'));
+
+    openLeaderCard(h, { turnId: 'turn-1', messageId: 'om-1' });
+    await settleCot();
+    // Nothing further on this generation is attempted: no append, no complete,
+    // and no second create for the card that never came into being.
+    h.adapter.onTurnMessage(assistant({ content: '同一代的输出' }));
+    h.adapter.onTurnToolCall(toolCall());
+    await settleCot();
+    expect(h.cot.requests).toHaveLength(0);
+
+    // A new inbound message is a new generation, and presentation resumes.
+    openLeaderCard(h, { turnId: 'turn-2', messageId: 'om-2' });
+    await settleCot();
+    expect(h.cot.createRequests()).toHaveLength(1);
+    expect(originOf(h, 0).originMessageId).toBe('om-2');
+    expect(textOn(h, cotIdOf(h, 0))).toBe(RECEIPT);
+    await h.adapter.close();
+  });
+
+  it('does not re-open a Dispatcher card on the generation whose create already failed', async () => {
+    const h = harness();
+    h.cot.failNextCreate(new FeishuCotApiError(230_002, 'no permission'));
+
+    h.adapter.onAnchoredSubmission({
+      event: dispatcherSubmitted('turn-d1'),
+      anchor: anchor('om-dm-1', chatTarget('oc-dm-1', 'p2p')),
+    });
+    await settleCot();
+    expect(h.cot.createRequests()).toHaveLength(0);
+
+    // A Dispatcher turn *is* its own admission, so nothing turn-scoped stops a
+    // second attempt here — only the disabled generation does. Without it the
+    // next activity would silently open a replacement card the operator never
+    // asked for, in a chat the first attempt already failed in.
+    h.adapter.onTurnMessage(
+      dispatcherAssistant('turn-d1', 'evt-d1', { content: '失败后的输出' }),
+    );
+    h.adapter.onTurnToolCall(
+      toolCall({
+        role: 'dispatcher',
+        teammate_name: DISPATCHER_AGENT,
+        turn_id: 'turn-d1',
+      }),
+    );
+    await settleCot();
+
+    expect(h.cot.requests).toHaveLength(0);
+    await h.adapter.close();
+  });
+
+  it('does not admit a continuation onto a TeamLeader generation whose create already failed', async () => {
+    const h = harness();
+    h.cot.failNextCreate(new FeishuCotApiError(230_002, 'no permission'));
+    openLeaderCard(h, { turnId: 'turn-1' });
+    await settleCot();
+    expect(h.cot.createRequests()).toHaveLength(0);
+
+    h.adapter.onTurnSubmitted(
+      submitted({ turn_id: 'turn-2', turn_source: 'task-notification' }),
+    );
+    h.adapter.onTurnMessage(
+      userMessage({ turn_id: 'turn-2', event_id: 'evt-user-2', content: '任务完成' }),
+    );
+    await settleCot();
+
+    expect(h.cot.requests).toHaveLength(0);
+
+    // Only a new inbound message clears it, because only that is a new
+    // conversation turn to present.
+    openLeaderCard(h, { turnId: 'turn-3', messageId: 'om-2' });
+    await settleCot();
+    expect(h.cot.createRequests()).toHaveLength(1);
+    await h.adapter.close();
+  });
+
+  it('best-effort completes the card once after an append failure and never retries it', async () => {
+    const h = harness();
+    openLeaderCard(h);
+    await settleCot();
+    const appendsBefore = h.cot.appendRequests().length;
+
+    h.cot.failNextAppend(new FeishuCotApiError(230_098, 'rate limited'));
+    h.adapter.onTurnMessage(assistant({ content: '写不进去的输出' }));
+    await settleCot();
+
+    // The card is closed out with `reason: error` on the same client, and the
+    // batch that failed is not retried.
+    expect(h.cot.completeRequests()).toHaveLength(1);
+    expect(h.cot.completeRequests()[0]?.params).toMatchObject({ reason: 'error' });
+    expect(h.cot.appendRequests()).toHaveLength(appendsBefore);
+
+    // Later activity on the abandoned generation reaches the platform never.
+    h.adapter.onTurnMessage(assistant({ event_id: 'evt-2', content: '之后的输出' }));
+    h.adapter.onTurnSettled(settled());
+    await settleCot();
+    expect(h.cot.appendRequests()).toHaveLength(appendsBefore);
+    expect(h.cot.completeRequests()).toHaveLength(1);
+    await h.adapter.close();
+  });
+
+  it('logs only an error category — never a message, payload, or stack', async () => {
+    const h = harness();
+    h.cot.failNextCreate(
+      new FeishuCotApiError(230_002, '/home/operator/secret/path denied'),
+    );
+
+    openLeaderCard(h);
+    await settleCot();
+
+    const failures = h.logs.filter((entry) => entry.message.startsWith('Feishu COT call'));
+    expect(failures.length).toBeGreaterThan(0);
+    for (const entry of failures) {
+      expect(entry.fields).toMatchObject({
+        err_name: 'FeishuCotApiError',
+        err_code: 230_002,
+        dispatcher_id: expect.any(String),
+      });
+      expect(Object.keys(entry.fields).sort()).toEqual([
+        'channel_id',
+        'dispatcher_id',
+        'err_code',
+        'err_name',
+        'leader_name',
+        'presentation_id',
+        'stage',
+        'team_name',
+      ]);
+    }
+    expect(JSON.stringify(h.logs)).not.toContain('/home/operator/secret/path');
+    await h.adapter.close();
+  });
+
+  it('reports a non-platform failure as an opaque category rather than its text', async () => {
+    const h = harness();
+    h.cot.failNextCreate(new Error('ECONNREFUSED 10.0.0.1:443'));
+
+    openLeaderCard(h);
+    await settleCot();
+
+    const failures = h.logs.filter((entry) => entry.message.startsWith('Feishu COT call'));
+    expect(failures[0]?.fields).toMatchObject({ err_name: 'Error', err_code: null });
+    expect(JSON.stringify(h.logs)).not.toContain('10.0.0.1');
+    await h.adapter.close();
+  });
+
+  it('warns once when a runaway conversation overruns the display buffer', async () => {
+    const h = harness();
+    const release = h.cot.blockNextCreate();
+    openLeaderCard(h);
+    await settleCot();
+
+    // The card is still being created, so everything buffers.
+    for (let index = 0; index < 600; index += 1) {
+      h.adapter.onTurnMessage(
+        assistant({ event_id: `evt-${index}`, content: `输出 ${index}` }),
+      );
+    }
+    release();
+    await settleCot(60);
+
+    const dropWarnings = h.logs.filter((entry) =>
+      entry.message.includes('buffer is full'),
+    );
+    expect(dropWarnings).toHaveLength(1);
+    expect(dropWarnings[0]?.fields).toMatchObject({ buffered_events: expect.any(Number) });
+    // The session survived the burst and the card is still usable.
+    expect(h.cot.appendRequests().length).toBeGreaterThan(0);
+    await h.adapter.close();
+  });
+
+  it('bounds the pending continuation ledger instead of growing without limit', async () => {
+    const h = harness();
+    await openSettledLeaderCard(h);
+
+    for (let index = 0; index < 600; index += 1) {
+      h.adapter.onTurnSubmitted(
+        submitted({ turn_id: `turn-p${index}`, turn_source: 'cron' }),
+      );
+    }
+    await settleCot();
+
+    const full = h.logs.filter((entry) => entry.message.includes('pending turn map is full'));
+    expect(full.length).toBeGreaterThan(0);
+    expect(full[0]?.fields).toMatchObject({ reason: 'pending_turns_full' });
+    await h.adapter.close();
+  });
+});
+
+describe('close leaves nothing running and nothing half-drawn', () => {
+  it('interrupts every open card and stops accepting anything afterwards', async () => {
+    const h = harness();
+    openLeaderCard(h, { turnId: 'turn-1' });
+    h.adapter.onAnchoredSubmission({
+      event: dispatcherSubmitted('turn-d1'),
+      anchor: anchor('om-dm', chatTarget('oc-dm', 'p2p')),
+    });
+    await settleCot();
+
+    await h.adapter.close();
+
+    expect(finishStatuses(h, cotIdOf(h, 0))).toEqual(['interrupted']);
+    expect(finishStatuses(h, cotIdOf(h, 1))).toEqual(['interrupted']);
+
+    const after = h.cot.requests.length;
+    openLeaderCard(h, { turnId: 'turn-2', messageId: 'om-2' });
+    h.adapter.onTurnMessage(assistant());
+    h.adapter.onTurnToolCall(toolCall());
+    h.adapter.onTurnSettled(settled());
+    h.adapter.onTeamState(teamState({ status: 'closed' }));
+    h.adapter.onRouteReleased({ teamName: TEAM, target: groupTarget() });
+    h.adapter.setFallbackAnchorIfAbsent(TEAM, LEADER, anchor('om-3'));
+    h.adapter.refreshNextAnchor(TEAM, LEADER, anchor('om-4'));
+    await settleCot();
+    expect(h.cot.requests).toHaveLength(after);
+
+    // Closing twice is a no-op, not a second teardown.
+    await h.adapter.close();
+    expect(h.cot.requests).toHaveLength(after);
+  });
+
+  it('gives up on a stalled platform call after the drain window and aborts it', async () => {
+    vi.useFakeTimers({ toFake: ['setTimeout', 'clearTimeout'] });
+    try {
+      const cot = createFakeCotClient();
+      const h = harness({ cot });
+      openLeaderCard(h);
+      await settleCot();
+
+      cot.blockNextAppend();
+      h.adapter.onTurnMessage(assistant({ content: '卡住的输出' }));
+      await settleCot();
+
+      let resolved = false;
+      const closing = h.adapter.close().then(() => {
+        resolved = true;
+      });
+      await settleCot();
+      // The drain window has not elapsed, so close is still waiting.
+      expect(resolved).toBe(false);
+
+      await vi.advanceTimersByTimeAsync(5_000);
+      await closing;
+      expect(resolved).toBe(true);
+
+      // The stalled call is aborted rather than left hanging, and the card is
+      // completed with an error exactly once.
+      await settleCot(30);
+      expect(cot.completeRequests()).toHaveLength(1);
+      expect(cot.completeRequests()[0]?.params).toMatchObject({ reason: 'error' });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});

--- a/packages/channel/feishu-channel/tests/feishu-cot-events.test.ts
+++ b/packages/channel/feishu-channel/tests/feishu-cot-events.test.ts
@@ -1,0 +1,430 @@
+/**
+ * COT display projection (COVERAGE CELL F).
+ *
+ * This is the layer that turns one Core-sanitized runtime activity into AG-UI
+ * card events. Core owns generic safety processing; this layer selects what is
+ * *shown* and enforces the Feishu per-event and per-batch budgets. Two
+ * contracts here are load-bearing and are asserted as behavior:
+ *
+ * - **no event may exceed the 4 KiB content budget**, whatever a provider or a
+ *   hostile payload does — the projector throws rather than emit one, so every
+ *   path that can produce a large value must shrink it first;
+ * - **display ids are opaque**, so a raw provider `call_id`/`event_id` never
+ *   reaches a card that other people in the chat can read.
+ */
+import { describe, expect, it } from 'vitest';
+
+import { createFeishuCotClient } from '@excitedjs/feishu-transport';
+
+import {
+  assembleToolResultContent,
+  cotAppendBatchBytes,
+  cotEventBytes,
+  cotEventContentBytes,
+  FEISHU_COT_EVENT_CONTENT_MAX_BYTES,
+  runFinishedEvent,
+  runStartedEvent,
+  textMessageEvents,
+  toolCallResultEvents,
+  toolCallStartEvents,
+} from '../src/feishu-cot-events.js';
+import { toolCall } from './helpers/cot-fixtures.js';
+
+function deltas(events: readonly { eventType: string; content: Record<string, unknown> }[]): string {
+  return events
+    .filter((event) => event.eventType === 'TEXT_MESSAGE_CONTENT')
+    .map((event) => String(event.content['delta']))
+    .join('');
+}
+
+function typesOf(
+  events: readonly { eventType: string }[],
+): string[] {
+  return events.map((event) => event.eventType);
+}
+
+describe('the run envelope names the presentation, not the turn', () => {
+  it('opens and closes on the presentation id with the status the adapter decided', () => {
+    expect(runStartedEvent('p-1')).toEqual({
+      eventType: 'RUN_STARTED',
+      content: { threadId: 'p-1', runId: 'p-1' },
+    });
+    expect(runFinishedEvent('p-1', 'done').content).toMatchObject({
+      status: 'done',
+    });
+    expect(runFinishedEvent('p-1', 'interrupted').content).toMatchObject({
+      status: 'interrupted',
+    });
+  });
+});
+
+describe('text message projection', () => {
+  it('passes Core-processed content through and splits it within the per-event budget', () => {
+    const prefix = 'Core 已处理：$WORKSPACE $HOME_PATH <redacted> oc_visible ';
+    const source = `${prefix}${'中文🙂'.repeat(2_000)}`;
+
+    const events = textMessageEvents({
+      sourceId: 'evt-message-1',
+      role: 'assistant',
+      content: source,
+    });
+
+    expect(typesOf(events).at(0)).toBe('TEXT_MESSAGE_START');
+    expect(typesOf(events).at(-1)).toBe('TEXT_MESSAGE_END');
+    // Split, but lossless — the projector is a budget, not a filter.
+    expect(events.filter((e) => e.eventType === 'TEXT_MESSAGE_CONTENT').length)
+      .toBeGreaterThan(1);
+    expect(deltas(events)).toBe(source);
+    expect(deltas(events)).not.toContain('�');
+    for (const event of events) {
+      expect(cotEventContentBytes(event)).toBeLessThanOrEqual(
+        FEISHU_COT_EVENT_CONTENT_MAX_BYTES,
+      );
+    }
+  });
+
+  it('carries the role and shares one bounded projector between assistant and user text', () => {
+    const assistantEvents = textMessageEvents({
+      sourceId: 'assistant-source',
+      role: 'assistant',
+      content: 'assistant text',
+    });
+    const userEvents = textMessageEvents({
+      sourceId: 'user-source',
+      role: 'user',
+      content: 'scheduled text',
+    });
+
+    expect(assistantEvents[0]?.content['role']).toBe('assistant');
+    expect(userEvents[0]?.content['role']).toBe('user');
+    expect(deltas(userEvents)).toBe('scheduled text');
+    expect(typesOf(assistantEvents)).toEqual(typesOf(userEvents));
+  });
+
+  it('projects nothing for content that is empty or only whitespace', () => {
+    expect(textMessageEvents({ sourceId: 's', role: 'assistant', content: '' }))
+      .toEqual([]);
+    expect(
+      textMessageEvents({ sourceId: 's', role: 'assistant', content: '   \n\t ' }),
+    ).toEqual([]);
+  });
+
+  it('bounds one message group and marks it truncated rather than dropping the message', () => {
+    const events = textMessageEvents({
+      sourceId: 'evt-huge',
+      role: 'assistant',
+      content: '中文🙂'.repeat(80_000),
+    });
+
+    const grouped = events.reduce((total, event) => total + cotEventBytes(event), 0);
+    expect(grouped).toBeLessThanOrEqual(224 * 1_024);
+    // The start/end pair still frames it, and the reader is told it was cut.
+    expect(typesOf(events).at(0)).toBe('TEXT_MESSAGE_START');
+    expect(typesOf(events).at(-1)).toBe('TEXT_MESSAGE_END');
+    expect(deltas(events).endsWith('…（已截断）')).toBe(true);
+  });
+
+  it('keeps the message id opaque — the source event id never reaches the card', () => {
+    const sourceId = 'evt-secret-correlation-1';
+    const events = textMessageEvents({
+      sourceId,
+      role: 'assistant',
+      content: 'hello',
+    });
+    const messageId = String(events[0]?.content['messageId']);
+
+    expect(messageId).not.toContain(sourceId);
+    expect(messageId.startsWith('message-')).toBe(true);
+    // Stable, so the start/content/end trio all name the same message.
+    expect(new Set(events.map((event) => event.content['messageId'])).size).toBe(1);
+    expect(
+      textMessageEvents({ sourceId, role: 'assistant', content: 'other' })[0]
+        ?.content['messageId'],
+    ).toBe(messageId);
+  });
+});
+
+describe('tool call projection selects what a reader may see', () => {
+  it('shows a generic tool with its bounded arguments and a leaf display name', () => {
+    const events = toolCallStartEvents(
+      toolCall({
+        tool_name: 'provider.namespace.run_command',
+        tool_action: null,
+        arguments_json: JSON.stringify({ command: 'pnpm test' }),
+      }),
+    );
+
+    expect(typesOf(events)).toEqual([
+      'TOOL_CALL_START',
+      'TOOL_CALL_ARGS',
+      'TOOL_CALL_END',
+    ]);
+    expect(events[0]?.content['toolCallName']).toBe('run_command');
+    expect(String(events[1]?.content['delta'])).toContain('pnpm test');
+    expect(String(events[0]?.content['toolCallId'])).not.toContain('call-1');
+  });
+
+  it('renames a recognized runtime action to its stable display verb', () => {
+    const events = toolCallStartEvents(
+      toolCall({ tool_name: 'exec_command', tool_action: 'run' }),
+    );
+    expect(events[0]?.content['toolCallName']).toBe('Bash');
+    expect(
+      toolCallStartEvents(toolCall({ tool_name: 'anything', tool_action: 'read' }))[0]
+        ?.content['toolCallName'],
+    ).toBe('Read');
+  });
+
+  it.each([
+    ['mcp__feishu__reply', undefined, '回复飞书消息'],
+    ['feishu.react', undefined, '点击飞书表情'],
+    ['mcp__primary__list_chat_bots', 'primary', '查看群机器人'],
+    ['channel-primary.reply', 'primary', '回复飞书消息'],
+  ])(
+    'presents this Channel\'s own tool %s as a titled action with no argument echo',
+    (toolName, channelId, title) => {
+      const events = toolCallStartEvents(
+        toolCall({
+          tool_name: toolName,
+          tool_action: null,
+          arguments_json: JSON.stringify({ text: 'secret outbound draft' }),
+        }),
+        channelId,
+      );
+
+      expect(events[0]?.content['title']).toBe(title);
+      // A Channel tool's own arguments are the message being sent; echoing them
+      // back onto the card would duplicate outbound content into the thread.
+      expect(typesOf(events)).toEqual(['TOOL_CALL_START', 'TOOL_CALL_END']);
+      expect(JSON.stringify(events)).not.toContain('secret outbound draft');
+    },
+  );
+
+  it.each([
+    // Another MCP server that merely happens to expose a `reply` leaf.
+    ['mcp__other__reply', 'primary'],
+    // This Channel's server, but a verb it does not own.
+    ['mcp__feishu__unknown', undefined],
+    // This Channel's verb under a channel id this session is not configured as.
+    ['channel-secondary.reply', 'primary'],
+  ] as const)(
+    'does not treat %s as this Channel\'s own tool',
+    (toolName, channelId) => {
+      const events = toolCallStartEvents(
+        toolCall({
+          tool_name: toolName,
+          tool_action: null,
+          arguments_json: 'visible-argument',
+        }),
+        channelId,
+      );
+      expect(typesOf(events)).toContain('TOOL_CALL_ARGS');
+      expect(events[0]?.content['title']).toBeUndefined();
+    },
+  );
+
+  it('summarizes a built-in TeamMate spawn by intent instead of echoing raw arguments', () => {
+    const start = toolCallStartEvents(
+      toolCall({
+        tool_name: 'mcp__teammate__spawn',
+        tool_action: null,
+        arguments_json: JSON.stringify({
+          name_prefix: 'scout',
+          prompt: 'go look at the failing suite',
+          intent: '排查测试失败',
+          agent_runtime: 'codex',
+          identity: 'reviewer',
+        }),
+      }),
+    );
+    const result = toolCallResultEvents(
+      toolCall({
+        tool_name: 'mcp__teammate__spawn',
+        tool_action: null,
+        status: 'completed',
+        arguments_json: JSON.stringify({
+          name_prefix: 'scout',
+          prompt: 'go look at the failing suite',
+          intent: '排查测试失败',
+          agent_runtime: 'codex',
+          identity: 'reviewer',
+        }),
+      }),
+    );
+
+    expect(start[0]?.content['title']).toBe('分派成员 排查测试失败');
+    expect(typesOf(start)).toEqual(['TOOL_CALL_START', 'TOOL_CALL_END']);
+    const rendered = JSON.stringify(result[0]?.content['content']);
+    expect(rendered).toContain('Agent Runtime：codex');
+    expect(rendered).toContain('go look at the failing suite');
+  });
+
+  it('renders a workflow script as code and names it from its own meta', () => {
+    const script = "export const meta = { name: 'review-changes', description: 'x' }\nreturn 1\n";
+    const start = toolCallStartEvents(
+      toolCall({
+        tool_name: 'mcp__teammate__workflow_run',
+        tool_action: null,
+        arguments_json: JSON.stringify({ script }),
+      }),
+    );
+    const result = toolCallResultEvents(
+      toolCall({
+        tool_name: 'mcp__teammate__workflow_run',
+        tool_action: null,
+        status: 'completed',
+        arguments_json: JSON.stringify({ script }),
+      }),
+    );
+
+    expect(start[0]?.content['title']).toBe('Workflow review-changes');
+    expect(result[0]?.content['content']).toMatchObject({
+      type: 'code',
+      language: 'javascript',
+    });
+  });
+
+  it('falls back to the bare Workflow title when the script declares no meta name', () => {
+    const start = toolCallStartEvents(
+      toolCall({
+        tool_name: 'teammate.workflow_run',
+        tool_action: null,
+        arguments_json: JSON.stringify({ scriptPath: '/tmp/wf.js' }),
+      }),
+    );
+    expect(start[0]?.content['title']).toBe('Workflow');
+  });
+});
+
+describe('tool result projection stays inside the per-event budget', () => {
+  it('shows a fixed status line for this Channel\'s own tool, never its payload', () => {
+    for (const status of ['completed', 'failed'] as const) {
+      const events = toolCallResultEvents(
+        toolCall({
+          tool_name: 'mcp__feishu__reply',
+          tool_action: null,
+          status,
+          result_json: JSON.stringify({ message_id: 'om-private-1' }),
+        }),
+      );
+      expect(events[0]?.content['content']).toEqual({
+        type: 'text',
+        text: status === 'failed' ? '执行失败' : '执行完成',
+      });
+      expect(JSON.stringify(events)).not.toContain('om-private-1');
+    }
+  });
+
+  it('measures the JSON-escaped serialization and never emits an oversized result event', () => {
+    const hostile = `${'"\\\n\t🙂'.repeat(2_000)}${'四字节🙂'.repeat(2_000)}`;
+    for (const status of ['completed', 'failed'] as const) {
+      const events = toolCallResultEvents(
+        toolCall({
+          status,
+          arguments_json: hostile,
+          result_json: hostile,
+          arguments_truncated: true,
+          result_truncated: true,
+        }),
+      );
+      expect(events).toHaveLength(1);
+      expect(cotEventContentBytes(events[0]!)).toBeLessThanOrEqual(
+        FEISHU_COT_EVENT_CONTENT_MAX_BYTES,
+      );
+      expect(JSON.stringify(events)).toContain('…（已截断）');
+    }
+  });
+
+  it('shrinks the result before the arguments when assembled content overflows', () => {
+    const argumentsText = 'argument-kept';
+    const content = assembleToolResultContent({
+      failed: true,
+      argumentsText,
+      resultText: 'result'.repeat(4_000),
+    });
+
+    expect(Buffer.byteLength(JSON.stringify(content), 'utf8')).toBeLessThan(4_096);
+    expect(content).toEqual(
+      expect.arrayContaining([
+        { type: 'text', text: '执行失败' },
+        { type: 'code', language: 'text', content: argumentsText },
+      ]),
+    );
+    expect(JSON.stringify(content)).toContain('…（已截断）');
+  });
+
+  it('marks Core-truncated arguments and results even when the local value is short', () => {
+    const start = toolCallStartEvents(
+      toolCall({ arguments_json: 'args', arguments_truncated: true, tool_action: null }),
+    );
+    const terminal = toolCallResultEvents(
+      toolCall({
+        status: 'completed',
+        arguments_json: null,
+        result_json: 'result',
+        result_truncated: true,
+        tool_action: null,
+      }),
+    );
+    expect(JSON.stringify([...start, ...terminal])).toContain('…（已截断）');
+  });
+
+  it('keeps a short single-line detail as plain text and states the outcome when there is none', () => {
+    expect(
+      assembleToolResultContent({
+        failed: false,
+        argumentsText: null,
+        resultText: 'ok',
+      }),
+    ).toEqual({ type: 'text', text: 'ok' });
+    expect(
+      assembleToolResultContent({
+        failed: false,
+        argumentsText: null,
+        resultText: null,
+      }),
+    ).toEqual({ type: 'text', text: '执行完成' });
+    expect(
+      assembleToolResultContent({
+        failed: true,
+        argumentsText: null,
+        resultText: null,
+      }),
+    ).toEqual({ type: 'text', text: '执行失败' });
+  });
+});
+
+describe('the local size estimate is conservative against the real wire request', () => {
+  it('never under-estimates what the transport actually sends', async () => {
+    const requests: unknown[] = [];
+    const cot = createFeishuCotClient(
+      {
+        request: async (request: unknown): Promise<{ code: number }> => {
+          requests.push(request);
+          return { code: 0 };
+        },
+      } as never,
+      { now: () => 1_725_000_000_000 },
+    );
+    const events = [
+      {
+        eventType: 'TEXT_"\\ 中文',
+        content: {
+          text: '引号"、反斜杠\\、控制 与中文🙂',
+          nested: ['line\nfeed', { value: '\tquoted"value' }],
+        },
+      },
+    ];
+    const input = {
+      cotId: 'cot-"\\中文',
+      messageId: 'message-"\\中文',
+      events,
+    };
+
+    await cot.appendCot(input);
+
+    const request = requests[0] as { readonly data?: unknown };
+    const actual = Buffer.byteLength(JSON.stringify(request.data), 'utf8');
+    expect(cotAppendBatchBytes(input)).toBeGreaterThanOrEqual(actual);
+  });
+});

--- a/packages/channel/feishu-channel/tests/feishu-cot-outbox.test.ts
+++ b/packages/channel/feishu-channel/tests/feishu-cot-outbox.test.ts
@@ -1,0 +1,258 @@
+/**
+ * The COT outbox contract (COVERAGE CELL F).
+ *
+ * This is the whole buffering half of the display: a presentation admits
+ * projected activity into a bounded buffer, and a flush takes as much of it as
+ * one platform append may legally carry. Both bounds are load-bearing —
+ * an unbounded buffer would let a runaway Agent grow a session's heap, and an
+ * over-budget batch would be rejected by Feishu itself — so they are asserted
+ * as observable behavior of the pure functions that own them, not as constants
+ * read back out of the module.
+ *
+ * Admission is *group-atomic*: one projected activity is several AG-UI events
+ * (start/content/end) that only make sense together, so a group that does not
+ * fit is dropped whole and never half-buffered.
+ */
+import { describe, expect, it } from 'vitest';
+
+import {
+  FEISHU_COT_APPEND_MAX_EVENTS,
+  type FeishuCotEventInput,
+} from '@excitedjs/feishu-transport';
+
+import {
+  cotAppendBatchBytes,
+  cotEventBytes,
+  FEISHU_COT_APPEND_MAX_BYTES,
+} from '../src/feishu-cot-events.js';
+import {
+  admitCotOutboxEvents,
+  appendCotTerminalIfFits,
+  clearCotOutbox,
+  cotOutboxHasEvents,
+  createCotOutbox,
+  takeCotAppendBatch,
+} from '../src/feishu-cot-outbox.js';
+
+const COT_ID = 'cot-1';
+const MESSAGE_ID = 'om-cot-1';
+
+function event(delta: string, messageId = 'message-1'): FeishuCotEventInput {
+  return {
+    eventType: 'TEXT_MESSAGE_CONTENT',
+    content: { messageId, delta },
+  };
+}
+
+/** A single event whose encoded size is at least `bytes`. */
+function heavyEvent(bytes: number): FeishuCotEventInput {
+  const built = event('x'.repeat(Math.max(1, bytes)));
+  return cotEventBytes(built) >= bytes ? built : event('x'.repeat(bytes * 2));
+}
+
+describe('outbox admission is bounded and group-atomic', () => {
+  it('starts empty and admits an ordinary activity group whole', () => {
+    const outbox = createCotOutbox();
+    expect(cotOutboxHasEvents(outbox)).toBe(false);
+
+    const group = [event('a'), event('b'), event('c')];
+    expect(admitCotOutboxEvents(outbox, group)).toEqual({ accepted: true });
+    expect(outbox.events).toEqual(group);
+    expect(outbox.bytes).toBe(
+      group.reduce((total, item) => total + cotEventBytes(item), 0),
+    );
+    expect(outbox.droppedEvents).toBe(0);
+    expect(cotOutboxHasEvents(outbox)).toBe(true);
+  });
+
+  it('refuses the group that would cross the 400-event bound, buffering none of it', () => {
+    const outbox = createCotOutbox();
+    for (let index = 0; index < 398; index += 1) {
+      expect(admitCotOutboxEvents(outbox, [event(`e${index}`)]).accepted).toBe(true);
+    }
+    expect(outbox.events).toHaveLength(398);
+
+    // Three more would be 401: the whole group is refused, not the one event
+    // that overflows, because a half-written message renders as garbage.
+    const rejected = admitCotOutboxEvents(outbox, [
+      event('x'),
+      event('y'),
+      event('z'),
+    ]);
+    expect(rejected.accepted).toBe(false);
+    expect(outbox.events).toHaveLength(398);
+    expect(outbox.droppedEvents).toBe(3);
+
+    // A group that still fits is admitted after the refusal: the buffer is
+    // bounded, not poisoned.
+    expect(admitCotOutboxEvents(outbox, [event('tail')]).accepted).toBe(true);
+    expect(outbox.events).toHaveLength(399);
+  });
+
+  it('refuses a group that would cross the 256 KiB byte bound', () => {
+    const outbox = createCotOutbox();
+    const chunk = heavyEvent(32 * 1_024);
+    let admitted = 0;
+    while (admitCotOutboxEvents(outbox, [chunk]).accepted) {
+      admitted += 1;
+      if (admitted > 64) throw new Error('byte bound never reached');
+    }
+    // The event count bound (400) is nowhere near reached, so the byte bound
+    // is what stopped it.
+    expect(outbox.events.length).toBeLessThan(400);
+    expect(outbox.bytes).toBeLessThanOrEqual(256 * 1_024);
+    expect(outbox.bytes + cotEventBytes(chunk)).toBeGreaterThan(256 * 1_024);
+  });
+
+  it('reports only the first drop, and counts every dropped event thereafter', () => {
+    const outbox = createCotOutbox();
+    const filler = heavyEvent(64 * 1_024);
+    let first = admitCotOutboxEvents(outbox, [filler]);
+    for (let guard = 0; first.accepted && guard < 64; guard += 1) {
+      first = admitCotOutboxEvents(outbox, [filler]);
+    }
+
+    // The refusal that ends the fill is the one the adapter logs about, and it
+    // reports what is still buffered so the warning is actionable.
+    expect(first).toMatchObject({
+      accepted: false,
+      firstDrop: true,
+      bufferedEvents: outbox.events.length,
+      bufferedBytes: outbox.bytes,
+    });
+    expect(outbox.droppedEvents).toBe(1);
+
+    // The warning is emitted once per presentation; later drops still count.
+    const second = admitCotOutboxEvents(outbox, [filler, filler]);
+    expect(second).toMatchObject({ accepted: false, firstDrop: false });
+    expect(outbox.droppedEvents).toBe(3);
+  });
+
+  it('clearing releases the buffer and its byte credit but keeps the drop tally', () => {
+    const outbox = createCotOutbox();
+    admitCotOutboxEvents(outbox, [event('a'), event('b')]);
+    const oversized = heavyEvent(300 * 1_024);
+    admitCotOutboxEvents(outbox, [oversized]);
+    expect(outbox.droppedEvents).toBe(1);
+
+    clearCotOutbox(outbox);
+
+    expect(outbox.events).toHaveLength(0);
+    expect(outbox.bytes).toBe(0);
+    expect(cotOutboxHasEvents(outbox)).toBe(false);
+    // The tally survives: it is what the finished-card log reports.
+    expect(outbox.droppedEvents).toBe(1);
+  });
+});
+
+describe('append batching respects both platform budgets', () => {
+  it('takes at most one legal append worth of events and removes exactly those', () => {
+    const outbox = createCotOutbox();
+    for (let index = 0; index < FEISHU_COT_APPEND_MAX_EVENTS + 7; index += 1) {
+      admitCotOutboxEvents(outbox, [event(`e${index}`)]);
+    }
+    const buffered = outbox.events.length;
+
+    const batch = takeCotAppendBatch(outbox, COT_ID, MESSAGE_ID);
+
+    expect(batch).toHaveLength(FEISHU_COT_APPEND_MAX_EVENTS);
+    expect(outbox.events).toHaveLength(buffered - FEISHU_COT_APPEND_MAX_EVENTS);
+    // FIFO: the batch is the head of the buffer, in order.
+    expect(batch[0]).toEqual(event('e0'));
+    expect(outbox.events[0]).toEqual(event(`e${FEISHU_COT_APPEND_MAX_EVENTS}`));
+    expect(outbox.bytes).toBe(
+      outbox.events.reduce((total, item) => total + cotEventBytes(item), 0),
+    );
+  });
+
+  it('stops below the 50-event cap when the next event would cross the append byte budget', () => {
+    const outbox = createCotOutbox();
+    const chunk = heavyEvent(8 * 1_024);
+    for (let index = 0; index < 20; index += 1) {
+      admitCotOutboxEvents(outbox, [chunk]);
+    }
+
+    const batch = takeCotAppendBatch(outbox, COT_ID, MESSAGE_ID);
+
+    expect(batch.length).toBeGreaterThan(0);
+    expect(batch.length).toBeLessThan(FEISHU_COT_APPEND_MAX_EVENTS);
+    expect(
+      cotAppendBatchBytes({ cotId: COT_ID, messageId: MESSAGE_ID, events: batch }),
+    ).toBeLessThanOrEqual(FEISHU_COT_APPEND_MAX_BYTES);
+    // What did not fit stays buffered for the next flush.
+    expect(cotOutboxHasEvents(outbox)).toBe(true);
+  });
+
+  it('takes nothing when the head event alone cannot fit — the signal a card is unsendable', () => {
+    const outbox = createCotOutbox();
+    const unsendable = heavyEvent(FEISHU_COT_APPEND_MAX_BYTES + 1_024);
+    admitCotOutboxEvents(outbox, [unsendable]);
+
+    const batch = takeCotAppendBatch(outbox, COT_ID, MESSAGE_ID);
+
+    // An empty batch over a non-empty outbox is exactly the state the flush
+    // loop treats as `append_batch_too_large`; without it the loop would spin.
+    expect(batch).toHaveLength(0);
+    expect(cotOutboxHasEvents(outbox)).toBe(true);
+  });
+
+  it('takes nothing from an empty outbox', () => {
+    const outbox = createCotOutbox();
+    expect(takeCotAppendBatch(outbox, COT_ID, MESSAGE_ID)).toHaveLength(0);
+  });
+});
+
+describe('the terminal event rides the last append only when it fits', () => {
+  const terminal: FeishuCotEventInput = {
+    eventType: 'RUN_FINISHED',
+    content: { threadId: 'p-1', runId: 'p-1', status: 'done' },
+  };
+
+  it('appends the terminal to a batch with room', () => {
+    const batch = [event('a')];
+    expect(appendCotTerminalIfFits(batch, terminal, COT_ID, MESSAGE_ID)).toBe(true);
+    expect(batch).toHaveLength(2);
+    expect(batch.at(-1)).toEqual(terminal);
+  });
+
+  it('refuses a batch already at the 50-event cap', () => {
+    const batch = Array.from({ length: FEISHU_COT_APPEND_MAX_EVENTS }, (_, i) =>
+      event(`e${i}`),
+    );
+    expect(appendCotTerminalIfFits(batch, terminal, COT_ID, MESSAGE_ID)).toBe(false);
+    expect(batch).toHaveLength(FEISHU_COT_APPEND_MAX_EVENTS);
+  });
+
+  it('refuses a batch that has no byte room left for it', () => {
+    const outbox = createCotOutbox();
+    const chunk = heavyEvent(8 * 1_024);
+    for (let index = 0; index < 20; index += 1) {
+      admitCotOutboxEvents(outbox, [chunk]);
+    }
+    const batch = takeCotAppendBatch(outbox, COT_ID, MESSAGE_ID);
+    // Pad the batch back up to the byte ceiling so the terminal cannot fit.
+    while (
+      batch.length < FEISHU_COT_APPEND_MAX_EVENTS &&
+      cotAppendBatchBytes({
+        cotId: COT_ID,
+        messageId: MESSAGE_ID,
+        events: [...batch, chunk],
+      }) <= FEISHU_COT_APPEND_MAX_BYTES
+    ) {
+      batch.push(chunk);
+    }
+    const filler = heavyEvent(
+      FEISHU_COT_APPEND_MAX_BYTES -
+        cotAppendBatchBytes({
+          cotId: COT_ID,
+          messageId: MESSAGE_ID,
+          events: batch,
+        }),
+    );
+    batch.push(filler);
+
+    const before = batch.length;
+    expect(appendCotTerminalIfFits(batch, terminal, COT_ID, MESSAGE_ID)).toBe(false);
+    expect(batch).toHaveLength(before);
+  });
+});

--- a/packages/channel/feishu-channel/tests/feishu-cot-session.test.ts
+++ b/packages/channel/feishu-channel/tests/feishu-cot-session.test.ts
@@ -1,0 +1,316 @@
+/**
+ * The fail-open seam between a live Feishu session and its COT adapter
+ * (COVERAGE CELL F).
+ *
+ * COT is optional display. The seam's entire job is that nothing it does can
+ * become a second failure for the session that owns it: a hostile event on the
+ * shared Core stream, a broken logger, or a stale generation must all end in
+ * "no card", never in a thrown error reaching Reply, inbound delivery, or
+ * teardown. The session fence (`isCurrent`) is the other half — a session whose
+ * generation was revoked must present nothing at all.
+ */
+import { describe, expect, it } from 'vitest';
+
+import type { ChannelCoreEvent, DreamuxLogger } from '@excitedjs/dreamux-types';
+
+import { FeishuCotSessionSeam } from '../src/feishu-cot-session.js';
+import { createFakeCotClient, settleCot, type FakeCotClient } from './helpers/fake-cot-client.js';
+import {
+  anchor,
+  assistant,
+  DISPATCHER_ID,
+  groupTarget,
+  LEADER,
+  recordingLogger,
+  settled,
+  submitted,
+  TEAM,
+  teamState,
+  toolCall,
+  type CapturedLog,
+} from './helpers/cot-fixtures.js';
+
+interface Seam {
+  readonly seam: FeishuCotSessionSeam;
+  readonly cot: FakeCotClient;
+  readonly logs: CapturedLog[];
+  current: boolean;
+}
+
+function newSeam(log?: DreamuxLogger): Seam {
+  const cot = createFakeCotClient();
+  const logs: CapturedLog[] = [];
+  const state: Seam = {
+    seam: new FeishuCotSessionSeam({
+      dispatcherId: DISPATCHER_ID,
+      channelId: 'primary',
+      log: log ?? recordingLogger(logs),
+      cotClient: () => cot,
+    }),
+    cot,
+    logs,
+    current: true,
+  };
+  state.seam.start(() => state.current);
+  return state;
+}
+
+/** The ordinary production sequence: submit, then bind the visible message. */
+function submitAndAnchor(state: Seam, turnId: string, messageId: string): void {
+  state.seam.handle(submitted({ turn_id: turnId }));
+  state.seam.attachInboundAnchor(turnId, anchor(messageId));
+}
+
+describe('the seam starts once and owns the adapter lifecycle', () => {
+  it('refuses a second start', () => {
+    const state = newSeam();
+    expect(() => state.seam.start(() => true)).toThrow(/already started/);
+  });
+
+  it('does nothing at all before start, and closing an unstarted seam resolves', async () => {
+    const cot = createFakeCotClient();
+    const seam = new FeishuCotSessionSeam({
+      dispatcherId: DISPATCHER_ID,
+      channelId: 'primary',
+      log: recordingLogger([]),
+      cotClient: () => cot,
+    });
+
+    seam.handle(submitted());
+    seam.attachInboundAnchor('turn-1', anchor('om-1'));
+    seam.setBindingFallbackAnchor(TEAM, LEADER, anchor('om-1'));
+    seam.onRouteReleased({ teamName: TEAM, target: groupTarget() });
+    await settleCot();
+
+    expect(cot.requests).toHaveLength(0);
+    await expect(seam.close()).resolves.toBeUndefined();
+  });
+
+  it('opens a card through the ordinary submit-then-anchor path', async () => {
+    const state = newSeam();
+
+    submitAndAnchor(state, 'turn-1', 'om-inbound-1');
+    state.seam.handle(assistant({ content: '正在处理' }));
+    state.seam.handle(settled());
+    await settleCot();
+
+    expect(state.cot.createRequests()).toHaveLength(1);
+    expect(state.cot.createRequests()[0]?.data?.['origin_message_id'])
+      .toBe('om-inbound-1');
+    expect(state.cot.eventTypesFor('cot-1')).toContain('RUN_FINISHED');
+    await state.seam.close();
+  });
+
+  it('closes the adapter and forgets every unclaimed submission', async () => {
+    const state = newSeam();
+    state.seam.handle(submitted({ turn_id: 'turn-1' }));
+
+    await state.seam.close();
+
+    // The claim proof did not survive teardown, so a late anchor binds nothing.
+    state.seam.attachInboundAnchor('turn-1', anchor('om-1'));
+    await settleCot();
+    expect(state.cot.requests).toHaveLength(0);
+    // Closing twice is a no-op.
+    await expect(state.seam.close()).resolves.toBeUndefined();
+  });
+});
+
+describe('the session fence: a revoked generation presents nothing', () => {
+  it('drops every event and every anchor call while the session is not current', async () => {
+    const state = newSeam();
+    state.current = false;
+
+    state.seam.handle(submitted({ turn_id: 'turn-1' }));
+    state.seam.attachInboundAnchor('turn-1', anchor('om-1'));
+    state.seam.setBindingFallbackAnchor(TEAM, LEADER, anchor('om-2'));
+    state.seam.refreshReplyNextAnchor({
+      caller: { kind: 'team_leader', team_name: TEAM, leader_name: LEADER },
+      anchor: anchor('om-3'),
+    });
+    state.seam.onRouteReleased({ teamName: TEAM, target: groupTarget() });
+    state.seam.onRouteClaimed({ teamName: TEAM, target: groupTarget() });
+    state.seam.handle(assistant());
+    state.seam.handle(teamState({ status: 'closed' }));
+    await settleCot();
+
+    expect(state.cot.requests).toHaveLength(0);
+    await state.seam.close();
+  });
+
+  it('records a submission even while fenced only through the events it is allowed to see', async () => {
+    const state = newSeam();
+    state.current = false;
+    state.seam.handle(submitted({ turn_id: 'turn-1' }));
+
+    // Becoming current again does not resurrect what the fence refused to see.
+    state.current = true;
+    state.seam.attachInboundAnchor('turn-1', anchor('om-1'));
+    await settleCot();
+
+    expect(state.cot.requests).toHaveLength(0);
+    await state.seam.close();
+  });
+});
+
+describe('the anchor claim is the proof of ownership', () => {
+  it('binds only a turn_id this session\'s own submit returned, exactly once', async () => {
+    const state = newSeam();
+    state.seam.handle(submitted({ turn_id: 'turn-1' }));
+
+    state.seam.attachInboundAnchor('turn-1', anchor('om-1'));
+    await settleCot();
+    expect(state.cot.createRequests()).toHaveLength(1);
+
+    // The claim is consumed: a repeated attach cannot re-anchor the turn, and
+    // a turn_id this session never submitted was never claimable.
+    state.seam.attachInboundAnchor('turn-1', anchor('om-2'));
+    state.seam.attachInboundAnchor('turn-foreign', anchor('om-3'));
+    await settleCot();
+    expect(state.cot.createRequests()).toHaveLength(1);
+    await state.seam.close();
+  });
+
+  it('takes a Reply anchor only from a TeamLeader caller', async () => {
+    const state = newSeam();
+    submitAndAnchor(state, 'turn-1', 'om-inbound-1');
+    await settleCot();
+    state.seam.handle(settled());
+    await settleCot();
+
+    // The Dispatcher's Reply is an ordinary outbound message; it never becomes
+    // a Team's next card anchor.
+    state.seam.refreshReplyNextAnchor({
+      caller: { kind: 'dispatcher' },
+      anchor: anchor('om-dispatcher-reply'),
+    });
+    state.seam.refreshReplyNextAnchor({
+      caller: { kind: 'team_leader', team_name: TEAM, leader_name: LEADER },
+      anchor: anchor('om-leader-reply'),
+    });
+
+    state.seam.handle(
+      submitted({ turn_id: 'turn-2', turn_source: 'task-notification' }),
+    );
+    state.seam.handle(
+      assistant({
+        turn_id: 'turn-2',
+        event_id: 'evt-user-2',
+        message_role: 'user',
+        content: '任务完成',
+      }),
+    );
+    await settleCot();
+
+    expect(state.cot.createRequests()).toHaveLength(2);
+    expect(state.cot.createRequests()[1]?.data?.['origin_message_id'])
+      .toBe('om-leader-reply');
+    await state.seam.close();
+  });
+});
+
+describe('the seam demultiplexes one subscription', () => {
+  it('routes each turn event kind and ignores every other Core event', async () => {
+    const state = newSeam();
+    submitAndAnchor(state, 'turn-1', 'om-1');
+    await settleCot();
+
+    state.seam.handle(toolCall({ status: 'started' }));
+    state.seam.handle(
+      toolCall({ status: 'completed', event_id: 'evt-r', result_json: 'ok' }),
+    );
+    // A kind this seam does not present must simply pass by.
+    state.seam.handle({
+      schema_version: 1,
+      kind: 'teammate.state',
+      occurred_at: 9,
+      teammate_name: LEADER,
+      role: 'team_leader',
+      team_name: TEAM,
+      status: 'running',
+    } as ChannelCoreEvent);
+    await settleCot();
+
+    const types = state.cot.eventTypesFor('cot-1');
+    expect(types).toContain('TOOL_CALL_START');
+    expect(types).toContain('TOOL_CALL_RESULT');
+
+    state.seam.handle(teamState({ status: 'closed' }));
+    await settleCot();
+    expect(state.cot.eventsFor('cot-1').filter(
+      (event) => event.eventType === 'RUN_FINISHED',
+    )).toHaveLength(1);
+    await state.seam.close();
+  });
+});
+
+describe('nothing the seam does can become a second failure', () => {
+  it('swallows a hostile event and keeps presenting afterwards', async () => {
+    const state = newSeam();
+    submitAndAnchor(state, 'turn-1', 'om-1');
+    await settleCot();
+
+    const hostile = {
+      get kind(): string {
+        throw new Error('/home/operator/secret exploded');
+      },
+    } as unknown as ChannelCoreEvent;
+    expect(() => state.seam.handle(hostile)).not.toThrow();
+
+    // The session is still alive and the card still takes activity.
+    state.seam.handle(assistant({ content: '故障之后仍在工作' }));
+    await settleCot();
+    expect(JSON.stringify(state.cot.allEvents())).toContain('故障之后仍在工作');
+    await state.seam.close();
+  });
+
+  it('logs only an error category for a swallowed failure', async () => {
+    const state = newSeam();
+    const hostile = {
+      get kind(): string {
+        throw new Error('/home/operator/secret exploded');
+      },
+    } as unknown as ChannelCoreEvent;
+
+    state.seam.handle(hostile);
+
+    const warned = state.logs.filter((entry) => entry.message.startsWith('Feishu COT '));
+    expect(warned).toHaveLength(1);
+    expect(warned[0]?.fields).toEqual({
+      dispatcher_id: DISPATCHER_ID,
+      err_name: 'Error',
+      err_code: null,
+    });
+    expect(JSON.stringify(state.logs)).not.toContain('/home/operator/secret');
+    await state.seam.close();
+  });
+
+  it('survives a logger that throws, so display can never break the session', async () => {
+    const hostileLogger: DreamuxLogger = {
+      trace: () => undefined,
+      debug: () => undefined,
+      info: () => undefined,
+      warn: () => {
+        throw new Error('logger is broken');
+      },
+      error: () => {
+        throw new Error('logger is broken');
+      },
+    };
+    const state = newSeam(hostileLogger);
+    const hostile = {
+      get kind(): string {
+        throw new Error('boom');
+      },
+    } as unknown as ChannelCoreEvent;
+
+    expect(() => state.seam.handle(hostile)).not.toThrow();
+    expect(() =>
+      state.seam.refreshReplyNextAnchor({
+        caller: { kind: 'team_leader', team_name: TEAM, leader_name: LEADER },
+        anchor: anchor('om-1'),
+      }),
+    ).not.toThrow();
+    await expect(state.seam.close()).resolves.toBeUndefined();
+  });
+});

--- a/packages/channel/feishu-channel/tests/feishu-cot-state.test.ts
+++ b/packages/channel/feishu-channel/tests/feishu-cot-state.test.ts
@@ -1,0 +1,530 @@
+/**
+ * The COT correlation ledger and its fences (COVERAGE CELL F).
+ *
+ * Everything here is session-local and pure: which visible message a Team's
+ * card hangs under, which turn a card is allowed to show, what a closed Team or
+ * a withdrawn binding forbids, and how a Dispatcher conversation is bounded.
+ * None of it is durable, so the whole contract is what a later call observes.
+ */
+import { describe, expect, it } from 'vitest';
+
+import {
+  DispatcherCotStateStore,
+  FEISHU_COT_DISPATCHER_CONVERSATIONS_MAX,
+  FEISHU_COT_DISPATCHER_TURNS_MAX,
+  FEISHU_COT_DISPATCHER_TURNS_PER_CHAT_MAX,
+} from '../src/feishu-cot-dispatcher-state.js';
+import {
+  cotLeaderKey,
+  cotOpenCallKey,
+  cotStateAdmitsTurn,
+  cotStateHasAnchor,
+  ensureLeaderState,
+  LeaderLifecycleFence,
+  prepareVisibleAnchor,
+  reapCotState,
+  refreshLeaderNextAnchor,
+  releaseLeaderTurn,
+  rememberOpenToolCall,
+  setLeaderFallbackAnchorIfAbsent,
+  type LeaderState,
+  type VisibleMessageAnchor,
+} from '../src/feishu-cot-state.js';
+import { chatTarget, topicTarget } from '../src/routing/target.js';
+import { anchor, groupTarget, LEADER, TEAM, threadTarget } from './helpers/cot-fixtures.js';
+
+function leaders(): Map<string, LeaderState> {
+  return new Map<string, LeaderState>();
+}
+
+function stateFor(
+  map: Map<string, LeaderState>,
+  teamName = TEAM,
+  leaderName = LEADER,
+): LeaderState {
+  const found = map.get(cotLeaderKey(teamName, leaderName));
+  if (found === undefined) throw new Error('no leader state');
+  return found;
+}
+
+describe('an anchor is accepted only when it names one real visible message', () => {
+  it('rejects a blank chat id, a blank message id, or a target that names another chat', () => {
+    expect(prepareVisibleAnchor(anchor('om-1', chatTarget('', 'group')))).toBeNull();
+    expect(prepareVisibleAnchor({ ...anchor('om-1'), messageId: '' })).toBeNull();
+    expect(
+      prepareVisibleAnchor({
+        chatId: 'oc-a',
+        messageId: 'om-1',
+        // A target pointing somewhere else would retire the wrong anchors when
+        // that other conversation is unbound.
+        target: chatTarget('oc-b', 'group'),
+      }),
+    ).toBeNull();
+  });
+
+  it('copies the target so a later mutation of the caller\'s value cannot move a live card', () => {
+    const target = { ...groupTarget() };
+    const prepared = prepareVisibleAnchor({
+      chatId: target.chatId,
+      messageId: 'om-1',
+      target,
+    });
+    expect(prepared).toEqual({ chatId: target.chatId, messageId: 'om-1', target });
+    expect(prepared?.target).not.toBe(target);
+  });
+});
+
+describe('the standing leader anchor', () => {
+  it('is set once by a binding fallback and never replaces an anchor already held', () => {
+    const map = leaders();
+    setLeaderFallbackAnchorIfAbsent(map, TEAM, LEADER, anchor('om-fallback-1'));
+    expect(stateFor(map).anchor?.messageId).toBe('om-fallback-1');
+
+    setLeaderFallbackAnchorIfAbsent(map, TEAM, LEADER, anchor('om-fallback-2'));
+    // An inbound conversation already owns the card; a later notification must
+    // not silently move it somewhere else.
+    expect(stateFor(map).anchor?.messageId).toBe('om-fallback-1');
+  });
+
+  it('ignores a blank identity and an unusable anchor without creating state', () => {
+    const map = leaders();
+    setLeaderFallbackAnchorIfAbsent(map, '', LEADER, anchor('om-1'));
+    setLeaderFallbackAnchorIfAbsent(map, TEAM, '', anchor('om-1'));
+    setLeaderFallbackAnchorIfAbsent(map, TEAM, LEADER, {
+      ...anchor('om-1'),
+      messageId: '',
+    });
+    expect(map.size).toBe(0);
+  });
+
+  it('takes a Reply as the *next* anchor, only inside the same conversation', () => {
+    const map = leaders();
+    setLeaderFallbackAnchorIfAbsent(map, TEAM, LEADER, anchor('om-inbound-1'));
+
+    refreshLeaderNextAnchor(map, TEAM, LEADER, anchor('om-reply-1'));
+    expect(stateFor(map).nextAnchor?.messageId).toBe('om-reply-1');
+    // The card on screen has not moved; only the next one will.
+    expect(stateFor(map).anchor?.messageId).toBe('om-inbound-1');
+
+    // Replying into a different conversation is an ordinary outbound message,
+    // not a new home for this leader's next card.
+    refreshLeaderNextAnchor(
+      map,
+      TEAM,
+      LEADER,
+      anchor('om-elsewhere', chatTarget('oc-other', 'group')),
+    );
+    expect(stateFor(map).nextAnchor?.messageId).toBe('om-reply-1');
+
+    // Last write inside the same conversation wins.
+    refreshLeaderNextAnchor(map, TEAM, LEADER, anchor('om-reply-2'));
+    expect(stateFor(map).nextAnchor?.messageId).toBe('om-reply-2');
+  });
+
+  it('never creates state, and never takes a next anchor, for a leader with no anchor at all', () => {
+    const map = leaders();
+    refreshLeaderNextAnchor(map, TEAM, LEADER, anchor('om-reply-1'));
+    expect(map.size).toBe(0);
+
+    ensureLeaderState(map, TEAM, LEADER);
+    refreshLeaderNextAnchor(map, TEAM, LEADER, anchor('om-reply-1'));
+    expect(stateFor(map).nextAnchor).toBeNull();
+    expect(cotStateHasAnchor(stateFor(map))).toBe(false);
+  });
+});
+
+describe('turn admission and the reap that keeps the ledger from growing', () => {
+  it('admits exactly the leader turn the session bound, and releases only that one', () => {
+    const map = leaders();
+    const state = ensureLeaderState(map, TEAM, LEADER);
+    state.admittedTurnId = 'turn-1';
+
+    expect(cotStateAdmitsTurn(state, 'turn-1')).toBe(true);
+    expect(cotStateAdmitsTurn(state, 'turn-2')).toBe(false);
+
+    releaseLeaderTurn(state, 'turn-2');
+    expect(state.admittedTurnId).toBe('turn-1');
+    releaseLeaderTurn(state, 'turn-1');
+    expect(state.admittedTurnId).toBeNull();
+  });
+
+  it('reaps an idle anchorless leader and keeps every leader that is still live', () => {
+    const map = leaders();
+    const dispatcher = new DispatcherCotStateStore();
+    const state = ensureLeaderState(map, TEAM, LEADER);
+    const key = cotLeaderKey(TEAM, LEADER);
+
+    state.anchor = anchor('om-1');
+    reapCotState(false, key, state, map, dispatcher);
+    expect(map.has(key)).toBe(true);
+
+    state.anchor = null;
+    state.openCalls.set('c', { generation: 0 });
+    reapCotState(false, key, state, map, dispatcher);
+    expect(map.has(key)).toBe(true);
+
+    state.openCalls.clear();
+    state.inFlight = 1;
+    reapCotState(false, key, state, map, dispatcher);
+    expect(map.has(key)).toBe(true);
+
+    state.inFlight = 0;
+    reapCotState(false, key, state, map, dispatcher);
+    expect(map.has(key)).toBe(false);
+  });
+
+  it('bounds the open tool-call ledger and refreshes an id instead of duplicating it', () => {
+    const openCalls = new Map<string, { readonly generation: number }>();
+    const max = 4;
+    for (let index = 0; index < max; index += 1) {
+      rememberOpenToolCall(openCalls, 1, cotOpenCallKey('turn-1', `call-${index}`), max);
+    }
+    expect(openCalls.size).toBe(max);
+
+    // Re-remembering an id moves it to newest without growing the map.
+    rememberOpenToolCall(openCalls, 1, cotOpenCallKey('turn-1', 'call-0'), max);
+    expect(openCalls.size).toBe(max);
+
+    rememberOpenToolCall(openCalls, 1, cotOpenCallKey('turn-1', 'call-new'), max);
+    expect(openCalls.size).toBe(max);
+    // `call-1` was the oldest after the refresh, so it is what fell out.
+    expect(openCalls.has(cotOpenCallKey('turn-1', 'call-1'))).toBe(false);
+    expect(openCalls.has(cotOpenCallKey('turn-1', 'call-0'))).toBe(true);
+  });
+
+  it('keys open calls per turn, so a reused call id cannot cross turns', () => {
+    expect(cotOpenCallKey('turn-1', 'call-1')).not.toBe(
+      cotOpenCallKey('turn-2', 'call-1'),
+    );
+  });
+});
+
+describe('LeaderLifecycleFence: what a leader may no longer present into', () => {
+  function fenced(): {
+    fence: LeaderLifecycleFence;
+    map: Map<string, LeaderState>;
+    interrupted: string[];
+  } {
+    const map = leaders();
+    const interrupted: string[] = [];
+    return {
+      fence: new LeaderLifecycleFence(),
+      map,
+      interrupted,
+    };
+  }
+
+  it('blocks every anchor for a Team that closed, and interrupts the cards it had', () => {
+    const { fence, map, interrupted } = fenced();
+    const state = ensureLeaderState(map, TEAM, LEADER);
+    state.anchor = anchor('om-1');
+
+    fence.onTeamState(
+      { team_name: TEAM, leader_name: LEADER, status: 'closed' },
+      map,
+      (key) => interrupted.push(key),
+    );
+
+    expect(interrupted).toEqual([cotLeaderKey(TEAM, LEADER)]);
+    expect(fence.blocksAnchor(cotLeaderKey(TEAM, LEADER), anchor('om-2'))).toBe(true);
+    // Another Team is untouched.
+    expect(fence.blocksAnchor(cotLeaderKey('team-beta', LEADER), anchor('om-2')))
+      .toBe(false);
+  });
+
+  it('lifts the fence when the Team runs again', () => {
+    const { fence, map } = fenced();
+    const key = cotLeaderKey(TEAM, LEADER);
+    fence.onTeamState({ team_name: TEAM, leader_name: LEADER, status: 'closed' }, map,
+      () => undefined);
+    expect(fence.blocksAnchor(key, anchor('om-1'))).toBe(true);
+
+    fence.onTeamState({ team_name: TEAM, leader_name: LEADER, status: 'running' }, map,
+      () => undefined);
+    expect(fence.blocksAnchor(key, anchor('om-1'))).toBe(false);
+  });
+
+  it('fences exactly the conversation a binding was withdrawn from, and no other', () => {
+    const { fence, map, interrupted } = fenced();
+    const key = cotLeaderKey(TEAM, LEADER);
+    const state = ensureLeaderState(map, TEAM, LEADER);
+    const released = groupTarget();
+    const surviving = topicTarget(released.chatId, 'omt-thread-9');
+    state.anchor = anchor('om-1', released);
+
+    fence.onRouteReleased({ teamName: TEAM, target: released }, map, (k) =>
+      interrupted.push(k),
+    );
+
+    expect(interrupted).toEqual([key]);
+    expect(fence.blocksAnchor(key, anchor('om-2', released))).toBe(true);
+    // A topic inside the same chat is a different place; its binding survives.
+    expect(fence.blocksAnchor(key, anchor('om-2', surviving))).toBe(false);
+  });
+
+  it('does not interrupt a leader whose anchors point somewhere else, but still fences the route', () => {
+    const { fence, map, interrupted } = fenced();
+    const key = cotLeaderKey(TEAM, LEADER);
+    const elsewhere = chatTarget('oc-elsewhere', 'group');
+    const state = ensureLeaderState(map, TEAM, LEADER);
+    state.anchor = anchor('om-1', elsewhere);
+
+    fence.onRouteReleased({ teamName: TEAM, target: groupTarget() }, map, (k) =>
+      interrupted.push(k),
+    );
+
+    expect(interrupted).toEqual([]);
+    // The card on screen keeps running; only the withdrawn place is closed off.
+    expect(fence.blocksAnchor(key, anchor('om-2', elsewhere))).toBe(false);
+    expect(fence.blocksAnchor(key, anchor('om-2', groupTarget()))).toBe(true);
+  });
+
+  it('interrupts a leader whose *next* anchor pointed at the withdrawn conversation', () => {
+    const { fence, map, interrupted } = fenced();
+    const state = ensureLeaderState(map, TEAM, LEADER);
+    state.anchor = anchor('om-1', chatTarget('oc-elsewhere', 'group'));
+    state.nextAnchor = anchor('om-2', groupTarget());
+
+    fence.onRouteReleased({ teamName: TEAM, target: groupTarget() }, map, (k) =>
+      interrupted.push(k),
+    );
+    expect(interrupted).toEqual([cotLeaderKey(TEAM, LEADER)]);
+  });
+
+  it('re-opens a conversation this Channel binds again', () => {
+    const { fence, map } = fenced();
+    const key = cotLeaderKey(TEAM, LEADER);
+    ensureLeaderState(map, TEAM, LEADER);
+    fence.onRouteReleased({ teamName: TEAM, target: groupTarget() }, map, () => undefined);
+    expect(fence.blocksAnchor(key, anchor('om-2'))).toBe(true);
+
+    fence.onRouteClaimed({ teamName: TEAM, target: groupTarget() });
+    expect(fence.blocksAnchor(key, anchor('om-2'))).toBe(false);
+  });
+
+  it('a route claim for one Team never lifts another Team\'s fence on the same conversation', () => {
+    const { fence, map } = fenced();
+    ensureLeaderState(map, TEAM, LEADER);
+    ensureLeaderState(map, 'team-beta', LEADER);
+    fence.onRouteReleased({ teamName: TEAM, target: groupTarget() }, map, () => undefined);
+    fence.onRouteReleased({ teamName: 'team-beta', target: groupTarget() }, map,
+      () => undefined);
+
+    fence.onRouteClaimed({ teamName: TEAM, target: groupTarget() });
+
+    expect(fence.blocksAnchor(cotLeaderKey(TEAM, LEADER), anchor('om-1'))).toBe(false);
+    expect(fence.blocksAnchor(cotLeaderKey('team-beta', LEADER), anchor('om-1')))
+      .toBe(true);
+  });
+
+  it('bounds both fence ledgers at 512 entries, dropping the oldest', () => {
+    const { fence, map } = fenced();
+    for (let index = 0; index < 512; index += 1) {
+      fence.onTeamState(
+        { team_name: `team-${index}`, leader_name: LEADER, status: 'closed' },
+        map,
+        () => undefined,
+      );
+    }
+    expect(fence.blocksAnchor(cotLeaderKey('team-0', LEADER), anchor('om-1'))).toBe(true);
+    fence.onTeamState(
+      { team_name: 'team-overflow', leader_name: LEADER, status: 'closed' },
+      map,
+      () => undefined,
+    );
+    expect(fence.blocksAnchor(cotLeaderKey('team-0', LEADER), anchor('om-1'))).toBe(false);
+    expect(
+      fence.blocksAnchor(cotLeaderKey('team-overflow', LEADER), anchor('om-1')),
+    ).toBe(true);
+
+    const routeFence = new LeaderLifecycleFence();
+    const routeMap = leaders();
+    ensureLeaderState(routeMap, TEAM, LEADER);
+    const leaderKey = cotLeaderKey(TEAM, LEADER);
+    for (let index = 0; index < 512; index += 1) {
+      routeFence.onRouteReleased(
+        { teamName: TEAM, target: chatTarget(`oc-${index}`, 'group') },
+        routeMap,
+        () => undefined,
+      );
+    }
+    expect(
+      routeFence.blocksAnchor(leaderKey, anchor('om-1', chatTarget('oc-0', 'group'))),
+    ).toBe(true);
+
+    routeFence.onRouteReleased(
+      { teamName: TEAM, target: chatTarget('oc-overflow', 'group') },
+      routeMap,
+      () => undefined,
+    );
+    expect(
+      routeFence.blocksAnchor(leaderKey, anchor('om-1', chatTarget('oc-0', 'group'))),
+    ).toBe(false);
+    expect(
+      routeFence.blocksAnchor(
+        leaderKey,
+        anchor('om-1', chatTarget('oc-overflow', 'group')),
+      ),
+    ).toBe(true);
+  });
+
+  it('clear() drops every fence, as session teardown requires', () => {
+    const { fence, map } = fenced();
+    ensureLeaderState(map, TEAM, LEADER);
+    fence.onTeamState({ team_name: TEAM, leader_name: LEADER, status: 'closed' }, map,
+      () => undefined);
+    fence.onRouteReleased({ teamName: TEAM, target: groupTarget() }, map, () => undefined);
+
+    fence.clear();
+
+    expect(fence.blocksAnchor(cotLeaderKey(TEAM, LEADER), anchor('om-1'))).toBe(false);
+  });
+});
+
+describe('DispatcherCotStateStore is one bounded turn ledger', () => {
+  const dispatcherAnchor = (chatId: string): VisibleMessageAnchor =>
+    anchor(`om-${chatId}`, chatTarget(chatId, 'p2p'));
+
+  it('begins one turn per turn_id and refuses a duplicate without disturbing it', () => {
+    const store = new DispatcherCotStateStore();
+    const first = store.begin('agent', 'turn-1', dispatcherAnchor('oc-1'));
+    expect(first.status).toBe('started');
+
+    expect(store.begin('agent', 'turn-1', dispatcherAnchor('oc-2'))).toEqual({
+      status: 'duplicate',
+    });
+    expect(store.find('agent', 'turn-1')?.state.chatId).toBe('oc-1');
+  });
+
+  it('settles once, and a settled turn is no longer findable', () => {
+    const store = new DispatcherCotStateStore();
+    store.begin('agent', 'turn-1', dispatcherAnchor('oc-1'));
+
+    expect(store.settle('agent', 'turn-1')).not.toBeNull();
+    expect(store.settle('agent', 'turn-1')).toBeNull();
+    expect(store.find('agent', 'turn-1')).toBeNull();
+    expect(store.find('agent', 'never-began')).toBeNull();
+  });
+
+  it('refuses the 65th turn in one chat with no partial state left behind', () => {
+    const store = new DispatcherCotStateStore();
+    for (let index = 0; index < FEISHU_COT_DISPATCHER_TURNS_PER_CHAT_MAX; index += 1) {
+      expect(store.begin('agent', `turn-${index}`, dispatcherAnchor('oc-1')).status)
+        .toBe('started');
+    }
+
+    expect(store.begin('agent', 'turn-overflow', dispatcherAnchor('oc-1'))).toEqual({
+      status: 'full',
+      reason: 'chat_turns',
+      maximum: FEISHU_COT_DISPATCHER_TURNS_PER_CHAT_MAX,
+    });
+    expect(store.find('agent', 'turn-overflow')).toBeNull();
+    // Another conversation is unaffected by one chat being busy.
+    expect(store.begin('agent', 'turn-other', dispatcherAnchor('oc-2')).status)
+      .toBe('started');
+  });
+
+  it('refuses a session turn past the whole-session cap without indexing it', () => {
+    const store = new DispatcherCotStateStore();
+    let created = 0;
+    for (let chat = 0; created < FEISHU_COT_DISPATCHER_TURNS_MAX; chat += 1) {
+      for (
+        let index = 0;
+        index < FEISHU_COT_DISPATCHER_TURNS_PER_CHAT_MAX &&
+        created < FEISHU_COT_DISPATCHER_TURNS_MAX;
+        index += 1
+      ) {
+        store.begin('agent', `turn-${created}`, dispatcherAnchor(`oc-${chat}`));
+        created += 1;
+      }
+    }
+
+    expect(store.begin('agent', 'turn-overflow', dispatcherAnchor('oc-fresh'))).toEqual({
+      status: 'full',
+      reason: 'session_turns',
+      maximum: FEISHU_COT_DISPATCHER_TURNS_MAX,
+    });
+    expect(store.find('agent', 'turn-overflow')).toBeNull();
+    expect([...store.all()]).toHaveLength(FEISHU_COT_DISPATCHER_TURNS_MAX);
+  });
+
+  it('caps distinct conversations at the same ceiling, refusing before any is indexed', () => {
+    // A conversation exists only while it holds a turn, and the session-turn
+    // bound is the same 512, so one turn per conversation reaches the ceiling
+    // for both at once. That is the reachable contract: the 513th distinct
+    // conversation is refused and indexed nowhere.
+    expect(FEISHU_COT_DISPATCHER_CONVERSATIONS_MAX).toBe(
+      FEISHU_COT_DISPATCHER_TURNS_MAX,
+    );
+    const store = new DispatcherCotStateStore();
+    for (let index = 0; index < FEISHU_COT_DISPATCHER_CONVERSATIONS_MAX; index += 1) {
+      expect(
+        store.begin('agent', `turn-${index}`, dispatcherAnchor(`oc-${index}`)).status,
+      ).toBe('started');
+    }
+
+    const refused = store.begin('agent', 'turn-overflow', dispatcherAnchor('oc-fresh'));
+    expect(refused).toMatchObject({
+      status: 'full',
+      maximum: FEISHU_COT_DISPATCHER_CONVERSATIONS_MAX,
+    });
+    expect(store.find('agent', 'turn-overflow')).toBeNull();
+    expect([...store.all()]).toHaveLength(FEISHU_COT_DISPATCHER_CONVERSATIONS_MAX);
+  });
+
+  it('reaps a finished turn and forgets its conversation once empty', () => {
+    const store = new DispatcherCotStateStore();
+    const started = store.begin('agent', 'turn-1', dispatcherAnchor('oc-1'));
+    if (started.status !== 'started') throw new Error('turn did not start');
+    store.begin('agent', 'turn-2', dispatcherAnchor('oc-1'));
+
+    store.reap(started.key, started.state);
+    expect(store.find('agent', 'turn-1')).toBeNull();
+    expect([...store.all()]).toHaveLength(1);
+    // The conversation is still live because a sibling turn holds it, so a new
+    // turn in it does not have to re-open one.
+    expect(store.begin('agent', 'turn-3', dispatcherAnchor('oc-1')).status)
+      .toBe('started');
+
+    store.clear();
+    expect([...store.all()]).toHaveLength(0);
+  });
+
+  it('scopes turns per agent name, so two agents never collide on one turn id', () => {
+    const store = new DispatcherCotStateStore();
+    expect(store.begin('agent-a', 'turn-1', dispatcherAnchor('oc-1')).status)
+      .toBe('started');
+    expect(store.begin('agent-b', 'turn-1', dispatcherAnchor('oc-2')).status)
+      .toBe('started');
+    expect(store.find('agent-a', 'turn-1')?.state.chatId).toBe('oc-1');
+    expect(store.find('agent-b', 'turn-1')?.state.chatId).toBe('oc-2');
+  });
+
+  it('a dispatcher turn state is always admitted for its own turn — it *is* the turn', () => {
+    const store = new DispatcherCotStateStore();
+    const started = store.begin('agent', 'turn-1', dispatcherAnchor('oc-1'));
+    if (started.status !== 'started') throw new Error('turn did not start');
+    expect(cotStateAdmitsTurn(started.state, 'turn-1')).toBe(true);
+    expect(cotStateAdmitsTurn(started.state, 'any-other')).toBe(true);
+    expect(cotStateHasAnchor(started.state)).toBe(true);
+  });
+});
+
+describe('leader identity keys are injective', () => {
+  it('cannot be spelled by another team/leader pair', () => {
+    expect(cotLeaderKey('a', 'b')).not.toBe(cotLeaderKey('ab', ''));
+    expect(cotLeaderKey(TEAM, LEADER)).toBe(cotLeaderKey(TEAM, LEADER));
+  });
+
+  it('a topic anchor and its group anchor are different places', () => {
+    const group = anchor('om-1', groupTarget());
+    const topic = anchor('om-1', threadTarget());
+    const fence = new LeaderLifecycleFence();
+    const map = leaders();
+    ensureLeaderState(map, TEAM, LEADER);
+
+    fence.onRouteReleased({ teamName: TEAM, target: topic.target }, map, () => undefined);
+    expect(fence.blocksAnchor(cotLeaderKey(TEAM, LEADER), topic)).toBe(true);
+    expect(fence.blocksAnchor(cotLeaderKey(TEAM, LEADER), group)).toBe(false);
+  });
+});

--- a/packages/channel/feishu-channel/tests/helpers/cot-fixtures.ts
+++ b/packages/channel/feishu-channel/tests/helpers/cot-fixtures.ts
@@ -1,0 +1,268 @@
+/**
+ * Current-architecture COT fixtures (COVERAGE CELL F).
+ *
+ * Every value here is built from the neutral Core event types the Channel
+ * actually receives today — there is no `ChannelOrigin`, no `ChannelTarget`,
+ * and no binding snapshot on a turn event. The anchor is the Channel's own
+ * `VisibleMessageAnchor`, supplied by the session that submitted the turn.
+ */
+import type {
+  DreamuxLogger,
+  TeamStateEvent,
+  TeammateTurnMessageEvent,
+  TeammateTurnSettledEvent,
+  TeammateTurnSubmittedEvent,
+  TeammateTurnToolCallEvent,
+} from '@excitedjs/dreamux-types';
+
+import { FeishuCotAdapter } from '../../src/feishu-cot-adapter.js';
+import type { VisibleMessageAnchor } from '../../src/feishu-cot-state.js';
+import {
+  chatTarget,
+  topicTarget,
+  type FeishuTarget,
+} from '../../src/routing/target.js';
+import {
+  createFakeCotClient,
+  type FakeCotClient,
+} from './fake-cot-client.js';
+
+export const CHANNEL_ID = 'primary';
+export const DISPATCHER_ID = 'dispatcher-a';
+export const TEAM = 'team-alpha';
+export const LEADER = 'leader';
+export const DISPATCHER_AGENT = 'dispatcher';
+export const GROUP_CHAT = 'oc-group-1';
+
+export interface CapturedLog {
+  readonly level: 'warn' | 'error' | 'info' | 'debug';
+  readonly fields: Record<string, unknown>;
+  readonly message: string;
+}
+
+export function recordingLogger(sink: CapturedLog[]): DreamuxLogger {
+  const at =
+    (level: CapturedLog['level']) =>
+    (fields: Record<string, unknown> | string, message?: string): void => {
+      sink.push({
+        level,
+        fields: typeof fields === 'string' ? {} : fields,
+        message: typeof fields === 'string' ? fields : (message ?? ''),
+      });
+    };
+  return {
+    trace: () => undefined,
+    debug: at('debug'),
+    info: at('info'),
+    warn: at('warn'),
+    error: at('error'),
+  };
+}
+
+export interface CotHarness {
+  readonly adapter: FeishuCotAdapter;
+  readonly cot: FakeCotClient;
+  readonly logs: CapturedLog[];
+}
+
+export function harness(
+  options: {
+    channelId?: string | undefined;
+    cot?: FakeCotClient | undefined;
+    cotClient?: (() => FakeCotClient | undefined) | undefined;
+  } = {},
+): CotHarness {
+  const cot = options.cot ?? createFakeCotClient();
+  const logs: CapturedLog[] = [];
+  const adapter = new FeishuCotAdapter({
+    dispatcherId: DISPATCHER_ID,
+    channelId: 'channelId' in options ? options.channelId : CHANNEL_ID,
+    log: recordingLogger(logs),
+    cotClient: options.cotClient ?? (() => cot),
+  });
+  return { adapter, cot, logs };
+}
+
+export function groupTarget(chatId = GROUP_CHAT): FeishuTarget {
+  return chatTarget(chatId, 'group');
+}
+
+export function threadTarget(
+  chatId = GROUP_CHAT,
+  threadId = 'omt-thread-1',
+): FeishuTarget {
+  return topicTarget(chatId, threadId);
+}
+
+export function anchor(
+  messageId: string,
+  target: FeishuTarget = groupTarget(),
+): VisibleMessageAnchor {
+  return { chatId: target.chatId, messageId, target };
+}
+
+export function submitted(
+  overrides: Partial<TeammateTurnSubmittedEvent> = {},
+): TeammateTurnSubmittedEvent {
+  return {
+    schema_version: 1,
+    kind: 'teammate.turn.submitted',
+    occurred_at: 1,
+    team_name: TEAM,
+    teammate_name: LEADER,
+    role: 'team_leader',
+    turn_id: 'turn-1',
+    turn_source: 'feishu',
+    ...overrides,
+  };
+}
+
+export function dispatcherSubmitted(
+  turnId: string,
+  overrides: Partial<TeammateTurnSubmittedEvent> = {},
+): TeammateTurnSubmittedEvent {
+  return submitted({
+    team_name: null,
+    teammate_name: DISPATCHER_AGENT,
+    role: 'dispatcher',
+    turn_id: turnId,
+    ...overrides,
+  });
+}
+
+export function assistant(
+  overrides: Partial<TeammateTurnMessageEvent> = {},
+): TeammateTurnMessageEvent {
+  return {
+    schema_version: 1,
+    kind: 'teammate.turn.message',
+    event_id: 'evt-message-1',
+    occurred_at: 2,
+    team_name: TEAM,
+    teammate_name: LEADER,
+    role: 'team_leader',
+    turn_id: 'turn-1',
+    message_role: 'assistant',
+    content: '正在处理',
+    content_truncated: false,
+    redacted: false,
+    ...overrides,
+  };
+}
+
+export function userMessage(
+  overrides: Partial<TeammateTurnMessageEvent> = {},
+): TeammateTurnMessageEvent {
+  return assistant({
+    event_id: 'evt-user-1',
+    message_role: 'user',
+    content: '内部推送正文',
+    ...overrides,
+  });
+}
+
+export function dispatcherAssistant(
+  turnId: string,
+  eventId: string,
+  overrides: Partial<TeammateTurnMessageEvent> = {},
+): TeammateTurnMessageEvent {
+  return assistant({
+    team_name: null,
+    teammate_name: DISPATCHER_AGENT,
+    role: 'dispatcher',
+    turn_id: turnId,
+    event_id: eventId,
+    ...overrides,
+  });
+}
+
+export function toolCall(
+  overrides: Partial<TeammateTurnToolCallEvent> = {},
+): TeammateTurnToolCallEvent {
+  return {
+    schema_version: 1,
+    kind: 'teammate.turn.tool_call',
+    event_id: 'evt-tool-1',
+    occurred_at: 3,
+    team_name: TEAM,
+    teammate_name: LEADER,
+    role: 'team_leader',
+    turn_id: 'turn-1',
+    call_id: 'call-1',
+    tool_name: 'exec_command',
+    tool_action: 'run',
+    status: 'started',
+    arguments_json: JSON.stringify({ command: 'pnpm test' }),
+    result_json: null,
+    arguments_truncated: false,
+    result_truncated: false,
+    redacted: false,
+    ...overrides,
+  };
+}
+
+export function settled(
+  overrides: Partial<TeammateTurnSettledEvent> = {},
+): TeammateTurnSettledEvent {
+  return {
+    schema_version: 1,
+    kind: 'teammate.turn.settled',
+    occurred_at: 4,
+    team_name: TEAM,
+    teammate_name: LEADER,
+    role: 'team_leader',
+    turn_id: 'turn-1',
+    status: 'completed',
+    assistant: 'done',
+    assistant_truncated: false,
+    redacted: false,
+    ...overrides,
+  };
+}
+
+export function dispatcherSettled(
+  turnId: string,
+  overrides: Partial<TeammateTurnSettledEvent> = {},
+): TeammateTurnSettledEvent {
+  return settled({
+    team_name: null,
+    teammate_name: DISPATCHER_AGENT,
+    role: 'dispatcher',
+    turn_id: turnId,
+    ...overrides,
+  });
+}
+
+export function teamState(
+  overrides: Partial<TeamStateEvent> = {},
+): TeamStateEvent {
+  return {
+    schema_version: 1,
+    kind: 'team.state',
+    occurred_at: 5,
+    team_name: TEAM,
+    leader_name: LEADER,
+    status: 'running',
+    teammates: [],
+    ...overrides,
+  };
+}
+
+/**
+ * Open one TeamLeader card the ordinary way: the session submitted an inbound
+ * message, held the returned `turn_id`, and says which visible message became
+ * it. The eager receipt is the first thing on the card.
+ */
+export function openLeaderCard(
+  h: CotHarness,
+  input: {
+    turnId?: string;
+    messageId?: string;
+    target?: FeishuTarget;
+  } = {},
+): void {
+  h.adapter.onAnchoredSubmission({
+    event: submitted({ turn_id: input.turnId ?? 'turn-1' }),
+    anchor: anchor(input.messageId ?? 'om-inbound-1', input.target ?? groupTarget()),
+  });
+}

--- a/packages/channel/feishu-channel/tests/helpers/fake-cot-client.ts
+++ b/packages/channel/feishu-channel/tests/helpers/fake-cot-client.ts
@@ -1,0 +1,194 @@
+/**
+ * The platform side of the COT display, observed exactly as Feishu would.
+ *
+ * It is deliberately built on the *real* `createFeishuCotClient` over a stub
+ * request function, so what a test observes is the actual HTTP request the
+ * transport would send — method, url, query params, and body. A test can only
+ * read an AG-UI field by parsing `events[i].content`, and the fake cannot drift
+ * from the transport's wire contract because it does not model the wire at all.
+ */
+import {
+  createFeishuCotClient,
+  type FeishuCotClient,
+} from '@excitedjs/feishu-transport';
+
+/**
+ * The per-event envelope the official Append page specifies, declared here
+ * independently of the transport. A test that imported the production type
+ * would absorb a drift in it instead of catching one.
+ */
+interface ExpectedWireEvent {
+  event_type: string;
+  content: string;
+  timestamp: number;
+}
+
+/** One HTTP request the real COT client issued, exactly as Feishu would see it. */
+export interface RecordedCotRequest {
+  readonly method: string;
+  readonly url: string;
+  readonly params?: Record<string, unknown>;
+  readonly data?: Record<string, unknown>;
+}
+
+/** One appended event with its `content` string parsed back, for assertions. */
+export interface DecodedCotEvent {
+  readonly eventType: string;
+  readonly content: Record<string, unknown>;
+  readonly timestamp: number;
+}
+
+export interface FakeCotClient extends FeishuCotClient {
+  /** Every COT request issued, in order. The single recorded model. */
+  readonly requests: RecordedCotRequest[];
+  createRequests(): RecordedCotRequest[];
+  appendRequests(): RecordedCotRequest[];
+  completeRequests(): RecordedCotRequest[];
+  /** Appended events for one card, in order, with `content` parsed. */
+  eventsFor(cotId: string): DecodedCotEvent[];
+  eventTypesFor(cotId: string): string[];
+  /** Every appended event across every card, in issue order. */
+  allEvents(): DecodedCotEvent[];
+  failNextCreate(error: Error): void;
+  failNextAppend(error: Error): void;
+  failNextComplete(error: Error): void;
+  /** Hold the next create until the returned resolver is called. */
+  blockNextCreate(): () => void;
+  /** Hold the next append until the returned resolver is called. */
+  blockNextAppend(): () => void;
+}
+
+export function createFakeCotClient(
+  options: { now?: () => number } = {},
+): FakeCotClient {
+  const requests: RecordedCotRequest[] = [];
+  let nextId = 1;
+  let createError: Error | null = null;
+  let appendError: Error | null = null;
+  let completeError: Error | null = null;
+  let createGate: Promise<void> | null = null;
+  let appendGate: Promise<void> | null = null;
+
+  const client = createFeishuCotClient(
+    {
+      async request(input: unknown): Promise<unknown> {
+        const request = input as RecordedCotRequest;
+        requests.push(request);
+        if (isCreate(request)) {
+          const id = nextId;
+          nextId += 1;
+          return {
+            code: 0,
+            data: { cot_id: `cot-${id}`, message_id: `om-cot-${id}` },
+          };
+        }
+        return { code: 0 };
+      },
+    } as Parameters<typeof createFeishuCotClient>[0],
+    options.now !== undefined ? { now: options.now } : {},
+  );
+
+  const takeError = (held: Error | null, clear: () => void): void => {
+    if (held === null) return;
+    clear();
+    throw held;
+  };
+
+  const wireEvents = (request: RecordedCotRequest): ExpectedWireEvent[] =>
+    (request.data?.['events'] ?? []) as ExpectedWireEvent[];
+
+  const decode = (event: ExpectedWireEvent): DecodedCotEvent => ({
+    eventType: event.event_type,
+    content: JSON.parse(event.content) as Record<string, unknown>,
+    timestamp: event.timestamp,
+  });
+
+  const fake: FakeCotClient = {
+    requests,
+    createRequests: () => requests.filter(isCreate),
+    appendRequests: () => requests.filter(isAppend),
+    completeRequests: () => requests.filter(isComplete),
+    eventsFor(cotId: string): DecodedCotEvent[] {
+      return requests
+        .filter(
+          (request) => isAppend(request) && request.data?.['cot_id'] === cotId,
+        )
+        .flatMap(wireEvents)
+        .map(decode);
+    },
+    eventTypesFor(cotId: string): string[] {
+      return this.eventsFor(cotId).map((event) => event.eventType);
+    },
+    allEvents(): DecodedCotEvent[] {
+      return requests.filter(isAppend).flatMap(wireEvents).map(decode);
+    },
+    failNextCreate: (error) => {
+      createError = error;
+    },
+    failNextAppend: (error) => {
+      appendError = error;
+    },
+    failNextComplete: (error) => {
+      completeError = error;
+    },
+    blockNextCreate(): () => void {
+      let resolve: () => void = () => undefined;
+      createGate = new Promise<void>((r) => {
+        resolve = r;
+      });
+      return resolve;
+    },
+    blockNextAppend(): () => void {
+      let resolve: () => void = () => undefined;
+      appendGate = new Promise<void>((r) => {
+        resolve = r;
+      });
+      return resolve;
+    },
+
+    async createCot(input) {
+      const gate = createGate;
+      createGate = null;
+      if (gate !== null) await gate;
+      takeError(createError, () => {
+        createError = null;
+      });
+      return client.createCot(input);
+    },
+    async appendCot(input) {
+      const gate = appendGate;
+      appendGate = null;
+      if (gate !== null) await gate;
+      takeError(appendError, () => {
+        appendError = null;
+      });
+      return client.appendCot(input);
+    },
+    async completeCot(input) {
+      takeError(completeError, () => {
+        completeError = null;
+      });
+      return client.completeCot(input);
+    },
+  };
+  return fake;
+}
+
+function isCreate(request: RecordedCotRequest): boolean {
+  return request.method === 'POST' && !request.url.includes('/complete/');
+}
+
+function isAppend(request: RecordedCotRequest): boolean {
+  return request.method === 'PUT';
+}
+
+function isComplete(request: RecordedCotRequest): boolean {
+  return request.method === 'POST' && request.url.includes('/complete/');
+}
+
+/** Let every enqueued adapter task and its bounded operation settle. */
+export async function settleCot(rounds = 12): Promise<void> {
+  for (let index = 0; index < rounds; index += 1) {
+    await new Promise((resolve) => setImmediate(resolve));
+  }
+}

--- a/packages/dreamux/tests/channel-service.test.ts
+++ b/packages/dreamux/tests/channel-service.test.ts
@@ -21,7 +21,7 @@
  *     composed; it is reached only from the Dispatcher-agent and TeamLeader
  *     delegate assemblies, never from the ordinary TeamMate one.
  */
-import { mkdtemp, readFile, rm } from 'node:fs/promises';
+import { mkdtemp, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
@@ -42,6 +42,11 @@ import {
 } from '../src/channel/external-channel-provider.js';
 import { channelMcpDelegates } from '../src/service/channel-service/mcp-delegates.js';
 import { ChannelService } from '../src/service/channel-service/index.js';
+import type { DispatcherService } from '../src/service/dispatcher-service/index.js';
+import {
+  dispatcherAgentMcpDelegates,
+  teamLeaderMcpDelegates,
+} from '../src/service/dispatcher-service/mcp-delegates.js';
 import { ProviderRegistry } from '../src/registry/registry.js';
 import { parseProviderRef } from '../src/registry/provider-ref.js';
 import { dispatcherCacheDir, dispatcherDir } from '../src/platform/paths.js';
@@ -50,6 +55,7 @@ import {
   fakeChannelToolRegistration,
   type FakeChannelProviderResult,
 } from './helpers/fake-channel-provider.js';
+import { moduleSpecifiers, parseSource } from './helpers/source-structure.js';
 
 function silentLogger(): DreamuxLogger {
   const noop = () => {};
@@ -404,21 +410,62 @@ describe('channelMcpDelegates (Channel MCP injection)', () => {
     expect(delegates).toHaveLength(0);
   });
 
-  it('is reached only from the Dispatcher-agent and TeamLeader delegate assemblies, never the ordinary TeamMate one', async () => {
+  it('puts a Channel MCP server into both role tool sets that exist — the Dispatcher Agent\'s and a TeamLeader\'s', async () => {
+    const { result } = mcpProviderWithCaller();
+    const catalog = catalogWith([{ ref: 'npm:@example/chan#create', provider: result.provider }]);
+    const channels = new ChannelService({
+      dispatcherId: 'flow',
+      config: dreamuxConfigWith('flow', [channelConfig('primary', 'npm:@example/chan#create')]),
+      channelProviders: catalog,
+      channelLoggerFactory: () => silentLogger(),
+    });
+    await channels.build();
+    // The role assemblies compose delegates lazily; none of them reaches the
+    // DispatcherService until a tool is actually called.
+    const input = {
+      dispatcherId: 'flow',
+      dispatcher: {} as unknown as DispatcherService,
+      channels,
+      channelProviders: catalog,
+    };
+
+    const dispatcherServers = dispatcherAgentMcpDelegates(input).map((d) => d.name);
+    const leaderServers = teamLeaderMcpDelegates({
+      ...input,
+      teamId: 'alpha',
+      leaderName: 'leader-alpha',
+    }).map((d) => d.name);
+
+    expect(dispatcherServers).toContain('channel-primary');
+    expect(leaderServers).toContain('channel-primary');
+    await channels.closeAll(silentLogger());
+  });
+
+  it('never reaches the ordinary TeamMate surface: that module has no dependency edge to it at all', async () => {
     // Architectural absence check: "ordinary TeamMates receive none" is proven
-    // by there being no call site at all in the TeamMate delegate assembly,
-    // not by a runtime flag a TeamMate-scoped call could theoretically flip.
-    const dispatcherAssembly = await readFile(
-      new URL('../src/service/dispatcher-service/mcp-delegates.ts', import.meta.url),
-      'utf8',
-    );
-    const teammateAssembly = await readFile(
+    // by there being no dependency edge at all from the TeamMate delegate to
+    // channel-service's caller-scoped MCP builder, not by a runtime flag a
+    // TeamMate-scoped call could theoretically flip. Read off the parsed
+    // import/export/dynamic-import graph, so a mention in prose is correctly
+    // not a violation and a renamed binding still is.
+    const teammateAssembly = await parseSource(
       new URL('../src/service/teammate-collection/mcp-delegate.ts', import.meta.url),
-      'utf8',
     );
-    expect(dispatcherAssembly).toMatch(/channelMcpDelegates\(/);
-    expect(dispatcherAssembly).toMatch(/dispatcherAgentMcpDelegates/);
-    expect(dispatcherAssembly).toMatch(/teamLeaderMcpDelegates/);
-    expect(teammateAssembly).not.toMatch(/channelMcpDelegates/);
+    const roleAssembly = await parseSource(
+      new URL('../src/service/dispatcher-service/mcp-delegates.ts', import.meta.url),
+    );
+
+    expect(moduleSpecifiers(teammateAssembly)).not.toContain(
+      '../channel-service/mcp-delegates.js',
+    );
+    expect(
+      moduleSpecifiers(teammateAssembly).some((specifier) =>
+        specifier.includes('channel-service'),
+      ),
+    ).toBe(false);
+    // And the one place that does depend on it is the role split itself.
+    expect(moduleSpecifiers(roleAssembly)).toContain(
+      '../channel-service/mcp-delegates.js',
+    );
   });
 });

--- a/packages/dreamux/tests/core-event-catalog.test.ts
+++ b/packages/dreamux/tests/core-event-catalog.test.ts
@@ -14,14 +14,20 @@
  * catalog.
  */
 import { existsSync } from 'node:fs';
-import { readFile } from 'node:fs/promises';
 import { join } from 'node:path';
 
+import ts from 'typescript';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import type {
+  AgentRuntimeActivitySink,
+  AgentRuntimeProvider,
   ChannelCoreEvent,
+  DreamuxLogger,
+  RuntimeActivityEvent,
+  RuntimeSubmission,
   TeamStateTeammateSummary,
+  TeammateRole,
 } from '@excitedjs/dreamux-types';
 
 import { DispatcherCoreEventBus } from '../src/service/dispatcher-core-events/index.js';
@@ -37,6 +43,12 @@ import {
   AgentEntityCollectionStore,
 } from '../src/service/agent-entity/identity-store.js';
 import { AgentRuntimeStateStore } from '../src/service/agent-entity/runtime-state.js';
+import { AgentRuntimeProviderCatalog } from '../src/agent-runtime/index.js';
+import type { DreamuxConfig } from '../src/config/config.js';
+import { ProviderRegistry } from '../src/registry/registry.js';
+import { parseProviderRef } from '../src/registry/provider-ref.js';
+import { AdmissionLedger } from '../src/service/teammate-service/admission-ledger.js';
+import { TeammateRuntimeOwner } from '../src/service/teammate-service/runtime-owner.js';
 import {
   createCapturingLogger,
   createCapturingPublisher,
@@ -46,6 +58,12 @@ import {
   makeTempDir,
   removeTempDir,
 } from './helpers/event-harness.js';
+import {
+  calleeName,
+  classMethod,
+  collect,
+  parseSource,
+} from './helpers/source-structure.js';
 
 const DISPATCHER_ID = 'dispatcher-fixture';
 
@@ -554,26 +572,34 @@ describe('teammate.state covers every Agent entity kind, with role a runtime pro
   });
 
   it('the Dispatcher and its dispatcher-scoped TeamMates are wired to the real publisher with role read from team_id, not asserted', async () => {
-    // `DispatcherService` is too heavy to construct here (full config,
-    // registry, catalog, admin socket...), so this anchors to the actual
-    // `dispatcher-service/index.ts` source instead of re-deriving the event
-    // shape from a local fixture (which would only prove the test's own
-    // construction, not production behavior).
-    const dispatcherServiceSource = await readFile(
+    // `DispatcherService` needs a full config, registry, catalog and admin
+    // socket to construct, so this claim is checked against the parsed class
+    // rather than re-derived from a local fixture (which would only prove the
+    // test's own construction). It is structural, not textual: every assertion
+    // below reads a node of the real AST, so a reformat or a rename of an
+    // unrelated neighbour cannot make it pass or fail.
+    const source = await parseSource(
       new URL('../src/service/dispatcher-service/index.ts', import.meta.url),
-      'utf8',
     );
 
     // Both onPersisted wirings exist, and use exactly the two roles a
     // dispatcher-scoped Agent (the dispatcher root itself, or one of its
     // TeamMates) can ever be: never 'team_leader', which only a Team-scoped
     // identity can carry.
-    expect(dispatcherServiceSource).toContain(
-      "onPersisted: (identity) => this.publishAgentState(identity, 'dispatcher')",
-    );
-    expect(dispatcherServiceSource).toContain(
-      "onPersisted: (identity) => this.publishAgentState(identity, 'teammate')",
-    );
+    const publishedRoles = collect(source, ts.isPropertyAssignment)
+      .filter(
+        (property) =>
+          ts.isIdentifier(property.name) && property.name.text === 'onPersisted',
+      )
+      .flatMap((property) => collect(property.initializer, ts.isCallExpression))
+      .filter((call) => calleeName(call) === 'publishAgentState')
+      .map((call) => call.arguments[1])
+      .map((argument) =>
+        argument !== undefined && ts.isStringLiteralLike(argument)
+          ? argument.text
+          : '?',
+      );
+    expect(publishedRoles.sort()).toEqual(['dispatcher', 'teammate']);
 
     // The single publisher method both wirings funnel through: it builds
     // `teammate.state` reading `team_name` off the identity's own `team_id`
@@ -582,23 +608,60 @@ describe('teammate.state covers every Agent entity kind, with role a runtime pro
     // parameter is typed to exclude 'team_leader' entirely, which is the
     // compile-time half of "a Dispatcher/dispatcher TeamMate never reports as
     // a team_leader".
-    const methodStart = dispatcherServiceSource.indexOf('private publishAgentState(');
-    expect(methodStart).toBeGreaterThan(-1);
-    const methodBody = dispatcherServiceSource.slice(methodStart, methodStart + 600);
-    expect(methodBody).toContain("role: 'dispatcher' | 'teammate'");
-    expect(methodBody).toContain("kind: 'teammate.state'");
-    expect(methodBody).toContain('team_name: identity.team_id');
+    const publisher = classMethod(source, 'publishAgentState');
+    const roleParameter = publisher.parameters.find(
+      (parameter) =>
+        ts.isIdentifier(parameter.name) && parameter.name.text === 'role',
+    );
+    const roleType = roleParameter?.type;
+    expect(roleType !== undefined && ts.isUnionTypeNode(roleType)).toBe(true);
+    expect(
+      (roleType as ts.UnionTypeNode).types
+        .map((member) =>
+          ts.isLiteralTypeNode(member) && ts.isStringLiteralLike(member.literal)
+            ? member.literal.text
+            : '?',
+        )
+        .sort(),
+    ).toEqual(['dispatcher', 'teammate']);
+
+    const published = Object.fromEntries(
+      collect(publisher, ts.isPropertyAssignment)
+        .filter((property) => ts.isIdentifier(property.name))
+        .map((property) => [
+          (property.name as ts.Identifier).text,
+          property.initializer.getText(source),
+        ]),
+    );
+    expect(published['kind']).toBe("'teammate.state'");
+    expect(published['team_name']).toBe('identity.team_id');
   });
 
-  it('the TeammateRole vocabulary excludes the deleted team_member kind (issue #63 deleted surface)', async () => {
-    const teammateTypesSource = await readFile(
-      new URL('../../dreamux-types/src/teammate.ts', import.meta.url),
-      'utf8',
-    );
-    expect(teammateTypesSource).not.toContain('team_member');
-    expect(teammateTypesSource).toMatch(
-      /TeammateRole = 'dispatcher' \| 'teammate' \| 'team_leader'/,
-    );
+  it('the TeammateRole vocabulary is exactly the three live roles — the deleted team_member kind is not assignable (issue #63 deleted surface)', () => {
+    const live: TeammateRole[] = ['dispatcher', 'teammate', 'team_leader'];
+
+    // Compile-time exhaustiveness: the `never` assignment only type-checks
+    // while the union has no fourth member, so adding one fails the build
+    // rather than this assertion.
+    const name = (role: TeammateRole): string => {
+      switch (role) {
+        case 'dispatcher':
+          return 'dispatcher';
+        case 'teammate':
+          return 'teammate';
+        case 'team_leader':
+          return 'team_leader';
+        default: {
+          const unreachable: never = role;
+          return unreachable;
+        }
+      }
+    };
+    expect(live.map(name)).toEqual(['dispatcher', 'teammate', 'team_leader']);
+
+    // @ts-expect-error 'team_member' was deleted from the role vocabulary.
+    const deleted: TeammateRole = 'team_member';
+    expect(live).not.toContain(deleted);
   });
 });
 
@@ -824,24 +887,144 @@ describe('activity from a revoked runtime generation can never reach a replaceme
     }
   });
 
-  it('TeammateRuntimeOwner forwards activity to Core only after checking that same lease, fail-open on rejection', async () => {
-    // `generationActivitySink` is private and reachable only through a full
-    // provider-backed runtime start, which is out of this cell's scope; the
-    // ownership of the gate (checked before forwarding, never after) is
-    // exactly what a regression here would silently remove, so it is the
-    // absence/ordering this guard proves.
-    const source = await readFile(
-      new URL('../src/service/teammate-service/runtime-owner.ts', import.meta.url),
-      'utf8',
-    );
-    const sinkStart = source.indexOf('private generationActivitySink');
-    expect(sinkStart).toBeGreaterThan(-1);
-    const sinkBody = source.slice(sinkStart, source.indexOf('private resolveLaunch'));
-    const guardIndex = sinkBody.indexOf('lease.isCurrent()');
-    const logIndex = sinkBody.indexOf('dropped Agent Runtime activity from a revoked runtime generation');
-    const forwardIndex = sinkBody.indexOf('this.callbacks.activitySink(event)');
-    expect(guardIndex).toBeGreaterThan(-1);
-    expect(logIndex).toBeGreaterThan(guardIndex);
-    expect(forwardIndex).toBeGreaterThan(logIndex);
+  it('TeammateRuntimeOwner forwards activity to Core only while that lease is current, and drops it fail-open once revoked', async () => {
+    const dir = await makeTempDir('runtime-generation-sink');
+    try {
+      const h = await bootRuntimeOwner(dir);
+
+      // The sink the provider was handed is the only way live activity can
+      // reach Core; it is generation-scoped by construction.
+      await h.owner.ensureStarted();
+      const sink = h.providerActivitySink();
+      sink(activityEvent('first'));
+      expect(h.forwarded.map((event) => event.activity.id)).toEqual(['first']);
+
+      // A replacement runtime opens the next generation, revoking this one.
+      h.state.leaseRuntimeGeneration();
+      sink(activityEvent('after-revocation'));
+
+      // The gate is checked *before* forwarding: nothing from the revoked
+      // generation reaches Core's conversation stream, and the drop is only
+      // logged.
+      expect(h.forwarded.map((event) => event.activity.id)).toEqual(['first']);
+      expect(
+        h.debugMessages.some((message) =>
+          message.includes('revoked runtime generation'),
+        ),
+      ).toBe(true);
+      // Fail-open by contract: a stale write is never raised back at the
+      // provider that made it.
+      expect(() => sink(activityEvent('again'))).not.toThrow();
+
+      await h.owner.stopRuntime();
+    } finally {
+      await removeTempDir(dir);
+    }
   });
 });
+
+function activityEvent(id: string): RuntimeActivityEvent {
+  return {
+    submission: Object.freeze({
+      settled: new Promise<never>(() => undefined),
+    }) as RuntimeSubmission,
+    activity: {
+      kind: 'assistant.message',
+      id,
+      text: 'hello',
+      truncated: false,
+    },
+    occurredAt: Date.now(),
+  };
+}
+
+/**
+ * A real {@link TeammateRuntimeOwner} over a fake Agent Runtime provider.
+ *
+ * Only the provider is fake — the identity store, the runtime-state store, and
+ * the generation lease are the production classes, because the contract under
+ * test is exactly how the owner scopes activity to a lease those classes issue.
+ */
+async function bootRuntimeOwner(dir: string): Promise<{
+  owner: TeammateRuntimeOwner;
+  state: AgentRuntimeStateStore;
+  forwarded: RuntimeActivityEvent[];
+  debugMessages: string[];
+  providerActivitySink: () => AgentRuntimeActivitySink;
+}> {
+  const store = makeIdentityStore({ dir });
+  const identity = await store.create(
+    makeIdentityCreateInput({ name: 'scout', status: 'running' }),
+  );
+  const state = new AgentRuntimeStateStore(store, identity);
+
+  let captured: AgentRuntimeActivitySink | null = null;
+  const provider: AgentRuntimeProvider<unknown> = {
+    getCapabilities: () => ({ tags: [] }),
+    readRecentActivity: async () => ({ records: [], truncated: false }),
+    createRuntime: async (context) => {
+      captured = context.activity ?? null;
+      return {
+        start: async () => ({ continuity: 'fresh' as const }),
+        submit: () => {
+          throw new Error('this fixture never submits');
+        },
+        stop: async () => undefined,
+      };
+    },
+  };
+  const registry = new ProviderRegistry();
+  const descriptor = {
+    id: 'npm:@example/rt#create',
+    kind: 'agentRuntime' as const,
+    ref: parseProviderRef('npm:@example/rt#create'),
+  };
+  registry.register(descriptor);
+  registry.registerImplementation(descriptor.id, provider);
+
+  const debugMessages: string[] = [];
+  const log = {
+    error: () => {},
+    warn: () => {},
+    info: () => {},
+    trace: () => {},
+    debug: (_fields: unknown, message?: string) => {
+      debugMessages.push(message ?? '');
+    },
+  } as unknown as DreamuxLogger;
+
+  const forwarded: RuntimeActivityEvent[] = [];
+  const owner = new TeammateRuntimeOwner(
+    {
+      config: {
+        agents: { [identity.agent_runtime]: { provider: descriptor.id, config: {} } },
+        dispatchers: [],
+      } as unknown as DreamuxConfig,
+      agentRuntimeProviders: new AgentRuntimeProviderCatalog({ registry }),
+      identities: store,
+      admissions: new AdmissionLedger(),
+      log,
+    },
+    DISPATCHER_ID,
+    state,
+    { runtimeId: 'runtime-1', role: 'teammate', ownsWorktreeOnClose: false },
+    {
+      isActive: () => true,
+      markClosing: () => undefined,
+      activitySink: (event) => forwarded.push(event),
+    },
+  );
+
+  return {
+    owner,
+    state,
+    forwarded,
+    debugMessages,
+    providerActivitySink: () => {
+      if (captured === null) {
+        throw new Error('the provider was never handed an activity sink');
+      }
+      return captured;
+    },
+  };
+}

--- a/packages/dreamux/tests/helpers/source-structure.ts
+++ b/packages/dreamux/tests/helpers/source-structure.ts
@@ -1,0 +1,156 @@
+/**
+ * Structural (AST) queries over this package's own source.
+ *
+ * A handful of architectural contracts are *absences* or *single-owner* claims
+ * that no runtime value can express: "this capability has exactly one call
+ * site", "this layer never imports that one". Those need a static check — but a
+ * static check on the parsed program, not on the file's text. Text matching
+ * fires on comments and string literals, misses a renamed import, and breaks on
+ * behavior-preserving reformatting; the queries below read the real TypeScript
+ * AST, so they mean what they say.
+ *
+ * Everything here is read-only and test-scoped. Nothing in `src/**` depends on
+ * it.
+ */
+import { readFile, readdir } from 'node:fs/promises';
+import { fileURLToPath } from 'node:url';
+
+import ts from 'typescript';
+
+export async function parseSource(source: URL): Promise<ts.SourceFile> {
+  const path = fileURLToPath(source);
+  return ts.createSourceFile(
+    path,
+    await readFile(path, 'utf8'),
+    ts.ScriptTarget.ES2022,
+    /* setParentNodes */ true,
+    ts.ScriptKind.TS,
+  );
+}
+
+/** Every `.ts` file directly inside `dir`, parsed. */
+export async function parseDirectory(dir: URL): Promise<ts.SourceFile[]> {
+  const entries = await readdir(dir);
+  return Promise.all(
+    entries
+      .filter((entry) => entry.endsWith('.ts'))
+      .map((entry) => parseSource(new URL(entry, dir))),
+  );
+}
+
+function walk(node: ts.Node, visit: (node: ts.Node) => void): void {
+  visit(node);
+  node.forEachChild((child) => walk(child, visit));
+}
+
+export function collect<T extends ts.Node>(
+  root: ts.Node,
+  match: (node: ts.Node) => node is T,
+): T[] {
+  const found: T[] = [];
+  walk(root, (node) => {
+    if (match(node)) found.push(node);
+  });
+  return found;
+}
+
+/**
+ * The member name a call expression invokes, for calls of the form `x.name(…)`
+ * (including `this.name(…)` and optional-chained `x?.name(…)`). A bare
+ * `name(…)` call yields the identifier itself.
+ */
+export function calleeName(call: ts.CallExpression): string | null {
+  const callee = call.expression;
+  if (ts.isPropertyAccessExpression(callee)) return callee.name.text;
+  if (ts.isIdentifier(callee)) return callee.text;
+  return null;
+}
+
+/** Every member/function name called anywhere under `root`. */
+export function calledNames(root: ts.Node): string[] {
+  return collect(root, ts.isCallExpression)
+    .map(calleeName)
+    .filter((name): name is string => name !== null);
+}
+
+/** The named method of the (single) class declared in `source`. */
+export function classMethod(
+  source: ts.SourceFile,
+  methodName: string,
+): ts.MethodDeclaration {
+  const found = collect(source, ts.isMethodDeclaration).find(
+    (method) => ts.isIdentifier(method.name) && method.name.text === methodName,
+  );
+  if (found === undefined) {
+    throw new Error(`no method named ${methodName} in ${source.fileName}`);
+  }
+  return found;
+}
+
+/**
+ * The name of the nearest enclosing named declaration — the method, function,
+ * property, or variable a node is written inside.
+ *
+ * This is what makes a "single call site" claim total: scanning methods alone
+ * would let the same call escape into a bare function or an arrow property, so
+ * the query starts from the call and asks who contains it.
+ */
+export function enclosingMemberName(node: ts.Node): string | null {
+  for (let current = node.parent; current !== undefined; current = current.parent) {
+    if (
+      ts.isMethodDeclaration(current) ||
+      ts.isFunctionDeclaration(current) ||
+      ts.isPropertyDeclaration(current) ||
+      ts.isVariableDeclaration(current)
+    ) {
+      const name = current.name;
+      if (name !== undefined && ts.isIdentifier(name)) return name.text;
+      return null;
+    }
+  }
+  return null;
+}
+
+/** Whether `source` declares a class member with this name (method or property). */
+export function hasClassMember(
+  source: ts.SourceFile,
+  memberName: string,
+): boolean {
+  return collect(source, ts.isClassDeclaration).some((declaration) =>
+    declaration.members.some(
+      (member) =>
+        member.name !== undefined &&
+        ts.isIdentifier(member.name) &&
+        member.name.text === memberName,
+    ),
+  );
+}
+
+/**
+ * Every module specifier `source` depends on: static imports, re-exports, and
+ * dynamic `import(...)` calls with a literal specifier. This is the whole
+ * static dependency edge set of one file.
+ */
+export function moduleSpecifiers(source: ts.SourceFile): string[] {
+  const specifiers: string[] = [];
+  walk(source, (node) => {
+    if (
+      (ts.isImportDeclaration(node) || ts.isExportDeclaration(node)) &&
+      node.moduleSpecifier !== undefined &&
+      ts.isStringLiteral(node.moduleSpecifier)
+    ) {
+      specifiers.push(node.moduleSpecifier.text);
+      return;
+    }
+    if (
+      ts.isCallExpression(node) &&
+      node.expression.kind === ts.SyntaxKind.ImportKeyword
+    ) {
+      const [first] = node.arguments;
+      if (first !== undefined && ts.isStringLiteral(first)) {
+        specifiers.push(first.text);
+      }
+    }
+  });
+  return specifiers;
+}

--- a/packages/dreamux/tests/team-dissolve-contract.test.ts
+++ b/packages/dreamux/tests/team-dissolve-contract.test.ts
@@ -1,7 +1,8 @@
-import { access, mkdir, readFile, writeFile } from 'node:fs/promises';
+import { access, mkdir, writeFile } from 'node:fs/promises';
 import { rm } from 'node:fs/promises';
 import { join } from 'node:path';
 
+import ts from 'typescript';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import type { TeamClosing } from '../src/service/team-service/closing.js';
@@ -21,6 +22,14 @@ import {
   newWorktreeManager,
   teamLeaderDissolve,
 } from './helpers/dissolve-harness.js';
+import {
+  calledNames,
+  calleeName,
+  classMethod,
+  collect,
+  enclosingMemberName,
+  parseSource,
+} from './helpers/source-structure.js';
 
 /**
  * COVERAGE CELL D (team-dissolve): the submission contract dissolve makes to
@@ -162,7 +171,7 @@ describe('the preflight ordering TeamClosing owns per caller kind', () => {
 });
 
 describe('no idle-drain machinery in the dissolve path', () => {
-  it('no file in the dissolve path — TeamClosing, TeamService, member close, or worktree reclaim — ever references waitIdle', async () => {
+  it('no file in the dissolve path — TeamClosing, TeamService, member close, or worktree reclaim — ever calls an idle-drain', async () => {
     const targets = [
       new URL('../src/service/team-service/closing.ts', import.meta.url),
       new URL('../src/service/team-service/index.ts', import.meta.url),
@@ -170,43 +179,44 @@ describe('no idle-drain machinery in the dissolve path', () => {
       new URL('../src/service/team-collection/worktree-cleanup.ts', import.meta.url),
     ];
     for (const target of targets) {
-      const text = await readFile(target, 'utf8');
       // Dissolve is a stop-and-reclaim, never a drain: this absence is the
       // contract, not an incidental fact about the current implementation.
-      expect(text).not.toMatch(/\bwaitIdle\b/);
-      expect(text).not.toMatch(/\bisIdle\b/);
+      // Asserted over the parsed call graph of each file, so a mention in a
+      // comment or a doc string is correctly *not* a violation, and a renamed
+      // or reformatted call still is.
+      const called = calledNames(await parseSource(target));
+      expect(called).not.toContain('waitIdle');
+      expect(called).not.toContain('waitForIdle');
+      expect(called).not.toContain('isIdle');
     }
   });
 });
 
 describe('one submission capability: the Dispatcher-facing dissolve surface has no second path', () => {
-  it('dissolveTeam and dissolveTeamForLeader both route through the same private submitDissolve, which itself is the only call site that invokes .dissolve(', async () => {
-    const text = await readFile(
+  it('both dissolve entry points call submitDissolve, and submitDissolve is the only member that reaches a Team\'s own dissolve', async () => {
+    // Structural, not textual: `DispatcherService` needs a full config,
+    // registry, catalog and admin socket to construct, so the "exactly one
+    // admission path" claim is checked against the parsed class rather than a
+    // window of its source text.
+    const source = await parseSource(
       new URL('../src/service/dispatcher-service/index.ts', import.meta.url),
-      'utf8',
     );
 
-    const sliceBody = (marker: string): string => {
-      const start = text.indexOf(marker);
-      expect(start).toBeGreaterThan(-1);
-      // Each of these members is short; the next blank-line-preceded closing
-      // brace at column 2 ends it. A generous fixed window is simpler and
-      // just as precise for a body this short.
-      return text.slice(start, start + 400);
-    };
-
-    expect(sliceBody('dissolveTeam(input: TeamDissolveInput)')).toMatch(
-      /this\.submitDissolve\(/,
-    );
-    expect(sliceBody('dissolveTeamForLeader(input:')).toMatch(
-      /this\.submitDissolve\(/,
-    );
+    expect(calledNames(classMethod(source, 'dissolveTeam')))
+      .toContain('submitDissolve');
+    expect(calledNames(classMethod(source, 'dissolveTeamForLeader')))
+      .toContain('submitDissolve');
 
     // The one place that actually calls the Team's own `.dissolve(...)` is
     // `submitDissolve` itself — there is no second, parallel admission path
-    // that reaches a Team's dissolve without going through it.
-    const dissolveCallSites = text.match(/\)\.dissolve\(input\)/g) ?? [];
-    expect(dissolveCallSites).toHaveLength(1);
+    // that reaches a Team's dissolve without going through it. The scan starts
+    // from every `dissolve(...)` call in the file, not from the class's
+    // methods, so a call written in a bare function or an arrow property is
+    // caught too.
+    const dissolveCallers = collect(source, ts.isCallExpression)
+      .filter((call) => calleeName(call) === 'dissolve')
+      .map(enclosingMemberName);
+    expect(dissolveCallers).toEqual(['submitDissolve']);
   });
 });
 

--- a/packages/dreamux/tests/workflow-service.test.ts
+++ b/packages/dreamux/tests/workflow-service.test.ts
@@ -18,6 +18,7 @@ import {
 } from '../src/platform/paths.js';
 import { WORKFLOW_AGENT_SYSTEM_PROMPT } from '../src/service/workflow-service/agent-policy.js';
 import { WorkflowService } from '../src/service/workflow-service/index.js';
+import type { WorkflowRunDeps } from '../src/service/workflow-service/run.js';
 import type { WorkflowRunRecord } from '../src/service/workflow-service/types.js';
 import type { LockedTeammate } from '../src/service/teammate-service/types.js';
 import {
@@ -34,6 +35,7 @@ import {
   waitUntil,
   type WorkflowRootState,
 } from './helpers/workflow-harness.js';
+import { moduleSpecifiers, parseDirectory } from './helpers/source-structure.js';
 
 let root: WorkflowRootState;
 
@@ -367,21 +369,21 @@ describe('owner-side exact-instance eviction', () => {
     });
   });
 
-  it('WorkflowRun itself never calls an eviction callback — eviction is the Collection/Service concern alone', async () => {
-    // Absence-is-the-contract: `WorkflowRunDeps` (run.ts) carries no evict/
-    // onSettled-shaped callback member, and nothing in the run's own
-    // orchestration files ever calls one — `run.ts`'s own doc comment states
-    // the boundary in prose ("the owner reads it to evict"), which this only
-    // checks for an actual call/field, not the word appearing in a comment.
-    // Only `WorkflowService` (index.ts) performs the exact-instance eviction.
-    const { readFile: read } = await import('node:fs/promises');
-    for (const file of ['run.ts', 'run-terminal.ts', 'run-support.ts', 'runner-process.ts']) {
-      const source = await read(
-        new URL(`../src/service/workflow-service/${file}`, import.meta.url),
-        'utf8',
-      );
-      expect(source).not.toMatch(/\bevict\w*\s*[(:]/i);
-    }
+  it('WorkflowRun is handed no eviction callback at all — eviction is the Service concern alone', () => {
+    // Absence-is-the-contract, checked where the contract actually lives: a run
+    // can only reach its owner through `WorkflowRunDeps`, so a callback that
+    // let it evict itself would have to be a member of that type. The
+    // `@ts-expect-error` lines fail the build the moment one is added, which is
+    // stronger than any text scan — and, unlike one, they cannot be tripped by
+    // the word appearing in a comment.
+    const deps = {} as WorkflowRunDeps;
+
+    // @ts-expect-error WorkflowRunDeps carries no eviction callback.
+    expect(deps.evict).toBeUndefined();
+    // @ts-expect-error WorkflowRunDeps carries no settlement callback either.
+    expect(deps.onSettled).toBeUndefined();
+    // @ts-expect-error nor a back-reference to the owning service.
+    expect(deps.service).toBeUndefined();
   });
 });
 
@@ -569,27 +571,68 @@ describe('team-scoped Workflow member creation: a narrow createLocked capability
     }
   });
 
-  it('never imports team-collection or team-service — the only path to Team ownership is the narrow capability it is handed', async () => {
-    const { readdir: list, readFile: read } = await import('node:fs/promises');
-    const dir = new URL('../src/service/workflow-service/', import.meta.url);
-    const entries = await list(dir);
-    for (const entry of entries) {
-      if (!entry.endsWith('.ts')) continue;
-      const source = await read(new URL(entry, dir), 'utf8');
-      expect(source).not.toMatch(/from ['"].*team-collection/);
-      expect(source).not.toMatch(/from ['"].*\/team-service/);
+  it('never depends on team-collection or team-service — the only path to Team ownership is the narrow capability it is handed', async () => {
+    // The whole static dependency edge set of every file in the module, read
+    // off the parsed import/export/dynamic-import nodes rather than matched in
+    // the file's text: a renamed binding, a re-export, or a lazy `import()`
+    // would all be a real edge, and a mention in prose is correctly not one.
+    const sources = await parseDirectory(
+      new URL('../src/service/workflow-service/', import.meta.url),
+    );
+    expect(sources.length).toBeGreaterThan(0);
+    for (const source of sources) {
+      for (const specifier of moduleSpecifiers(source)) {
+        expect(
+          specifier.includes('team-collection'),
+          `${source.fileName} must not depend on ${specifier}`,
+        ).toBe(false);
+        expect(
+          specifier.includes('/team-service'),
+          `${source.fileName} must not depend on ${specifier}`,
+        ).toBe(false);
+      }
     }
   });
 
   it('has no per-spawn Team-generation revalidation as a second lifecycle mechanism', async () => {
-    const { readdir: list, readFile: read } = await import('node:fs/promises');
-    const dir = new URL('../src/service/workflow-service/', import.meta.url);
-    const entries = await list(dir);
-    for (const entry of entries) {
-      if (!entry.endsWith('.ts')) continue;
-      const source = await read(new URL(entry, dir), 'utf8');
-      expect(source.toLowerCase()).not.toContain('generation');
+    // Three spawns through a capability surface that throws on any member
+    // other than `createLocked`. A Workflow that revalidated a Team generation
+    // — or any other Team lifecycle fact — per spawn would have to reach some
+    // other member of that dependency and would fail here, instead of quietly
+    // becoming a second lifecycle mechanism beside the lock it already holds.
+    const runnerFactory = fakeWorkflowRunnerFactory();
+    const delivery = fakeCompletionDelivery();
+    const rawFactory = fakeTeammateFactory(
+      (input) => controllableLockedTeammate(input.name).handle,
+    );
+    const service = new WorkflowService({
+      ...SCOPE,
+      teamId: 'team-1',
+      callerKind: 'team_leader',
+      teammates: onlyCreateLockedSurface(rawFactory),
+      completionDelivery: delivery.policy,
+      completionInitiator: () => fakeCompletionInitiator(),
+      log: silentLog(),
+      createRunner: runnerFactory.factory,
+      generateRunId: fixedRunIds('run-a'),
+    });
+    await service.start();
+    await service.run({ script: 'noop' });
+    const runner = runnerFactory.runners[0]!;
+
+    for (let index = 0; index < 3; index += 1) {
+      runner.emit({
+        type: 'agent_start',
+        index,
+        prompt: `step ${index}`,
+        options: {},
+      });
     }
+    await waitUntil(() => rawFactory.calls.length >= 3);
+
+    // Exactly one capability call per spawn, and no revalidation call between
+    // them: the lock a spawn already holds is the whole lifecycle mechanism.
+    expect(rawFactory.calls).toHaveLength(3);
   });
 });
 


### PR DESCRIPTION
## Summary

- restore direct behavior-level coverage for the current Feishu COT adapter and session contracts
- cover visible-message anchors, outbox budgets, settlement, routing fences, failure isolation, and close behavior through real public seams
- replace brittle source-text mirrors with runtime assertions, type-level contracts, and TypeScript AST boundary queries

This PR addresses the test-coverage portion of #352. The canonical KB follow-up remains outside this PR.

## Validation

- `node common/scripts/install-run-rush.js build`
- `node common/scripts/install-run-rush.js test`
- `.agents/scripts/check.sh`
- `node common/scripts/install-run-rush.js change --verify`
- `git diff --check`

The focused additions cover 116 Feishu COT cases and 80 rewritten boundary cases. Mutation checks demonstrated that the restored suites or type gates reject all 13 targeted regressions.