### PR TITLE
Use a COT label glyph Feishu renders as text

### DIFF
--- a/common/changes/@excitedjs/feishu-channel/fix-cot-label-glyph_2026-09-02-05-40.json
+++ b/common/changes/@excitedjs/feishu-channel/fix-cot-label-glyph_2026-09-02-05-40.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "comment": "Render the COT card's opening label with a glyph Feishu shows as text. The previous character is in the Unicode emoji set, so Feishu replaced it with a coloured emoji tile; the replacement is a dingbat with no emoji presentation. Labels and behaviour are otherwise unchanged.",
+      "type": "minor",
+      "packageName": "@excitedjs/feishu-channel"
+    }
+  ],
+  "packageName": "@excitedjs/feishu-channel"
+}

--- a/packages/channel/feishu-channel/src/feishu-cot-adapter.ts
+++ b/packages/channel/feishu-channel/src/feishu-cot-adapter.ts
@@ -75,11 +75,11 @@ import {
 const FEISHU_COT_OPEN_TOOL_CALLS_MAX = 512;
 const FEISHU_COT_CLOSE_DRAIN_MS = 5_000;
 export const FEISHU_COT_OPENING_LABELS = [
-  '✳ Vibing...',
-  '✳ Shipping...',
-  '✳ Reticulating...',
-  '✳ Manifesting...',
-  '✳ Baking...',
+  '❋ Vibing...',
+  '❋ Shipping...',
+  '❋ Reticulating...',
+  '❋ Manifesting...',
+  '❋ Baking...',
 ] as const;
 
 export interface FeishuCotAdapterOptions {


### PR DESCRIPTION
## Why

The card's opening label shipped with U+2733 EIGHT SPOKED ASTERISK, which is in the Unicode emoji set. A terminal renders it as text; Feishu upgrades it to a coloured emoji tile, which is not what a terminal-styled progress line should look like beside its word.

## What changed

The five labels keep their words and their per-card random selection; only the leading glyph changes to U+274B HEAVY EIGHT TEARDROP-SPOKED PROPELLER ASTERISK, a dingbat with no emoji presentation.

```
❋ Vibing...     ❋ Shipping...     ❋ Reticulating...
❋ Manifesting...     ❋ Baking...
```

Chosen by the operator from candidates rendered in the client itself, which is the only reliable test for this — the character's Unicode category does not tell you what a given chat client will do with it.

## Validation

The focused Feishu COT suites pass unchanged (56 tests): they assert the opening line is a member of the exported label set rather than a fixed string, so the glyph is covered without pinning it. Full Rush build, lint, test, `tsc --noEmit`, `rush change --verify`, knowledge-base check and the release manifest scan run in CI.