### PR TITLE
feat(channel): ask the user a question as a Feishu card

### DIFF
--- a/.agents/domains/channel.md
+++ b/.agents/domains/channel.md
@@ -125,11 +125,14 @@ it against the provider output schema.
 The arguments deliberately mirror Claude Code's own AskUserQuestion, down to the
 field descriptions, so a model reads the two as one tool: 1-4 `questions`, each
 with a `header` chip, a `question`, and 2-4 `options` of `label` +
-`description` + optional `preview`. Two things differ, and both are forced.
-A `chat_id` is required, because a chat tool needs a destination and
-AskUserQuestion has no such concept. There is no `multiSelect`: the operator
-ruled multi-select out of this channel, so every question takes exactly one
-answer.
+`description`. Three fields differ. A `chat_id` is required, because a chat
+tool needs a destination and AskUserQuestion has no such concept. There is no
+`multiSelect`: the operator ruled multi-select out of this channel, so every
+question takes exactly one answer. And there is no `preview`: it shipped first
+as a column beside the options, and the operator removed it on sight —
+"这个 preview 有点复杂了，给他去掉，他也会影响卡片的布局". A per-option preview
+cannot be drawn without a second column, and that column reshaped the layout of
+every question carrying one, so the field went with the column.
 
 The third difference is the one that shapes the design: **the tool does not
 return the answer.** It returns `{ request_id, status: 'asked', next }` as soon

--- a/.agents/domains/channel.md
+++ b/.agents/domains/channel.md
@@ -128,8 +128,8 @@ with a `header` chip, a `question`, and 2-4 `options` of `label` +
 `description`. Three fields differ. A `chat_id` is required, because a chat
 tool needs a destination and AskUserQuestion has no such concept. There is no
 `multiSelect`: the operator ruled multi-select out of this channel, so every
-question takes exactly one answer. And there is no `preview`: it shipped first
-as a column beside the options, and the operator removed it on sight —
+question takes exactly one answer. And there is no `preview`: it was first
+drawn as a column beside the options, and the operator removed it on sight —
 "这个 preview 有点复杂了，给他去掉，他也会影响卡片的布局". A per-option preview
 cannot be drawn without a second column, and that column reshaped the layout of
 every question carrying one, so the field went with the column.

--- a/.agents/domains/channel.md
+++ b/.agents/domains/channel.md
@@ -125,17 +125,27 @@ it against the provider output schema.
 The arguments deliberately mirror Claude Code's own AskUserQuestion, down to the
 field descriptions, so a model reads the two as one tool: 1-4 `questions`, each
 with a `header` chip, a `question`, and 2-4 `options` of `label` +
-`description`. Three fields differ. A `chat_id` is required, because a chat
-tool needs a destination and AskUserQuestion has no such concept. There is no
-`multiSelect`: the operator ruled multi-select out of this channel, so every
-question takes exactly one answer. And there is no `preview`: it was first
-drawn as a column beside the options, and the operator removed it on sight —
-"这个 preview 有点复杂了，给他去掉，他也会影响卡片的布局". A per-option preview
-cannot be drawn without a second column, and that column reshaped the layout of
-every question carrying one, so the field went with the column.
+`description`. Four fields differ, and two of them are the chat. A `chat_id` is
+required, because a chat tool needs a destination and AskUserQuestion has no
+such concept; a `message_id` is optional, and when the model names the message
+its question came out of, the card is addressed the way a reply is — into that
+message's topic, under the anchor the target router already holds for it. With
+no message named, the card is addressed at the chat, which in a topic group
+opens a topic of its own: right for a question belonging to no particular
+message, wrong for one that does. A message id from another chat is ignored
+rather than obeyed, the same rule `reply` follows, so a stale id cannot
+redirect a question into a conversation it was not meant for.
 
-The third difference is the one that shapes the design: **the tool does not
-return the answer.** It returns `{ request_id, status: 'asked', next }` as soon
+The other two fields are gone. There is no `multiSelect`: the operator ruled
+multi-select out of this channel, so every question takes exactly one answer.
+And there is no `preview`: it was first drawn as a column beside the options,
+and the operator removed it on sight — "这个 preview 有点复杂了，给他去掉，
+他也会影响卡片的布局". A per-option preview cannot be drawn without a second
+column, and that column reshaped the layout of every question carrying one, so
+the field went with the column.
+
+The difference that shapes the design is not an argument at all: **the tool does
+not return the answer.** It returns `{ request_id, status: 'asked', next }` as soon
 as the card is sent, and `next` instructs the model to end its turn. A click
 settles the round server-side and the answer reaches Core as an ordinary
 inbound submission, on the path a typed reply takes. Blocking the tool call was
@@ -158,6 +168,18 @@ oversight: asked whether a non-asker clicking should be gated, the operator
 ruled "不需要限制，所有人都可以点". The answer carries the clicker's open_id as
 `sender_id`, so who answered is never lost — but no authorization check stands
 between a group member and the card.
+
+A round exists only once its card does. The registry builds the round and the
+card together but puts neither in play until the send lands, so a send that
+throws leaves nothing waiting — rather than a question with no card, whose TTL
+would later report an unanswered question to a model whose user was never asked
+one.
+
+提交 with nothing chosen is refused with a toast instead of settling. The button
+sits directly under the questions, so it is also the one pressed by accident,
+and a round settles exactly once: spending that settlement to tell the model
+every question was left unanswered is worse than saying nothing. A partial
+answer still submits, and the questions nobody answered are reported as such.
 
 A round closes itself after `ASK_USER_CARD_TTL_MS`, which is under the 15
 minutes after which Feishu stops accepting clicks on a card. Past that cutoff

--- a/.agents/domains/channel.md
+++ b/.agents/domains/channel.md
@@ -79,10 +79,11 @@ Source:
 
 ### Provider tools and MCP
 
-The Feishu package owns its tool names and JSON schemas. Twelve definitions are
-registered, and the served surface is caller-scoped:
+The Feishu package owns its tool names and JSON schemas. Thirteen definitions
+are registered, and the served surface is caller-scoped:
 
-- messaging (both callers): `reply`, `react`, `list_chat_bots`
+- messaging (both callers): `reply`, `react`, `list_chat_bots`,
+  `ask_user_question`
 - Dispatcher routing: `bind_channel`, `unbind_channel`, `list_bindings`
 - TeamLeader routing: `bind_channel`, `unbind_channel`, each with no team field
 - Dispatcher Collaboration Space: `bind_collaboration_space`,
@@ -119,10 +120,57 @@ Successful results are canonical values: `reply` returns
 the value unchanged as `structuredContent` with exact `content: []` and validates
 it against the provider output schema.
 
+#### `ask_user_question`
+
+The arguments deliberately mirror Claude Code's own AskUserQuestion, down to the
+field descriptions, so a model reads the two as one tool: 1-4 `questions`, each
+with a `header` chip, a `question`, and 2-4 `options` of `label` +
+`description` + optional `preview`. Two things differ, and both are forced.
+A `chat_id` is required, because a chat tool needs a destination and
+AskUserQuestion has no such concept. There is no `multiSelect`: the operator
+ruled multi-select out of this channel, so every question takes exactly one
+answer.
+
+The third difference is the one that shapes the design: **the tool does not
+return the answer.** It returns `{ request_id, status: 'asked', next }` as soon
+as the card is sent, and `next` instructs the model to end its turn. A click
+settles the round server-side and the answer reaches Core as an ordinary
+inbound submission, on the path a typed reply takes. Blocking the tool call was
+the alternative and it loses the case that matters — a person who answers after
+lunch — because the MCP client, not Dreamux, bounds how long a tool call may
+run.
+
+The card carries no client state, and that is deliberate rather than incidental.
+Feishu has no radio component: `select_static` is its only native single-select
+and its options hold a label and nothing else, so an option's description would
+vanish the moment the dropdown closed. Each option is therefore an
+`interactive_container`, which holds no state at all — so "which option is
+selected" exists only in the session's registry, every click is a callback, and
+the selection is visible solely because the whole card is repainted from the
+server's answer map. There is no `form`, because a form batches its inputs until
+submit and would cost each question the ability to settle on its own.
+
+Anyone in the chat may answer the card, and that is a decision rather than an
+oversight: asked whether a non-asker clicking should be gated, the operator
+ruled "不需要限制，所有人都可以点". The answer carries the clicker's open_id as
+`sender_id`, so who answered is never lost — but no authorization check stands
+between a group member and the card.
+
+A round closes itself after `ASK_USER_CARD_TTL_MS`, which is under the 15
+minutes after which Feishu stops accepting clicks on a card. Past that cutoff
+the card still looks live but every click is dropped, so an unanswered round
+repaints the card as closed and tells the model no answer came and to stand
+still until the user's next message. Rounds live in memory: a session teardown
+abandons them, and a later click reports the round as gone rather than
+answering nothing.
+
 Source:
 
 - `/packages/channel/feishu-channel/src/tools/registry.ts`
 - `/packages/channel/feishu-channel/src/tools/messaging-tools.ts`
+- `/packages/channel/feishu-channel/src/tools/ask-user-question.ts`
+- `/packages/channel/feishu-channel/src/feishu-ask-user.ts`
+- `/packages/channel/feishu-channel/src/feishu-ask-user-card.ts`
 - `/packages/channel/feishu-channel/src/tools/routing-tools.ts`
 - `/packages/channel/feishu-channel/src/tools/space-tools.ts`
 - `/packages/dreamux-types/src/channel.ts`

--- a/.agents/product/README.md
+++ b/.agents/product/README.md
@@ -36,6 +36,17 @@ the same change that touches it.
   needing no orphan governance; a later message on that conversation simply
   creates or selects another Team. Dissolving a Team cancels all bindings that
   point at it.
+- **A question the agent cannot answer becomes a card, and the turn ends.**
+  When an agent is blocked on a decision only the user can make, the built-in
+  Feishu channel posts an interactive question card — 1-4 single-select
+  questions, each with an "Other" text box — and the agent stops and waits: the
+  tool returns as soon as the card is sent, never the answer. Anyone in the chat
+  may answer, an explicit operator ruling rather than a gap, and the answer
+  arrives as an ordinary inbound message carrying who clicked. Dismissing the
+  card tells the agent to stop asking and talk it through instead; a card nobody
+  answers closes itself before Feishu stops accepting clicks and tells the agent
+  to stand still rather than wait forever.
+  (Domain: [channel](/.agents/domains/channel.md).)
 - **A collaboration space is a Channel product flow.** The Channel provisions a
   Team via ordinary `team.create` for a chat or topic it manages; provisioning
   progress is volatile, and a crash may leave an accepted orphan Team rather

--- a/common/changes/@excitedjs/dreamux/next_2026-09-02-14-55.json
+++ b/common/changes/@excitedjs/dreamux/next_2026-09-02-14-55.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "comment": "Test-only: the live-gate `FeishuBot` double implements the interface structurally, so it gains the `editCard` method the Feishu channel added for card repaints. No package behavior or version change.",
+      "type": "none",
+      "packageName": "@excitedjs/dreamux"
+    }
+  ],
+  "packageName": "@excitedjs/dreamux"
+}

--- a/common/changes/@excitedjs/feishu-channel/next_2026-09-01-17-30.json
+++ b/common/changes/@excitedjs/feishu-channel/next_2026-09-01-17-30.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Add the `ask_user_question` MCP tool: the model sends a Feishu decision card (1-4 single-select questions, each option carrying a description and an optional preview) and the tool returns as soon as the card is sent. The answer is not awaited \u2014 a click settles the round server-side and the result arrives as an ordinary inbound message, so a user may take as long as they like. A round closes itself before Feishu stops accepting clicks on the card and tells the model no answer came.",
+      "type": "minor",
+      "packageName": "@excitedjs/feishu-channel"
+    }
+  ],
+  "packageName": "@excitedjs/feishu-channel",
+  "email": "hvjfccdy6s@privaterelay.appleid.com"
+}

