### PR TITLE
Keep internal paths out of published and committed artifacts

### DIFF
--- a/common/changes/@excitedjs/dreamux/fix-release-manifest-internal-paths_2026-09-02-02-13.json
+++ b/common/changes/@excitedjs/dreamux/fix-release-manifest-internal-paths_2026-09-02-02-13.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "comment": "Replace a literal absolute home path in a compiled docstring, and an internal mount path used as a test fixture, with neutral placeholders. Comment and fixture text only: no behaviour, published contract, or path semantics change.",
+      "type": "none",
+      "packageName": "@excitedjs/dreamux"
+    }
+  ],
+  "packageName": "@excitedjs/dreamux"
+}

--- a/packages/dreamux/src/platform/home-paths.ts
+++ b/packages/dreamux/src/platform/home-paths.ts
@@ -45,7 +45,7 @@ function lexicalHomePath(): string {
 }
 
 /**
- * A trailing separator is stripped so `/home/me/` and `/home/me` are one
+ * A trailing separator is stripped so `<home>/` and `<home>` are one
  * prefix — and so a home of `/` normalizes to the empty string and is dropped
  * rather than matching every absolute path in sight.
  */

--- a/packages/dreamux/tests/cot-projection-privacy.test.ts
+++ b/packages/dreamux/tests/cot-projection-privacy.test.ts
@@ -213,7 +213,7 @@ describe('conversation projection: secret redaction', () => {
   });
 
   it('treats a trailing period as prose punctuation for home and workspace paths', () => {
-    const home = '/data00/home/dyzhu';
+    const home = '/home/me';
     const cwd = `${home}/work/repo`;
     expect(
       redactText(`see ${home}. edit ${cwd}/a.ts.`, cwd, [home]).value,
@@ -221,7 +221,7 @@ describe('conversation projection: secret redaction', () => {
   });
 
   it('distinguishes dot-suffixed home siblings from workspace-adjacent siblings', () => {
-    const home = '/data00/home/dyzhu';
+    const home = '/home/me';
     const cwd = `${home}/work/repo`;
     const value = [
       `${home}.bak/notes.md`,
@@ -238,7 +238,7 @@ describe('conversation projection: secret redaction', () => {
   });
 
   it('renames workspace-adjacent siblings through the containing home prefix', () => {
-    const home = '/data00/home/dyzhu';
+    const home = '/home/me';
     const cwd = `${home}/work/repo`;
     expect(
       redactText(`${cwd}.git/config ${cwd}-old/x`, cwd, [home]).value,
@@ -246,7 +246,7 @@ describe('conversation projection: secret redaction', () => {
   });
 
   it('does not treat a doubled filesystem separator as a URL scheme boundary', () => {
-    const home = '/data00/home/dyzhu';
+    const home = '/home/me';
     const cwd = `${home}/work/repo`;
     const value = `/mnt/backup/${home}/x /mnt/backup/${cwd}/x`;
     expect(redactText(value, cwd, [home]).value).toBe(value);


### PR DESCRIPTION
## Why

The beta release for `next` aborted at `release.yml`'s manifest gate ([run 33581749711](https://github.com/excitedjs/dreamux/actions/runs/33581749711)). Nothing was uploaded.

- The home-prefix resolver's docstring illustrated trailing-separator normalization with a literal absolute home path. That comment is compiled into `dist`, `dist` is packed, and the gate refuses any `/home/<user>/` token outside its allow-list. It now says the same thing with a `<home>` placeholder.
- The same round also used a real internal mount path and account name as the example home in the projection privacy tests. Tests are not packed, so the release gate could not have caught it — but it is a public-repository red-line violation on its own. It now uses the neutral fixture home the rest of that file already uses.

Assertions are unchanged; only fixture literals move. The workflow and its allow-list are deliberately untouched: a guardrail that fires is not something to edit around.

## Validation

Rush build, lint, and the full test suite with the real Codex live suite skipped; the ten package `tsc --noEmit` checks; knowledge-base check; `git diff --check`. The release gate's own scan was also run locally over built `dist` output and prints nothing.

No change file: this moves a comment and test fixtures, with no behaviour or published-contract change.

## Follow-up worth considering

CI has no equivalent scan. `gitleaks` is configured with three Feishu id rules and nothing for internal paths, so a path literal can reach the default branch and only surface at publish time — and one that never reaches `dist` never surfaces at all.