### PR TITLE
Open a COT card with a flavour label, not a promise

### DIFF
--- a/common/changes/@excitedjs/feishu-channel/fix-cot-receipt-does-not-promise_2026-09-02-04-43.json
+++ b/common/changes/@excitedjs/feishu-channel/fix-cot-receipt-does-not-promise_2026-09-02-04-43.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "comment": "Open a Feishu COT card with one of five flavour labels chosen independently per card, replacing the fixed line that said processing had started. That line was written before Core was called, so it asserted an admission the Channel could not yet know; an ambiguous submission may never reach the runtime. The opening line now states nothing about admission or progress. Cards are append-only, so the label is picked once when the card opens and does not animate. This is an intentional operator-visible presentation change to a deliberately tuned surface.",
+      "type": "minor",
+      "packageName": "@excitedjs/feishu-channel"
+    }
+  ],
+  "packageName": "@excitedjs/feishu-channel"
+}

--- a/packages/channel/feishu-channel/src/feishu-cot-adapter.ts
+++ b/packages/channel/feishu-channel/src/feishu-cot-adapter.ts
@@ -74,7 +74,13 @@ import {
 
 const FEISHU_COT_OPEN_TOOL_CALLS_MAX = 512;
 const FEISHU_COT_CLOSE_DRAIN_MS = 5_000;
-const FEISHU_COT_RECEIVED_TEXT = '已收到消息，开始处理。';
+export const FEISHU_COT_OPENING_LABELS = [
+  '✳ Vibing...',
+  '✳ Shipping...',
+  '✳ Reticulating...',
+  '✳ Manifesting...',
+  '✳ Baking...',
+] as const;
 
 export interface FeishuCotAdapterOptions {
   readonly dispatcherId: string;
@@ -209,15 +215,18 @@ export class FeishuCotAdapter {
     );
   }
 
-  /** The one line a card opens with, so the operator sees it was received. */
+  /** Pick one independent flavour label when this append-only card opens. */
   private openReceipt(key: string, state: CotState): void {
+    const label = FEISHU_COT_OPENING_LABELS[
+      Math.floor(Math.random() * FEISHU_COT_OPENING_LABELS.length)
+    ]!;
     this.acceptOpeningActivityForState(
       key,
       state,
       textMessageEvents({
         sourceId: `receipt:${randomUUID()}`,
         role: 'assistant',
-        content: FEISHU_COT_RECEIVED_TEXT,
+        content: label,
       }),
     );
   }

--- a/packages/channel/feishu-channel/tests/feishu-cot-delivery.test.ts
+++ b/packages/channel/feishu-channel/tests/feishu-cot-delivery.test.ts
@@ -32,16 +32,25 @@ import type {
 } from '@excitedjs/dreamux-types';
 
 import { FeishuChannelSession } from '../src/feishu-channel.js';
+import { FEISHU_COT_OPENING_LABELS } from '../src/feishu-cot-adapter.js';
 import { chatTarget } from '../src/routing/target.js';
 import { createFakeFeishuBot, type FakeFeishuBot } from './helpers/fake-feishu-bot.js';
 import {
   cotRunStatus,
   cotTexts,
   createFakeCotClient,
+  type FakeCotCard,
   type FakeCotClient,
 } from './helpers/fake-feishu-cot.js';
 
-const RECEIPT = '已收到消息，开始处理。';
+function expectOpeningTexts(
+  card: FakeCotCard,
+  expectedAfterOpening: readonly string[],
+): void {
+  const texts = cotTexts(card);
+  expect(FEISHU_COT_OPENING_LABELS).toContain(texts[0]);
+  expect(texts.slice(1)).toEqual(expectedAfterOpening);
+}
 
 let dir: string;
 let attachDir: string;
@@ -222,7 +231,7 @@ async function harness(
 }
 
 describe('FeishuChannelSession COT — the anchor is the visible inbound message', () => {
-  it('opens the card under the message that produced the turn, and closes it on the native end', async () => {
+  it('opens normally without an unknown-outcome line, and closes on the native end', async () => {
     const { session, cot, port } = await harness('chan-cot-anchor', async (
       command,
       payload,
@@ -250,13 +259,13 @@ describe('FeishuChannelSession COT — the anchor is the visible inbound message
 
     expect(cot.cards[0]!.chatId).toBe('oc_dm');
     expect(cot.cards[0]!.originMessageId).toBe('om_user_1');
-    expect(cotTexts(cot.cards[0]!)).toEqual([RECEIPT]);
+    expectOpeningTexts(cot.cards[0]!, []);
 
     port.emit(assistantMessage('turn-1', 'dispatcher', 'the answer'));
     port.emit(nativeEnd('dispatcher'));
     await waitFor(() => cotRunStatus(cot.cards[0]!) !== null);
 
-    expect(cotTexts(cot.cards[0]!)).toEqual([RECEIPT, 'the answer']);
+    expectOpeningTexts(cot.cards[0]!, ['the answer']);
     expect(cotRunStatus(cot.cards[0]!)).toBe('done');
 
     port.emit(submittedEvent('turn-task', 'dispatcher', 'task-source', 'task'));
@@ -317,8 +326,8 @@ describe('FeishuChannelSession COT — the anchor is the visible inbound message
       'message-two',
     ]);
     expect(cot.cards.map(cotRunStatus)).toEqual(['interrupted', null]);
-    expect(cotTexts(cot.cards[0]!)).toEqual([RECEIPT, 'first answer']);
-    expect(cotTexts(cot.cards[1]!)).toEqual([RECEIPT]);
+    expectOpeningTexts(cot.cards[0]!, ['first answer']);
+    expectOpeningTexts(cot.cards[1]!, []);
 
     await session.close();
   });
@@ -363,12 +372,12 @@ describe('FeishuChannelSession COT — the anchor is the visible inbound message
       'message-repeat',
     ]);
     expect(cot.cards.map(cotRunStatus)).toEqual(['interrupted', null]);
-    expect(cotTexts(cot.cards[1]!)).toEqual([RECEIPT]);
+    expectOpeningTexts(cot.cards[1]!, []);
 
     port.emit(assistantMessage('turn-original', 'dispatcher', 'after repeat'));
     await waitFor(() => cotTexts(cot.cards[1]!).length === 2);
     expect(cot.cards).toHaveLength(2);
-    expect(cotTexts(cot.cards[1]!)).toEqual([RECEIPT, 'after repeat']);
+    expectOpeningTexts(cot.cards[1]!, ['after repeat']);
 
     await session.close();
   });
@@ -426,7 +435,7 @@ describe('FeishuChannelSession COT — the anchor is the visible inbound message
     expect(cot.cards.map(cotRunStatus)).toEqual(['interrupted', null]);
     port.emit(assistantMessage('turn-fallback', 'dispatcher', 'dispatcher answered'));
     await waitFor(() => cotTexts(cot.cards[1]!).length === 2);
-    expect(cotTexts(cot.cards[1]!)).toEqual([RECEIPT, 'dispatcher answered']);
+    expectOpeningTexts(cot.cards[1]!, ['dispatcher answered']);
 
     // The TeamLeader whose route was refused cannot present anything further.
     port.emit(assistantMessage('turn-fallback', 'leader', 'never displayed'));
@@ -475,6 +484,37 @@ describe('FeishuChannelSession COT — the anchor is the visible inbound message
       await session.close();
     },
   );
+
+  it('keeps an ambiguous submission open with only its opening flavour', async () => {
+    const { session, cot } = await harness(
+      'chan-cot-ambiguous-result',
+      async () => ({
+        status: 'ambiguous',
+        error: { code: 'ADMISSION_UNKNOWN', message: 'fixture ambiguity' },
+      }),
+    );
+
+    const outcome = await session.submit(null, {
+      attrs: {},
+      text: 'hello',
+      reminder: '',
+      sourceId: 'message-ambiguous',
+      anchor: {
+        chatId: 'chat-dm',
+        messageId: 'message-ambiguous',
+        target: chatTarget('chat-dm', 'p2p'),
+      },
+    });
+
+    expect(outcome.status).toBe('ambiguous');
+    await waitFor(() => cot.cards.length === 1);
+    await waitFor(() => cotTexts(cot.cards[0]!).length === 1);
+    expect(cot.cards[0]!.originMessageId).toBe('message-ambiguous');
+    expect(cotRunStatus(cot.cards[0]!)).toBeNull();
+    expectOpeningTexts(cot.cards[0]!, []);
+
+    await session.close();
+  });
 
   it('keeps the optimistic anchor when an ambiguous failure proves nothing', async () => {
     const { session, cot } = await harness('chan-cot-ambiguous', async () => {

--- a/packages/channel/feishu-channel/tests/feishu-cot.test.ts
+++ b/packages/channel/feishu-channel/tests/feishu-cot.test.ts
@@ -36,7 +36,10 @@ import type {
   TeammateTurnToolCallEvent,
 } from '@excitedjs/dreamux-types';
 
-import { FeishuCotAdapter } from '../src/feishu-cot-adapter.js';
+import {
+  FeishuCotAdapter,
+  FEISHU_COT_OPENING_LABELS,
+} from '../src/feishu-cot-adapter.js';
 import { FeishuCotSessionSeam } from '../src/feishu-cot-session.js';
 import type { VisibleMessageAnchor } from '../src/feishu-cot-state.js';
 import { chatTarget, topicTarget } from '../src/routing/target.js';
@@ -47,11 +50,18 @@ import {
   cotToolNames,
   cotToolResultCount,
   createFakeCotClient,
+  type FakeCotCard,
   type FakeCotClient,
 } from './helpers/fake-feishu-cot.js';
 
-/** The fixed line every card opens with; it is the receipt, not the body. */
-const RECEIPT = '已收到消息，开始处理。';
+function expectOpeningTexts(
+  card: FakeCotCard,
+  expectedAfterOpening: readonly string[],
+): void {
+  const texts = cotTexts(card);
+  expect(FEISHU_COT_OPENING_LABELS).toContain(texts[0]);
+  expect(texts.slice(1)).toEqual(expectedAfterOpening);
+}
 
 const silentLog: DreamuxLogger = {
   error: () => undefined,
@@ -287,10 +297,7 @@ describe.each([LEADER, DISPATCHER])(
       const card = cot.cards[0]!;
       expect(card.chatId).toBe('oc_home');
       expect(card.originMessageId).toBe('om_user_1');
-      expect(cotTexts(card)).toEqual([
-        RECEIPT,
-        'working on it',
-      ]);
+      expectOpeningTexts(card, ['working on it']);
 
       await adapter.close();
     });
@@ -345,11 +352,11 @@ describe.each([LEADER, DISPATCHER])(
       expect(cot.cards).toHaveLength(2);
       const [first, second] = cot.cards as [typeof cot.cards[0], typeof cot.cards[0]];
       expect(cotRunStatus(first)).toBe('interrupted');
-      expect(cotTexts(first)).toEqual([RECEIPT, 'first thought']);
+      expectOpeningTexts(first, ['first thought']);
       // The still-running native turn keeps producing, into the card the
       // operator is now looking at.
       expect(second.originMessageId).toBe('om_second');
-      expect(cotTexts(second)).toEqual([RECEIPT, 'still the same native turn']);
+      expectOpeningTexts(second, ['still the same native turn']);
       expect(cotRunStatus(second)).toBeNull();
 
       await adapter.close();
@@ -451,7 +458,7 @@ describe.each([LEADER, DISPATCHER])(
       submitInbound(adapter, recipient, 'turn-1', anchorAt('oc_home', 'om_1'));
       adapter.onTurnMessage(message(recipient, 'turn-1', 'assistant', 'now visible'));
       await settle();
-      expect(cotTexts(cot.cards[0]!)).toEqual([RECEIPT, 'now visible']);
+      expectOpeningTexts(cot.cards[0]!, ['now visible']);
 
       await adapter.close();
     });
@@ -470,7 +477,7 @@ describe.each([LEADER, DISPATCHER])(
 
       const card = cot.cards[0]!;
       expect(cotRunStatus(card)).toBeNull();
-      expect(cotTexts(card)).toEqual([RECEIPT, 'after settlement']);
+      expectOpeningTexts(card, ['after settlement']);
 
       await adapter.close();
     });
@@ -521,8 +528,8 @@ describe('Feishu COT — the two recipients are independent presentations', () =
     await settle();
 
     expect(cot.cards).toHaveLength(2);
-    expect(cotTexts(cot.cards[0]!)).toEqual([RECEIPT, 'leader says']);
-    expect(cotTexts(cot.cards[1]!)).toEqual([RECEIPT, 'dispatcher says']);
+    expectOpeningTexts(cot.cards[0]!, ['leader says']);
+    expectOpeningTexts(cot.cards[1]!, ['dispatcher says']);
 
     // One recipient's native turn ending closes only that recipient's card.
     adapter.onNativeTurnEnded(nativeEnd(LEADER, 'completed'));
@@ -635,8 +642,7 @@ describe('Feishu COT — narrow Channel-body suppression', () => {
     );
     await settle();
 
-    expect(cotTexts(cot.cards[0]!)).toEqual([
-      RECEIPT,
+    expectOpeningTexts(cot.cards[0]!, [
       'another producer body',
       'the projected answer',
     ]);
@@ -674,7 +680,7 @@ describe('Feishu COT — stale lifecycle callbacks', () => {
 
     expect(cot.cards).toHaveLength(1);
     expect(cotRunStatus(cot.cards[0]!)).toBeNull();
-    expect(cotTexts(cot.cards[0]!)).toEqual([RECEIPT, 'still going']);
+    expectOpeningTexts(cot.cards[0]!, ['still going']);
 
     await adapter.close();
   });
@@ -839,8 +845,7 @@ describe('FeishuCotSessionSeam — default-show, without a source whitelist', ()
       seam.handle(message(LEADER, 'turn-other', 'assistant', `${source} answer`));
       await settle();
 
-      expect(cotTexts(cot.cards[0]!)).toEqual([
-        RECEIPT,
+      expectOpeningTexts(cot.cards[0]!, [
         `${source} input`,
         `${source} answer`,
       ]);
@@ -876,7 +881,7 @@ describe('FeishuCotSessionSeam — default-show, without a source whitelist', ()
     lease?.release();
     await settle();
     expect(cot.cards).toHaveLength(1);
-    expect(cotTexts(cot.cards[0]!)).toEqual([RECEIPT, 'another producer body']);
+    expectOpeningTexts(cot.cards[0]!, ['another producer body']);
 
     await seam.close();
   });
@@ -891,7 +896,7 @@ describe('FeishuCotSessionSeam — default-show, without a source whitelist', ()
     seam.handle(nativeEnd(LEADER, 'completed'));
     await settle();
 
-    expect(cotTexts(cot.cards[0]!)).toEqual([RECEIPT]);
+    expectOpeningTexts(cot.cards[0]!, []);
     await seam.close();
   });
 


### PR DESCRIPTION
## Why

The card's opening line said processing had started. It is written *before* Core is called, so it asserted something the Channel cannot know at that moment: an ambiguous submission may never reach the runtime, and the line claimed otherwise.

## What changed

The fixed line becomes one of five labels, chosen independently per card:

```
✳ Vibing...
✳ Shipping...
✳ Reticulating...
✳ Manifesting...
✳ Baking...
```

Cards are append-only, so this cannot animate — the label is picked once when the card opens. Selection is random rather than round-robin: a counter would be state, and a fixed sequence would invite reading meaning into the order.

The labels state nothing about admission or progress, which is the point: the line has to remain correct when nothing follows it.

## Scope

Presentation only. No anchor, terminal, suppression, or admission behaviour changes — an ambiguous outcome still keeps the anchor and adds nothing, because a runtime-native end already closes a genuinely broken turn's card, and otherwise the next inbound replaces the anchor.

`.agents/product/README.md` calls the Feishu COT card a deliberately tuned surface whose changes are their own requirement rather than a refactor side effect, so this is recorded as an intentional operator-visible presentation decision, taken by the operator.

## Validation

Rush build, lint, and the full test suite with the real Codex live suite skipped; ten package `tsc --noEmit` checks; `rush change --verify` against `origin/next`; knowledge-base check; `git diff --check`; the release manifest gate's own scan over built `dist`.

Every existing assertion on the opening line was kept and changed from equality to set membership — they pin that a freshly opened card starts with the opening line, and that contract is unchanged.