--- a/common/changes/@excitedjs/feishu-channel/next_2026-09-01-17-30.json
+++ b/common/changes/@excitedjs/feishu-channel/next_2026-09-01-17-30.json
@@ -1,7 +1,7 @@
 {
   "changes": [
     {
-      "comment": "Add the `ask_user_question` MCP tool: the model sends a Feishu decision card (1-4 single-select questions, each option carrying a description and an optional preview) and the tool returns as soon as the card is sent. The answer is not awaited \u2014 a click settles the round server-side and the result arrives as an ordinary inbound message, so a user may take as long as they like. A round closes itself before Feishu stops accepting clicks on the card and tells the model no answer came.",
+      "comment": "Add the `ask_user_question` MCP tool: the model sends a Feishu decision card (1-4 single-select questions, each option carrying a label and a description) and the tool returns as soon as the card is sent. The answer is not awaited \u2014 a click settles the round server-side and the result arrives as an ordinary inbound message, so a user may take as long as they like. A round closes itself before Feishu stops accepting clicks on the card and tells the model no answer came.",
       "type": "minor",
       "packageName": "@excitedjs/feishu-channel"
     }

--- a/common/changes/@excitedjs/feishu-channel/next_2026-09-01-17-30.json
+++ b/common/changes/@excitedjs/feishu-channel/next_2026-09-01-17-30.json
@@ -1,7 +1,7 @@
 {
   "changes": [
     {
-      "comment": "Add the `ask_user_question` MCP tool: the model sends a Feishu decision card (1-4 single-select questions, each option carrying a label and a description) and the tool returns as soon as the card is sent. The answer is not awaited \u2014 a click settles the round server-side and the result arrives as an ordinary inbound message, so a user may take as long as they like. A round closes itself before Feishu stops accepting clicks on the card and tells the model no answer came.",
+      "comment": "Add the `ask_user_question` MCP tool: the model sends a Feishu decision card (1-4 single-select questions, each option carrying a label and a description) and the tool returns as soon as the card is sent. The answer is not awaited \u2014 a click settles the round server-side and the result arrives as an ordinary inbound message, so a user may take as long as they like. An optional `message_id` addresses the card under the message the question came out of, the way a reply is addressed. A round closes itself before Feishu stops accepting clicks on the card and tells the model no answer came.",
       "type": "minor",
       "packageName": "@excitedjs/feishu-channel"
     }

--- a/common/changes/@excitedjs/feishu-transport/next_2026-09-01-17-30.json
+++ b/common/changes/@excitedjs/feishu-transport/next_2026-09-01-17-30.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Add `editCard(messageId, card)`, which repaints an already-sent card in place. It generalizes the patch call `editText` already made, so a card can be closed out without a click to answer it.",
+      "type": "minor",
+      "packageName": "@excitedjs/feishu-transport"
+    }
+  ],
+  "packageName": "@excitedjs/feishu-transport",
+  "email": "hvjfccdy6s@privaterelay.appleid.com"
+}

--- a/packages/channel/feishu-channel/src/bot.ts
+++ b/packages/channel/feishu-channel/src/bot.ts
@@ -108,6 +108,13 @@ export type BotMemberAddedHandler = (
 export interface FeishuCardActionEvent {
   operatorOpenId?: string;
   actionValue: Record<string, unknown>;
+  /**
+   * What the user typed, for an `input` that carries its own callback. Feishu
+   * sends it as `action.input_value`, outside `action.value`, and only a
+   * form-less input ever reports one: inside a `form` the text is withheld
+   * until submit and arrives as `form_value` instead.
+   */
+  inputValue?: string;
   openChatId?: string;
   openMessageId?: string;
   raw: unknown;
@@ -159,6 +166,8 @@ export interface FeishuBot extends FeishuMessageResourceFetcher {
   /** Optional for externally supplied bots; absence disables topic projection. */
   getChatMode?(chatId: string): Promise<FeishuChatMode | undefined>;
   addReaction(messageId: string, emoji: string): Promise<string>;
+  /** Repaint an already-sent card in place, by message id. */
+  editCard(messageId: string, card: unknown): Promise<void>;
   fetchMessageResource(
     request: FeishuMessageResourceRequest,
   ): Promise<FeishuMessageResourceResponse>;
@@ -291,6 +300,10 @@ export function createFeishuBot(
       return transport.getChatMode?.(chatId) ?? Promise.resolve(undefined);
     },
 
+    editCard(messageId: string, card: unknown): Promise<void> {
+      return transport.editCard(messageId, card);
+    },
+
     addReaction(messageId: string, emoji: string): Promise<string> {
       return transport.addReaction(messageId, emoji);
     },
@@ -420,6 +433,7 @@ function normalizeCardActionEvent(raw: unknown): FeishuCardActionEvent {
     asRecord(event['card_action']);
   const context = asRecord(root['context']) ?? asRecord(event['context']) ?? root;
   const actionValue = asRecord(action?.['value']) ?? {};
+  const inputValue = firstString(action?.['input_value'], action?.['inputValue']);
   const operatorOpenId = firstString(operator?.['open_id'], operator?.['openId']);
   const openChatId = firstString(
     context['open_chat_id'],
@@ -436,6 +450,7 @@ function normalizeCardActionEvent(raw: unknown): FeishuCardActionEvent {
   return {
     ...(operatorOpenId !== '' ? { operatorOpenId } : {}),
     actionValue,
+    ...(inputValue !== '' ? { inputValue } : {}),
     ...(openChatId !== '' ? { openChatId } : {}),
     ...(openMessageId !== '' ? { openMessageId } : {}),
     raw,

--- a/packages/channel/feishu-channel/src/feishu-ask-user-card.ts
+++ b/packages/channel/feishu-channel/src/feishu-ask-user-card.ts
@@ -39,7 +39,6 @@ export const DREAMUX_ASK_ACTIONS: ReadonlySet<string> = new Set([
 export interface AskUserOption {
   readonly label: string;
   readonly description: string;
-  readonly preview?: string;
 }
 
 export interface AskUserQuestionSpec {
@@ -158,42 +157,6 @@ function otherInput(
   };
 }
 
-/**
- * The preview column tracks the focused option, which is the selected one, or
- * the first when nothing is chosen yet — the same focus-follows-selection
- * behavior the tool's own preview field describes. The column is drawn whenever
- * any option declares a preview, so choosing one never reflows the card.
- */
-function previewColumn(
-  question: AskUserQuestionSpec,
-  answer: AskUserAnswer | undefined,
-): Record<string, unknown> | undefined {
-  if (!question.options.some((option) => option.preview !== undefined)) {
-    return undefined;
-  }
-  const focused = answer?.kind === 'option' ? answer.index : 0;
-  const option = question.options[focused];
-  const elements: Record<string, unknown>[] =
-    option?.preview === undefined
-      ? []
-      : [
-          markdown(`<font color='grey'>preview · ${option.label}</font>`, {
-            text_size: 'notation',
-          }),
-          markdown(`\`\`\`\n${option.preview}\n\`\`\``, {
-            text_size: 'notation',
-          }),
-        ];
-  return {
-    tag: 'column',
-    width: 'weighted',
-    weight: 2,
-    vertical_align: 'top',
-    vertical_spacing: '4px',
-    elements,
-  };
-}
-
 function questionPanel(
   view: AskUserRequestView,
   questionIndex: number,
@@ -201,36 +164,16 @@ function questionPanel(
   expanded: boolean,
 ): Record<string, unknown> {
   const answer = view.answers.get(questionIndex);
-  const options = question.options.map((option, optionIndex) =>
-    optionCard(
-      view.requestId,
-      questionIndex,
-      optionIndex,
-      option,
-      answer?.kind === 'option' && answer.index === optionIndex,
-    ),
+  const elements: Record<string, unknown>[] = question.options.map(
+    (option, optionIndex) =>
+      optionCard(
+        view.requestId,
+        questionIndex,
+        optionIndex,
+        option,
+        answer?.kind === 'option' && answer.index === optionIndex,
+      ),
   );
-  const preview = previewColumn(question, answer);
-  const elements: Record<string, unknown>[] =
-    preview === undefined
-      ? [...options]
-      : [
-          {
-            tag: 'column_set',
-            flex_mode: 'none',
-            horizontal_spacing: '12px',
-            columns: [
-              {
-                tag: 'column',
-                width: 'weighted',
-                weight: 3,
-                vertical_spacing: '8px',
-                elements: options,
-              },
-              preview,
-            ],
-          },
-        ];
   elements.push(otherInput(view.requestId, questionIndex, answer));
   // The panel's own padding is 0 so options reach the card edge, which also
   // removes the gap under the header; the first element restores it.

--- a/packages/channel/feishu-channel/src/feishu-ask-user-card.ts
+++ b/packages/channel/feishu-channel/src/feishu-ask-user-card.ts
@@ -299,7 +299,11 @@ export function buildAskUserCard(view: AskUserRequestView): unknown {
 export function buildAskUserSubmittedCard(view: AskUserRequestView): unknown {
   return {
     schema: '2.0',
-    config: { update_multi: true, width_mode: 'default' },
+    config: {
+      update_multi: true,
+      width_mode: 'default',
+      summary: { content: '已收到你的回答' },
+    },
     header: {
       title: { tag: 'plain_text', content: '已收到你的回答' },
       template: 'green',

--- a/packages/channel/feishu-channel/src/feishu-ask-user-card.ts
+++ b/packages/channel/feishu-channel/src/feishu-ask-user-card.ts
@@ -1,0 +1,404 @@
+/**
+ * The `ask_user_question` card — a v2 card, and the only place its shape lives.
+ *
+ * Feishu has no radio component: `select_static` is the one native single-select
+ * and its options carry a label and nothing else, so an option's description
+ * would be lost the moment the dropdown closes. The card therefore draws each
+ * option as its own `interactive_container` — label, then description — which is
+ * the same shape the open-source Feishu ask-user renderers converged on.
+ *
+ * That choice is what makes the server authoritative: an `interactive_container`
+ * holds no client state, so "which option is selected" only exists here. Every
+ * click is a callback, and the answer is visible solely because this module
+ * repaints the whole card from {@link AskUserRequestView}.
+ *
+ * Deliberately no `form`. A `form` would batch its inputs until submit, which
+ * costs each question the ability to settle on its own; without one, an `input`
+ * carries its own callback and Feishu draws it a send button, so committing free
+ * text is the same explicit click as choosing an option.
+ */
+import { DREAMUX_ACTION_KEY } from './feishu-pairing-card.js';
+
+export const DREAMUX_ASK_PICK_ACTION = 'ask_user_pick';
+export const DREAMUX_ASK_OTHER_ACTION = 'ask_user_other';
+export const DREAMUX_ASK_SUBMIT_ACTION = 'ask_user_submit';
+export const DREAMUX_ASK_CANCEL_ACTION = 'ask_user_cancel';
+
+export const DREAMUX_ASK_REQUEST_KEY = 'dreamux_ask_request';
+export const DREAMUX_ASK_QUESTION_KEY = 'dreamux_ask_question';
+export const DREAMUX_ASK_OPTION_KEY = 'dreamux_ask_option';
+
+/** Every ask action, for the one membership test the ops dispatcher needs. */
+export const DREAMUX_ASK_ACTIONS: ReadonlySet<string> = new Set([
+  DREAMUX_ASK_PICK_ACTION,
+  DREAMUX_ASK_OTHER_ACTION,
+  DREAMUX_ASK_SUBMIT_ACTION,
+  DREAMUX_ASK_CANCEL_ACTION,
+]);
+
+export interface AskUserOption {
+  readonly label: string;
+  readonly description: string;
+  readonly preview?: string;
+}
+
+export interface AskUserQuestionSpec {
+  readonly header: string;
+  readonly question: string;
+  readonly options: readonly AskUserOption[];
+}
+
+/** What the user has settled on for one question, if anything. */
+export type AskUserAnswer =
+  | { readonly kind: 'option'; readonly index: number }
+  | { readonly kind: 'other'; readonly text: string };
+
+/** Everything a repaint reads. The card is a pure function of this. */
+export interface AskUserRequestView {
+  readonly requestId: string;
+  readonly questions: readonly AskUserQuestionSpec[];
+  readonly answers: ReadonlyMap<number, AskUserAnswer>;
+}
+
+/** The label an answered question shows, in the card and in the injected text. */
+export function answerLabel(
+  question: AskUserQuestionSpec,
+  answer: AskUserAnswer | undefined,
+): string | undefined {
+  if (answer === undefined) return undefined;
+  return answer.kind === 'option'
+    ? question.options[answer.index]?.label
+    : answer.text;
+}
+
+function markdown(
+  content: string,
+  extra: Record<string, unknown> = {},
+): Record<string, unknown> {
+  return { tag: 'markdown', content, ...extra };
+}
+
+function actionValue(
+  action: string,
+  requestId: string,
+  extra: Record<string, unknown> = {},
+): Record<string, unknown> {
+  return {
+    [DREAMUX_ACTION_KEY]: action,
+    [DREAMUX_ASK_REQUEST_KEY]: requestId,
+    ...extra,
+  };
+}
+
+function optionCard(
+  requestId: string,
+  questionIndex: number,
+  optionIndex: number,
+  option: AskUserOption,
+  selected: boolean,
+): Record<string, unknown> {
+  return {
+    tag: 'interactive_container',
+    width: 'fill',
+    has_border: true,
+    border_color: selected ? 'blue-500' : 'grey-300',
+    background_style: selected ? 'blue-50' : 'bg-white',
+    corner_radius: '8px',
+    padding: '8px 12px 8px 12px',
+    vertical_spacing: '2px',
+    behaviors: [
+      {
+        type: 'callback',
+        value: actionValue(DREAMUX_ASK_PICK_ACTION, requestId, {
+          [DREAMUX_ASK_QUESTION_KEY]: questionIndex,
+          [DREAMUX_ASK_OPTION_KEY]: optionIndex,
+        }),
+      },
+    ],
+    elements: [
+      markdown(
+        selected
+          ? `**<font color='blue'>${option.label}</font>**`
+          : `**${option.label}**`,
+      ),
+      markdown(`<font color='grey'>${option.description}</font>`, {
+        text_size: 'notation',
+      }),
+    ],
+  };
+}
+
+/**
+ * The free-text escape hatch, outside any form so it settles on its own.
+ *
+ * `default_value` is not cosmetic: a repaint replaces the whole card, so text
+ * already committed has to be written back or the user watches their own answer
+ * disappear the next time they touch another question.
+ */
+function otherInput(
+  requestId: string,
+  questionIndex: number,
+  answer: AskUserAnswer | undefined,
+): Record<string, unknown> {
+  return {
+    tag: 'input',
+    name: `ask_${questionIndex}_other`,
+    width: 'fill',
+    max_length: 200,
+    ...(answer?.kind === 'other' ? { default_value: answer.text } : {}),
+    placeholder: { tag: 'plain_text', content: 'Other：直接写你的答案' },
+    behaviors: [
+      {
+        type: 'callback',
+        value: actionValue(DREAMUX_ASK_OTHER_ACTION, requestId, {
+          [DREAMUX_ASK_QUESTION_KEY]: questionIndex,
+        }),
+      },
+    ],
+  };
+}
+
+/**
+ * The preview column tracks the focused option, which is the selected one, or
+ * the first when nothing is chosen yet — the same focus-follows-selection
+ * behavior the tool's own preview field describes. The column is drawn whenever
+ * any option declares a preview, so choosing one never reflows the card.
+ */
+function previewColumn(
+  question: AskUserQuestionSpec,
+  answer: AskUserAnswer | undefined,
+): Record<string, unknown> | undefined {
+  if (!question.options.some((option) => option.preview !== undefined)) {
+    return undefined;
+  }
+  const focused = answer?.kind === 'option' ? answer.index : 0;
+  const option = question.options[focused];
+  const elements: Record<string, unknown>[] =
+    option?.preview === undefined
+      ? []
+      : [
+          markdown(`<font color='grey'>preview · ${option.label}</font>`, {
+            text_size: 'notation',
+          }),
+          markdown(`\`\`\`\n${option.preview}\n\`\`\``, {
+            text_size: 'notation',
+          }),
+        ];
+  return {
+    tag: 'column',
+    width: 'weighted',
+    weight: 2,
+    vertical_align: 'top',
+    vertical_spacing: '4px',
+    elements,
+  };
+}
+
+function questionPanel(
+  view: AskUserRequestView,
+  questionIndex: number,
+  question: AskUserQuestionSpec,
+  expanded: boolean,
+): Record<string, unknown> {
+  const answer = view.answers.get(questionIndex);
+  const options = question.options.map((option, optionIndex) =>
+    optionCard(
+      view.requestId,
+      questionIndex,
+      optionIndex,
+      option,
+      answer?.kind === 'option' && answer.index === optionIndex,
+    ),
+  );
+  const preview = previewColumn(question, answer);
+  const elements: Record<string, unknown>[] =
+    preview === undefined
+      ? [...options]
+      : [
+          {
+            tag: 'column_set',
+            flex_mode: 'none',
+            horizontal_spacing: '12px',
+            columns: [
+              {
+                tag: 'column',
+                width: 'weighted',
+                weight: 3,
+                vertical_spacing: '8px',
+                elements: options,
+              },
+              preview,
+            ],
+          },
+        ];
+  elements.push(otherInput(view.requestId, questionIndex, answer));
+  // The panel's own padding is 0 so options reach the card edge, which also
+  // removes the gap under the header; the first element restores it.
+  elements[0] = { ...elements[0], margin: '8px 0px 0px 0px' };
+  const chosen = answerLabel(question, answer);
+  return {
+    tag: 'collapsible_panel',
+    expanded,
+    padding: '0px',
+    vertical_spacing: '8px',
+    header: {
+      title: markdown(
+        `<text_tag color='${chosen === undefined ? 'blue' : 'green'}'>` +
+          `${question.header}</text_tag> **${question.question}**` +
+          (chosen === undefined ? '' : ` <font color='grey'>· ${chosen}</font>`),
+      ),
+      width: 'fill',
+      vertical_align: 'center',
+    },
+    elements,
+  };
+}
+
+/** The live question card. One unanswered question is open at a time. */
+export function buildAskUserCard(view: AskUserRequestView): unknown {
+  const answered = view.questions.filter(
+    (_, index) => view.answers.has(index),
+  ).length;
+  const openIndex = view.questions.findIndex(
+    (_, index) => !view.answers.has(index),
+  );
+  return {
+    schema: '2.0',
+    config: {
+      update_multi: true,
+      width_mode: 'default',
+      summary: { content: `有 ${view.questions.length} 个问题需要你确认` },
+    },
+    header: {
+      title: { tag: 'plain_text', content: '需要你做几个决策' },
+      template: 'blue',
+      icon: { tag: 'standard_icon', token: 'myai_colorful' },
+      text_tag_list: [
+        {
+          tag: 'text_tag',
+          text: {
+            tag: 'plain_text',
+            content: `${answered}/${view.questions.length}`,
+          },
+          color: answered === view.questions.length ? 'green' : 'yellow',
+        },
+      ],
+    },
+    body: {
+      direction: 'vertical',
+      padding: '12px 12px 20px 12px',
+      vertical_spacing: '16px',
+      elements: [
+        ...view.questions.map((question, index) =>
+          questionPanel(view, index, question, index === openIndex),
+        ),
+        {
+          tag: 'column_set',
+          flex_mode: 'none',
+          horizontal_spacing: '8px',
+          margin: '8px 0px 0px 0px',
+          columns: [
+            {
+              tag: 'column',
+              width: 'weighted',
+              weight: 3,
+              elements: [
+                {
+                  tag: 'button',
+                  type: 'primary_filled',
+                  width: 'fill',
+                  size: 'medium',
+                  text: { tag: 'plain_text', content: '提交回答' },
+                  behaviors: [
+                    {
+                      type: 'callback',
+                      value: actionValue(
+                        DREAMUX_ASK_SUBMIT_ACTION,
+                        view.requestId,
+                      ),
+                    },
+                  ],
+                },
+              ],
+            },
+            {
+              tag: 'column',
+              width: 'weighted',
+              weight: 2,
+              elements: [
+                {
+                  tag: 'button',
+                  // Red, because it ends the whole round rather than one answer.
+                  type: 'danger',
+                  width: 'fill',
+                  size: 'medium',
+                  text: { tag: 'plain_text', content: 'Talk about this' },
+                  behaviors: [
+                    {
+                      type: 'callback',
+                      value: actionValue(
+                        DREAMUX_ASK_CANCEL_ACTION,
+                        view.requestId,
+                      ),
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    },
+  };
+}
+
+/** The settled card: the questions with what was chosen, nothing clickable. */
+export function buildAskUserSubmittedCard(view: AskUserRequestView): unknown {
+  return {
+    schema: '2.0',
+    config: { update_multi: true, width_mode: 'default' },
+    header: {
+      title: { tag: 'plain_text', content: '已收到你的回答' },
+      template: 'green',
+      icon: { tag: 'standard_icon', token: 'done_outlined' },
+    },
+    body: {
+      padding: '12px 12px 20px 12px',
+      vertical_spacing: '12px',
+      elements: view.questions.map((question, index) =>
+        markdown(
+          `**${question.header}** · ${question.question}\n> ` +
+            (answerLabel(question, view.answers.get(index)) ?? '未作答'),
+        ),
+      ),
+    },
+  };
+}
+
+/** Why a round closed without an answer. */
+export type AskUserClosedReason = 'cancelled' | 'expired';
+
+/**
+ * The closed card. A sent card cannot be deleted, so the nearest thing to
+ * taking the question back is collapsing it to a single line with no header.
+ */
+export function buildAskUserClosedCard(reason: AskUserClosedReason): unknown {
+  const line =
+    reason === 'cancelled'
+      ? '已取消这轮提问，直接说你的想法就行。'
+      : '这轮提问已超时关闭，直接说你的想法就行。';
+  return {
+    schema: '2.0',
+    config: {
+      update_multi: true,
+      width_mode: 'default',
+      summary: {
+        content: reason === 'cancelled' ? '这轮提问已取消' : '这轮提问已超时',
+      },
+    },
+    body: {
+      padding: '12px 12px 12px 12px',
+      elements: [markdown(`<font color='grey'>${line}</font>`)],
+    },
+  };
+}

--- a/packages/channel/feishu-channel/src/feishu-ask-user-card.ts
+++ b/packages/channel/feishu-channel/src/feishu-ask-user-card.ts
@@ -24,6 +24,12 @@ export const DREAMUX_ASK_OTHER_ACTION = 'ask_user_other';
 export const DREAMUX_ASK_SUBMIT_ACTION = 'ask_user_submit';
 export const DREAMUX_ASK_CANCEL_ACTION = 'ask_user_cancel';
 
+/**
+ * What the cancel button says. Shared because a toast points at it by name,
+ * and a toast naming a button the card does not have is worse than no toast.
+ */
+export const ASK_USER_CANCEL_LABEL = 'Talk about this';
+
 export const DREAMUX_ASK_REQUEST_KEY = 'dreamux_ask_request';
 export const DREAMUX_ASK_QUESTION_KEY = 'dreamux_ask_question';
 export const DREAMUX_ASK_OPTION_KEY = 'dreamux_ask_option';
@@ -275,7 +281,7 @@ export function buildAskUserCard(view: AskUserRequestView): unknown {
                   type: 'danger',
                   width: 'fill',
                   size: 'medium',
-                  text: { tag: 'plain_text', content: 'Talk about this' },
+                  text: { tag: 'plain_text', content: ASK_USER_CANCEL_LABEL },
                   behaviors: [
                     {
                       type: 'callback',

--- a/packages/channel/feishu-channel/src/feishu-ask-user.ts
+++ b/packages/channel/feishu-channel/src/feishu-ask-user.ts
@@ -26,6 +26,7 @@ import {
   DREAMUX_ASK_QUESTION_KEY,
   DREAMUX_ASK_REQUEST_KEY,
   DREAMUX_ASK_SUBMIT_ACTION,
+  ASK_USER_CANCEL_LABEL,
   answerLabel,
   buildAskUserCard,
   buildAskUserClosedCard,
@@ -345,14 +346,18 @@ export function createAskUserRegistry(
       }
 
       if (action === DREAMUX_ASK_SUBMIT_ACTION) {
-        // 提交 sits directly under the questions, so it is also the button
-        // pressed before anything has been chosen. Settling on that click
-        // would spend the round's one settlement telling the model every
+        // 提交回答 sits directly under the questions, so it is also the
+        // button pressed before anything has been chosen. Settling on that
+        // click would spend the round's one settlement telling the model every
         // question was left unanswered, which is worse than saying nothing.
+        // The toast names the other button by the text printed on it.
         if (round.answers.size === 0) {
           return {
             kind: 'response',
-            response: toast('warning', '先选一个再提交，或者点「不用问了」。'),
+            response: toast(
+              'warning',
+              `先选一个再提交，或者点「${ASK_USER_CANCEL_LABEL}」。`,
+            ),
           };
         }
         return settle(round, 'submitted', event);

--- a/packages/channel/feishu-channel/src/feishu-ask-user.ts
+++ b/packages/channel/feishu-channel/src/feishu-ask-user.ts
@@ -1,0 +1,385 @@
+/**
+ * Open ask-user rounds, and what a click does to one.
+ *
+ * The tool does not wait for an answer. It sends the card and returns, and the
+ * answer arrives later as an ordinary inbound submission — the same path a
+ * typed reply takes. That is the whole reason this registry exists: something
+ * has to hold the question between the tool call that asked it and the click
+ * that answers it, and a tool handler that has already returned cannot.
+ *
+ * Waiting inside the tool call was the alternative, and it loses on the case
+ * that matters: a person who answers after lunch. The MCP client, not this
+ * package, decides how long a tool call may run, so a blocking handler would
+ * have been abandoned mid-question by a timeout Dreamux does not own.
+ *
+ * The module is pure. `apply` decides and hands back what to deliver; the ops
+ * layer performs the delivery, matching how the access gate splits from its IO.
+ */
+import { randomBytes } from 'node:crypto';
+
+import type { FeishuCardActionEvent } from './bot.js';
+import {
+  DREAMUX_ASK_ACTIONS,
+  DREAMUX_ASK_CANCEL_ACTION,
+  DREAMUX_ASK_OPTION_KEY,
+  DREAMUX_ASK_OTHER_ACTION,
+  DREAMUX_ASK_PICK_ACTION,
+  DREAMUX_ASK_QUESTION_KEY,
+  DREAMUX_ASK_REQUEST_KEY,
+  DREAMUX_ASK_SUBMIT_ACTION,
+  answerLabel,
+  buildAskUserCard,
+  buildAskUserClosedCard,
+  buildAskUserSubmittedCard,
+  type AskUserAnswer,
+  type AskUserQuestionSpec,
+} from './feishu-ask-user-card.js';
+import { DREAMUX_ACTION_KEY, type FeishuCardActionResponse } from './feishu-pairing-card.js';
+import type { FeishuTarget } from './routing/target.js';
+
+const REQUEST_ID_BYTES = 8;
+
+/**
+ * How long a question card stays answerable.
+ *
+ * Feishu stops accepting interaction on a card 15 minutes after it is sent, so
+ * a round has to close itself before that: past the platform's cutoff the card
+ * still looks live but every click is dropped, and the model would wait for an
+ * answer that can no longer be given. Closing a minute early leaves room for
+ * the repaint to land while the card is still writable.
+ */
+export const ASK_USER_CARD_TTL_MS = 14 * 60 * 1000;
+
+/** The timer seam, so tests can expire a round without waiting for one. */
+export interface AskUserTimers {
+  set(fn: () => void, ms: number): unknown;
+  clear(handle: unknown): void;
+}
+
+const realTimers: AskUserTimers = {
+  set(fn, ms) {
+    const handle = setTimeout(fn, ms);
+    // A waiting question must never be the reason a process stays alive.
+    (handle as { unref?: () => void }).unref?.();
+    return handle;
+  },
+  clear(handle) {
+    clearTimeout(handle as Parameters<typeof clearTimeout>[0]);
+  },
+};
+
+export interface AskUserOpenInput {
+  readonly questions: readonly AskUserQuestionSpec[];
+  readonly target: FeishuTarget;
+}
+
+export interface AskUserOpened {
+  readonly requestId: string;
+  readonly card: unknown;
+}
+
+/**
+ * What a settled round hands the ops layer to deliver. `sourceId` is derived
+ * from the request, so the round can only ever be delivered once even if two
+ * clicks race — the same identity Core deduplicates an inbound repeat on.
+ */
+export interface AskUserSettlement {
+  readonly requestId: string;
+  readonly target: FeishuTarget;
+  readonly outcome: 'submitted' | 'cancelled' | 'expired';
+  readonly text: string;
+  /**
+   * The dedup identity Core keys the submission on. Synthetic on purpose: one
+   * round settles once, however many clicks race for it. It is NOT a Feishu
+   * message id and must never be used as one.
+   */
+  readonly sourceId: string;
+  /**
+   * The question card's own message id — a real `om_` id, and the anchor the
+   * answer belongs under. Absent only if the send never reported one.
+   */
+  readonly cardMessageId?: string;
+  /** Who clicked. Absent when the round closed on its timer. */
+  readonly operatorOpenId?: string;
+}
+
+/**
+ * A round that closed on its own. Unlike a click, nothing is there to repaint
+ * the card from a callback response, so the message id is carried out and the
+ * session patches the card in place.
+ */
+export interface AskUserExpiry {
+  readonly settlement: AskUserSettlement;
+  /** Absent only if the card's id never came back from the send. */
+  readonly messageId?: string;
+  readonly card: unknown;
+}
+
+export type AskUserApplyResult =
+  /** Not an ask action — some other card owns it. */
+  | { readonly kind: 'ignored' }
+  | { readonly kind: 'response'; readonly response: FeishuCardActionResponse }
+  | {
+      readonly kind: 'settled';
+      readonly response: FeishuCardActionResponse;
+      readonly settlement: AskUserSettlement;
+    };
+
+export interface AskUserRegistry {
+  open(input: AskUserOpenInput): AskUserOpened;
+  /** Record the sent card's id, so an expiring round can repaint it. */
+  attachMessage(requestId: string, messageId: string): void;
+  apply(event: FeishuCardActionEvent): AskUserApplyResult;
+  /** Drop every open round; their cards report the round as gone on next click. */
+  abandonAll(): void;
+}
+
+interface OpenRound {
+  readonly requestId: string;
+  readonly questions: readonly AskUserQuestionSpec[];
+  readonly target: FeishuTarget;
+  readonly answers: Map<number, AskUserAnswer>;
+  messageId?: string;
+  timer?: unknown;
+}
+
+function toast(
+  type: 'info' | 'success' | 'error' | 'warning',
+  content: string,
+): FeishuCardActionResponse {
+  return { toast: { type, content } };
+}
+
+function repaint(round: OpenRound, message: string): FeishuCardActionResponse {
+  return {
+    toast: { type: 'info', content: message },
+    card: { type: 'raw', data: buildAskUserCard(round) },
+  };
+}
+
+function asIndex(value: unknown): number | undefined {
+  const index = typeof value === 'number' ? value : Number(value);
+  return Number.isInteger(index) && index >= 0 ? index : undefined;
+}
+
+/** The body Core is handed when the user submits. */
+function submittedText(round: OpenRound): string {
+  const lines = round.questions.map((question, index) => {
+    const chosen = answerLabel(question, round.answers.get(index));
+    return `- ${question.header} · ${question.question} → ${
+      chosen ?? '(left unanswered)'
+    }`;
+  });
+  return [
+    'The user answered the question card:',
+    '',
+    ...lines,
+  ].join('\n');
+}
+
+/**
+ * The body for an abandoned round. It states the consequence rather than the
+ * click, because "the user pressed a red button" is not something the model can
+ * act on and "stop asking, talk it through" is.
+ */
+function cancelledText(): string {
+  return [
+    'The user dismissed the question card and wants to talk it through instead.',
+    '',
+    'Do not send another question card for this decision. Continue in plain',
+    'conversation and let the user steer.',
+  ].join('\n');
+}
+
+/** The body for a round nobody answered before the card stopped accepting clicks. */
+function expiredText(): string {
+  return [
+    'The question card expired with no answer from the user.',
+    '',
+    'Stop where you are and take no further action. Wait for the user\'s next',
+    'message, and decide only then whether to ask again with a new card.',
+  ].join('\n');
+}
+
+export interface AskUserRegistryOptions {
+  /**
+   * Called when a round closes on its own. The session delivers the settlement
+   * and repaints the card; the registry only decides that the round is over.
+   */
+  readonly onExpire?: (expiry: AskUserExpiry) => void;
+  readonly ttlMs?: number;
+  readonly newRequestId?: () => string;
+  readonly timers?: AskUserTimers;
+}
+
+export function createAskUserRegistry(
+  options: AskUserRegistryOptions = {},
+): AskUserRegistry {
+  const rounds = new Map<string, OpenRound>();
+  const timers = options.timers ?? realTimers;
+  const ttlMs = options.ttlMs ?? ASK_USER_CARD_TTL_MS;
+  const newRequestId =
+    options.newRequestId ??
+    ((): string => randomBytes(REQUEST_ID_BYTES).toString('hex'));
+
+  /** Take the round out of play and describe what Core should be told. */
+  function closeRound(
+    round: OpenRound,
+    outcome: AskUserSettlement['outcome'],
+    by?: { cardMessageId?: string; operatorOpenId?: string },
+  ): AskUserSettlement {
+    rounds.delete(round.requestId);
+    if (round.timer !== undefined) timers.clear(round.timer);
+    const text =
+      outcome === 'submitted'
+        ? submittedText(round)
+        : outcome === 'cancelled'
+          ? cancelledText()
+          : expiredText();
+    // The click reports the card it came from; the timer has only what the
+    // send recorded.
+    const cardMessageId = by?.cardMessageId ?? round.messageId;
+    return {
+      requestId: round.requestId,
+      target: round.target,
+      outcome,
+      text,
+      sourceId: `ask_user_question:${round.requestId}`,
+      ...(cardMessageId !== undefined ? { cardMessageId } : {}),
+      ...(by?.operatorOpenId !== undefined
+        ? { operatorOpenId: by.operatorOpenId }
+        : {}),
+    };
+  }
+
+
+  function settle(
+    round: OpenRound,
+    outcome: 'submitted' | 'cancelled',
+    event: FeishuCardActionEvent,
+  ): AskUserApplyResult {
+    const view = { ...round };
+    const settlement = closeRound(round, outcome, {
+      ...(event.openMessageId !== undefined
+        ? { cardMessageId: event.openMessageId }
+        : {}),
+      ...(event.operatorOpenId !== undefined
+        ? { operatorOpenId: event.operatorOpenId }
+        : {}),
+    });
+    return {
+      kind: 'settled',
+      response: {
+        toast: {
+          type: outcome === 'submitted' ? 'success' : 'info',
+          content: outcome === 'submitted' ? '已提交' : '已取消',
+        },
+        card: {
+          type: 'raw',
+          data:
+            outcome === 'submitted'
+              ? buildAskUserSubmittedCard(view)
+              : buildAskUserClosedCard('cancelled'),
+        },
+      },
+      settlement,
+    };
+  }
+
+  return {
+    open(input): AskUserOpened {
+      const requestId = newRequestId();
+      const round: OpenRound = {
+        requestId,
+        questions: input.questions,
+        target: input.target,
+        answers: new Map(),
+      };
+      rounds.set(requestId, round);
+      round.timer = timers.set(() => {
+        // Already settled by a click? Then this timer lost the race and the
+        // round is gone; `closeRound` on a stale round would report a second
+        // settlement for one question.
+        if (rounds.get(requestId) !== round) return;
+        const settlement = closeRound(round, 'expired');
+        options.onExpire?.({
+          settlement,
+          ...(round.messageId !== undefined
+            ? { messageId: round.messageId }
+            : {}),
+          card: buildAskUserClosedCard('expired'),
+        });
+      }, ttlMs);
+      return { requestId, card: buildAskUserCard(round) };
+    },
+
+    attachMessage(requestId, messageId): void {
+      const round = rounds.get(requestId);
+      if (round !== undefined) round.messageId = messageId;
+    },
+
+    apply(event): AskUserApplyResult {
+      const action = String(event.actionValue[DREAMUX_ACTION_KEY] ?? '');
+      if (!DREAMUX_ASK_ACTIONS.has(action)) return { kind: 'ignored' };
+
+      const requestId = String(event.actionValue[DREAMUX_ASK_REQUEST_KEY] ?? '');
+      const round = rounds.get(requestId);
+      if (round === undefined) {
+        // The round is gone: settled already, expired, or lost with a previous
+        // session. Saying so beats a dead click the user cannot explain.
+        return {
+          kind: 'response',
+          response: toast('error', '这轮提问已失效，直接说你的想法就行。'),
+        };
+      }
+
+      if (action === DREAMUX_ASK_SUBMIT_ACTION) {
+        return settle(round, 'submitted', event);
+      }
+      if (action === DREAMUX_ASK_CANCEL_ACTION) {
+        return settle(round, 'cancelled', event);
+      }
+
+      const questionIndex = asIndex(event.actionValue[DREAMUX_ASK_QUESTION_KEY]);
+      const question =
+        questionIndex === undefined
+          ? undefined
+          : round.questions[questionIndex];
+      if (questionIndex === undefined || question === undefined) {
+        return { kind: 'response', response: toast('error', '这个选项已失效') };
+      }
+
+      if (action === DREAMUX_ASK_PICK_ACTION) {
+        const optionIndex = asIndex(event.actionValue[DREAMUX_ASK_OPTION_KEY]);
+        const option =
+          optionIndex === undefined ? undefined : question.options[optionIndex];
+        if (optionIndex === undefined || option === undefined) {
+          return { kind: 'response', response: toast('error', '这个选项已失效') };
+        }
+        // Single-select, and an option and free text answer the same question:
+        // whichever came last is the answer.
+        round.answers.set(questionIndex, { kind: 'option', index: optionIndex });
+        return { kind: 'response', response: repaint(round, option.label) };
+      }
+
+      if (action === DREAMUX_ASK_OTHER_ACTION) {
+        const text = (event.inputValue ?? '').trim();
+        if (text === '') {
+          round.answers.delete(questionIndex);
+          return { kind: 'response', response: repaint(round, '已清空') };
+        }
+        round.answers.set(questionIndex, { kind: 'other', text });
+        return { kind: 'response', response: repaint(round, `Other：${text}`) };
+      }
+
+      return { kind: 'ignored' };
+    },
+
+    abandonAll(): void {
+      for (const round of rounds.values()) {
+        if (round.timer !== undefined) timers.clear(round.timer);
+      }
+      rounds.clear();
+    },
+  };
+}

--- a/packages/channel/feishu-channel/src/feishu-ask-user.ts
+++ b/packages/channel/feishu-channel/src/feishu-ask-user.ts
@@ -22,7 +22,6 @@ import {
   DREAMUX_ASK_ACTIONS,
   DREAMUX_ASK_CANCEL_ACTION,
   DREAMUX_ASK_OPTION_KEY,
-  DREAMUX_ASK_OTHER_ACTION,
   DREAMUX_ASK_PICK_ACTION,
   DREAMUX_ASK_QUESTION_KEY,
   DREAMUX_ASK_REQUEST_KEY,
@@ -76,6 +75,12 @@ export interface AskUserOpenInput {
 export interface AskUserOpened {
   readonly requestId: string;
   readonly card: unknown;
+  /**
+   * Put the round in play, carrying the id of the card that now shows it —
+   * absent only when the send reported none. Nothing can answer a round before
+   * this runs, and nothing has to undo one when the send never lands.
+   */
+  activate(messageId: string | undefined): void;
 }
 
 /**
@@ -126,9 +131,14 @@ export type AskUserApplyResult =
     };
 
 export interface AskUserRegistry {
+  /**
+   * Build a round and the card that asks it. The round is neither answerable
+   * nor on the clock until `activate`, because a round this registry holds is
+   * a card somebody can look at. Registering it here instead would let a send
+   * that threw leave a question behind with no card, and its TTL would later
+   * report an unanswered question to a model whose user was never asked one.
+   */
   open(input: AskUserOpenInput): AskUserOpened;
-  /** Record the sent card's id, so an expiring round can repaint it. */
-  attachMessage(requestId: string, messageId: string): void;
   apply(event: FeishuCardActionEvent): AskUserApplyResult;
   /** Drop every open round; their cards report the round as gone on next click. */
   abandonAll(): void;
@@ -295,27 +305,28 @@ export function createAskUserRegistry(
         target: input.target,
         answers: new Map(),
       };
-      rounds.set(requestId, round);
-      round.timer = timers.set(() => {
-        // Already settled by a click? Then this timer lost the race and the
-        // round is gone; `closeRound` on a stale round would report a second
-        // settlement for one question.
-        if (rounds.get(requestId) !== round) return;
-        const settlement = closeRound(round, 'expired');
-        options.onExpire?.({
-          settlement,
-          ...(round.messageId !== undefined
-            ? { messageId: round.messageId }
-            : {}),
-          card: buildAskUserClosedCard('expired'),
-        });
-      }, ttlMs);
-      return { requestId, card: buildAskUserCard(round) };
-    },
-
-    attachMessage(requestId, messageId): void {
-      const round = rounds.get(requestId);
-      if (round !== undefined) round.messageId = messageId;
+      return {
+        requestId,
+        card: buildAskUserCard(round),
+        activate(messageId): void {
+          if (messageId !== undefined) round.messageId = messageId;
+          rounds.set(requestId, round);
+          round.timer = timers.set(() => {
+            // Already settled by a click? Then this timer lost the race and
+            // the round is gone; `closeRound` on a stale round would report a
+            // second settlement for one question.
+            if (rounds.get(requestId) !== round) return;
+            const settlement = closeRound(round, 'expired');
+            options.onExpire?.({
+              settlement,
+              ...(round.messageId !== undefined
+                ? { messageId: round.messageId }
+                : {}),
+              card: buildAskUserClosedCard('expired'),
+            });
+          }, ttlMs);
+        },
+      };
     },
 
     apply(event): AskUserApplyResult {
@@ -334,6 +345,16 @@ export function createAskUserRegistry(
       }
 
       if (action === DREAMUX_ASK_SUBMIT_ACTION) {
+        // 提交 sits directly under the questions, so it is also the button
+        // pressed before anything has been chosen. Settling on that click
+        // would spend the round's one settlement telling the model every
+        // question was left unanswered, which is worse than saying nothing.
+        if (round.answers.size === 0) {
+          return {
+            kind: 'response',
+            response: toast('warning', '先选一个再提交，或者点「不用问了」。'),
+          };
+        }
         return settle(round, 'submitted', event);
       }
       if (action === DREAMUX_ASK_CANCEL_ACTION) {
@@ -362,17 +383,15 @@ export function createAskUserRegistry(
         return { kind: 'response', response: repaint(round, option.label) };
       }
 
-      if (action === DREAMUX_ASK_OTHER_ACTION) {
-        const text = (event.inputValue ?? '').trim();
-        if (text === '') {
-          round.answers.delete(questionIndex);
-          return { kind: 'response', response: repaint(round, '已清空') };
-        }
-        round.answers.set(questionIndex, { kind: 'other', text });
-        return { kind: 'response', response: repaint(round, `Other：${text}`) };
+      // Free text is the last action the guard at the top admitted, so it is
+      // what is left once pick, submit and cancel have been handled.
+      const text = (event.inputValue ?? '').trim();
+      if (text === '') {
+        round.answers.delete(questionIndex);
+        return { kind: 'response', response: repaint(round, '已清空') };
       }
-
-      return { kind: 'ignored' };
+      round.answers.set(questionIndex, { kind: 'other', text });
+      return { kind: 'response', response: repaint(round, `Other：${text}`) };
     },
 
     abandonAll(): void {

--- a/packages/channel/feishu-channel/src/feishu-channel.ts
+++ b/packages/channel/feishu-channel/src/feishu-channel.ts
@@ -44,6 +44,7 @@ import {
   isFeishuOperationError,
   runFeishuBoundedOperation,
 } from './feishu-bounded-operation.js';
+import { createAskUserRegistry } from './feishu-ask-user.js';
 import { FeishuCotSessionSeam } from './feishu-cot-session.js';
 import { FeishuProvisioning } from './feishu-provisioning.js';
 import { FeishuBindingOperations } from './feishu-session-bindings.js';
@@ -56,6 +57,8 @@ import {
 } from './feishu-submit.js';
 import {
   handleCardAction as sessionHandleCardAction,
+  askUserQuestion as sessionAskUserQuestion,
+  expireAskUserQuestion as sessionExpireAskUser,
   sendCard as sessionSendCard,
   sendReply as sessionSendReply,
   addReaction as sessionAddReaction,
@@ -67,7 +70,6 @@ import { FeishuTargetRouter } from './feishu-target-router.js';
 import { FeishuRouting } from './routing/index.js';
 import { FeishuRoutingStore } from './routing/store.js';
 import {
-  chatTarget,
   describeTarget,
   type FeishuTarget,
 } from './routing/target.js';
@@ -125,6 +127,11 @@ export class FeishuChannelSession {
   private readonly provisioning: FeishuProvisioning;
   private readonly _accessMutex = new AsyncMutex();
   private readonly inactiveFence = alwaysActiveSessionFence();
+  private readonly askUser = createAskUserRegistry({
+    onExpire: (expiry) => {
+      void sessionExpireAskUser(this.handle, expiry).catch(() => undefined);
+    },
+  });
   private lifecycle: FeishuSessionLifecycle | undefined;
   private subscription: ChannelEventSubscription | undefined;
   private invoker: JsonInvoker | undefined;
@@ -252,6 +259,7 @@ export class FeishuChannelSession {
     lifecycle.controller.abort();
     this.subscription?.unsubscribe();
     this.subscription = undefined;
+    this.askUser.abandonAll();
     // Interrupt every live card before the bot goes away. The adapter fences
     // itself first and drains within a bounded window, so a slow Feishu can
     // never hold session shutdown open.
@@ -475,6 +483,7 @@ export class FeishuChannelSession {
           ...(chatId !== undefined ? { chatId } : {}),
         }),
       listKnownChatBots: async (chatId) => this.readChatBots(chatId),
+      askUserQuestion: async (input) => sessionAskUserQuestion(this.handle, input),
       bindChannel: (input) => this.bindings.bindChannel(input),
       unbindChannel: (input, requireOwner) =>
         this.bindings.unbindChannel(input, requireOwner),
@@ -514,26 +523,13 @@ export class FeishuChannelSession {
               if (lifecycle?.fence.isCurrent() !== true) return;
               this.targetRouter.observe(
                 messageId,
-                this.outboundTarget(input.chatId, input.messageId),
+                this.targetRouter.outboundTarget(input.chatId, input.messageId),
               );
             },
           }
         : {}),
     });
     return { message_ids: result.messageIds };
-  }
-
-  /** Where a reply landed, in this Channel's own terms. */
-  private outboundTarget(
-    chatId: string,
-    replyToMessageId: string | undefined,
-  ): FeishuTarget {
-    const observed = replyToMessageId === undefined
-      ? undefined
-      : this.targetRouter.targetForMessage(replyToMessageId);
-    return observed !== undefined && observed.chatId === chatId
-      ? observed
-      : chatTarget(chatId, 'group');
   }
 
   private async addReaction(input: {
@@ -664,6 +660,7 @@ export class FeishuChannelSession {
       targetRouter: this.targetRouter,
       sessionFence: fence,
       delivery: this,
+      askUser: this.askUser,
     });
   }
 

--- a/packages/channel/feishu-channel/src/feishu-channel.ts
+++ b/packages/channel/feishu-channel/src/feishu-channel.ts
@@ -129,7 +129,7 @@ export class FeishuChannelSession {
   private readonly inactiveFence = alwaysActiveSessionFence();
   private readonly askUser = createAskUserRegistry({
     onExpire: (expiry) => {
-      void sessionExpireAskUser(this.handle, expiry).catch(() => undefined);
+      void sessionExpireAskUser(this.handle, expiry);
     },
   });
   private lifecycle: FeishuSessionLifecycle | undefined;

--- a/packages/channel/feishu-channel/src/feishu-session-ops.ts
+++ b/packages/channel/feishu-channel/src/feishu-session-ops.ts
@@ -40,7 +40,13 @@ import { AsyncMutex } from './lib/mutex.js';
 import type { FeishuChannelSessionOptions } from './feishu-channel.js';
 import type { PeerBot } from './chat-bots-store.js';
 import type { FeishuTargetRouter } from './feishu-target-router.js';
-import type { FeishuInboundDelivery } from './feishu-submit.js';
+import { CHANNEL_REMINDER, type FeishuInboundDelivery } from './feishu-submit.js';
+import type {
+  AskUserExpiry,
+  AskUserRegistry,
+  AskUserSettlement,
+} from './feishu-ask-user.js';
+import type { AskUserQuestionSpec } from './feishu-ask-user-card.js';
 import { FeishuOperationError } from './feishu-bounded-operation.js';
 import {
   alwaysActiveSessionFence,
@@ -71,6 +77,8 @@ export interface SessionHandle {
    * learns what a binding or a space policy is.
    */
   delivery: FeishuInboundDelivery;
+  /** Open ask-user rounds; a question outlives the tool call that asked it. */
+  askUser: AskUserRegistry;
 }
 
 /** Build a package-private handle from a session's internal fields. */
@@ -81,6 +89,7 @@ export function sessionHandle(input: {
   botDisplayName: string;
   targetRouter: FeishuTargetRouter;
   delivery: FeishuInboundDelivery;
+  askUser: AskUserRegistry;
   sessionFence?: FeishuSessionFence;
 }): SessionHandle {
   return {
@@ -90,6 +99,7 @@ export function sessionHandle(input: {
     botDisplayName: input.botDisplayName,
     targetRouter: input.targetRouter,
     delivery: input.delivery,
+    askUser: input.askUser,
     sessionFence: input.sessionFence ?? alwaysActiveSessionFence(),
   };
 }
@@ -359,10 +369,151 @@ export async function approvePairingByToken(
   });
 }
 
+/**
+ * Hand a settled ask-user round to Core as an ordinary inbound submission.
+ *
+ * The answer travels the path a typed reply travels, so nothing downstream has
+ * to learn that a card produced it. A delivery that fails is logged and
+ * dropped, exactly as the inbound path treats a message Core would not take:
+ * re-delivering risks a second turn for one answer, and the user can say it
+ * again.
+ */
+async function deliverAskUserSettlement(
+  h: SessionHandle,
+  settlement: AskUserSettlement,
+): Promise<void> {
+  const { target } = settlement;
+  try {
+    const outcome = await h.delivery.deliver({
+      target,
+      containerChatId: target.kind === 'topic' ? target.chatId : null,
+      submission: {
+        attrs: {
+          chat_id: target.chatId,
+          ...(target.threadId !== undefined
+            ? { thread_id: target.threadId }
+            : {}),
+          ...(settlement.cardMessageId !== undefined
+            ? { message_id: settlement.cardMessageId }
+            : {}),
+          // Anyone in the chat may answer the card — an operator ruling, not a
+          // gap ("不需要限制，所有人都可以点"), so there is no check on who
+          // clicked. Carrying the clicker keeps the fact the model would
+          // otherwise lose.
+          ...(settlement.operatorOpenId !== undefined
+            ? { sender_id: settlement.operatorOpenId }
+            : {}),
+          ask_user_request_id: settlement.requestId,
+        },
+        text: settlement.text,
+        reminder: CHANNEL_REMINDER,
+        sourceId: settlement.sourceId,
+        anchor: {
+          chatId: target.chatId,
+          // The question card, never `sourceId`: this id is handed to Feishu as
+          // a COT presentation's origin, and a synthetic one would be sent to
+          // the API as if it were real. Empty when the card id is unknown,
+          // which the COT layer already treats as "no anchor".
+          messageId: settlement.cardMessageId ?? '',
+          target,
+        },
+      },
+    });
+    log(h).info(
+      {
+        dispatcher_id: h.opts.dispatcherId,
+        chat_id: target.chatId,
+        ask_user_request_id: settlement.requestId,
+        ask_user_outcome: settlement.outcome,
+        status: outcome.status,
+      },
+      '[ask-user] answer delivered',
+    );
+  } catch (err) {
+    log(h).error(
+      {
+        dispatcher_id: h.opts.dispatcherId,
+        chat_id: target.chatId,
+        ask_user_request_id: settlement.requestId,
+        err: errInfo(err),
+      },
+      '[ask-user] answer delivery failed',
+    );
+  }
+}
+
+/**
+ * Send a question card and return the round's id.
+ *
+ * Nothing is awaited beyond the send. The click that answers arrives on the
+ * card-action route, and the answer reaches Core as an inbound submission, so
+ * the tool that called this is long finished by the time the user decides.
+ *
+ * With no message to thread under, the target names the chat itself — all the
+ * tool is given, a question being addressed to a conversation rather than to
+ * one message in it.
+ */
+export async function askUserQuestion(
+  h: SessionHandle,
+  input: {
+    chatId: string;
+    questions: readonly AskUserQuestionSpec[];
+  },
+): Promise<{ request_id: string }> {
+  const target = h.targetRouter.outboundTarget(input.chatId, undefined);
+  const opened = h.askUser.open({ questions: input.questions, target });
+  const sent = await sendCard(h, {
+    target: h.targetRouter.notificationTarget(target),
+    card: opened.card,
+    mode: 'inbound',
+  });
+  const messageId = sent.messageIds[0];
+  if (messageId !== undefined) h.askUser.attachMessage(opened.requestId, messageId);
+  return { request_id: opened.requestId };
+}
+
+/**
+ * Close out a round that ran out of time.
+ *
+ * Both halves are best-effort and independent: the model is told there is no
+ * answer, and the card is repainted so the user is not left looking at a
+ * question that silently stopped working. A failed repaint must not cost the
+ * model its notification, which is why the patch is awaited separately.
+ */
+export async function expireAskUserQuestion(
+  h: SessionHandle,
+  expiry: AskUserExpiry,
+): Promise<void> {
+  await deliverAskUserSettlement(h, expiry.settlement);
+  const { messageId } = expiry;
+  if (messageId === undefined) return;
+  try {
+    await h.bot.editCard(messageId, expiry.card);
+  } catch (err) {
+    log(h).warn(
+      {
+        dispatcher_id: h.opts.dispatcherId,
+        message_id: messageId,
+        ask_user_request_id: expiry.settlement.requestId,
+        err: errInfo(err),
+      },
+      '[ask-user] expired card repaint failed',
+    );
+  }
+}
+
 export async function handleCardAction(
   h: SessionHandle,
   event: FeishuCardActionEvent,
 ): Promise<FeishuCardActionResponse | Record<string, never>> {
+  const applied = h.askUser.apply(event);
+  if (applied.kind !== 'ignored') {
+    if (applied.kind === 'settled') {
+      await deliverAskUserSettlement(h, applied.settlement);
+    }
+    return applied.response;
+  }
+
   const action = String(event.actionValue[DREAMUX_ACTION_KEY] ?? '');
   if (action !== DREAMUX_PAIRING_CARD_ACTION) return {};
 

--- a/packages/channel/feishu-channel/src/feishu-session-ops.ts
+++ b/packages/channel/feishu-channel/src/feishu-session-ops.ts
@@ -449,26 +449,31 @@ async function deliverAskUserSettlement(
  * card-action route, and the answer reaches Core as an inbound submission, so
  * the tool that called this is long finished by the time the user decides.
  *
- * With no message to thread under, the target names the chat itself — all the
- * tool is given, a question being addressed to a conversation rather than to
- * one message in it.
+ * `messageId` is the message the question came out of, and the target follows
+ * it the way an ordinary reply does — into that message's topic, under the
+ * anchor the router holds for it. Without one the target names the chat, and
+ * in a topic group the card opens a topic of its own, which is right for a
+ * question that belongs to no particular message and wrong for one that does.
+ *
+ * The round is put in play only once the card is really sent, so a send that
+ * throws leaves no question behind and fails where the model can see it.
  */
 export async function askUserQuestion(
   h: SessionHandle,
   input: {
     chatId: string;
     questions: readonly AskUserQuestionSpec[];
+    messageId?: string;
   },
 ): Promise<{ request_id: string }> {
-  const target = h.targetRouter.outboundTarget(input.chatId, undefined);
+  const target = h.targetRouter.outboundTarget(input.chatId, input.messageId);
   const opened = h.askUser.open({ questions: input.questions, target });
   const sent = await sendCard(h, {
     target: h.targetRouter.notificationTarget(target),
     card: opened.card,
     mode: 'inbound',
   });
-  const messageId = sent.messageIds[0];
-  if (messageId !== undefined) h.askUser.attachMessage(opened.requestId, messageId);
+  opened.activate(sent.messageIds[0]);
   return { request_id: opened.requestId };
 }
 
@@ -509,7 +514,12 @@ export async function handleCardAction(
   const applied = h.askUser.apply(event);
   if (applied.kind !== 'ignored') {
     if (applied.kind === 'settled') {
-      await deliverAskUserSettlement(h, applied.settlement);
+      // Detached deliberately. Feishu gives a card callback a few seconds
+      // before it gives up and the click looks dead, and handing the answer to
+      // Core means waking an agent — long enough to lose that window. Delivery
+      // logs its own failure at error level and has nothing to report back
+      // here anyway.
+      void deliverAskUserSettlement(h, applied.settlement);
     }
     return applied.response;
   }

--- a/packages/channel/feishu-channel/src/feishu-target-router.ts
+++ b/packages/channel/feishu-channel/src/feishu-target-router.ts
@@ -102,6 +102,27 @@ export class FeishuTargetRouter {
     this.targetAnchors.set(targetKey(target), messageId);
   }
 
+  /**
+   * The target an outbound message is addressed to.
+   *
+   * Threading under a message means speaking wherever that message lives, so a
+   * reply inherits the observed target — but only when it is in the chat the
+   * caller named, because a stale message id must not redirect a message into
+   * another conversation. Everything else names the chat itself.
+   */
+  outboundTarget(
+    chatId: string,
+    replyToMessageId: string | undefined,
+  ): FeishuTarget {
+    const observed =
+      replyToMessageId === undefined
+        ? undefined
+        : this.targetForMessage(replyToMessageId);
+    return observed !== undefined && observed.chatId === chatId
+      ? observed
+      : chatTarget(chatId, 'group');
+  }
+
   targetForMessage(messageId: string): FeishuTarget | undefined {
     return this.messageTargets.get(messageId);
   }

--- a/packages/channel/feishu-channel/src/tools/ask-user-question.ts
+++ b/packages/channel/feishu-channel/src/tools/ask-user-question.ts
@@ -1,0 +1,225 @@
+/**
+ * `ask_user_question` — the decision card, offered to the model.
+ *
+ * The arguments are AskUserQuestion's, near enough to be read as the same tool:
+ * `questions`, each with a `header` chip, a `question`, and 2-4 `options` of
+ * `label` + `description` + optional `preview`. Two things differ, and both are
+ * forced rather than chosen: a `chat_id`, because a chat tool needs a
+ * destination and AskUserQuestion has no such concept, and no `multiSelect`,
+ * because the operator ruled multi-select out of this channel.
+ *
+ * The other difference is in the answer, not the arguments. AskUserQuestion
+ * returns what the user chose; this returns as soon as the card is sent, and
+ * the answer arrives later as an ordinary inbound message. The model therefore
+ * has to be told to stop and wait — which is what `next` in the result is for,
+ * repeated on every call so it survives a long context.
+ */
+import { PublicInvokeFailure } from '@excitedjs/dreamux-utils';
+
+import type { AskUserOption, AskUserQuestionSpec } from '../feishu-ask-user-card.js';
+import {
+  asRecord,
+  closedObjectSchema,
+  nonEmptyString,
+  requireString,
+} from './schema.js';
+import type { FeishuToolDef } from './types.js';
+
+const MAX_HEADER_CHARS = 12;
+const MIN_QUESTIONS = 1;
+const MAX_QUESTIONS = 4;
+const MIN_OPTIONS = 2;
+const MAX_OPTIONS = 4;
+
+/** The standing instruction for a tool whose answer never arrives in its result. */
+export const ASK_USER_NEXT_INSTRUCTION =
+  'The question card has been sent. Do NOT do any further work and do NOT ' +
+  'guess an answer: end your turn now and wait. The user\'s answer arrives ' +
+  'later as a normal inbound message. If the user dismisses the card, that ' +
+  'message will say so — drop the card and continue in plain conversation.';
+
+const optionSchema = closedObjectSchema(
+  {
+    label: {
+      ...nonEmptyString,
+      description:
+        'The display text for this option that the user will see and select. ' +
+        'Should be concise (1-5 words) and clearly describe the choice.',
+    },
+    description: {
+      ...nonEmptyString,
+      description:
+        'Explanation of what this option means or what will happen if chosen. ' +
+        'Useful for providing context about trade-offs or implications.',
+    },
+    preview: {
+      ...nonEmptyString,
+      description:
+        'Optional preview content shown beside the options while this option ' +
+        'is the selected one. Use for mockups, code snippets, or visual ' +
+        'comparisons that help users compare options. Rendered as a monospace ' +
+        'block.',
+    },
+  },
+  ['label', 'description'],
+);
+
+const questionSchema = closedObjectSchema(
+  {
+    header: {
+      ...nonEmptyString,
+      maxLength: MAX_HEADER_CHARS,
+      description:
+        'Very short label displayed as a chip/tag (max 12 chars). Examples: ' +
+        '"Auth method", "Library", "Approach".',
+    },
+    question: {
+      ...nonEmptyString,
+      description:
+        'The complete question to ask the user. Should be clear, specific, ' +
+        'and end with a question mark.',
+    },
+    options: {
+      type: 'array',
+      minItems: MIN_OPTIONS,
+      maxItems: MAX_OPTIONS,
+      items: optionSchema,
+      description:
+        'The available choices for this question. Must have 2-4 options. Each ' +
+        'option should be a distinct, mutually exclusive choice. There should ' +
+        "be no 'Other' option, that will be provided automatically.",
+    },
+  },
+  ['header', 'question', 'options'],
+);
+
+interface AskUserQuestionInput {
+  chatId: string;
+  questions: readonly AskUserQuestionSpec[];
+}
+
+function parseOption(raw: unknown, where: string): AskUserOption {
+  const obj = asRecord(raw, where);
+  const preview = obj['preview'];
+  if (preview !== undefined && typeof preview !== 'string') {
+    throw new PublicInvokeFailure(`${where}.preview must be a string`);
+  }
+  return {
+    label: requireString(obj, 'label'),
+    description: requireString(obj, 'description'),
+    ...(typeof preview === 'string' && preview !== '' ? { preview } : {}),
+  };
+}
+
+function parseQuestion(raw: unknown, index: number): AskUserQuestionSpec {
+  const where = `questions[${index}]`;
+  const obj = asRecord(raw, where);
+  const header = requireString(obj, 'header');
+  if ([...header].length > MAX_HEADER_CHARS) {
+    throw new PublicInvokeFailure(
+      `${where}.header must be at most ${MAX_HEADER_CHARS} characters`,
+    );
+  }
+  const options = obj['options'];
+  if (
+    !Array.isArray(options) ||
+    options.length < MIN_OPTIONS ||
+    options.length > MAX_OPTIONS
+  ) {
+    throw new PublicInvokeFailure(
+      `${where}.options must have ${MIN_OPTIONS}-${MAX_OPTIONS} options`,
+    );
+  }
+  return {
+    header,
+    question: requireString(obj, 'question'),
+    options: options.map((option, optionIndex) =>
+      parseOption(option, `${where}.options[${optionIndex}]`),
+    ),
+  };
+}
+
+export const askUserQuestionDef: FeishuToolDef<AskUserQuestionInput> = {
+  name: 'ask_user_question',
+  title: 'Ask the user a question',
+  description:
+    'Use this tool only when you are blocked on a decision that is genuinely ' +
+    "the user's to make: one you cannot resolve from the request, the code, " +
+    'or sensible defaults. It renders the questions as an interactive Feishu ' +
+    'card in the chat.\n\n' +
+    'Usage notes:\n' +
+    '- Users will always be able to write an "Other" answer of their own, so ' +
+    'never add an "Other" option yourself\n' +
+    '- If you recommend a specific option, make that the first option in the ' +
+    'list and add "(Recommended)" at the end of the label\n' +
+    '- Single-select only: every question takes exactly one answer. Split a ' +
+    'decision that needs several answers into several questions\n' +
+    '- This tool does NOT return the answer. It returns as soon as the card ' +
+    'is sent; end your turn and wait, and the answer will arrive as a normal ' +
+    'inbound message\n\n' +
+    "Reserve this for decisions where the user's answer changes what you do " +
+    'next — not for choices with a conventional default or facts you can ' +
+    'verify in the codebase yourself. In those cases pick the obvious option, ' +
+    'mention it in your response, and proceed.\n\n' +
+    'Preview feature: use the optional `preview` field on options when ' +
+    'presenting concrete artifacts that users need to visually compare — ' +
+    'ASCII mockups of UI layouts, code snippets showing different ' +
+    'implementations, diagram variations, configuration examples. The preview ' +
+    'of the selected option is shown beside the options in a monospace block.',
+  callers: ['dispatcher', 'team_leader'],
+  inputSchema: closedObjectSchema(
+    {
+      chat_id: {
+        ...nonEmptyString,
+        description:
+          'Feishu chat id from the inbound <channel source="feishu"> block. ' +
+          'The card is sent to this conversation.',
+      },
+      questions: {
+        type: 'array',
+        minItems: MIN_QUESTIONS,
+        maxItems: MAX_QUESTIONS,
+        items: questionSchema,
+        description: 'Questions to ask the user (1-4 questions)',
+      },
+    },
+    ['chat_id', 'questions'],
+  ),
+  outputSchema: closedObjectSchema(
+    {
+      request_id: nonEmptyString,
+      status: { type: 'string', enum: ['asked'] },
+      next: nonEmptyString,
+    },
+    ['request_id', 'status', 'next'],
+  ),
+  annotations: { readOnlyHint: false, destructiveHint: false },
+  parse(raw) {
+    const obj = asRecord(raw, 'ask_user_question arguments');
+    const questions = obj['questions'];
+    if (
+      !Array.isArray(questions) ||
+      questions.length < MIN_QUESTIONS ||
+      questions.length > MAX_QUESTIONS
+    ) {
+      throw new PublicInvokeFailure(
+        `questions must have ${MIN_QUESTIONS}-${MAX_QUESTIONS} questions`,
+      );
+    }
+    return {
+      chatId: requireString(obj, 'chat_id'),
+      questions: questions.map(parseQuestion),
+    };
+  },
+  async handle(ctx, input) {
+    const result = await ctx.session.askUserQuestion({
+      chatId: input.chatId,
+      questions: input.questions,
+    });
+    return {
+      request_id: result.request_id,
+      status: 'asked',
+      next: ASK_USER_NEXT_INSTRUCTION,
+    };
+  },
+};

--- a/packages/channel/feishu-channel/src/tools/ask-user-question.ts
+++ b/packages/channel/feishu-channel/src/tools/ask-user-question.ts
@@ -3,10 +3,13 @@
  *
  * The arguments are AskUserQuestion's, near enough to be read as the same tool:
  * `questions`, each with a `header` chip, a `question`, and 2-4 `options` of
- * `label` + `description` + optional `preview`. Two things differ, and both are
- * forced rather than chosen: a `chat_id`, because a chat tool needs a
- * destination and AskUserQuestion has no such concept, and no `multiSelect`,
- * because the operator ruled multi-select out of this channel.
+ * `label` + `description`. Three fields differ, none of them by choice here: a
+ * `chat_id` is required, because a chat tool needs a destination and
+ * AskUserQuestion has no such concept; `multiSelect` is absent, because the
+ * operator ruled multi-select out of this channel; and so is `preview`, which
+ * the operator dropped after seeing what it cost the card — "这个 preview 有点
+ * 复杂了，给他去掉，他也会影响卡片的布局". Rendering it meant a second column
+ * beside the options, which reshaped every question that used it.
  *
  * The other difference is in the answer, not the arguments. AskUserQuestion
  * returns what the user chose; this returns as soon as the card is sent, and
@@ -52,14 +55,6 @@ const optionSchema = closedObjectSchema(
         'Explanation of what this option means or what will happen if chosen. ' +
         'Useful for providing context about trade-offs or implications.',
     },
-    preview: {
-      ...nonEmptyString,
-      description:
-        'Optional preview content shown beside the options while this option ' +
-        'is the selected one. Use for mockups, code snippets, or visual ' +
-        'comparisons that help users compare options. Rendered as a monospace ' +
-        'block.',
-    },
   },
   ['label', 'description'],
 );
@@ -100,14 +95,9 @@ interface AskUserQuestionInput {
 
 function parseOption(raw: unknown, where: string): AskUserOption {
   const obj = asRecord(raw, where);
-  const preview = obj['preview'];
-  if (preview !== undefined && typeof preview !== 'string') {
-    throw new PublicInvokeFailure(`${where}.preview must be a string`);
-  }
   return {
     label: requireString(obj, 'label'),
     description: requireString(obj, 'description'),
-    ...(typeof preview === 'string' && preview !== '' ? { preview } : {}),
   };
 }
 
@@ -160,12 +150,7 @@ export const askUserQuestionDef: FeishuToolDef<AskUserQuestionInput> = {
     "Reserve this for decisions where the user's answer changes what you do " +
     'next — not for choices with a conventional default or facts you can ' +
     'verify in the codebase yourself. In those cases pick the obvious option, ' +
-    'mention it in your response, and proceed.\n\n' +
-    'Preview feature: use the optional `preview` field on options when ' +
-    'presenting concrete artifacts that users need to visually compare — ' +
-    'ASCII mockups of UI layouts, code snippets showing different ' +
-    'implementations, diagram variations, configuration examples. The preview ' +
-    'of the selected option is shown beside the options in a monospace block.',
+    'mention it in your response, and proceed.',
   callers: ['dispatcher', 'team_leader'],
   inputSchema: closedObjectSchema(
     {

--- a/packages/channel/feishu-channel/src/tools/ask-user-question.ts
+++ b/packages/channel/feishu-channel/src/tools/ask-user-question.ts
@@ -7,9 +7,10 @@
  * `chat_id` is required, because a chat tool needs a destination and
  * AskUserQuestion has no such concept; `multiSelect` is absent, because the
  * operator ruled multi-select out of this channel; and so is `preview`, which
- * the operator dropped after seeing what it cost the card — "这个 preview 有点
- * 复杂了，给他去掉，他也会影响卡片的布局". Rendering it meant a second column
- * beside the options, which reshaped every question that used it.
+ * the operator dropped after seeing what it cost the card —
+ * "这个 preview 有点复杂了，给他去掉，他也会影响卡片的布局". Rendering it meant
+ * a second column beside the options, which reshaped every question that used
+ * it.
  *
  * The other difference is in the answer, not the arguments. AskUserQuestion
  * returns what the user chose; this returns as soon as the card is sent, and

--- a/packages/channel/feishu-channel/src/tools/ask-user-question.ts
+++ b/packages/channel/feishu-channel/src/tools/ask-user-question.ts
@@ -3,11 +3,13 @@
  *
  * The arguments are AskUserQuestion's, near enough to be read as the same tool:
  * `questions`, each with a `header` chip, a `question`, and 2-4 `options` of
- * `label` + `description`. Three fields differ, none of them by choice here: a
- * `chat_id` is required, because a chat tool needs a destination and
- * AskUserQuestion has no such concept; `multiSelect` is absent, because the
- * operator ruled multi-select out of this channel; and so is `preview`, which
- * the operator dropped after seeing what it cost the card —
+ * `label` + `description`. Four fields differ. Two are the chat: `chat_id` is
+ * required and `message_id` is offered, because a card has to be addressed at
+ * a conversation and, when the question came out of something someone said, at
+ * the message it came out of. AskUserQuestion, answered inside the client that
+ * called it, needs neither. The other two are gone: `multiSelect`, because the
+ * operator ruled multi-select out of this channel, and `preview`, which the
+ * operator dropped after seeing what it cost the card —
  * "这个 preview 有点复杂了，给他去掉，他也会影响卡片的布局". Rendering it meant
  * a second column beside the options, which reshaped every question that used
  * it.
@@ -25,6 +27,7 @@ import {
   asRecord,
   closedObjectSchema,
   nonEmptyString,
+  optionalString,
   requireString,
 } from './schema.js';
 import type { FeishuToolDef } from './types.js';
@@ -92,6 +95,7 @@ const questionSchema = closedObjectSchema(
 interface AskUserQuestionInput {
   chatId: string;
   questions: readonly AskUserQuestionSpec[];
+  messageId?: string;
 }
 
 function parseOption(raw: unknown, where: string): AskUserOption {
@@ -161,6 +165,12 @@ export const askUserQuestionDef: FeishuToolDef<AskUserQuestionInput> = {
           'Feishu chat id from the inbound <channel source="feishu"> block. ' +
           'The card is sent to this conversation.',
       },
+      message_id: {
+        ...nonEmptyString,
+        description:
+          'Optional id of the message this question came out of. The card is ' +
+          'sent under it, in the same topic, exactly as a reply would be.',
+      },
       questions: {
         type: 'array',
         minItems: MIN_QUESTIONS,
@@ -192,15 +202,18 @@ export const askUserQuestionDef: FeishuToolDef<AskUserQuestionInput> = {
         `questions must have ${MIN_QUESTIONS}-${MAX_QUESTIONS} questions`,
       );
     }
+    const messageId = optionalString(obj, 'message_id');
     return {
       chatId: requireString(obj, 'chat_id'),
       questions: questions.map(parseQuestion),
+      ...(messageId !== null ? { messageId } : {}),
     };
   },
   async handle(ctx, input) {
     const result = await ctx.session.askUserQuestion({
       chatId: input.chatId,
       questions: input.questions,
+      ...(input.messageId !== undefined ? { messageId: input.messageId } : {}),
     });
     return {
       request_id: result.request_id,

--- a/packages/channel/feishu-channel/src/tools/registry.ts
+++ b/packages/channel/feishu-channel/src/tools/registry.ts
@@ -23,6 +23,7 @@ import type {
   ChannelMcpToolRegistration,
 } from '@excitedjs/dreamux-types';
 
+import { askUserQuestionDef } from './ask-user-question.js';
 import {
   listChatBotsDef,
   reactDef,
@@ -47,6 +48,7 @@ export const FEISHU_TOOLS: readonly FeishuToolDef[] = [
   replyDef,
   reactDef,
   listChatBotsDef,
+  askUserQuestionDef,
   bindChannelDef,
   unbindChannelDef,
   leaderBindChannelDef,

--- a/packages/channel/feishu-channel/src/tools/types.ts
+++ b/packages/channel/feishu-channel/src/tools/types.ts
@@ -73,6 +73,7 @@ export interface FeishuToolSession {
   askUserQuestion(input: {
     chatId: string;
     questions: readonly AskUserQuestionSpec[];
+    messageId?: string;
   }): Promise<{ request_id: string }>;
   /**
    * `requireOwner` is the Team a route must already belong to, if any Team

--- a/packages/channel/feishu-channel/src/tools/types.ts
+++ b/packages/channel/feishu-channel/src/tools/types.ts
@@ -13,6 +13,7 @@ import type {
   JsonValue,
 } from '@excitedjs/dreamux-types';
 
+import type { AskUserQuestionSpec } from '../feishu-ask-user-card.js';
 import type { FeishuSpaceRecord } from '../routing/document.js';
 import type { FeishuBindingView } from '../routing/index.js';
 import type { FeishuTargetKind } from '../routing/target.js';
@@ -64,6 +65,15 @@ export interface FeishuToolSession {
     emoji: string,
   ): Promise<{ reaction_id: string }>;
   listKnownChatBots(chatId: string): Promise<FeishuListChatBotsResult>;
+  /**
+   * Send a question card and return once it is sent. The answer is not awaited:
+   * it reaches the model later as an inbound submission, so this resolves with
+   * the round's identity rather than with what the user chose.
+   */
+  askUserQuestion(input: {
+    chatId: string;
+    questions: readonly AskUserQuestionSpec[];
+  }): Promise<{ request_id: string }>;
   /**
    * `requireOwner` is the Team a route must already belong to, if any Team
    * does. A Dispatcher omits it and may move any route; a TeamLeader passes

--- a/packages/channel/feishu-channel/tests/feishu-ask-user.test.ts
+++ b/packages/channel/feishu-channel/tests/feishu-ask-user.test.ts
@@ -22,6 +22,7 @@ import {
   ASK_USER_CARD_TTL_MS,
   createAskUserRegistry,
   type AskUserExpiry,
+  type AskUserRegistry,
   type AskUserTimers,
 } from '../src/feishu-ask-user.js';
 import {
@@ -35,12 +36,13 @@ import {
   type AskUserQuestionSpec,
 } from '../src/feishu-ask-user-card.js';
 import { DREAMUX_ACTION_KEY } from '../src/feishu-pairing-card.js';
+import { FeishuTargetRouter } from '../src/feishu-target-router.js';
 import {
   ASK_USER_NEXT_INSTRUCTION,
   askUserQuestionDef,
 } from '../src/tools/ask-user-question.js';
 import type { FeishuToolContext, FeishuToolSession } from '../src/tools/types.js';
-import { chatTarget } from '../src/routing/target.js';
+import { chatTarget, topicTarget } from '../src/routing/target.js';
 
 const QUESTIONS: readonly AskUserQuestionSpec[] = [
   {
@@ -103,10 +105,40 @@ function manualTimers(): AskUserTimers & { fire(): void } {
   };
 }
 
+/**
+ * Open a round and put it in play, which is what a successful send does. A
+ * round nobody activated is answerable by nobody, so every test that clicks
+ * one has to go through here.
+ */
+function openRound(
+  registry: AskUserRegistry,
+  messageId: string | undefined = undefined,
+): string {
+  const opened = registry.open({ questions: QUESTIONS, target });
+  opened.activate(messageId);
+  return opened.requestId;
+}
+
+/** Answer a question, so a submit has something to submit. */
+function pickOption(
+  registry: AskUserRegistry,
+  requestId: string,
+  questionIndex: number,
+  optionIndex: number,
+): void {
+  registry.apply(
+    event(DREAMUX_ASK_PICK_ACTION, {
+      [DREAMUX_ASK_REQUEST_KEY]: requestId,
+      [DREAMUX_ASK_QUESTION_KEY]: questionIndex,
+      [DREAMUX_ASK_OPTION_KEY]: optionIndex,
+    }),
+  );
+}
+
 describe('ask-user registry', () => {
   it('records a pick server-side and repaints the card as selected', () => {
     const registry = createAskUserRegistry({ timers: manualTimers() });
-    const { requestId } = registry.open({ questions: QUESTIONS, target });
+    const requestId = openRound(registry);
 
     const applied = registry.apply(
       event(DREAMUX_ASK_PICK_ACTION, {
@@ -127,7 +159,7 @@ describe('ask-user registry', () => {
 
   it('lets free text answer a question, and replace a picked option', () => {
     const registry = createAskUserRegistry({ timers: manualTimers() });
-    const { requestId } = registry.open({ questions: QUESTIONS, target });
+    const requestId = openRound(registry);
     registry.apply(
       event(DREAMUX_ASK_PICK_ACTION, {
         [DREAMUX_ASK_REQUEST_KEY]: requestId,
@@ -159,7 +191,7 @@ describe('ask-user registry', () => {
 
   it('clearing the free-text box takes the answer back', () => {
     const registry = createAskUserRegistry({ timers: manualTimers() });
-    const { requestId } = registry.open({ questions: QUESTIONS, target });
+    const requestId = openRound(registry);
     registry.apply(
       event(
         DREAMUX_ASK_OTHER_ACTION,
@@ -174,6 +206,9 @@ describe('ask-user registry', () => {
         '   ',
       ),
     );
+    // The second question keeps the submit alive; a round with no answer at
+    // all is refused, which is a different test.
+    pickOption(registry, requestId, 1, 0);
 
     const settled = registry.apply(
       event(DREAMUX_ASK_SUBMIT_ACTION, { [DREAMUX_ASK_REQUEST_KEY]: requestId }),
@@ -184,7 +219,7 @@ describe('ask-user registry', () => {
 
   it('cancel tells the model to stop asking, not that a button was pressed', () => {
     const registry = createAskUserRegistry({ timers: manualTimers() });
-    const { requestId } = registry.open({ questions: QUESTIONS, target });
+    const requestId = openRound(registry);
 
     const settled = registry.apply(
       event(DREAMUX_ASK_CANCEL_ACTION, { [DREAMUX_ASK_REQUEST_KEY]: requestId }),
@@ -196,7 +231,8 @@ describe('ask-user registry', () => {
 
   it('settles a round exactly once, so a double click cannot deliver twice', () => {
     const registry = createAskUserRegistry({ timers: manualTimers() });
-    const { requestId } = registry.open({ questions: QUESTIONS, target });
+    const requestId = openRound(registry);
+    pickOption(registry, requestId, 0, 0);
     const first = registry.apply(
       event(DREAMUX_ASK_SUBMIT_ACTION, { [DREAMUX_ASK_REQUEST_KEY]: requestId }),
     );
@@ -212,7 +248,7 @@ describe('ask-user registry', () => {
 
   it('answers a click on a round it no longer has instead of going silent', () => {
     const registry = createAskUserRegistry({ timers: manualTimers() });
-    registry.open({ questions: QUESTIONS, target });
+    openRound(registry);
     registry.abandonAll();
 
     const applied = registry.apply(
@@ -222,6 +258,56 @@ describe('ask-user registry', () => {
     expect(applied.response.toast?.type).toBe('error');
   });
 
+  it('leaves nothing behind when the card never reached the chat', () => {
+    const timers = manualTimers();
+    const expired: AskUserExpiry[] = [];
+    const registry = createAskUserRegistry({
+      timers,
+      onExpire: (expiry) => expired.push(expiry),
+    });
+    // The send threw, so `activate` was never reached.
+    const opened = registry.open({ questions: QUESTIONS, target });
+
+    const applied = registry.apply(
+      event(DREAMUX_ASK_SUBMIT_ACTION, {
+        [DREAMUX_ASK_REQUEST_KEY]: opened.requestId,
+      }),
+    );
+    expect(applied.kind).toBe('response');
+    // And no clock is running: a round with no card must never tell the model
+    // that a question it never asked went unanswered.
+    timers.fire();
+    expect(expired).toHaveLength(0);
+  });
+
+  it('refuses a submit with nothing chosen instead of spending the round', () => {
+    const registry = createAskUserRegistry({ timers: manualTimers() });
+    const requestId = openRound(registry);
+
+    const empty = registry.apply(
+      event(DREAMUX_ASK_SUBMIT_ACTION, { [DREAMUX_ASK_REQUEST_KEY]: requestId }),
+    );
+    expect(empty.kind).toBe('response');
+    if (empty.kind !== 'response') return;
+    expect(empty.response.toast?.type).toBe('warning');
+
+    // The round survived the misfire, so the next click still answers it.
+    registry.apply(
+      event(DREAMUX_ASK_PICK_ACTION, {
+        [DREAMUX_ASK_REQUEST_KEY]: requestId,
+        [DREAMUX_ASK_QUESTION_KEY]: 0,
+        [DREAMUX_ASK_OPTION_KEY]: 1,
+      }),
+    );
+    const settled = registry.apply(
+      event(DREAMUX_ASK_SUBMIT_ACTION, { [DREAMUX_ASK_REQUEST_KEY]: requestId }),
+    );
+    if (settled.kind !== 'settled') throw new Error('expected settled');
+    // One question answered, one not: still a submit, and still worth sending.
+    expect(settled.settlement.text).toContain('Move to SQLite');
+    expect(settled.settlement.text).toContain('(left unanswered)');
+  });
+
   it('leaves other cards alone', () => {
     const registry = createAskUserRegistry({ timers: manualTimers() });
     expect(registry.apply(event('approve_pairing', {})).kind).toBe('ignored');
@@ -229,7 +315,8 @@ describe('ask-user registry', () => {
 
   it('anchors the answer on the real card, never on the dedup id', () => {
     const registry = createAskUserRegistry({ timers: manualTimers() });
-    const { requestId } = registry.open({ questions: QUESTIONS, target });
+    const requestId = openRound(registry);
+    pickOption(registry, requestId, 0, 0);
 
     const settled = registry.apply(
       event(DREAMUX_ASK_SUBMIT_ACTION, { [DREAMUX_ASK_REQUEST_KEY]: requestId }),
@@ -254,8 +341,7 @@ describe('ask-user registry', () => {
       timers,
       onExpire: (expiry) => expired.push(expiry),
     });
-    const { requestId } = registry.open({ questions: QUESTIONS, target });
-    registry.attachMessage(requestId, 'om_sent');
+    const requestId = openRound(registry, 'om_sent');
 
     timers.fire();
     // No click means no event to read the card id from — only what the send
@@ -271,8 +357,7 @@ describe('ask-user registry', () => {
       timers,
       onExpire: (expiry) => expired.push(expiry),
     });
-    const { requestId } = registry.open({ questions: QUESTIONS, target });
-    registry.attachMessage(requestId, 'om_card');
+    const requestId = openRound(registry, 'om_card');
 
     timers.fire();
 
@@ -292,7 +377,8 @@ describe('ask-user registry', () => {
       timers,
       onExpire: (expiry) => expired.push(expiry),
     });
-    const { requestId } = registry.open({ questions: QUESTIONS, target });
+    const requestId = openRound(registry);
+    pickOption(registry, requestId, 0, 0);
     registry.apply(
       event(DREAMUX_ASK_SUBMIT_ACTION, { [DREAMUX_ASK_REQUEST_KEY]: requestId }),
     );
@@ -360,6 +446,38 @@ describe('ask_user_question tool', () => {
     expect(Object.keys(option)).toEqual(['label', 'description']);
   });
 
+  it('sends the card under the message the question came out of', async () => {
+    const askUserQuestion = vi.fn().mockResolvedValue({ request_id: 'r1' });
+    await askUserQuestionDef.handle(
+      context({ askUserQuestion }),
+      askUserQuestionDef.parse({ ...validArgs, message_id: 'om_asked' }),
+    );
+
+    expect(askUserQuestion.mock.calls[0]?.[0]).toMatchObject({
+      chatId: 'oc_test',
+      messageId: 'om_asked',
+    });
+  });
+
+  it('leaves the message id out when the model named none', () => {
+    // Not an empty string: the target router reads "no message to thread
+    // under" from the field's absence, and would look up '' as an id.
+    expect(askUserQuestionDef.parse(validArgs)).not.toHaveProperty('messageId');
+  });
+
+  it('needs a chat, offers a message, and asks for nothing else', () => {
+    const schema = askUserQuestionDef.inputSchema as {
+      properties: Record<string, unknown>;
+      required: readonly string[];
+    };
+    expect(Object.keys(schema.properties)).toEqual([
+      'chat_id',
+      'message_id',
+      'questions',
+    ]);
+    expect(schema.required).toEqual(['chat_id', 'questions']);
+  });
+
   it('rejects a header too long to fit the chip', () => {
     expect(() =>
       askUserQuestionDef.parse({
@@ -390,5 +508,54 @@ describe('ask_user_question tool', () => {
         questions: Array.from({ length: 5 }, () => validArgs.questions[0]),
       }),
     ).toThrow(/1-4 questions/);
+  });
+});
+
+/**
+ * Where `message_id` sends the card. The rule is the one `reply` already
+ * follows — the card belongs wherever the message it answers lives — so this
+ * covers the router, not a second routing path for questions.
+ */
+describe('addressing the question card', () => {
+  const silent = {
+    error: () => undefined,
+    warn: () => undefined,
+    info: () => undefined,
+    debug: () => undefined,
+    trace: () => undefined,
+  };
+
+  function router(): FeishuTargetRouter {
+    return new FeishuTargetRouter({ chatModes: {}, log: silent });
+  }
+
+  it('follows the named message into its topic', () => {
+    const r = router();
+    r.observe('om_asked', topicTarget('oc_room', 'omt_thread'));
+
+    expect(r.outboundTarget('oc_room', 'om_asked')).toEqual(
+      topicTarget('oc_room', 'omt_thread'),
+    );
+  });
+
+  it('addresses the chat itself when no message is named', () => {
+    const r = router();
+    r.observe('om_asked', topicTarget('oc_room', 'omt_thread'));
+
+    // A question that belongs to no message opens a topic of its own.
+    expect(r.outboundTarget('oc_room', undefined)).toEqual(
+      chatTarget('oc_room', 'group'),
+    );
+  });
+
+  it('ignores a message from another chat rather than redirecting the card', () => {
+    const r = router();
+    r.observe('om_elsewhere', topicTarget('oc_other', 'omt_thread'));
+
+    // Deliberate: a stale or copied id must not send a question meant for one
+    // conversation into another. The named chat wins.
+    expect(r.outboundTarget('oc_room', 'om_elsewhere')).toEqual(
+      chatTarget('oc_room', 'group'),
+    );
   });
 });

--- a/packages/channel/feishu-channel/tests/feishu-ask-user.test.ts
+++ b/packages/channel/feishu-channel/tests/feishu-ask-user.test.ts
@@ -26,6 +26,7 @@ import {
   type AskUserTimers,
 } from '../src/feishu-ask-user.js';
 import {
+  ASK_USER_CANCEL_LABEL,
   DREAMUX_ASK_CANCEL_ACTION,
   DREAMUX_ASK_OPTION_KEY,
   DREAMUX_ASK_OTHER_ACTION,
@@ -282,7 +283,9 @@ describe('ask-user registry', () => {
 
   it('refuses a submit with nothing chosen instead of spending the round', () => {
     const registry = createAskUserRegistry({ timers: manualTimers() });
-    const requestId = openRound(registry);
+    const opened = registry.open({ questions: QUESTIONS, target });
+    opened.activate(undefined);
+    const { requestId } = opened;
 
     const empty = registry.apply(
       event(DREAMUX_ASK_SUBMIT_ACTION, { [DREAMUX_ASK_REQUEST_KEY]: requestId }),
@@ -290,6 +293,10 @@ describe('ask-user registry', () => {
     expect(empty.kind).toBe('response');
     if (empty.kind !== 'response') return;
     expect(empty.response.toast?.type).toBe('warning');
+    // The toast sends the user to the other button, so it has to name one the
+    // card actually draws.
+    expect(empty.response.toast?.content).toContain(ASK_USER_CANCEL_LABEL);
+    expect(stringLeaves(opened.card)).toContain(ASK_USER_CANCEL_LABEL);
 
     // The round survived the misfire, so the next click still answers it.
     registry.apply(

--- a/packages/channel/feishu-channel/tests/feishu-ask-user.test.ts
+++ b/packages/channel/feishu-channel/tests/feishu-ask-user.test.ts
@@ -47,7 +47,7 @@ const QUESTIONS: readonly AskUserQuestionSpec[] = [
     header: '存储方案',
     question: 'Where does session state live?',
     options: [
-      { label: 'Keep JSON', description: 'Smallest change', preview: 'state/' },
+      { label: 'Keep JSON', description: 'Smallest change' },
       { label: 'Move to SQLite', description: 'Better concurrency' },
     ],
   },
@@ -345,13 +345,19 @@ describe('ask_user_question tool', () => {
     expect(ASK_USER_NEXT_INSTRUCTION).toContain('end your turn');
   });
 
-  it('has no multi-select field to accept', () => {
-    const properties = (
+  it('offers neither a multi-select nor a preview to fill in', () => {
+    const question = (
       askUserQuestionDef.inputSchema as {
-        properties: { questions: { items: { properties: object } } };
+        properties: {
+          questions: { items: { properties: Record<string, unknown> } };
+        };
       }
     ).properties.questions.items.properties;
-    expect(Object.keys(properties)).toEqual(['header', 'question', 'options']);
+    expect(Object.keys(question)).toEqual(['header', 'question', 'options']);
+    const option = (
+      question['options'] as { items: { properties: Record<string, unknown> } }
+    ).items.properties;
+    expect(Object.keys(option)).toEqual(['label', 'description']);
   });
 
   it('rejects a header too long to fit the chip', () => {

--- a/packages/channel/feishu-channel/tests/feishu-ask-user.test.ts
+++ b/packages/channel/feishu-channel/tests/feishu-ask-user.test.ts
@@ -1,0 +1,388 @@
+/**
+ * `ask_user_question`: the round outlives the tool call, and the server owns
+ * the answer.
+ *
+ * Two properties carry the whole design and neither is visible in the card
+ * JSON alone. The card holds no client state — an `interactive_container` has
+ * none — so "which option is selected" exists only in the registry, and every
+ * assertion about a selected option is really an assertion that a click was
+ * applied server-side and the card repainted from it. And the tool never
+ * returns an answer: it returns once the card is sent, so what the model is
+ * told to do next (`next`) is the only thing standing between a sent question
+ * and a model that keeps working while the user reads it.
+ *
+ * Expiry is the third: Feishu stops accepting clicks on a card 15 minutes in,
+ * so a round that nobody answers has to close itself and say so, or the model
+ * waits forever for an answer the platform will no longer accept.
+ */
+import { describe, expect, it, vi } from 'vitest';
+
+import type { FeishuCardActionEvent } from '../src/bot.js';
+import {
+  ASK_USER_CARD_TTL_MS,
+  createAskUserRegistry,
+  type AskUserExpiry,
+  type AskUserTimers,
+} from '../src/feishu-ask-user.js';
+import {
+  DREAMUX_ASK_CANCEL_ACTION,
+  DREAMUX_ASK_OPTION_KEY,
+  DREAMUX_ASK_OTHER_ACTION,
+  DREAMUX_ASK_PICK_ACTION,
+  DREAMUX_ASK_QUESTION_KEY,
+  DREAMUX_ASK_REQUEST_KEY,
+  DREAMUX_ASK_SUBMIT_ACTION,
+  type AskUserQuestionSpec,
+} from '../src/feishu-ask-user-card.js';
+import { DREAMUX_ACTION_KEY } from '../src/feishu-pairing-card.js';
+import {
+  ASK_USER_NEXT_INSTRUCTION,
+  askUserQuestionDef,
+} from '../src/tools/ask-user-question.js';
+import type { FeishuToolContext, FeishuToolSession } from '../src/tools/types.js';
+import { chatTarget } from '../src/routing/target.js';
+
+const QUESTIONS: readonly AskUserQuestionSpec[] = [
+  {
+    header: '存储方案',
+    question: 'Where does session state live?',
+    options: [
+      { label: 'Keep JSON', description: 'Smallest change', preview: 'state/' },
+      { label: 'Move to SQLite', description: 'Better concurrency' },
+    ],
+  },
+  {
+    header: '发布节奏',
+    question: 'When does it ship?',
+    options: [
+      { label: 'Next beta', description: 'Batch it' },
+      { label: 'Own patch', description: 'Ship now' },
+    ],
+  },
+];
+
+const target = chatTarget('oc_test', 'group');
+
+function event(
+  action: string,
+  value: Record<string, unknown>,
+  inputValue?: string,
+): FeishuCardActionEvent {
+  return {
+    actionValue: { [DREAMUX_ACTION_KEY]: action, ...value },
+    ...(inputValue !== undefined ? { inputValue } : {}),
+    operatorOpenId: 'ou_clicker',
+    openMessageId: 'om_the_card',
+    raw: {},
+  };
+}
+
+/** Every string leaf in a card tree, so a repaint can be asserted on text. */
+function stringLeaves(value: unknown, out: string[] = []): string[] {
+  if (typeof value === 'string') out.push(value);
+  else if (Array.isArray(value)) for (const item of value) stringLeaves(item, out);
+  else if (value !== null && typeof value === 'object') {
+    for (const item of Object.values(value)) stringLeaves(item, out);
+  }
+  return out;
+}
+
+function manualTimers(): AskUserTimers & { fire(): void } {
+  const queued: (() => void)[] = [];
+  return {
+    set(fn) {
+      queued.push(fn);
+      return queued.length - 1;
+    },
+    clear(handle) {
+      queued[handle as number] = () => undefined;
+    },
+    fire() {
+      for (const fn of [...queued]) fn();
+    },
+  };
+}
+
+describe('ask-user registry', () => {
+  it('records a pick server-side and repaints the card as selected', () => {
+    const registry = createAskUserRegistry({ timers: manualTimers() });
+    const { requestId } = registry.open({ questions: QUESTIONS, target });
+
+    const applied = registry.apply(
+      event(DREAMUX_ASK_PICK_ACTION, {
+        [DREAMUX_ASK_REQUEST_KEY]: requestId,
+        [DREAMUX_ASK_QUESTION_KEY]: 0,
+        [DREAMUX_ASK_OPTION_KEY]: 1,
+      }),
+    );
+
+    expect(applied.kind).toBe('response');
+    if (applied.kind !== 'response') return;
+    // The toast names the choice, and the repainted card carries it in the
+    // panel header — which is only possible because the server stored it.
+    expect(applied.response.toast?.content).toBe('Move to SQLite');
+    const leaves = stringLeaves(applied.response.card?.data).join('\n');
+    expect(leaves).toContain('· Move to SQLite');
+  });
+
+  it('lets free text answer a question, and replace a picked option', () => {
+    const registry = createAskUserRegistry({ timers: manualTimers() });
+    const { requestId } = registry.open({ questions: QUESTIONS, target });
+    registry.apply(
+      event(DREAMUX_ASK_PICK_ACTION, {
+        [DREAMUX_ASK_REQUEST_KEY]: requestId,
+        [DREAMUX_ASK_QUESTION_KEY]: 0,
+        [DREAMUX_ASK_OPTION_KEY]: 0,
+      }),
+    );
+
+    registry.apply(
+      event(
+        DREAMUX_ASK_OTHER_ACTION,
+        {
+          [DREAMUX_ASK_REQUEST_KEY]: requestId,
+          [DREAMUX_ASK_QUESTION_KEY]: 0,
+        },
+        'neither, use Postgres',
+      ),
+    );
+
+    const settled = registry.apply(
+      event(DREAMUX_ASK_SUBMIT_ACTION, { [DREAMUX_ASK_REQUEST_KEY]: requestId }),
+    );
+    expect(settled.kind).toBe('settled');
+    if (settled.kind !== 'settled') return;
+    // Single-select: the later answer replaced the option rather than joining it.
+    expect(settled.settlement.text).toContain('neither, use Postgres');
+    expect(settled.settlement.text).not.toContain('Keep JSON');
+  });
+
+  it('clearing the free-text box takes the answer back', () => {
+    const registry = createAskUserRegistry({ timers: manualTimers() });
+    const { requestId } = registry.open({ questions: QUESTIONS, target });
+    registry.apply(
+      event(
+        DREAMUX_ASK_OTHER_ACTION,
+        { [DREAMUX_ASK_REQUEST_KEY]: requestId, [DREAMUX_ASK_QUESTION_KEY]: 0 },
+        'something',
+      ),
+    );
+    registry.apply(
+      event(
+        DREAMUX_ASK_OTHER_ACTION,
+        { [DREAMUX_ASK_REQUEST_KEY]: requestId, [DREAMUX_ASK_QUESTION_KEY]: 0 },
+        '   ',
+      ),
+    );
+
+    const settled = registry.apply(
+      event(DREAMUX_ASK_SUBMIT_ACTION, { [DREAMUX_ASK_REQUEST_KEY]: requestId }),
+    );
+    if (settled.kind !== 'settled') throw new Error('expected settled');
+    expect(settled.settlement.text).toContain('(left unanswered)');
+  });
+
+  it('cancel tells the model to stop asking, not that a button was pressed', () => {
+    const registry = createAskUserRegistry({ timers: manualTimers() });
+    const { requestId } = registry.open({ questions: QUESTIONS, target });
+
+    const settled = registry.apply(
+      event(DREAMUX_ASK_CANCEL_ACTION, { [DREAMUX_ASK_REQUEST_KEY]: requestId }),
+    );
+    if (settled.kind !== 'settled') throw new Error('expected settled');
+    expect(settled.settlement.outcome).toBe('cancelled');
+    expect(settled.settlement.text).toContain('Do not send another question card');
+  });
+
+  it('settles a round exactly once, so a double click cannot deliver twice', () => {
+    const registry = createAskUserRegistry({ timers: manualTimers() });
+    const { requestId } = registry.open({ questions: QUESTIONS, target });
+    const first = registry.apply(
+      event(DREAMUX_ASK_SUBMIT_ACTION, { [DREAMUX_ASK_REQUEST_KEY]: requestId }),
+    );
+    const second = registry.apply(
+      event(DREAMUX_ASK_SUBMIT_ACTION, { [DREAMUX_ASK_REQUEST_KEY]: requestId }),
+    );
+
+    expect(first.kind).toBe('settled');
+    expect(second.kind).toBe('response');
+    if (second.kind !== 'response') return;
+    expect(second.response.toast?.type).toBe('error');
+  });
+
+  it('answers a click on a round it no longer has instead of going silent', () => {
+    const registry = createAskUserRegistry({ timers: manualTimers() });
+    registry.open({ questions: QUESTIONS, target });
+    registry.abandonAll();
+
+    const applied = registry.apply(
+      event(DREAMUX_ASK_SUBMIT_ACTION, { [DREAMUX_ASK_REQUEST_KEY]: 'gone' }),
+    );
+    if (applied.kind !== 'response') throw new Error('expected a response');
+    expect(applied.response.toast?.type).toBe('error');
+  });
+
+  it('leaves other cards alone', () => {
+    const registry = createAskUserRegistry({ timers: manualTimers() });
+    expect(registry.apply(event('approve_pairing', {})).kind).toBe('ignored');
+  });
+
+  it('anchors the answer on the real card, never on the dedup id', () => {
+    const registry = createAskUserRegistry({ timers: manualTimers() });
+    const { requestId } = registry.open({ questions: QUESTIONS, target });
+
+    const settled = registry.apply(
+      event(DREAMUX_ASK_SUBMIT_ACTION, { [DREAMUX_ASK_REQUEST_KEY]: requestId }),
+    );
+    if (settled.kind !== 'settled') throw new Error('expected settled');
+    // `sourceId` is synthetic so one round settles once; it is not a Feishu
+    // message id, and the anchor built from it would be handed to the COT
+    // create API as a presentation origin.
+    expect(settled.settlement.sourceId).toContain('ask_user_question:');
+    expect(settled.settlement.cardMessageId).toBe('om_the_card');
+    expect(settled.settlement.cardMessageId).not.toBe(
+      settled.settlement.sourceId,
+    );
+    // Anyone in a group can answer the card, so who clicked is carried too.
+    expect(settled.settlement.operatorOpenId).toBe('ou_clicker');
+  });
+
+  it('falls back to the id recorded at send time when a round expires', () => {
+    const timers = manualTimers();
+    const expired: AskUserExpiry[] = [];
+    const registry = createAskUserRegistry({
+      timers,
+      onExpire: (expiry) => expired.push(expiry),
+    });
+    const { requestId } = registry.open({ questions: QUESTIONS, target });
+    registry.attachMessage(requestId, 'om_sent');
+
+    timers.fire();
+    // No click means no event to read the card id from — only what the send
+    // recorded — and nobody to attribute the (absent) answer to.
+    expect(expired[0]?.settlement.cardMessageId).toBe('om_sent');
+    expect(expired[0]?.settlement.operatorOpenId).toBeUndefined();
+  });
+
+  it('closes an unanswered round and tells the model to stand still', () => {
+    const timers = manualTimers();
+    const expired: AskUserExpiry[] = [];
+    const registry = createAskUserRegistry({
+      timers,
+      onExpire: (expiry) => expired.push(expiry),
+    });
+    const { requestId } = registry.open({ questions: QUESTIONS, target });
+    registry.attachMessage(requestId, 'om_card');
+
+    timers.fire();
+
+    expect(expired).toHaveLength(1);
+    expect(expired[0]?.settlement.outcome).toBe('expired');
+    expect(expired[0]?.messageId).toBe('om_card');
+    expect(expired[0]?.settlement.text).toContain('take no further action');
+    // The card id is carried out because nothing else can repaint a card that
+    // expired without a click to answer.
+    expect(stringLeaves(expired[0]?.card).join('\n')).toContain('超时');
+  });
+
+  it('does not expire a round a click already settled', () => {
+    const timers = manualTimers();
+    const expired: AskUserExpiry[] = [];
+    const registry = createAskUserRegistry({
+      timers,
+      onExpire: (expiry) => expired.push(expiry),
+    });
+    const { requestId } = registry.open({ questions: QUESTIONS, target });
+    registry.apply(
+      event(DREAMUX_ASK_SUBMIT_ACTION, { [DREAMUX_ASK_REQUEST_KEY]: requestId }),
+    );
+
+    timers.fire();
+    expect(expired).toHaveLength(0);
+  });
+
+  it('closes before Feishu stops accepting clicks', () => {
+    // The platform drops interaction at 15 minutes; closing after that would
+    // repaint a card nobody can answer any more.
+    expect(ASK_USER_CARD_TTL_MS).toBeLessThan(15 * 60 * 1000);
+  });
+});
+
+describe('ask_user_question tool', () => {
+  function context(session: Partial<FeishuToolSession>): FeishuToolContext {
+    return {
+      caller: { kind: 'dispatcher' } as FeishuToolContext['caller'],
+      session: session as FeishuToolSession,
+    };
+  }
+
+  const validArgs = {
+    chat_id: 'oc_test',
+    questions: [
+      {
+        header: '存储方案',
+        question: 'Where does session state live?',
+        options: [
+          { label: 'Keep JSON', description: 'Smallest change' },
+          { label: 'Move to SQLite', description: 'Better concurrency' },
+        ],
+      },
+    ],
+  };
+
+  it('returns once the card is sent, and tells the model to stop and wait', async () => {
+    const askUserQuestion = vi.fn().mockResolvedValue({ request_id: 'r1' });
+    const result = await askUserQuestionDef.handle(
+      context({ askUserQuestion }),
+      askUserQuestionDef.parse(validArgs),
+    );
+
+    expect(result['status']).toBe('asked');
+    expect(result['request_id']).toBe('r1');
+    // The answer never comes back through this tool, so the instruction not to
+    // keep working is the only thing carrying that fact to the model.
+    expect(result['next']).toBe(ASK_USER_NEXT_INSTRUCTION);
+    expect(ASK_USER_NEXT_INSTRUCTION).toContain('end your turn');
+  });
+
+  it('has no multi-select field to accept', () => {
+    const properties = (
+      askUserQuestionDef.inputSchema as {
+        properties: { questions: { items: { properties: object } } };
+      }
+    ).properties.questions.items.properties;
+    expect(Object.keys(properties)).toEqual(['header', 'question', 'options']);
+  });
+
+  it('rejects a header too long to fit the chip', () => {
+    expect(() =>
+      askUserQuestionDef.parse({
+        ...validArgs,
+        questions: [{ ...validArgs.questions[0], header: 'x'.repeat(13) }],
+      }),
+    ).toThrow(/at most 12 characters/);
+  });
+
+  it('rejects a question with only one option', () => {
+    expect(() =>
+      askUserQuestionDef.parse({
+        ...validArgs,
+        questions: [
+          {
+            ...validArgs.questions[0],
+            options: [{ label: 'Only', description: 'one' }],
+          },
+        ],
+      }),
+    ).toThrow(/2-4 options/);
+  });
+
+  it('rejects more questions than the card can hold', () => {
+    expect(() =>
+      askUserQuestionDef.parse({
+        ...validArgs,
+        questions: Array.from({ length: 5 }, () => validArgs.questions[0]),
+      }),
+    ).toThrow(/1-4 questions/);
+  });
+});

--- a/packages/channel/feishu-transport/src/transport/feishu.ts
+++ b/packages/channel/feishu-transport/src/transport/feishu.ts
@@ -291,6 +291,8 @@ export interface FeishuTransport {
     getChatMode?(chatId: string): Promise<FeishuChatMode | undefined>
     addReaction(messageId: string, emoji: string): Promise<string>
     editText(messageId: string, text: string): Promise<void>
+    /** Repaint an already-sent card in place, by message id. */
+    editCard(messageId: string, card: unknown): Promise<void>
     fetchDocComment(fileToken: string, fileType: string, commentId: string): Promise<FeishuDocComment | null>
     fetchDocMeta(fileToken: string, fileType: string): Promise<FeishuDocMeta | null>
     fetchMessageResource(request: FeishuMessageResourceRequest): Promise<FeishuMessageResourceResponse>
@@ -511,6 +513,15 @@ export function createFeishuTransport(
         data: { reaction_type: { emoji_type: emoji } },
       })
       return res.data?.reaction_id ?? ''
+    },
+
+    async editCard(messageId: string, card: unknown): Promise<void> {
+      const cardContent = JSON.stringify(card)
+      assertCardContentFits(cardContent)
+      await client.im.message.patch({
+        path: { message_id: messageId },
+        data: { content: cardContent },
+      })
     },
 
     async editText(messageId: string, text: string): Promise<void> {

--- a/packages/dreamux/tests/helpers/fake-feishu-bot.ts
+++ b/packages/dreamux/tests/helpers/fake-feishu-bot.ts
@@ -101,6 +101,14 @@ export function createFakeFeishuBot(appId = 'fake-bot'): FakeFeishuBot {
       return { messageIds };
     },
 
+    async editCard(messageId: string, card: unknown): Promise<void> {
+      // A repaint replaces what that card shows, so the recorded card has to
+      // move with it: a double that kept the first version would let a test
+      // assert on a card the user stopped seeing.
+      const sent = sentCards.find((entry) => entry.messageIds.includes(messageId));
+      if (sent !== undefined) sent.card = card;
+    },
+
     async inviteMembers(
       input: FeishuInviteMembersInput,
     ): Promise<FeishuInviteMembersResult> {


### PR DESCRIPTION
Adds the `ask_user_question` MCP tool, offered to both the Dispatcher and a
TeamLeader. The model sends a decision card into a Feishu chat; the user picks
an option or writes their own answer; the answer comes back as an ordinary
inbound message.

## Arguments mirror AskUserQuestion

Field names and descriptions are lifted from Claude Code's own AskUserQuestion
so a model reads the two as one tool: 1-4 `questions`, each with a `header`
chip, a `question`, and 2-4 `options` of `label` + `description`.

Four differences:

- **`chat_id` is required.** A chat tool needs a destination; AskUserQuestion
  has no such concept.
- **`message_id` is offered.** When the question came out of something someone
  said, the card is addressed under that message — into its topic, under the
  anchor the target router already holds — exactly as `reply` is addressed.
  Without one the card addresses the chat, which in a topic group opens a topic
  of its own: right for a question belonging to no particular message, wrong
  for one that does. A message id from another chat is ignored rather than
  obeyed, `reply`'s rule, so a stale id cannot redirect a question into a
  conversation it was not meant for.
- **No `multiSelect`.** The operator ruled multi-select out of this channel, so
  every question takes exactly one answer. The two sentences in the upstream
  descriptions that referenced the field are dropped rather than left dangling.
- **No `preview`.** A preview belonging to the focused option has to sit beside
  the options, so it cost every question a two-column `column_set` and reshaped
  the layout. The operator removed it on sight:
  "这个 preview 有点复杂了，给他去掉，他也会影响卡片的布局".
  The field, its schema property, its parse branch, and the tool-description
  paragraph that taught the model to use it went with the column.

## The tool does not return the answer

It returns `{ request_id, status: 'asked', next }` as soon as the card is sent,
and `next` instructs the model to end its turn. A click settles the round
server-side and the answer reaches Core as an ordinary inbound submission — the
path a typed reply takes, so nothing downstream learns a card produced it.

Blocking the tool call was the alternative, and it loses the case that matters:
a person who answers after lunch. The MCP client, not Dreamux, bounds how long
a tool call may run, so a blocking handler would be abandoned mid-question by a
timeout this repo does not own.

## Why the card looks the way it does

Feishu has no radio component. `select_static` is its only native single-select
and its options carry a label and nothing else, so an option's `description`
would vanish the moment the dropdown closed. Each option is therefore its own
`interactive_container` — label, then description — which is also what the
open-source Feishu ask-user renderers converged on.

That choice is what makes the server authoritative: an `interactive_container`
holds no client state, so "which option is selected" exists only in the
session's registry, and the selection is visible solely because every click
repaints the whole card.

There is deliberately no `form`. A form batches its inputs until submit, which
would cost each question the ability to settle on its own; without one, an
`input` carries its own callback and Feishu draws it a send button, so
committing free text is the same explicit click as choosing an option.

## Expiry

Feishu stops accepting interaction on a card 15 minutes after it is sent. Past
that cutoff the card still looks live but every click is dropped, and the model
would wait for an answer that can no longer be given. A round therefore closes
itself before the cutoff, repaints the card as closed, and tells the model that
no answer came and to stand still until the user's next message.

`editCard(messageId, card)` is added to `@excitedjs/feishu-transport` for that
repaint. It generalizes the `im.message.patch` call `editText` already made.

## Operator rulings recorded

Quoted in `.agents/domains/channel.md` and at the code sites they govern, so a
later reader meets a decision rather than an apparent gap:

- multi-select dropped: "废弃多选（大概率完全用不到），只把单选做好即可"
- anyone may answer: "不需要限制，所有人都可以点" — the clicker's open_id rides
  along as `sender_id`, but no authorization check stands between a group
  member and the card.

## Boundary fix on the way through

`feishu-channel.ts` sat two lines under the `max-lines` gate, so any new
capability would have broken it. Rather than widen the gate, `outboundTarget`
moves to `FeishuTargetRouter` — it reads state the router already owns, and had
its fallback reimplemented outside its owner. The file ends up smaller than it
started (698 → 696).

## Verification

`rush build`, `rush lint`, `rush typecheck`, `rush typecheck:tests`,
`rush test`, and `rush smoke-built-cli` all green, including the live Codex
tests. `.agents/scripts/check.sh` passes. 25 tests cover the round state
machine (pick, free text replacing a pick, clearing an answer, cancel, double
submit, unknown round, a round whose card never sent, an empty submit, expiry,
and expiry losing a race to a click), how the card is addressed, the tool's
argument rejections, and the anchor regression below.

**Verified live** against a real bot on the `0.23.0-alpha.g7bf178cf6e11`
build: the full MCP tool → card → click → inbound injection chain, and both
refusals — a submit with nothing chosen stopped by its toast, and dismissing the
card ending the round.

**Still not exercised live:** the expired-card repaint, which needs the full
14-minute wait, and addressing a card under a `message_id` in a topic-mode
group.

## Note for review

One bug worth a second pair of eyes, since it was caught late: the settlement
originally used its synthetic dedup id (`ask_user_question:<hex>`) as the
submission `anchor.messageId`. That anchor becomes a COT presentation's
`originMessageId` and is handed to Feishu's API, so every answered round would
have produced a broken COT card. It now carries the question card's real
message id — from the click event, or from what the send recorded when a round
expires — with a regression test pinning the distinction.

## Review round

Seven findings from @YisenFE's review, in `022f5195`:

- **A failed send no longer leaves a round behind.** `open` builds the round
  and its card but registers neither; `activate`, called once the send lands,
  puts the round in play and starts its clock. Previously a send that threw
  left an armed round whose TTL would, 14 minutes later, tell the model no
  answer came for a question the user was never asked. Making the round's
  existence a construction property removes the rollback rather than adding
  one.
- **`message_id`**, above — in a topic-mode group the card used to open a topic
  of its own no matter what, so the answer came back somewhere the asking agent
  was not.
- **The repaint no longer waits on delivery to Core.** Feishu gives a card
  callback a few seconds before the click looks dead, and waking an agent can
  outlast that. Delivery already swallowed and logged its own failures at error
  level, so nothing was lost by detaching it.
- **提交 with nothing chosen is refused with a toast.** The button sits directly
  under the questions, so it is also the one pressed by accident, and a round
  settles exactly once: spending that settlement to report every question as
  unanswered is worse than saying nothing. A partial answer still submits.
- The free-text branch is unconditional, so the unreachable
  `return { kind: 'ignored' }` after it is gone.
- The expiry callback drops a `.catch` that could not fire — both halves of the
  expiry path already handle their own failures.
- The submitted card gains the `summary` its two siblings carry, so a
  notification names it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K8SjnH3Kt7uSUjgLFZ7m8D



