### PR TITLE
Move role skill guidance into MCP descriptions and role prompts

### DIFF
--- a/.agents/domains/dispatcher-skill.md
+++ b/.agents/domains/dispatcher-skill.md
@@ -74,10 +74,12 @@ channel's own MCP server owns those tools and their schemas.
 `dissolve({ team_name, note, force? })` is submitted, not awaited. It answers
 `{ accepted, team_name, status: "submitted" }` as soon as the Team owns the
 background work and never reports how the dissolve went; read the Team's status
-afterwards. Uncommitted, untracked, or unmerged work in a managed worktree
-leaves the Team open and running instead of closing it, and `force: true`
-discards exactly that local work — never the branch, its commits, a reused
-directory, or the source repository.
+afterwards. Uncommitted, untracked, or unmerged work in a managed
+`delete-on-close` worktree leaves the Team open and running instead of closing
+it, and `force: true` discards exactly that local work so the removal can
+proceed — never the branch, its commits, a reused directory, or the source
+repository. A `cleanup: keep` checkout is retained with its changes whether or
+not `force` is set.
 
 Dispatcher `cron` MCP tools are `cron_create`, `cron_list`, `cron_update`, and
 `cron_delete`. Cron prompts are injected back into the

--- a/.agents/domains/dispatcher-skill.md
+++ b/.agents/domains/dispatcher-skill.md
@@ -6,8 +6,11 @@ parent directories do not expose another role's skills; a shared root is
 deliberately composed into both Dispatcher and TeamLeader runtimes:
 
 - `skills/dispatcher/dispatcher-workflow` is injected only into Dispatcher
-  runtimes. It covers provider-visible replies and dispatcher-visible
-  TeamMate/Team/cron MCP cautions.
+  runtimes. It is an optional, on-demand skill about collaborating with
+  TeamMates: choosing between doing the work directly, an engine-native
+  subagent, a TeamMate, or a Team; writing the prompt that hands work down;
+  asking a delegate why before overriding a surprising action; and continuing
+  one collaboration instead of starting another.
 - `skills/dispatcher/dreamux-maintenance` is injected only into Dispatcher
   runtimes. Its concise root owns authorization, common diagnosis, reporting,
   and a seven-row routing table. One-level references separately own service
@@ -19,9 +22,11 @@ deliberately composed into both Dispatcher and TeamLeader runtimes:
   doctor passes, then perform notification restart. It carries no
   release-specific schema or migration body.
 - `skills/team-leader/team-workflow` is injected only into TeamLeader runtimes.
-  It covers team-scoped TeamMate MCP cautions, shared Team workspace
-  coordination, provider-visible channel replies, TeamLeader cron cautions, and
-  the Channel-owned routing tools a TeamLeader may reach for its own Team.
+  It is the same optional, on-demand collaboration skill from the TeamLeader's
+  vantage: a TeamMate against an engine-native subagent; writing a hand-down
+  prompt for members who share one Team workspace; asking a TeamMate why before
+  overriding a surprising action; and continuing one collaboration instead of
+  starting another.
 - The shared `workflow` skill at `skills/shared/workflow` is injected into both
   Dispatcher and TeamLeader runtimes. It owns the Dynamic Workflow tool and
   deterministic runner contract.
@@ -50,6 +55,9 @@ shared roots; it therefore reserves the bundled `team-workflow` and `workflow`
 names so custom roots cannot shadow either required skill.
 
 ## Dispatcher-Visible MCP
+
+Every input property of the Dispatcher's `teammate`, `team`, and `cron` tools
+carries a description.
 
 Dispatcher `teammate` MCP tools are `spawn`, `send`, `close`, `list`, `status`,
 `history`, `last`, and `get_capabilities`. `spawn.name_prefix` is only a
@@ -87,6 +95,9 @@ schema rather than assuming a shape.
 
 ## TeamLeader-Visible MCP
 
+Every input property of the TeamLeader's `teammate`, `team`, and `cron` tools
+carries a description.
+
 TeamLeader `teammate` MCP tools are `spawn`, `send`, `close`, `list`, `status`,
 `history`, `last`, and `get_capabilities`, scoped to the Team's members.
 TeamLeader `spawn` does not accept a `repo` input because the Team workspace is
@@ -99,9 +110,9 @@ returns the same submitted receipt — its own runtime is one of the things bein
 stopped, so it should expect to lose that response. TeamLeaders cannot create,
 send to, list, inspect, or select Teams through this projection.
 
-The bundled `team-workflow` skill tells a TeamLeader to check uncommitted,
+The TeamLeader `dissolve` description tells a TeamLeader to check uncommitted,
 untracked, and unmerged work before dissolving, and to ask the user through the
-visible reply path when the workspace is not clean. That prompt check is
+visible reply path when the workspace is not clean. That description check is
 guidance, not authority: the non-destructive assessment inside the worktree
 manager is what actually refuses an unsafe close. Keep the two layers distinct
 when editing either.

--- a/.agents/domains/model-facing-writing.md
+++ b/.agents/domains/model-facing-writing.md
@@ -11,7 +11,9 @@ Current source owners:
 - `/packages/dreamux/skills/`
 - `/packages/dreamux/src/service/dispatcher-service/base-prompt.ts`
 - `/packages/dreamux/src/service/team-service/index.ts`
+- `/packages/dreamux/src/service/mcp/tool-metadata.ts` (the shared `repo` input and its property descriptions)
 - `/packages/dreamux/src/service/teammate-collection/mcp-delegate.ts`
+- `/packages/dreamux/src/service/teammate-collection/mcp-tool-descriptors.ts`
 - `/packages/dreamux/src/service/team-collection/mcp-delegate.ts`
 - `/packages/dreamux/src/service/scheduler/mcp-delegate.ts`
 - `/packages/dreamux/src/service/channel-service/index.ts`
@@ -111,7 +113,8 @@ guidance unless the Dispatcher role itself needs it.
 Dispatcher prompt content should still be compact and role-specific:
 
 - identify the Dreamux Dispatcher role;
-- load `dispatcher-workflow` before TeamMate, Team, channel, or cron MCP work;
+- map the role's MCP servers (`teammate`, `team`, `cron`, `channel-<id>`) and
+  say to load a tool's definition before calling it;
 - load `dreamux-maintenance` before Dreamux host/server diagnosis;
 - state that repository implementation, debugging, and review work should be
   delegated to TeamMate/Team MCP by default;
@@ -137,7 +140,8 @@ MCP descriptions are model-facing. Keep them short and operational:
 - what the tool does;
 - which identifier the caller must use;
 - what result or side effect is authoritative;
-- important non-obvious cautions, such as shared-workspace write coordination.
+- important non-obvious cautions, such as shared-workspace write coordination;
+- every input property carries a one-sentence description.
 
 Avoid internal architecture adjectives and implementation layouts in tool
 descriptions: "core-owned", "hidden tool", `.workspace/work/<name>`, and

--- a/.agents/domains/provider-runtime.md
+++ b/.agents/domains/provider-runtime.md
@@ -213,10 +213,9 @@ Source:
 
 ### Bundled Skills And Injection
 
-Dreamux ships bundled skills under `/packages/dreamux/skills/`. Which skill
-covers what — and the tool surfaces those skills describe — is owned by
-[bundled Dreamux skills](dispatcher-skill.md); this page owns the role gate and
-how a root reaches an engine.
+Dreamux ships bundled skills under `/packages/dreamux/skills/`. What each skill
+is for is owned by [bundled Dreamux skills](dispatcher-skill.md); this page owns
+the role gate and how a root reaches an engine.
 
 Current role gate, by root rather than by skill:
 

--- a/.agents/skills/dev-workflow/SKILL.md
+++ b/.agents/skills/dev-workflow/SKILL.md
@@ -120,7 +120,7 @@ knowledge re-supply, structural pre-review accounts, and reporting cadence.
 
 ## TeamLeader ownership
 
-Load and follow `team-workflow` before using TeamMate or Team tools. The TeamLeader
+Load `team-workflow` when composing a hand-down prompt for a TeamMate. The TeamLeader
 owns task identity, requirement accuracy, factual adjudication, the final solution,
 development authorization, authoritative `.agents/**` and GitHub updates, commits,
 pushes, PR actions, and the final merge outcome. Technical consultation may

--- a/.agents/skills/dev-workflow/references/team-dissolution.md
+++ b/.agents/skills/dev-workflow/references/team-dissolution.md
@@ -11,8 +11,7 @@ earlier preference.
 If the operator declines or has not answered, leave the Team open and take no
 lifecycle action.
 
-If the operator confirms dissolution, load and follow `team-workflow`, then inspect
-the shared worktree for:
+If the operator confirms dissolution, inspect the shared worktree for:
 
 - uncommitted changes;
 - untracked files;

--- a/.agents/tasks/mcp/README.md
+++ b/.agents/tasks/mcp/README.md
@@ -16,3 +16,4 @@
 
 ## Tasks
 - [MCP Protocol Conformance Rulings](/.agents/tasks/mcp/protocol-conformance/README.md) — `done`: Preserve the settled rulings behind the official-SDK MCP server replacement.
+- [Relocate role skill guidance into MCP descriptions and role prompts](/.agents/tasks/mcp/relocate-role-skill-guidance/README.md) — `implementation`: Dispatcher and TeamLeader stop loading dispatcher-workflow and team-workflow every turn: tool knowledge moves into MCP tool and parameter descriptions, behavioral rules move into the role prompts, and both skills stay bundled as optional, non-mandated skills.

--- a/.agents/tasks/mcp/README.md
+++ b/.agents/tasks/mcp/README.md
@@ -16,4 +16,4 @@
 
 ## Tasks
 - [MCP Protocol Conformance Rulings](/.agents/tasks/mcp/protocol-conformance/README.md) — `done`: Preserve the settled rulings behind the official-SDK MCP server replacement.
-- [Relocate role skill guidance into MCP descriptions and role prompts](/.agents/tasks/mcp/relocate-role-skill-guidance/README.md) — `implementation`: Dispatcher and TeamLeader stop loading dispatcher-workflow and team-workflow every turn: tool knowledge moves into MCP tool and parameter descriptions, behavioral rules move into the role prompts, and both skills stay bundled as optional, non-mandated skills.
+- [Relocate role skill guidance into MCP descriptions and role prompts](/.agents/tasks/mcp/relocate-role-skill-guidance/README.md) — `review`: Dispatcher and TeamLeader stop loading dispatcher-workflow and team-workflow every turn: tool knowledge moves into MCP tool and parameter descriptions, the pre-schema server map moves into the role prompts, and both skills stay bundled as optional TeamMate-collaboration methodology.

--- a/.agents/tasks/mcp/relocate-role-skill-guidance/README.md
+++ b/.agents/tasks/mcp/relocate-role-skill-guidance/README.md
@@ -2,14 +2,14 @@
 
 ## Current state
 
-- Goal: Dispatcher and TeamLeader stop loading dispatcher-workflow and team-workflow every turn: tool knowledge moves into MCP tool and parameter descriptions, behavioral rules move into the role prompts, and both skills stay bundled as optional, non-mandated skills.
+- Goal: Dispatcher and TeamLeader stop loading dispatcher-workflow and team-workflow every turn: tool knowledge moves into MCP tool and parameter descriptions, the pre-schema map of the role's MCP servers moves into the role prompts (no behavioral rules), and both skills stay bundled as optional, on-demand TeamMate-collaboration methodology.
 - State: `review`
 - Requirement: [Current requirement](/.agents/tasks/mcp/relocate-role-skill-guidance/requirement.md)
 - Final solution: [technical-design/final.md](/.agents/tasks/mcp/relocate-role-skill-guidance/technical-design/final.md) (draft: [draft.md](/.agents/tasks/mcp/relocate-role-skill-guidance/technical-design/draft.md); review: [reviews/codex-review.md](/.agents/tasks/mcp/relocate-role-skill-guidance/technical-design/reviews/codex-review.md)).
 - Solution review Issue: https://github.com/excitedjs/dreamux/issues/368
 - Blockers: None. The task record was restored and WIP-committed (operator-approved) after the incident below; the leftover edits of the stopped run were discarded (operator-approved).
-- Next action: Independent implementation review (code-review workflow at xhigh with the requirement-fidelity finder) over the current workspace; then adjudication, operator ratification, knowledge closeout, PR.
-- Implementation: workflow `run-2e69c695-1f27-403a-a814-2b5965a913f2` completed with all gates green (the earlier `run-2973de5d-635f-4feb-9df2-6a71857d38aa` failed at script compile before any agent started). TeamLeader pre-review passed; evidence in [verification.md](/.agents/tasks/mcp/relocate-role-skill-guidance/verification.md).
+- Next action: Land the adjudicated review findings (verification.md, "Review adjudication") through one developer TeamMate as a follow-up commit on PR #369, complete knowledge closeout, set `done`, request re-review.
+- Implementation: the re-run implementation workflow completed with all gates green (an earlier re-run failed at script compile before any agent started). TeamLeader pre-review passed; evidence in [verification.md](/.agents/tasks/mcp/relocate-role-skill-guidance/verification.md).
 - Related tasks: None.
 - Solution path (operator ruling, 2026-09-02, Feishu group, verbatim): "ok，拉一个 codex 评审即可，不用走三位了" — TeamLeader-authored solution reviewed by exactly one Codex reviewer instead of three. Requirement input revision: requirement.md as of this ruling.
 - Review adjudication (2026-09-02): one Codex reviewer, 11 findings; 10 accepted, 1 partially (test coverage of the private TeamLeader prompt builder); rulings recorded in final.md §10.
@@ -23,10 +23,10 @@
 
 ## Incident (2026-09-02)
 
-- Implementation workflow run `run-27f7158a-ca05-4865-a395-1f8963ced47a` (9 disjoint writer lanes → fidelity critic + gates → bounded self-repair) started 17:25 Asia/Shanghai. Every writer lane completed, then the Team workspace directory was deleted from under the run at about 17:39: the Dreamux server log shows a dissolve of a different Team, `dreamux-fable-ylw3mjs`, first blocked because "the managed worktree is dirty" (dirty with this Team's uncommitted lane edits), which points at both Teams having resolved to the same managed worktree path. The round-1 fixer re-created the worktree clean at ca30883; all uncommitted work, including this task record, was lost. The run was stopped by the TeamLeader at 18:10 before the round-2 fixer could invent prompt text without the solution.
+- Implementation workflow run (9 disjoint writer lanes → fidelity critic + gates → bounded self-repair) started 17:25 Asia/Shanghai. Every writer lane completed, then the Team workspace directory was deleted from under the run at about 17:39: the Dreamux server log shows a dissolve of a different Team with the same name prefix, first blocked because "the managed worktree is dirty" (dirty with this Team's uncommitted lane edits), which points at both Teams having resolved to the same managed worktree path. The round-1 fixer re-created the worktree clean at ca30883; all uncommitted work, including this task record, was lost. The run was stopped by the TeamLeader at 18:10 before the round-2 fixer could invent prompt text without the solution.
 - Recovery: the task record (README, requirement, draft, final, review) was rewritten from the TeamLeader's context. Lane reports from the stopped run are the only record of the lost edits; the implementation is re-run from the restored solution.
 
 ## Delivery
 
-- Pull request / CI / merge: Not started.
+- Pull request / CI / merge: https://github.com/excitedjs/dreamux/pull/369 (opened 2026-09-02 on the operator's instruction before the independent review finished; head `YisenFE:dreamux/dreamux-fable` on the fork `YisenFE/dreamux-fork` because the pushing account has read-only access to `excitedjs/dreamux`; commit `1d5e6c9`). CI: pending. Merge: pending operator.
 - Knowledge closeout: Pending.

--- a/.agents/tasks/mcp/relocate-role-skill-guidance/README.md
+++ b/.agents/tasks/mcp/relocate-role-skill-guidance/README.md
@@ -28,5 +28,5 @@
 
 ## Delivery
 
-- Pull request / CI / merge: https://github.com/excitedjs/dreamux/pull/369 (opened 2026-09-02 on the operator's instruction before the independent review finished; head `YisenFE:dreamux/dreamux-fable` on the fork `YisenFE/dreamux-fork` because the pushing account has read-only access to `excitedjs/dreamux`; commit `1d5e6c9`). CI: pending. Merge: pending operator.
+- Pull request / CI / merge: https://github.com/excitedjs/dreamux/pull/369 (opened 2026-09-02 on the operator's instruction before the independent review finished; head `YisenFE:dreamux/dreamux-fable` on the fork `YisenFE/dreamux-fork` because the pushing account has read-only access to `excitedjs/dreamux`; rebased onto `next` on 2026-09-03 at the operator's request, no conflicts; commits `8dcbf98` (implementation) and `771d35b` (accepted review findings), plus the closeout commit). CI: green before the rebase; re-running after it. Review: the operator requested changes on 2026-09-02; all nine items landed in `771d35b` and each thread was answered. Merge: pending operator.
 - Knowledge closeout: Pending.

--- a/.agents/tasks/mcp/relocate-role-skill-guidance/README.md
+++ b/.agents/tasks/mcp/relocate-role-skill-guidance/README.md
@@ -1,0 +1,32 @@
+# Relocate role skill guidance into MCP descriptions and role prompts
+
+## Current state
+
+- Goal: Dispatcher and TeamLeader stop loading dispatcher-workflow and team-workflow every turn: tool knowledge moves into MCP tool and parameter descriptions, behavioral rules move into the role prompts, and both skills stay bundled as optional, non-mandated skills.
+- State: `review`
+- Requirement: [Current requirement](/.agents/tasks/mcp/relocate-role-skill-guidance/requirement.md)
+- Final solution: [technical-design/final.md](/.agents/tasks/mcp/relocate-role-skill-guidance/technical-design/final.md) (draft: [draft.md](/.agents/tasks/mcp/relocate-role-skill-guidance/technical-design/draft.md); review: [reviews/codex-review.md](/.agents/tasks/mcp/relocate-role-skill-guidance/technical-design/reviews/codex-review.md)).
+- Solution review Issue: https://github.com/excitedjs/dreamux/issues/368
+- Blockers: None. The task record was restored and WIP-committed (operator-approved) after the incident below; the leftover edits of the stopped run were discarded (operator-approved).
+- Next action: Independent implementation review (code-review workflow at xhigh with the requirement-fidelity finder) over the current workspace; then adjudication, operator ratification, knowledge closeout, PR.
+- Implementation: workflow `run-2e69c695-1f27-403a-a814-2b5965a913f2` completed with all gates green (the earlier `run-2973de5d-635f-4feb-9df2-6a71857d38aa` failed at script compile before any agent started). TeamLeader pre-review passed; evidence in [verification.md](/.agents/tasks/mcp/relocate-role-skill-guidance/verification.md).
+- Related tasks: None.
+- Solution path (operator ruling, 2026-09-02, Feishu group, verbatim): "ok，拉一个 codex 评审即可，不用走三位了" — TeamLeader-authored solution reviewed by exactly one Codex reviewer instead of three. Requirement input revision: requirement.md as of this ruling.
+- Review adjudication (2026-09-02): one Codex reviewer, 11 findings; 10 accepted, 1 partially (test coverage of the private TeamLeader prompt builder); rulings recorded in final.md §10.
+
+## Development approval
+
+- Status: Granted by the operator on 2026-09-02 (Feishu group), verbatim: "批准，启动 ultracode 一次性搞定，成员都用 opus".
+- Approved implementation boundary: the boundary played back in the approval request — `base-prompt.ts` (both prompts), `leader-agent.ts` TeamLeader prompt; tool and property descriptions in the `teammate`, `team`, and `cron` delegates; feishu-channel `reply` and both `bind_channel` descriptions; both `SKILL.md` bodies and descriptions; `dispatcher-skill.md`, `model-facing-writing.md`, `provider-runtime.md`, two `dev-workflow` references; one new structural test; change files (`dreamux` minor, `feishu-channel` patch). Unchanged: skill names/roots/injection, tool names, schema types and constraints, results, `workflow` and `dreamux-maintenance` skills.
+- Adjacent `react` correction: operator ruling (2026-09-02, Feishu group, verbatim): "React那个东西是要去掉的，因为这个工具，dispatcher和TeamLeader都可以调，把这个Dispatcher Channel的描述去掉" — the "dispatcher channel" wording on `react` is removed because both callers reach the tool.
+- Implementation method (operator ruling in the same message): run the implementation through the ultracode workflow with all members on the Opus-backed runtime (`claude`), instead of a single developer TeamMate.
+
+## Incident (2026-09-02)
+
+- Implementation workflow run `run-27f7158a-ca05-4865-a395-1f8963ced47a` (9 disjoint writer lanes → fidelity critic + gates → bounded self-repair) started 17:25 Asia/Shanghai. Every writer lane completed, then the Team workspace directory was deleted from under the run at about 17:39: the Dreamux server log shows a dissolve of a different Team, `dreamux-fable-ylw3mjs`, first blocked because "the managed worktree is dirty" (dirty with this Team's uncommitted lane edits), which points at both Teams having resolved to the same managed worktree path. The round-1 fixer re-created the worktree clean at ca30883; all uncommitted work, including this task record, was lost. The run was stopped by the TeamLeader at 18:10 before the round-2 fixer could invent prompt text without the solution.
+- Recovery: the task record (README, requirement, draft, final, review) was rewritten from the TeamLeader's context. Lane reports from the stopped run are the only record of the lost edits; the implementation is re-run from the restored solution.
+
+## Delivery
+
+- Pull request / CI / merge: Not started.
+- Knowledge closeout: Pending.

--- a/.agents/tasks/mcp/relocate-role-skill-guidance/requirement.md
+++ b/.agents/tasks/mcp/relocate-role-skill-guidance/requirement.md
@@ -1,0 +1,280 @@
+# Requirement
+
+## Initial request
+
+- Operator, 2026-09-02, via the bound Feishu group (Chinese, paraphrased): Codex
+  running as the Dispatcher or as a TeamLeader loads `dispatcher-workflow` /
+  `team-workflow` on every turn and wastes context. The MCP tool descriptions
+  are not clear enough and the parameters carry no descriptions. Move the
+  tool-introduction content of the two skills into the MCP tool descriptions,
+  move the tool-loading content into the built-in prompts, and stop forcing
+  the model to load the skills.
+- Refinement 1: do **not** dissolve the two skills. The operator will write
+  other content into them later. The hard requirement is only that the model
+  is no longer forced to load them.
+- Refinement 2: what moves into the prompt is not behavioral rules. The MCP
+  tools are lazily loaded — the model sees only tool *names* until it fetches
+  a tool's schema — so the prompt must carry what the model needs before any
+  schema is loaded: which tool families exist for this role and that the
+  schema is loaded before use. Everything else, including cautions, belongs
+  to the tool or parameter description the model reads once it loads the tool.
+- Refinement 3 (answer to U1): the two skills become the place for **how to
+  collaborate with TeamMates** — methodology, not tool operation: the
+  difference between a TeamMate and a subagent; how to write the prompt that
+  hands a task down; when a TeamMate does something unexpected, first ask it
+  why and discuss so the two perspectives complement each other; and similar
+  guidance. The operator listed these as an open-ended outline ("等等等").
+
+## Current alignment
+
+- Status: Clarification converged on 2026-09-02; solution path confirmed
+  (one Codex reviewer); development approved.
+
+### Confirmed current behavior and evidence
+
+- **The load mandate is in the role prompts, not in the skills.**
+  `packages/dreamux/src/service/dispatcher-service/base-prompt.ts` (replace
+  prompt line 22 and append prompt line 72) says "Load `dispatcher-workflow`
+  before this Dispatcher's TeamMate, Team, channel, or cron MCP tools".
+  `packages/dreamux/src/service/team-service/leader-agent.ts`
+  (`teamLeaderSystemPrompt`) says "Load `team-workflow` before using this
+  Team's TeamMate tools, Team tools (`dissolve`), provider-exposed channel
+  tools, or cron tools". Almost every Dispatcher/TeamLeader turn touches one
+  of those four tool families, so the mandate turns an on-demand skill body
+  (5.3 KB and 5.6 KB) into a per-turn read. Neither engine caches a loaded
+  skill body across turns; Codex receives the roots through
+  `skills/extraRoots/set`, Claude Code through a materialized `--add-dir`
+  root, and both read `SKILL.md` when the model decides to load it.
+- **What the model sees before loading a tool.** Observed from this
+  TeamLeader's own Claude Code runtime on 2026-09-02: MCP tools are deferred.
+  Before a schema fetch the context holds only the names
+  (`mcp__cron__cron_create`, `mcp__cron__cron_delete`, `mcp__cron__cron_list`,
+  `mcp__cron__cron_update`, and likewise for `teammate`, `team`, and the
+  channel tools) with no description, no parameters, and no server summary;
+  the runtime states that calling an unloaded tool fails and that the schema
+  is fetched by name first. The full description and JSON schema appear only
+  after that fetch. A read-only Codex probe TeamMate (codex-cli 0.147.0,
+  2026-09-02) reported the same shape for Codex: MCP tools are deferred
+  nested tools that are not expanded in the prompt; the model finds them by
+  filtering an `ALL_TOOLS` catalog of `{ name, description }` entries inside
+  its exec tool, where each entry also carries a TypeScript-shaped argument
+  declaration; no `tool_search` tool was present. Codex also lists every skill
+  as name, description, and `SKILL.md` location each turn, reads the body only
+  when it decides to use the skill, and is instructed not to carry a skill
+  across turns unless it is mentioned again — which is why a prompt mandate
+  makes the body a per-turn read. The probe had no Dreamux MCP servers (an
+  ordinary TeamMate receives none), so it could not quote the `cron` tools.
+- **Both skills have the same five sections** (TeamMate, Workflow, Team,
+  Channel, Cron notes). Role deltas: the Dispatcher copy has `spawn.repo`
+  modes, the full Team surface, `list_bindings`, and a pointer to
+  `dreamux-maintenance`; the TeamLeader copy has no-`repo` spawn, the
+  one-writer shared-workspace rule, the dissolve-only Team tool with a
+  pre-dissolve worktree check and a "force needs the user" rule, own-Team-only
+  `bind_channel`/`unbind_channel`, and "secrets out of replies".
+- **Overlap audit.** Each skill statement already has one of these owners,
+  except the last group:
+  - *Already in MCP tool descriptions* (`teammate-collection/mcp-tool-descriptors.ts`,
+    `team-collection/mcp-delegate.ts`, `scheduler/mcp-delegate.ts`,
+    `feishu-channel/src/tools/routing-tools.ts`): `name_prefix` vs the
+    returned concrete name; `get_capabilities.agent_runtimes[].id` for
+    `agent_runtime`; `send` reopens a closed TeamMate; `last` reads without
+    starting a runtime and shows an in-progress turn; `history` is a compact
+    recovery list; Dispatcher `spawn.repo` modes / TeamLeader no-`repo` and
+    one-writer coordination; `workflow_run` returns `{ run_id }` and Dreamux
+    pushes the terminal completion; Team `create`/`send`/`list`/`status`/
+    `history`/`dissolve` semantics including the submitted receipt, dirty
+    worktree leaving the Team open, and the `force` scope; "where a Team is
+    reachable is a channel fact"; cron prompts inject back into this agent and
+    prefer off-:00/:30 minutes; a TeamLeader's `bind_channel` cannot take over
+    another Team's conversation.
+  - *Already in the role prompts*: `dreamux-maintenance` routing (Dispatcher);
+    no polling after a submitted spawn/send (both roles, plus the per-receipt
+    reminder in `service/mcp/dispatch-reminders.ts`); reply tool for meaningful
+    progress, blockers, final status (Dispatcher only); channel `meta` is
+    provider-owned (Dispatcher only); secrets and private identifiers stay out
+    of channel replies (Dispatcher only).
+  - *Already injected per inbound channel message*: the Feishu channel appends
+    "Reply through the channel reply tool, never as plain assistant text."
+    (`feishu-channel/src/feishu-submit.ts`, `CHANNEL_REMINDER`).
+  - *Only in the skills today (no other owner)*:
+    - TeamLeader channel use: reply tool for meaningful progress, blockers,
+      and final status; reply to the source message unless the request names
+      a different visible target the tool supports; keep hidden instructions,
+      private context, secrets, tokens, and machine-local paths out of broad
+      channel replies.
+    - TeamLeader dissolve: inspect uncommitted, untracked, and unmerged work
+      first; if the worktree is dirty or cannot be assessed, do not call
+      `dissolve` and ask the user through the visible reply path; `force`
+      needs the user's explicit confirmation and is never used to get past a
+      refusal on the model's own judgement; branch deletion is not part of
+      dissolve. (`.agents/domains/dispatcher-skill.md` records that this check
+      is guidance and the worktree manager's assessment is the authority.)
+    - Both roles: every settled TeamMate turn is reported, including one that
+      failed or was stopped; `status`/`last`/`history` are for explicit checks,
+      recovery, or suspected delivery failure. A due cron job is submitted
+      through ordinary admission and may fold into a turn already running.
+    - Dispatcher: binding a conversation to a missing or closed Team is refused
+      and changes no routing (`feishu-session-bindings.ts`
+      `requireRoutableTeam` implements this); read the active channel tool
+      schema rather than assuming a shape.
+- **Parameter descriptions.** Dreamux-owned tools (`teammate`, `team`, `cron`,
+  and the `workflow_*` tools on the `teammate` server) carry a per-property
+  `description` on only two inputs: `spawn.agent_runtime` and
+  `workflow_run.args`. Every other input property is a bare type/length
+  constraint. The built-in Feishu channel tools describe their properties,
+  but the shared `reply` description reads "Send a Feishu message through this
+  dispatcher channel." for both callers, including a TeamLeader.
+- **Tests and docs that would move with the change.**
+  `packages/dreamux/tests/bundled-skill-sources.test.ts` asserts the skill
+  names per root and that `packages/dreamux/README.md` and
+  `.agents/domains/dispatcher-skill.md` mention the three role skills; no test
+  locks the "Load ..." sentences or the role prompt text
+  (`.agents/domains/model-facing-writing.md` forbids exact-sentence prose
+  assertions). Docs that state the mandate or describe the skills' content:
+  `.agents/domains/dispatcher-skill.md`, `provider-runtime.md` ("Bundled Skills
+  And Injection"), `model-facing-writing.md` ("Prompt Shape"),
+  `packages/dreamux/README.md`, the `dev-workflow` skill (`SKILL.md` and five
+  references say "load and follow `team-workflow`"), and the draft proposal
+  `.agents/proposals/admin-control-plane-surface.md`.
+- **History.** The two skills were shaped by PR #280 (bundled role skills) and
+  #281 (role-isolated roots), then grew per feature (#287, #303, #305, #317,
+  #335, #347, #350). Their original purpose was to give each role its MCP
+  operating notes at a time when tool descriptions were thin; the descriptions
+  have since absorbed most of that content, so the per-turn load now buys
+  mostly repetition — while the one thing a lazily loaded tool set really
+  needs before any schema is fetched, a one-line map of the families, lives
+  nowhere but the "load the skill" line.
+
+### Desired outcome
+
+Dispatcher and TeamLeader turns no longer read `dispatcher-workflow` or
+`team-workflow` as a matter of course. Before any tool schema is loaded, the
+role prompt tells the model which tool families it has and that it loads a
+tool's schema before calling it. Once a tool is loaded, its description and
+parameter descriptions carry everything the skills used to say about it,
+cautions included. Both skills stay bundled, unchanged in name, root, and
+injection, and each becomes an optional, on-demand skill about collaborating
+with TeamMates: the model reaches for it when it is about to hand work down or
+when a TeamMate's behavior needs discussing, never as a precondition for
+calling a tool.
+
+### Desired behavior
+
+1. Neither role prompt instructs the model to load `dispatcher-workflow` or
+   `team-workflow`, and neither skill's `description` asks to be loaded before
+   tool use.
+2. Each role prompt carries a compact tool map: the MCP tool families this
+   role has (TeamMate, Team, workflow, cron, and channel-provided tools) with
+   one line each on what the family is for, plus the instruction to load a
+   tool's schema before calling it. The map replaces the "load the skill"
+   line; it is not a tool manual.
+3. Every tool fact and caution the skills carry lives once, in that tool's
+   `description` or in the relevant input property's `description` — for
+   example the pre-dissolve worktree check and the "ask the user before
+   `force`" rule on `dissolve` and its `force` property, and the channel-reply
+   guidance on the channel's `reply` tool. Every input property of a
+   Dreamux-owned MCP tool has a description.
+4. Both skill directories and `SKILL.md` files remain; `BUNDLED_SKILL_NAMES`,
+   the role roots, required-source normalization, and the injection mechanism
+   are untouched. Each `SKILL.md` is rewritten as a collaboration-methodology
+   skill for its role: a frontmatter description that says when the skill is
+   worth loading (about to delegate, or a TeamMate surprised you) without any
+   "load before tools" mandate, and a body covering at least the operator's
+   outline — TeamMate vs subagent, how to write a hand-down prompt, and
+   ask-then-discuss when a TeamMate behaves unexpectedly — written from each
+   role's own vantage (the Dispatcher also chooses between a TeamMate and a
+   Team; a TeamLeader coordinates one shared workspace). No tool facts remain
+   in the body.
+5. Model-facing docs and the `dev-workflow` skill references reflect the new
+   owners.
+
+### Scope
+
+- `base-prompt.ts` (both prompts), `leader-agent.ts` (`teamLeaderSystemPrompt`).
+- Tool and parameter descriptions in `teammate-collection/mcp-tool-descriptors.ts`,
+  `team-collection/mcp-delegate.ts`, `scheduler/mcp-delegate.ts`, and the
+  built-in Feishu channel tools (`feishu-channel/src/tools/`) where a skill
+  statement belongs to a channel tool (`reply`, `bind_channel`,
+  `unbind_channel`).
+- The two `SKILL.md` files (frontmatter description and body).
+- KB and doc updates listed above; tests that assert the changed contracts;
+  Rush change files for the touched packages.
+
+### Non-goals
+
+- The shared `workflow` skill and `dreamux-maintenance` skill are unchanged,
+  and the "Load the bundled `workflow` skill before use" sentence on the
+  `workflow_*` tools stays: writing a runner script genuinely needs that
+  reference.
+- No change to the skill injection mechanism, tool names, schema types or
+  constraints, results, or annotations.
+- No change to how either engine defers or loads MCP tools; that is the
+  engine's behavior, and this task only writes for it.
+- The methodology text is a first draft for operator review, not a final
+  doctrine; the operator's outline is open-ended and later additions are
+  ordinary skill edits.
+
+### Constraints and invariants
+
+- `.agents/domains/model-facing-writing.md`: descriptions are short and
+  operational; present-tense current contract; core text stays provider
+  neutral; no migration or history prose; tests protect contracts, not prose;
+  system prompts route and state role boundaries, they are not tool manuals.
+- Engineering whitepaper: every added sentence is paid for by a relocated one
+  or by the stated "parameters need descriptions" requirement; the final
+  solution lists removals against additions.
+- Keep the description-side dissolve check and the worktree manager's
+  authority as two distinct layers (`dispatcher-skill.md`).
+- Public-repository safety for every artifact.
+- Rush change files for `@excitedjs/dreamux` (bundled skills and role prompts
+  are upgrade-visible) and for `@excitedjs/feishu-channel` if its tool text
+  changes.
+
+## Acceptance criteria
+
+- `grep -rn 'Load \`dispatcher-workflow\`\|Load \`team-workflow\`' packages/dreamux/src`
+  returns nothing, and neither skill's frontmatter description contains a load
+  mandate.
+- Each role prompt names every MCP tool family that role's catalogs advertise
+  and says to load a tool's schema before calling it.
+- Every input property in the `teammate` (both callers), `team` (both
+  callers), and `cron` catalogs carries a non-empty `description`; a
+  catalog-level test asserts this structurally.
+- The final solution contains a relocation table: each statement from the two
+  current skills maps to exactly one owner (an existing description, a new
+  description, a prompt line, or "dropped, because ...").
+- Both skill directories still ship with a `SKILL.md`; the bundled-skill root
+  test passes with names unchanged. Each `SKILL.md` body covers the three
+  named outline items and contains no MCP tool name used as an operating
+  instruction (tool facts live in descriptions).
+- `rush build`, `rush lint`, `rush test`, and `.agents/scripts/check.sh` pass.
+
+## Decisions and unknowns
+
+- Confirmed operator decisions (2026-09-02, Feishu group; original Chinese):
+  - "那是不是这两个技能里边，对于工具介绍相关的东西，可以直接移动到 MCP 工具的
+    Description 里？然后加载工具这块的东西可以直接移动到内置的 Prompt 里？" —
+    tool-introduction content moves to MCP tool descriptions; tool-loading
+    content moves to the built-in prompts.
+  - "不不，也不是完全消解，我要在里面写一些其他的东西。但不强制要求模型去加载他" —
+    the skills are not removed; the operator will add other content later; the
+    model is not forced to load them.
+  - "不是行为约束，是因为这些工具基本都会延迟加载，比如你自己就要用 toolSearch
+    去搜索这几个工具吧？" — the prompt content is about lazily loaded tools
+    (what exists, load before use), not behavioral rules.
+  - "这里放的是如何与 teammate 协作 主要讲方法论：1. teammate 和 subagent
+    的区别 2. 下发任务的提示词应该怎么写 3. 如果 teammate 做出了非预期的行为，
+    应该优先去问他为什么会这样做，要讨论，做到视角互补 4. 等等等" — the skill
+    bodies hold TeamMate-collaboration methodology with at least those three
+    items.
+- Assumptions (labeled, to be confirmed at approval):
+  - A1: the `workflow_*` "Load the bundled `workflow` skill before use"
+    sentences stay.
+  - A2: the "no polling after a submitted spawn/send" prompt line stays in
+    both role prompts (it is a durable role rule and the per-receipt reminder
+    already backs it); nothing else behavioral is added to the prompts.
+  - A3: the TeamLeader drafts the methodology text in this task and the
+    operator reviews it through the solution Issue and the PR; the operator
+    did not ask to author it personally.
+- Blocking unknowns: none. U1 (post-task skill body) was resolved by
+  Refinement 3.

--- a/.agents/tasks/mcp/relocate-role-skill-guidance/technical-design/draft.md
+++ b/.agents/tasks/mcp/relocate-role-skill-guidance/technical-design/draft.md
@@ -1,0 +1,39 @@
+# Technical solution (draft)
+
+Superseded by [final.md](final.md) after the Codex review; kept as the
+reviewed input. Input: [requirement.md](../requirement.md) as of the
+operator's path ruling on 2026-09-02. Author: TeamLeader.
+
+The draft differed from the final in these respects, each changed by a review
+finding recorded in final.md §10:
+
+- Role prompts enumerated every tool name per server and said "the
+  description and parameter descriptions are the tool's contract"; the final
+  maps server names plus purpose and keeps only "load a tool's definition
+  before calling it". The draft assumed one "connected channel's own server";
+  the final says one `channel-<id>` server per configured channel that
+  provides tools.
+- The relocation table lacked rows for the frontmatter load mandates, the
+  branch-deletion warning, the background worktree deletion note, the
+  key-milestone reply guidance, and the due-cron folding fact; it dropped the
+  TeamLeader "user asked for parallel edits" clause and attributed the whole
+  routing inventory to `bind_channel`.
+- Property descriptions said `recurring:false` "fires once and then disables
+  the job", `last.limit` "newest page first", Team `history.grep` over three
+  fields, and unconditional `repo.base_ref` / `repo.slug` effects; the
+  existing malformed `spawn.agent_runtime` text was kept as "exists".
+- `reply.text` banned secrets and machine-local paths from every reply
+  instead of from broad-audience replies; the TeamLeader `bind_channel`
+  "ask the Dispatcher" wording was marked as an existing owner.
+- Skill bodies described a TeamMate through its tool operations (addressed
+  by name, pushed completion, reopen after close, `identity`/`prompt`/`intent`
+  field mapping, polling and close-note rules) and asserted subagent
+  lifecycle facts Dreamux does not own; frontmatter descriptions began with
+  "Load when …".
+- The test plan special-cased a "repo union" (it is one closed object) and
+  gated only the Dispatcher prompt constants; `react` was an unlabeled
+  adjacent edit; the feishu-channel change file was typed `minor`.
+
+The Codex probe evidence (Codex 0.147.0 defers MCP definitions behind an
+`ALL_TOOLS` catalog; skills are name+description per turn, body on read) was
+recorded in the draft's §2 and §9 before review and carried into the final.

--- a/.agents/tasks/mcp/relocate-role-skill-guidance/technical-design/final.md
+++ b/.agents/tasks/mcp/relocate-role-skill-guidance/technical-design/final.md
@@ -1,0 +1,426 @@
+# Technical solution (final)
+
+Input: [requirement.md](../requirement.md) as of the operator's path ruling on
+2026-09-02. Author: TeamLeader. Reviewed by one Codex reviewer
+([reviews/codex-review.md](reviews/codex-review.md)); adjudication in §10.
+
+## 1. Shape of the change
+
+Three model-facing surfaces change owners; nothing structural moves.
+
+| Surface | Today | After |
+| --- | --- | --- |
+| Role prompts (`base-prompt.ts` ×2, `leader-agent.ts`) | "Load `<role>-workflow` before TeamMate/Team/channel/cron tools" | A compact tool map: which MCP servers this role has and what each is for, and "load a tool's definition before calling it". |
+| MCP catalogs (`teammate`, `team`, `cron`; Feishu `reply`, both `bind_channel`) | Tool descriptions carry most facts; 2 of ~45 input properties have a description | Every input property has a one-sentence description; the facts and cautions that only the skills carried join the tool or property they are about. |
+| `dispatcher-workflow` / `team-workflow` | MCP operation notes, mandated per turn | TeamMate-collaboration methodology, loaded on demand; the frontmatter says when it is useful and that tool calls do not depend on it. |
+
+Entropy accounting:
+
+- Removed: the load mandate at three prompt sites and in two frontmatter
+  descriptions; ~10 KB of skill body that restated tool contracts; one KB
+  claim that the skills own "tool cautions"; the invented "ask the
+  Dispatcher" instruction on the TeamLeader `bind_channel`.
+- Added: a 2-line tool map per role prompt (operator requirement for lazily
+  loaded tools); ~45 property descriptions (operator requirement); short
+  relocated cautions on `spawn`/`send`, TeamLeader `dissolve`, `force`,
+  `note`, `cron_create`/`cron_update`, `reply`, `reply.message_id`,
+  `reply.text`, Dispatcher `bind_channel.team_name`; two methodology skill
+  bodies (operator-requested content); one structural test.
+- Unchanged: skill names, roots, `BUNDLED_SKILL_NAMES`, required-source
+  normalization, engine injection, tool names, schema types and constraints,
+  results, annotations, the `workflow` and `dreamux-maintenance` skills, the
+  `workflow_*` "load the bundled `workflow` skill" sentences.
+
+## 2. Role prompts
+
+The map names servers and their purpose. It does not enumerate operations or
+explain semantics: both engines defer MCP definitions and find a tool by
+server/name (Claude Code fetches by name; Codex filters an `ALL_TOOLS`
+catalog by name and description), so the server names are what the model
+needs before any definition is loaded, and the definition itself carries the
+rest.
+
+### 2.1 Dispatcher, replace prompt (`DREAMUX_DISPATCHER_BASE_INSTRUCTIONS`, `# Dispatcher Role`)
+
+Replace the "Load `dispatcher-workflow` …" bullet with:
+
+```
+- Your Dreamux MCP servers: `teammate` (TeamMates you run directly, and scripted workflows), `team` (Teams: a TeamLeader with its own workspace and members), `cron` (scheduled prompts that wake this Dispatcher), and one `channel-<id>` server per configured channel that provides tools (that channel's own reply, routing, and policy tools; its schema is the authority).
+- Load a tool's definition before calling it.
+```
+
+Every other bullet stays, including the `dreamux-maintenance` one.
+
+### 2.2 Dispatcher, append prompt (`DREAMUX_DISPATCHER_APPEND_INSTRUCTIONS`)
+
+Opening sentence becomes:
+
+```
+You are running as a Dreamux Dispatcher. Your Dreamux MCP servers are `teammate` (TeamMates and scripted workflows), `team` (Teams), `cron` (scheduled prompts for this Dispatcher), and one `channel-<id>` server per configured channel that provides tools; load a tool's definition before calling it. Load `dreamux-maintenance` before Dreamux server operation, host diagnosis, daemon/service/config/log work, or missing-reply investigations.
+```
+
+### 2.3 TeamLeader (`teamLeaderSystemPrompt`)
+
+```
+You are the TeamLeader of Dreamux Team "<id>".
+Your Dreamux MCP servers: `teammate` (this Team's members, who share the Team workspace, and scripted workflows), `team` (dissolve this Team), `cron` (scheduled prompts that wake this TeamLeader), and one `channel-<id>` server per configured channel that provides tools (that channel's own tools; its schema is the authority). Load a tool's definition before calling it.
+When a prompt-submitting TeamMate tool returns success, … (existing no-poll sentence, unchanged)
+<identity prompt, unchanged>
+```
+
+Neither prompt names the role skill: both engines list bundled skills by
+name and description every turn, and the skill's own description says when
+it is useful (§4).
+
+## 3. Catalog changes
+
+### 3.1 Relocation table
+
+Every statement of the two current skills and its owner after this change.
+"exists" means the owner already says it today and the skill line is
+deleted. "dropped" rows state the reason; none removes a capability.
+
+| # | Skill statement | Owner after |
+| --- | --- | --- |
+| F1 | Frontmatter: "Load before using TeamMate, Team, workflow, channel, or cron tools" (both skills) | replaced by the §4 descriptions; the prompt map §2 owns "what exists before loading" |
+| D1 | Use `dreamux-maintenance` for server operation … | Dispatcher prompts, exists |
+| D2/T1 | TeamMate verbs; scope (this Dispatcher's / this Team's) | prompt map §2; `get_capabilities.verbs` |
+| D3/T2 | `name_prefix` is a label; use the returned concrete name | `spawn` description exists; new `name_prefix` and `name` property descriptions |
+| D4/T5 | `send` reopens a closed TeamMate | `send` description exists |
+| D5/T6 | Wait for the pushed completion; every settled turn is reported, including failed or stopped; `status`/`last`/`history` for explicit checks, recovery, delivery doubt | prompt no-poll sentence exists; receipt reminder exists; **new** clause on `spawn`/`send`: "Dreamux pushes the turn's completion back into your context whether it finished, failed, or was stopped."; `status` description gains "for an explicit check"; `last`/`history` exist |
+| D6/T7 | `history` compact recovery; `last` reads without starting, shows a running turn | exist |
+| D7/T8 | `get_capabilities.agent_runtimes[].id` for `agent_runtime` | exists; the property description is corrected (§3.2) |
+| D8 | `spawn.repo` optional; omitted → per-TeamMate work dir; managed → git worktree; reuse-cwd → existing path | `spawn` description exists; new property descriptions inside `repoInputSchema()` (shared with `team.create`) |
+| D9/T9 | Workflow tools on the same server; load `workflow` skill; `{ run_id }` and pushed terminal completion | exist |
+| D10 | Team verbs; where a Team is reachable is a channel fact | prompt map; `team.list` description exists |
+| D11 | `create.name_prefix` label; concrete never-reused `team_name` | exists; new property description |
+| D12 | `create` starts a TeamLeader; `send` reaches the leader only, not members, not a channel | exist |
+| D13 | `create.prompt` optional; idle until routed inbound or a later `send` | exists; new property description |
+| D14/T14 | `dissolve` is a submission; never reports the outcome; `note` records why | exist; new `note` description |
+| D15 | Dirty worktree leaves the Team open; read `status` afterwards; do not report dissolved on the receipt | Dispatcher `dissolve` exists |
+| D16/T11 | `force` discards local work; never the branch, commits, reused dir, source repo | exists; new `force` property description |
+| T13 | Branch deletion is a separate destructive capability; never inferred from `delete-on-close` | **new** clause on both `dissolve` descriptions after "never deletes the branch …": "deleting them is a separate decision that is the user's" |
+| T14b | Eligible worktree deletion may continue in the background after the Team is closed | dropped: the TeamLeader is stopped behind the receipt and cannot act on this; the Dispatcher `dissolve` already says to read the Team's status afterwards |
+| D17/T15 | Channel tools come from the channel's own server; read its schema | prompt map ("its schema is the authority") |
+| D18 | Routing is a channel operation; Feishu bind/unbind/list_bindings and collaboration-space tools; rebind reports the previous Team; "there is no separate transfer tool" | each Feishu descriptor's own description exists (`routing-tools.ts`, `space-tools.ts`); the "no separate tool" sentence is history prose, dropped |
+| D19 | A bind names an existing, open Team; missing or closed is refused, routing unchanged | **new** Dispatcher `bind_channel.team_name` property description |
+| D20/T17 | Reply tool for meaningful progress, blockers, final status; assistant text is not delivery | Dispatcher prompt exists; per-message `CHANNEL_REMINDER` exists; **new** `reply` description sentence so a TeamLeader reads it where it acts |
+| D21/T17b | Report at key milestones; prefer the latest user message's channel source; reply to the source message unless the request names another target | `reply` description ("at key milestones") and **new** `reply.message_id` property description |
+| D22 | Channel selectors are channel-owned; do not infer them | Dispatcher prompt exists; `chat_id` property descriptions exist |
+| D23/T19 | Cron verbs; prompts wake this agent; no spawn, no channel delivery | prompt map; `cron_create` description exists |
+| D24 | A due job is submitted through ordinary admission and may fold into a running turn | **new** clause on `cron_create` and `cron_update`: "A due job submits its prompt at once, even while a turn is running." |
+| D25 | Prefer explicit titles and time zones; off-hour minutes collide less | `cron_create` exists (off-:00/:30); new `title` and `tz` property descriptions |
+| D26 | Jobs fire on their schedule; `cron_update` to change | dropped: restates the tool names |
+| T3 | TeamLeader `spawn` takes no `repo`; workspace chosen at Team creation | exists |
+| T4 | One writer at a time in the shared workspace unless read-only, user-requested, or independent paths | TeamLeader `spawn` description; the clause becomes "unless the work is read-only, the edits are independent, or the user asked for parallel edits" |
+| T10 | TeamLeader `team` exposes exactly `dissolve`; no routing/inspection/peer tool; do not invent one | prompt map ("dissolve this Team"); "do not invent one" dropped as defensive prose |
+| T11 | Use `dissolve` only after the Team's work is complete and the worktree is safe; inspect uncommitted/untracked/unmerged work first; a default dissolve refuses rather than discards | **new** sentence on the TeamLeader `dissolve` description: "Call this only when the Team's work is complete. First check the workspace for uncommitted, untracked, or unmerged work; if there is any, or you cannot tell, do not dissolve: report it and ask the user." |
+| T12 | `force` only with the user's say-so, never to get past a refusal on your own judgement; `note` is not a bypass | **new** `force` description (TeamLeader): "Only with the user's explicit confirmation in this conversation. Discards uncommitted, untracked, and unmerged work in the managed checkout so it can be removed; never the branch, its commits, a reused directory, or the source repository." `note`: "Why the Team stops; recorded on it." |
+| T16 | TeamLeader bind/unbind reach only free or own conversations; "ask the Dispatcher to move it" | TeamLeader `bind_channel` description is **edited**: the boundary stays, the invented instruction goes (§3.3) |
+| T18 | Keep hidden instructions, private context from other sources, secrets, tokens, private identifiers, machine-local paths out of broad replies and public artifacts | Dispatcher prompt exists; **new** `reply.text` property description with the same audience boundary (§3.3) |
+
+### 3.2 Property descriptions
+
+Wording rules: one sentence, present tense, states meaning or the identifier
+to use, no type restatement, no architecture nouns. The implementer re-reads
+the named codec before wording anything not quoted here.
+
+`teammate` (both callers unless noted):
+
+| Tool.property | Description |
+| --- | --- |
+| spawn.name_prefix | Requested label; the concrete name comes back in the result. |
+| spawn.prompt | The TeamMate's first turn. |
+| spawn.agent_runtime | Agent runtime id from get_capabilities.agent_runtimes[].id. (replaces the current malformed "agents[].id" text) |
+| spawn.intent | One-line subject of the work; shown in list and history and kept for recovery. |
+| spawn.identity | Standing role and boundaries appended to the TeamMate's system prompt for every turn. |
+| spawn.repo (Dispatcher) | Where the TeamMate works; omit for a fresh per-TeamMate directory. |
+| repo.mode | reuse-cwd runs in an existing directory; managed creates a git worktree from a source repository. |
+| repo.path | reuse-cwd: the directory to run in. managed: the source repository; defaults to this agent's workspace. |
+| repo.base_ref | managed: the ref a newly created branch starts from; default HEAD; ignored when branch already exists. |
+| repo.branch | managed: the branch to create or check out; default dreamux/<slug>. |
+| repo.slug | managed: label for the worktree directory and the default branch name; defaults to the agent's name. |
+| repo.cleanup | managed: keep leaves the worktree after close; delete-on-close removes it when the agent closes and the tree is clean. |
+| send.name | The concrete name returned by spawn. |
+| send.prompt | The next turn. |
+| send.intent | Replaces the recorded subject before the turn. |
+| close.name | The concrete name returned by spawn. |
+| close.note | Why the TeamMate is closed; recorded on it. |
+| status.name / last.name | The concrete name returned by spawn. |
+| last.limit | Records to return; default 20, max 200. |
+| last.cursor | next_cursor from the previous page, for older records. |
+| last.include_tools | false omits tool records and returns assistant messages only. |
+| history.name | Exact concrete name. |
+| history.status | Filter by lifecycle status. |
+| history.agent_runtime | Exact agent runtime id. |
+| history.repo | Case-insensitive substring of the source repository path. |
+| history.grep | Case-insensitive substring over name, agent runtime, source repository, intent, and close note. |
+| history.since / until | Epoch milliseconds compared with each record's last update. |
+| history.limit | Rows per page; default 20, max 100. |
+| history.cursor | next_cursor from the previous page. |
+| workflow_run.script | Inline workflow module source. |
+| workflow_run.scriptPath | Path to a workflow module file readable by the Dreamux server. |
+| workflow_run.args | (exists) |
+| workflow_run.max_concurrency | Agents allowed to run at once; default 16, range 1..16. |
+| workflow_status.run_id / workflow_stop.run_id | The run_id returned by workflow_run. |
+
+`team` (Dispatcher):
+
+| Tool.property | Description |
+| --- | --- |
+| create.name_prefix | Requested label; the concrete team_name comes back in the result. |
+| create.repo | Where the Team works; omit for a fresh shared directory. (nested: the shared `repoInputSchema()` texts; "agent's name" reads as the Team's) |
+| create.leader_agent_runtime | Agent runtime id for the TeamLeader, from get_capabilities.agent_runtimes[].id on the teammate server. |
+| create.intent | One-line subject of the Team's work; shown in list and history and kept for recovery. |
+| create.identity | Standing role and boundaries appended to the TeamLeader's system prompt for every turn. |
+| create.prompt | The TeamLeader's first turn; omit to start it idle until a routed inbound or a later send. |
+| send.team_name | The concrete team_name returned by create. |
+| send.prompt | The next turn for the TeamLeader. |
+| send.intent | Replaces the Team's recorded subject before the turn. |
+| status.team_name | The concrete team_name returned by create. |
+| history.team_name | Exact concrete team_name. |
+| history.status | Filter by Team status: starting, running, or closed. |
+| history.repo | Case-insensitive substring of the source repository path. |
+| history.grep | Case-insensitive substring over team_name, intent, source repository, leader name, and close note. |
+| history.since / until | Epoch milliseconds compared with each record's last update. |
+| history.limit | Rows per page; default 20, max 100. |
+| history.cursor | next_cursor from the previous page. |
+| dissolve.team_name | The concrete team_name returned by create. |
+| dissolve.note | Why the Team stops; recorded on it. |
+| dissolve.force | Discards uncommitted, untracked, and unmerged work in the managed checkout so it can be removed; never the branch, its commits, a reused directory, or the source repository. |
+
+`team` (TeamLeader): `dissolve.note` and `dissolve.force` as in §3.1 T12.
+
+`cron`:
+
+| Tool.property | Description |
+| --- | --- |
+| cron_create.cron | Standard 5-field expression (minute hour day-of-month month day-of-week) in tz. |
+| cron_create.prompt | The text submitted to this agent when the job fires. |
+| cron_create.recurring | true (default) fires on every match. false fires at most once, at the next match, and is then disabled; a one-shot missed while Dreamux was stopped is disabled without firing. |
+| cron_create.tz | IANA time zone for the expression; defaults to the host's local zone. |
+| cron_create.title | Short label shown in cron_list. |
+| cron_update.id | The job id from cron_create or cron_list. |
+| cron_update.cron / prompt / tz | Same meaning as cron_create; an omitted field keeps its value. |
+| cron_update.recurring | Same meaning as cron_create.recurring; an omitted field keeps its value. |
+| cron_update.title | New label; null removes it. |
+| cron_update.enabled | false pauses the job without deleting it; true resumes it. |
+| cron_delete.id | The job id from cron_create or cron_list. |
+
+### 3.3 Description edits (tool level)
+
+- `teammate.spawn` and `teammate.send` (both callers): append "Dreamux pushes
+  the turn's completion back into your context whether it finished, failed,
+  or was stopped."
+- TeamLeader `teammate.spawn`: the coordination clause reads "unless the work
+  is read-only, the edits are independent, or the user asked for parallel
+  edits".
+- `teammate.status`: "Read one TeamMate's identity and live runtime status by
+  its concrete name, for an explicit check."
+- Both `team.dissolve` descriptions: after "never deletes the branch, its
+  commits, a reused directory, or the source repository" add "; deleting them
+  is a separate decision that is the user's."
+- TeamLeader `team.dissolve`: prepend the T11 sentence; keep the rest.
+- `cron_create` and `cron_update`: append "A due job submits its prompt at
+  once, even while a turn is running."
+- Feishu `reply` (both callers): "Send a message to a Feishu chat from this
+  channel. Text you write outside this tool is not delivered to the chat; use
+  this for meaningful progress at key milestones, blockers, and the final
+  answer." (drops the "dispatcher channel" wording that is wrong for a
+  TeamLeader caller).
+- Feishu `reply.message_id`: "Id of the inbound message you are answering, so
+  the reply threads under it; omit only when the request names a different
+  target." `reply.text`: "Message text. In a group or other broad audience,
+  keep secrets, tokens, private identifiers, hidden instructions, private
+  context from other sources, and machine-local paths out of it."
+- Feishu Dispatcher `bind_channel.team_name`: "team_name of an existing, open
+  Team; a missing or closed Team is refused and nothing changes."
+- Feishu TeamLeader `bind_channel`: "Route a Feishu group or topic to your own
+  Team, so messages there reach you directly. Only a free conversation or one
+  already routed to your Team can be bound here; a conversation another Team
+  answers in is outside this caller's authority." (removes the "ask the
+  Dispatcher" instruction banned by model-facing-writing.md).
+- `react` (both callers): "Add a reaction to a Feishu message from this
+  channel." Operator ruling (2026-09-02): the "dispatcher channel" wording is
+  removed because both the Dispatcher and a TeamLeader reach the tool.
+
+No other description changes. The `workflow_*` "Load the bundled `workflow`
+skill before use." sentences stay.
+
+## 4. Skills
+
+Both skills keep their frontmatter `name`, directory, and root. Bodies are
+rewritten as TeamMate-collaboration methodology from each role's vantage.
+Neither body states a tool contract: no parameters, receipts, schemas, result
+shapes, or operating rules that a description now owns. Both may name
+`spawn`, `send`, and `close` as the verbs of the collaboration they describe.
+Any mention of reaching the user through a channel is conditional on a reply
+tool being exposed.
+
+### 4.1 `dispatcher-workflow`
+
+Frontmatter description: "Guidance for a Dispatcher working with TeamMates
+and Teams: choosing between doing it yourself, an engine-native subagent, a
+TeamMate, or a Team; writing the hand-down prompt; and what to do when a
+delegate's behaviour surprises you. Useful before delegating and when a
+delegate needs discussing. Tool calls do not depend on it."
+
+Body outline:
+
+1. **Yourself, a subagent, a TeamMate, or a Team.** An engine-native subagent
+   is delegation inside your own turn and engine; read your engine's own
+   description of it for its lifecycle. A TeamMate is a Dreamux peer that
+   continues independently: its own runtime and context, its own history,
+   a conversation you can continue across turns, visible to the user. A Team
+   is a TeamLeader with its own workspace and members, for work that needs a
+   coordinator of its own. Choose by whether the work outlives your turn,
+   needs its own context or workspace, may need to be inspected or continued
+   by the user, or needs its own coordination.
+2. **Writing the hand-down prompt.** State the outcome and the evidence that
+   would show it, not the steps. Give the context the TeamMate cannot see:
+   the source request, constraints, files, what is already known or ruled
+   out. Set the boundary: what not to touch, read-only or writing, one writer
+   per workspace. Ask for a report shape: what changed, evidence, open
+   questions. Standing role and boundaries belong with the TeamMate for every
+   turn; the task belongs to the turn.
+3. **When a TeamMate does something you did not expect.** Ask it why before
+   overriding; read its reasoning. It may have seen something you did not;
+   the goal is two perspectives, not one corrected one. Discuss until you
+   converge; only then restate the boundary, or end the collaboration with a
+   note that says what was learned.
+4. **Keeping the thread.** Continue with the same TeamMate for follow-ups on
+   the same work rather than starting another; a fresh TeamMate has none of
+   the context the conversation built.
+
+### 4.2 `team-workflow`
+
+Frontmatter description: "Guidance for a TeamLeader working with this Team's
+TeamMates: TeamMate versus engine-native subagent, writing the hand-down
+prompt for a shared workspace, and what to do when a TeamMate's behaviour
+surprises you. Useful before handing work down and when a TeamMate needs
+discussing. Tool calls do not depend on it."
+
+Body: the same four sections from the TeamLeader's vantage: no Team choice;
+members share one workspace (one writer at a time, disjoint identities such
+as developer and reviewer, task artefact paths in the prompt); the user is
+reached through whatever visible reply path the connected channel exposes.
+
+Both bodies are first drafts for operator review; the outline is the
+operator's, and later additions are ordinary skill edits.
+
+## 5. Knowledge and docs
+
+- `.agents/domains/dispatcher-skill.md`: rewrite the two skill bullets
+  (methodology, on demand); replace "The bundled `team-workflow` skill tells a
+  TeamLeader to check … before dissolving" with "The TeamLeader `dissolve`
+  description tells it to check …"; keep the guidance-vs-authority
+  distinction; state in the MCP sections that every input property is
+  described.
+- `.agents/domains/model-facing-writing.md`: Prompt Shape bullets: replace
+  "load `dispatcher-workflow` before …" with "map the role's MCP servers and
+  say to load a tool's definition before calling it"; MCP Descriptions: add
+  "every input property carries a one-sentence description".
+- `.agents/domains/provider-runtime.md`: role-gate bullets stay (names
+  unchanged); "the tool surfaces those skills describe" becomes "what each
+  skill is for".
+- `packages/dreamux/README.md`: no change.
+- `.agents/skills/dev-workflow/SKILL.md` line 123: "Load and follow
+  `team-workflow` before using TeamMate or Team tools" → "Load `team-workflow`
+  when composing a hand-down prompt for a TeamMate".
+  `references/team-dissolution.md`: drop "load and follow `team-workflow`,
+  then"; the worktree inspection steps stay as written. The other four
+  references ("Load and follow `team-workflow`, then start …") stay: they
+  hand work down, which is what the skill is now about.
+- `.agents/proposals/admin-control-plane-surface.md`: unchanged.
+- Task record: `verification.md` when implementation starts; README delivery
+  fields.
+
+## 6. Tests
+
+- New `packages/dreamux/tests/mcp-tool-descriptions.test.ts`: for the
+  `teammate` catalog (`teammateToolDescriptors('dispatcher')` and
+  `('team_leader')`), the `team` catalog (`createTeamMcpDelegate` for both
+  callers, `describe()`), and the `cron` catalog (`createCronMcpDelegate`,
+  `describe()`): walk every `inputSchema.properties` object recursively (the
+  `repo` object included) and assert a non-empty string `description` on each
+  property. Negative gates on stable names, not sentences: the two exported
+  Dispatcher prompt constants do not contain "`dispatcher-workflow`"; the two
+  bundled `SKILL.md` frontmatter descriptions do not contain "before using".
+- The TeamLeader prompt builder is private and no existing test captures a
+  TeamLeader launch context; the acceptance grep covers it. No test-only
+  export.
+- `bundled-skill-sources.test.ts`, Feishu routing/messaging tests: unchanged.
+
+## 7. Change files
+
+- `@excitedjs/dreamux`, `minor`: Dispatcher and TeamLeader prompts no longer
+  ask the model to load `dispatcher-workflow`/`team-workflow` before tool
+  use; those bundled skills now hold TeamMate-collaboration methodology and
+  are loaded on demand; every Dreamux MCP tool input property carries a
+  description and tool descriptions carry the cautions the skills used to.
+- `@excitedjs/feishu-channel`, `patch`: `reply`, `react`, and both
+  `bind_channel` descriptions and property descriptions; no schema, name,
+  result, or behavior change.
+
+## 8. Verification
+
+- `rush build`, `rush lint`, `rush test`, `.agents/scripts/check.sh`.
+- Acceptance grep from the requirement returns nothing.
+- Dump both callers' `teammate`/`team` catalogs and the `cron` catalog in a
+  script and read every description once as the model would.
+- Manual: start a Team on this branch, read the TeamLeader's system prompt in
+  the runtime log, confirm the tool map and the absence of the load line.
+
+## 9. Risks and rejected alternatives
+
+- *One shared methodology skill instead of two role skills.* Rejected: the
+  operator ruled the two skills stay; a third skill is a new entity. Two
+  self-contained bodies with a shared outline are plain repetition.
+- *Naming the optional skill in the prompt.* Rejected: the engine already
+  lists skill name and description every turn.
+- *Listing every tool name in the prompt map.* Rejected after review: both
+  engines find deferred tools by server, and the operation list is what the
+  definitions are for.
+- *Description length.* Neither engine carries MCP definitions in the prompt,
+  so description length is paid per load, not per turn.
+
+## 10. Review adjudication
+
+Findings from [reviews/codex-review.md](reviews/codex-review.md), each with
+the TeamLeader's ruling after checking the cited code.
+
+1. Relocation table incomplete — **accepted.** Rows F1, T13, T14b, T17b,
+   D24 added; T4 keeps the user-request clause; D18 corrected to each Feishu
+   descriptor. T14b is the one labeled drop (§3.1).
+2. Skill bodies restate tool contracts; subagent claims are engine-owned —
+   **accepted.** Bodies now describe what a TeamMate is without naming
+   receipts, history tools, field mapping, polling, or close notes; the
+   subagent comparison defers to the engine's own description; channel
+   mention is conditional. The operator's item 1 (TeamMate vs subagent)
+   stays, phrased that way.
+3. Prompt map invents a single channel server and drifts into a manual —
+   **accepted.** Verified `channel-<id>` per configured channel with an MCP
+   capability (`channel-service/mcp-delegates.ts`). Map reduced to server
+   names plus purpose; "the description and parameter descriptions are the
+   contract" removed.
+4. `recurring:false` promises a fire — **accepted.** Verified
+   `scheduler/service.ts` `reconcile` and `rearmAfterMiss`; wording in §3.2.
+5. `reply.text` caution overbroad — **accepted.** Audience boundary and all
+   categories restored.
+6. TeamLeader `bind_channel` "ask the Dispatcher" is banned wording —
+   **accepted.** Descriptor edited (§3.3).
+7. Property inaccuracies — **accepted.** Verified `worktree/manager.ts`
+   (base_ref only for a new branch; slug default = agent name; branch default
+   `dreamux/<slug>`), `team-collection/read-helpers.ts` (grep fields), result
+   order of `last`; `agent_runtime` text replaced.
+8. Frontmatter still imperative — **accepted.** Descriptive trigger wording.
+9. Test coverage — **partially accepted.** Recursive walk over one closed
+   `repo` object; frontmatter negative gate added. The TeamLeader prompt gate
+   is not added: no existing test captures a TeamLeader launch context, and
+   building one for a prose gate is not paid; the acceptance grep covers it.
+10. `team-dissolution.md` reference — **accepted.**
+11. `react` unpaid; Feishu change type — **accepted on the change type**
+    (`patch`, package is 5.0.0 and nothing but description text changes);
+    `react` was kept as a labeled adjacent correction and the operator then
+    ruled explicitly that the "dispatcher channel" wording goes (README,
+    Development approval).

--- a/.agents/tasks/mcp/relocate-role-skill-guidance/technical-design/reviews/codex-review.md
+++ b/.agents/tasks/mcp/relocate-role-skill-guidance/technical-design/reviews/codex-review.md
@@ -1,0 +1,98 @@
+# Codex solution review
+
+Reviewer: TeamMate `tm-codex-solution-review-6ksge` (codex runtime), 2026-09-02.
+Restored verbatim from the TeamLeader's context after the workspace loss
+recorded in the task README.
+
+Verdict: the ownership direction is sound, but the draft is not ready for approval. It contains several silent behavior deletions, inaccurate tool/default descriptions, and new skill text that recreates the tool-manual duplication this task is meant to remove.
+
+## Findings
+
+1. **[High] The relocation table silently drops current behavior and is not a complete statement-by-statement account.**
+
+   **Claim.** Several current statements have no row or are marked "dropped" without an operator decision even though they describe observable behavior or a user override. In particular: both current frontmatter load mandates are absent from the table (`packages/dreamux/skills/dispatcher/dispatcher-workflow/SKILL.md:3`, `packages/dreamux/skills/team-leader/team-workflow/SKILL.md:3`); the TeamLeader's user-requested parallel-edit exception is dropped (`team-workflow/SKILL.md:16-18`; draft:114); the due-cron ordinary-admission/folding behavior is dropped (`dispatcher-workflow/SKILL.md:90-91`; draft:110); and the separate warning not to infer branch-deletion authorization is reduced to the narrower fact that dissolve itself does not delete a branch (`team-workflow/SKILL.md:58-60`; draft:118). The table also does not account for "only after this Team's work is complete" or eligible cleanup continuing in the background (`team-workflow/SKILL.md:42-47,61-66`), and it does not fully account for the key-milestone/latest-source reply guidance present in both skills (`dispatcher-workflow/SKILL.md:76-80`, `team-workflow/SKILL.md:81-85`). D18 attributes the entire routing/tool-inventory statement to `bind_channel`, although the collaboration-space tools have their own owners (`packages/channel/feishu-channel/src/tools/space-tools.ts:80-87,149-179,226-230`).
+
+   **Evidence.** Ordinary admission and possible folding are current scheduler behavior, not history (`packages/dreamux/src/service/scheduler/service.ts:264-270`). The requirement explicitly says every tool fact and caution moves to exactly one description owner (`requirement.md:170-175,242-244`). The whitepaper forbids treating capability deletion as simplification (`.agents/skills/engineering-whitepaper/SKILL.md:46-49,196-204`).
+
+   **Recommended draft change.** Add rows for the two frontmatter mandates and every omitted sentence above. Relocate the due-fire behavior to the create/update cron descriptions; preserve the explicit user-request exception in the TeamLeader shared-workspace caution; preserve "dissolve does not authorize branch deletion" (which is distinct from "dissolve never deletes a branch"); and either relocate the other omitted facts or label each proposed deletion as a user-visible change requiring an operator ruling. Correct D18 to point to the individual Feishu routing and collaboration-space descriptors rather than `bind_channel` alone.
+
+2. **[High] The proposed skill bodies reintroduce tool contracts, contrary to the core requirement, and the subagent comparison asserts engine behavior Dreamux does not own.**
+
+   **Claim.** The outline says a TeamMate is addressed by name, has durable history, receives pushed completion, reopens after close, and appears in `list`/`status` (draft:252-255); tells the reader how to divide values among `identity`, `prompt`, and `intent` (draft:265-266); and repeats waiting, follow-up, and close-note operation rules (draft:272-274). The TeamLeader outline adds an unconditional channel reply-tool path (draft:284-287). These are precisely tool/schema contracts that the requirement says must leave the skill body (`requirement.md:178-186`). They already have descriptor owners (`packages/dreamux/src/service/teammate-collection/mcp-tool-descriptors.ts:97-168,185-200,277-305`).
+
+   The statement that a subagent shares the caller's session, returns inline, and cannot be addressed again (draft:250-253) is not a Dreamux contract at all. Subagents are engine-owned; this repository defines the TeamMate surface but no cross-engine subagent lifecycle. The unconditional reply path is also false when the active Channel exposes no reply tool (`.agents/domains/model-facing-writing.md:37,225`).
+
+   **Recommended draft change.** Keep the skills at the methodology level: compare Dreamux-owned, independently continuing collaboration with engine-native delegation whose exact lifecycle must be read from that engine; explain how to provide outcome, context, boundaries, and evidence without naming schema fields; and retain ask-then-discuss. Remove receipt, history, naming, reopen, polling, close-note, and reply-tool instructions from the bodies. Any channel communication guidance must be conditional on an exposed provider tool.
+
+3. **[High] The role prompt map describes a channel surface that does not exist as stated and is already drifting into a tool manual.**
+
+   **Claim.** All three proposed prompts say there is one "connected channel's own server" with "reply and routing" tools (draft:39-40,52,59). In reality, Core creates one `channel-<configured-id>` delegate for every configured Channel whose provider supplies MCP, and supplies none for a provider without MCP (`packages/dreamux/src/service/channel-service/mcp-delegates.ts:40-59`, `packages/dreamux/src/service/channel-service/mcp-delegate.ts:104-112`). The built-in Feishu Dispatcher catalog includes reply, reaction, peer-bot discovery, binding, and collaboration-space policy; the TeamLeader catalog includes reply, reaction, peer-bot discovery, and self-scoped binding (`packages/channel/feishu-channel/src/tools/registry.ts:46-64`). "Reply and routing" therefore omits advertised families, while the singular/unconditional wording invents a server in some configurations.
+
+   Enumerating every operation in long parentheticals and embedding Team/workspace/cron semantics also exceeds the requested family map. Prompt Shape says prompts route and state role boundaries rather than becoming manuals (`.agents/domains/model-facing-writing.md:94-97,124-130`). "The description and parameter descriptions are the tool's contract" is also too broad: schemas, annotations, results, and runtime outcomes remain authoritative parts of the contract (`model-facing-writing.md:132-163`).
+
+   **Recommended draft change.** Replace the inventories with four compact, engine-neutral family entries: `teammate` (individual delegates and scoped workflows), `team` (Dispatcher Team management or the leader's own dissolve), `cron` (scheduled prompts for this role), and zero or more provider-defined `channel-*` servers when configured. Describe Channel capabilities generically rather than promising reply/routing specifically. Keep only the instruction to load the selected tool's definition/schema before calling it; remove the claim that two prose fields are the complete contract.
+
+4. **[High] `cron_create.recurring` promises a fire that the service does not guarantee.**
+
+   **Claim.** "false fires once and then disables the job" (draft:199) is false when the one-shot becomes due while the scheduler is stopped: startup disables it without submitting the prompt (`packages/dreamux/src/service/scheduler/service.ts:154-167`). It is also disabled after an unsuccessful due submission through the missed-fire path (`service.ts:287-289,323-346`). Only an accepted or ambiguous submission follows the stated fire-then-disable sequence (`service.ts:297-307`). The `true` default is correct (`service.ts:349-369`).
+
+   **Recommended draft change.** Describe `false` as one-shot scheduling that disables after its scheduled opportunity, including a concise missed-while-stopped caveat, rather than promising exactly one fire. Use the same semantics for `cron_update.recurring`.
+
+5. **[High] The proposed `reply.text` caution turns a broad/public-reply rule into a ban on every Feishu reply.**
+
+   **Claim.** The current TeamLeader rule is scoped to "broad channel replies and public artifacts" and includes private context from other sources (`packages/dreamux/skills/team-leader/team-workflow/SKILL.md:84-87`). The Dispatcher prompt similarly scopes the restriction to broad/public delivery and includes private identifiers (`packages/dreamux/src/service/dispatcher-service/base-prompt.ts:29-32`). Draft D/T18 instead says to keep the listed values "out of it" for every `reply.text` (`draft.md:120,226`). That would incorrectly prevent an explicitly requested, appropriately targeted troubleshooting reply from containing a machine-local path, while also losing "private context from other sources" and private identifiers.
+
+   **Recommended draft change.** Preserve the original audience boundary in the property/tool wording and retain all protected categories. Do not convert a broad/public disclosure caution into an unconditional content prohibition.
+
+6. **[High] Marking the TeamLeader `bind_channel` description as an existing owner preserves wording explicitly banned by the writing rules.**
+
+   **Claim.** T16 says the current descriptor already owns "ask the Dispatcher to move another Team's" (draft:119). The current descriptor does say that (`packages/channel/feishu-channel/src/tools/routing-tools.ts:181-190`), but the governing writing page explicitly says not to invent "ask the Dispatcher" or a reporting path when no such tool/runtime delivery mechanism exists (`.agents/domains/model-facing-writing.md:39-41`). "Exists" is therefore not evidence of correctness.
+
+   **Recommended draft change.** Include this descriptor in the edit set and state only the positive authority boundary: a TeamLeader can bind a free or own conversation; moving another Team's route is outside this caller's surface. Remove the invented communication instruction from both the descriptor and the rewritten skill.
+
+7. **[Medium] Several property descriptions are inaccurate or incomplete against their codecs and readers.**
+
+   **Claim and evidence.**
+
+   - `last.limit` says "newest page first" (draft:150), while the advertised result orders records oldest first (`packages/dreamux/src/service/teammate-collection/mcp-tool-descriptors.ts:121-128`). The limit default/max themselves are correct (`packages/dreamux/src/service/agent-entity/read-helpers.ts:147-157`).
+   - Team `history.grep` is described as covering team name, repo, and intent only (draft:186), but it also searches leader name and close note (`packages/dreamux/src/service/team-collection/read-helpers.ts:64-73`). "as teammate.history" is additionally unsafe shorthand because Team and TeamMate status vocabularies differ (`team-collection/mcp-delegate.ts:333-344`, `teammate-collection/mcp-tool-descriptors.ts:67-82`).
+   - `repo.base_ref` is used only when the requested branch does not already exist, and `repo.slug` supplies the default branch only when `branch` is omitted (`packages/dreamux/src/service/worktree/manager.ts:137-160`). Draft:140-142 states both effects unconditionally.
+   - The existing `spawn.agent_runtime` description retained by draft:134 begins "Spawnable agents[].id" even though the actual output is `agent_runtimes[]` (`packages/dreamux/src/service/teammate-collection/mcp-tool-descriptors.ts:153-166,174-178`). Calling it "exists" leaves a malformed identifier path in the new all-properties contract.
+
+   **Recommended draft change.** Give `last.limit` a limit/pagination meaning without contradicting result order; spell out Team history fields and its own status vocabulary; make the `base_ref` and `slug` effects conditional; and replace the malformed runtime-id description. Avoid cross-tool "as ..." descriptions where the contracts are not identical.
+
+8. **[Medium] Both proposed frontmatter descriptions still contain an imperative load mandate.**
+
+   **Claim.** "Load when you are about to ..." (draft:242-246,278-282) is a mandate, just narrower than the one being removed. The requirement asks the frontmatter to say when the skill is worth loading without a load-before-tools mandate (`requirement.md:178-184`), and the review question specifically requires avoiding a load mandate.
+
+   **Recommended draft change.** Use descriptive trigger wording such as "Useful when ..." or "Guidance for ... especially when ...". Keep the explicit statement that tool calls do not depend on the skill, but do not phrase the new trigger as an imperative.
+
+9. **[Medium] The catalog test is the right structural shape, but the prompt/skill negative coverage is incomplete.**
+
+   **Claim.** Driving `describe()` for live Dispatcher/TeamLeader delegates and recursively asserting non-empty descriptions protects a schema contract rather than prose, and follows the existing live-catalog construction pattern (`packages/dreamux/tests/mcp-public-failures.test.ts:126-145,381-417`). `repoInputSchema()` is one closed object selected by `mode`, not a schema union (`packages/dreamux/src/service/worktree/repo-request.ts:21-40`), so the proposed test should simply recurse through every `properties` object rather than special-case a "repo union".
+
+   The planned negative gate checks only the two Dispatcher constants (draft:327-329). It leaves the TeamLeader generated prompt and both skill descriptions unprotected even though the acceptance contract covers all four surfaces (`requirement.md:232-248`). Negative gates on stable banned coupling names are allowed; exact-sentence prose mirrors are not (`.agents/domains/model-facing-writing.md:194-214`).
+
+   **Recommended draft change.** Keep the recursive catalog assertion and run it over both caller projections. Add a behavior-level observation of the generated TeamLeader system prompt (without exporting a private helper merely for testing) and a frontmatter-description check that bans the role-skill-as-tool-precondition coupling, using stable names/patterns rather than a full sentence. The existing bundled-skill test can remain unchanged; it only locks names, roots, files, and documentation mentions (`packages/dreamux/tests/bundled-skill-sources.test.ts:23-49,61-80`). I found no existing Feishu or prompt test with an exact description sentence that these edits would break.
+
+10. **[Medium] One `dev-workflow` reference the draft says can stay would point at a skill that no longer contains the procedure.**
+
+    **Claim.** The draft keeps all five step-scoped references (draft:308-313), but `references/team-dissolution.md` says to load and follow `team-workflow` before inspecting the worktree (`.agents/skills/dev-workflow/references/team-dissolution.md:14-15`). After this change, the skill intentionally contains no dissolve/tool facts, so that instruction becomes a false owner pointer. The implementation, solution-consultation, and implementation-review references do hand work to TeamMates and remain aligned with the new methodology purpose.
+
+    **Recommended draft change.** Update the team-dissolution reference to follow the dissolve tool definition/worktree check directly, without loading `team-workflow`. The full non-archive grep otherwise found the owner/name references already considered by the draft: `dispatcher-skill.md`, `model-facing-writing.md`, `provider-runtime.md`, `dev-workflow` plus its four reference files/five occurrences, the package README, and the name-protection proposal. Historical changelogs need no edit.
+
+11. **[Low] The `react` edit is unpaid scope, and the Feishu change-file bump should be `patch`, not `minor`.**
+
+    **Claim.** No current role skill contains a `react` instruction. Correcting its "dispatcher channel" wording (draft:219-223,342-343) is useful cleanup, but it is neither relocated content nor a property-description requirement. The whitepaper requires every addition to be paid for (`.agents/skills/engineering-whitepaper/SKILL.md:29-37`), and requirement scope names Channel edits where a skill statement belongs (`requirement.md:190-200`).
+
+    A Feishu Rush change file is necessary because `reply` and Dispatcher `bind_channel` model-facing package source does change (`requirement.md:228-230`; `.agents/domains/repository-operations-and-release.md:176-184`). However, `@excitedjs/feishu-channel` is already 5.0.0 (`packages/channel/feishu-channel/package.json:1-9`), and the requirement explicitly leaves tool names, schema types/constraints, results, annotations, and runtime behavior unchanged (`requirement.md:202-211`). These are compatible description corrections, so `minor` overstates the release surface.
+
+    **Recommended draft change.** Remove the `react` edit from this task or explicitly obtain scope for the adjacent cleanup. Keep the Feishu change file for the required `reply`/binding description changes, but type it `patch` and describe it as model-facing guidance correction.
+
+## Verified as correct
+
+- The main ownership split is correct: prompts provide pre-schema routing, descriptors own operation/parameter facts, and the two role skills remain bundled as optional methodology.
+- The existing descriptions do already cover concrete-name usage, `send` reopening, `last` cold/in-progress reads, recovery history, runtime-id discovery, workflow `{ run_id }` plus terminal delivery, Team submission receipts, dirty-worktree refusal, and caller-scoped binding. The draft is right not to duplicate those facts elsewhere once the wording issues above are fixed.
+- The proposed `tz` default matches `Intl.DateTimeFormat().resolvedOptions().timeZone || 'UTC'` (`packages/dreamux/src/service/scheduler/service.ts:349-369,504-505`), and workflow concurrency really defaults to 16 with range 1..16 (`packages/dreamux/src/service/workflow-service/limits.ts:3-24`). TeamMate/Team history limits default to 20 and cap at 100 (`agent-entity/read-helpers.ts:107-113`, `team-collection/read-helpers.ts:29-35`).
+- The skill outline does cover the operator's three named methodological topics and distinguishes the Dispatcher choice (TeamMate versus Team) from TeamLeader shared-workspace coordination; the defects are the operational duplication and unstable subagent claims, not the overall outline.
+- `packages/dreamux/README.md:27-35`, the role-root/name-protection assertions, and `BUNDLED_SKILL_NAMES` remain accurate and need no product-text change.

--- a/.agents/tasks/mcp/relocate-role-skill-guidance/verification.md
+++ b/.agents/tasks/mcp/relocate-role-skill-guidance/verification.md
@@ -1,0 +1,69 @@
+# Verification
+
+Evidence for the implementation of [final.md](technical-design/final.md).
+Commands ran in the Team workspace on the `dreamux/dreamux-fable` branch on
+2026-09-02 (Asia/Shanghai).
+
+## Implementation run
+
+- Workflow `run-2e69c695-1f27-403a-a814-2b5965a913f2` (9 disjoint writer
+  lanes on the `claude` runtime → fidelity critic + build/typecheck/lint/
+  focused-test/acceptance gates → bounded self-repair). All nine lanes
+  settled with their files changed; no blockers. The round-1 critic found no
+  `must` gap in the code, skills, docs, test, or change files; its one `must`
+  (missing `verification.md`) is a TeamLeader artifact and is this file. All
+  five gates passed in round 1 and again in round 2.
+- The earlier run `run-27f7158a-ca05-4865-a395-1f8963ced47a` was destroyed
+  by the workspace incident recorded in the task README and its edits were
+  discarded; nothing from it survives in the tree.
+
+## Gate results (workflow, round 2)
+
+| Gate | Command | Result |
+| --- | --- | --- |
+| build | `node common/scripts/install-run-rush.js build` | exit 0 (incremental cache hits after a full round-1 build) |
+| typecheck | `… typecheck` then `… typecheck:tests` | exit 0, 7 operations succeeded each |
+| lint | `… lint` | exit 0, 7 operations succeeded |
+| focused tests | `packages/dreamux`: mcp-tool-descriptions, bundled-skill-sources, mcp-public-failures, mcp-delegate-catalog, mcp-protocol-conformance; `packages/channel/feishu-channel`: feishu-routing-tools | 117 tests passed in dreamux; feishu file passed |
+| acceptance | `git diff --check`; no `Load \`dispatcher-workflow\`` / `Load \`team-workflow\`` under `packages/dreamux/src`, `packages/dreamux/skills`, `.agents/domains`; no "before using" in either skill description; both change files present; both `SKILL.md` present; worktree and `final.md` present | all exit 0 |
+
+## TeamLeader pre-review
+
+- Whole diff read against final.md §2–§7: role prompts carry the quoted map;
+  every input property of the `teammate` (both callers), `team` (both
+  callers), and `cron` catalogs is described; §3.3 tool-level edits present
+  including the operator's `react` ruling; both skills rewritten as
+  methodology with the §4 descriptions; §5 docs and `dev-workflow`
+  references updated; new test and both change files present with the right
+  types.
+- One follow-up sent to the `team-catalog` writer: Dispatcher `team.history`
+  `since`/`until` carried the same sentence; now lower/upper bound wording
+  as in the `teammate` catalog.
+- TeamLeader-owned closeout edit: `model-facing-writing.md` "Current source
+  owners" gains `service/mcp/tool-metadata.ts` and
+  `teammate-collection/mcp-tool-descriptors.ts`.
+
+## Full suite
+
+- `node common/scripts/install-run-rush.js test` (full, live Codex tests
+  included), run in the TeamLeader's own turn at 18:51: 6 packages passed;
+  `@excitedjs/dreamux` reported one failure, `team-dissolve-contract.test.ts
+  > FORCE WORKTREE SEMANTICS > force refuses a worktree identity whose path
+  is not actually registered to the source repo` — "Test timed out in
+  5000ms". The host was running the review-free tail of the workflow plus
+  six Codex app-servers at the time. Re-run alone at 19:02:
+  `npx vitest run tests/team-dissolve-contract.test.ts` passed 20/20, that
+  test in 4597 ms against its 5000 ms budget. The test exercises git worktree
+  registration and does not read any file this task changes; recorded as a
+  host-load timing sensitivity, not a regression.
+- The `since`/`until` follow-up on the Dispatcher `team.history` tool landed
+  after the run (`mcp-tool-descriptions.test.ts` 7/7 re-run by the writer).
+
+## Known limitations
+
+- `.agents/scripts/check.sh` does not parse under this host's system bash
+  3.2 (`case` pattern with `continue`, line 222); it runs in CI on Linux.
+- The manual step "start a Team and read the TeamLeader system prompt in the
+  runtime log" is replaced by the static read of `teamLeaderSystemPrompt`
+  and the acceptance grep; the next Team this branch launches shows the map
+  in its runtime log.

--- a/.agents/tasks/mcp/relocate-role-skill-guidance/verification.md
+++ b/.agents/tasks/mcp/relocate-role-skill-guidance/verification.md
@@ -92,3 +92,21 @@ finding → ruling → reason → operator-ruling conflict.
 | I10, I11 | Feishu runtime refusal text still says "Ask the Dispatcher to move it" | accept, pending operator OK | Same banned wording as the description this change removed; one string in `routing/index.ts`, outside the approved boundary | Needs a ruling (asked 2026-09-03) |
 | I14 | `spawn`/`send` completion clause unconditional | accept | Condition on a submitted turn: a `failed`/`stopped`/`ambiguous` receipt has no turn to push | No |
 | refuted (2) | `cron` property vs tool sentence; `force` lost its guards | reject | Verifier refuted both with quotes; `force` keeps "only with the user's explicit confirmation" | — |
+
+## Rebase and anti-leak gate (2026-09-03)
+
+- Rebased onto `next` at the operator's request (three commits behind: the
+  Feishu `ask_user_question` tool, the mandatory anti-leak gate, the runnable
+  self-upgrade SOP); no conflicts. After the rebase: `rush update
+  --bypass-policy` (the host's global `core.hooksPath` points at a
+  machine-wide security hook, so Rush cannot install the repository hook and
+  Rush's own documented bypass is used for the install step only), `rush
+  build`, `rush typecheck`, `rush typecheck:tests`, `rush lint`, and the
+  focused tests (dreamux: 7 files / 123 tests including
+  `internal-content-scan.test.ts`; feishu-channel routing: 7) all passed.
+- `common/scripts/check-internal-content.sh` over the tree: clean.
+- gitleaks 8.30.1 installed with `common/scripts/install-gitleaks.sh`;
+  `gitleaks git --config .gitleaks.toml` over this branch's commits: no leaks.
+  Because the repository pre-commit hook is not wired on this host (global
+  `core.hooksPath`), the hook script is run by hand against the staged
+  changes before each commit instead of changing the host's hook setting.

--- a/.agents/tasks/mcp/relocate-role-skill-guidance/verification.md
+++ b/.agents/tasks/mcp/relocate-role-skill-guidance/verification.md
@@ -6,14 +6,14 @@ Commands ran in the Team workspace on the `dreamux/dreamux-fable` branch on
 
 ## Implementation run
 
-- Workflow `run-2e69c695-1f27-403a-a814-2b5965a913f2` (9 disjoint writer
+- The successful implementation run (9 disjoint writer
   lanes on the `claude` runtime → fidelity critic + build/typecheck/lint/
   focused-test/acceptance gates → bounded self-repair). All nine lanes
   settled with their files changed; no blockers. The round-1 critic found no
   `must` gap in the code, skills, docs, test, or change files; its one `must`
   (missing `verification.md`) is a TeamLeader artifact and is this file. All
   five gates passed in round 1 and again in round 2.
-- The earlier run `run-27f7158a-ca05-4865-a395-1f8963ced47a` was destroyed
+- The first implementation run was destroyed
   by the workspace incident recorded in the task README and its edits were
   discarded; nothing from it survives in the tree.
 
@@ -67,3 +67,28 @@ Commands ran in the Team workspace on the `dreamux/dreamux-fable` branch on
   runtime log" is replaced by the static read of `teamLeaderSystemPrompt`
   and the acceptance grep; the next Team this branch launches shows the map
   in its runtime log.
+
+## Review adjudication (2026-09-03)
+
+Two reviews of the PR change set: the operator's GitHub review on the pull
+request (nine inline items) and the internal code-review workflow (xhigh:
+seven finders, 55 candidates, 39 verified, 2 refuted, 15 reported after the
+synthesis step failed and the ranked list was returned unmerged). Each row is
+finding → ruling → reason → operator-ruling conflict.
+
+| # | Finding | Ruling | Reason | Conflicts with a ruling? |
+| --- | --- | --- | --- | --- |
+| G1 (P1) / I2 | TeamLeader prompt lost the generic visible-delivery rule (use the provider reply tool for progress, blockers, final status; assistant text is not delivery) | accept | Same sentence the Dispatcher prompt already carries; a role boundary, not a tool manual; external providers add no per-message reminder | No; the operator asked for it on the PR |
+| G2 (P1) / I3, I4 | Public-artifact half of the confidentiality rule lost its owner; `reply.text` covers chat text only | accept | Add the Dispatcher's generic line to the TeamLeader prompt; keep `reply.text` | No |
+| G3 (P1) | `force` descriptions claim discard/removal regardless of cleanup policy | accept | Verified `WorktreeManager.assessCleanup`: `cleanup: keep` returns terminal `kept` before any dirtiness check, so `force` only overrides a blocked `delete-on-close` removal | No |
+| G4 (P1) | Task record publishes run ids and a Team name | accept | Public-repo red line on internal identifiers; replace with non-identifying labels in README and this file | No |
+| G5 (P2) / I5 | Dispatcher replace prompt over-specifies channel tools ("reply, routing, and policy") | accept | Use the neutral wording of the append and TeamLeader prompts | No |
+| G6 (P2) / I0, I1, I12, I13 | `repo.slug` default text wrong for Teams (`team-<team_name>`) | accept | Verified `runtime-registry.ts` passes `team-${teamId}`; state both defaults | No (the slug input itself is removed by the separate task) |
+| G7 (P2) | README goal says behavioral rules move into prompts | accept | Requirement refinement 2 says the opposite; reword goal and index line | No |
+| G8 (P2) | Task record not at closeout while the PR is presented | accept | The PR was opened early on the operator's instruction; complete closeout with the follow-up commit | No |
+| G9 (P2) | No behavioral coverage of the TeamLeader prompt | accept | Build the TeamLeader through `createTeamLeaderAgent`/`restoreTeamLeaderAgentForTeam` with a fake agent-runtime provider that captures the launch context's `systemPrompt`; assert stable phrases; no private export, no source mirror | No |
+| I6, I7, I9 | TeamLeader `dissolve` sentence dropped "through the visible reply path"; KB page claims it is there | accept | Five words restore the original; the KB claim then holds | No |
+| I8 | Cron "prefer explicit titles and time zones" dropped | accept | Fold the preference into the `tz` and `title` property descriptions | No |
+| I10, I11 | Feishu runtime refusal text still says "Ask the Dispatcher to move it" | accept, pending operator OK | Same banned wording as the description this change removed; one string in `routing/index.ts`, outside the approved boundary | Needs a ruling (asked 2026-09-03) |
+| I14 | `spawn`/`send` completion clause unconditional | accept | Condition on a submitted turn: a `failed`/`stopped`/`ambiguous` receipt has no turn to push | No |
+| refuted (2) | `cron` property vs tool sentence; `force` lost its guards | reject | Verifier refuted both with quotes; `force` keeps "only with the user's explicit confirmation" | — |

--- a/common/changes/@excitedjs/dreamux/relocate-role-skill-guidance_2026-09-02-10-31.json
+++ b/common/changes/@excitedjs/dreamux/relocate-role-skill-guidance_2026-09-02-10-31.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "comment": "The Dispatcher and TeamLeader prompts no longer ask the model to load `dispatcher-workflow` or `team-workflow` before using a tool; each prompt now maps the MCP servers that role has — `teammate`, `team`, `cron`, and one `channel-<id>` server per configured channel that provides tools — and says to load a tool's definition before calling it. Both skills still ship under the same names and roots, and each now holds TeamMate-collaboration methodology the model loads on demand: TeamMate versus engine-native subagent, how to write the hand-down prompt, and asking a delegate why before correcting it. Every Dreamux MCP tool input property now carries a description, and the tool descriptions carry the cautions the skills used to carry, so a tool the model has just loaded tells it everything it needs to call that tool.",
+      "type": "minor",
+      "packageName": "@excitedjs/dreamux"
+    }
+  ],
+  "packageName": "@excitedjs/dreamux"
+}

--- a/common/changes/@excitedjs/feishu-channel/relocate-role-skill-guidance_2026-09-02-10-31.json
+++ b/common/changes/@excitedjs/feishu-channel/relocate-role-skill-guidance_2026-09-02-10-31.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "comment": "Rewrite the built-in Feishu tool text a model reads: `reply` says that text written outside the tool is not delivered and that it carries meaningful progress, blockers, and the final answer, and its `message_id` and `text` properties say to thread under the inbound message and to keep secrets, private identifiers, hidden instructions, and machine-local paths out of a broad reply; `react` drops the \"dispatcher channel\" wording, since a TeamLeader reaches it too; the Dispatcher `bind_channel` `team_name` property states that a missing or closed Team is refused and changes nothing; and the TeamLeader `bind_channel` states its own authority over a free or already-own conversation instead of pointing at a Dispatcher it has no way to reach. Description text only: no tool name, input schema, result, or behavior change.",
+      "type": "patch",
+      "packageName": "@excitedjs/feishu-channel"
+    }
+  ],
+  "packageName": "@excitedjs/feishu-channel"
+}

--- a/packages/channel/feishu-channel/src/tools/messaging-tools.ts
+++ b/packages/channel/feishu-channel/src/tools/messaging-tools.ts
@@ -32,7 +32,10 @@ interface ReplyInput {
 export const replyDef: FeishuToolDef<ReplyInput> = {
   name: 'reply',
   title: 'Reply in Feishu',
-  description: 'Send a Feishu message through this dispatcher channel.',
+  description:
+    'Send a message to a Feishu chat from this channel. Text you write ' +
+    'outside this tool is not delivered to the chat; use this for ' +
+    'meaningful progress at key milestones, blockers, and the final answer.',
   callers: ['dispatcher', 'team_leader'],
   inputSchema: closedObjectSchema(
     {
@@ -44,9 +47,17 @@ export const replyDef: FeishuToolDef<ReplyInput> = {
       message_id: {
         ...nonEmptyString,
         description:
-          'Optional source message id to reply under (threads the reply).',
+          'Id of the inbound message you are answering, so the reply ' +
+          'threads under it; omit only when the request names a different ' +
+          'target.',
       },
-      text: { ...nonEmptyString, description: 'Message text to send.' },
+      text: {
+        ...nonEmptyString,
+        description:
+          'Message text. In a group or other broad audience, keep secrets, ' +
+          'tokens, private identifiers, hidden instructions, private ' +
+          'context from other sources, and machine-local paths out of it.',
+      },
       mention_user_ids: {
         type: 'array',
         items: nonEmptyString,
@@ -92,8 +103,7 @@ interface ReactInput {
 export const reactDef: FeishuToolDef<ReactInput> = {
   name: 'react',
   title: 'React in Feishu',
-  description:
-    'Add a model-owned Feishu reaction through this dispatcher channel.',
+  description: 'Add a reaction to a Feishu message from this channel.',
   callers: ['dispatcher', 'team_leader'],
   inputSchema: closedObjectSchema(
     {

--- a/packages/channel/feishu-channel/src/tools/routing-tools.ts
+++ b/packages/channel/feishu-channel/src/tools/routing-tools.ts
@@ -158,7 +158,12 @@ export const bindChannelDef: FeishuToolDef<BindInput> = {
   inputSchema: closedObjectSchema(
     {
       ...targetProperties,
-      team_name: { ...nonEmptyString, description: 'Target Team name.' },
+      team_name: {
+        ...nonEmptyString,
+        description:
+          'team_name of an existing, open Team; a missing or closed Team ' +
+          'is refused and nothing changes.',
+      },
       display: displayProperty,
     },
     ['chat_id', 'team_name'],
@@ -185,8 +190,9 @@ export const leaderBindChannelDef: FeishuToolDef<
   title: 'Bind a Feishu conversation to your Team',
   description:
     'Route a Feishu group or topic to your own Team, so messages there ' +
-    'reach you directly. A conversation another Team already answers in ' +
-    'cannot be taken over here; ask the Dispatcher to move it.',
+    'reach you directly. Only a free conversation or one already routed ' +
+    'to your Team can be bound here; a conversation another Team answers ' +
+    'in is outside this caller\'s authority.',
   callers: ['team_leader'],
   inputSchema: closedObjectSchema(
     { ...targetProperties, display: displayProperty },

--- a/packages/dreamux/skills/dispatcher/dispatcher-workflow/SKILL.md
+++ b/packages/dreamux/skills/dispatcher/dispatcher-workflow/SKILL.md
@@ -1,95 +1,85 @@
 ---
 name: dispatcher-workflow
-description: MCP operation notes for Dispatcher orchestration. Load before using TeamMate, Team, workflow, channel, or cron tools, including spawning or messaging TeamMates, creating or dissolving Teams, running workflows, replying or routing through channel tools, and managing cron jobs.
+description: "Guidance for a Dispatcher working with TeamMates and Teams: choosing between doing it yourself, an engine-native subagent, a TeamMate, or a Team; writing the hand-down prompt; and what to do when a delegate's behaviour surprises you. Useful before delegating and when a delegate needs discussing. Tool calls do not depend on it."
 ---
 
 # Dispatcher Workflow
 
-Use `dreamux-maintenance` instead for Dreamux server operation, host diagnosis,
-daemon/service/config/log work, or missing-reply investigations.
+How a Dispatcher hands work down and works with a delegate afterwards.
+Methodology, not tool operation.
 
-## TeamMate MCP Notes
+## Yourself, a Subagent, a TeamMate, or a Team
 
-- `spawn`, `send`, `close`, `list`, `status`, `history`, `last`, and
-  `get_capabilities` operate on this Dispatcher's TeamMates.
-- `spawn.name_prefix` is only a requested label; use the returned concrete
-  `teammate.name` for every later `send`, `status`, `last`, or `close`.
-- `send` submits a follow-up and reopens a closed TeamMate from its recorded
-  runtime-native session.
-- After a complete `spawn` or `send`, wait for the TeamMate completion that
-  Dreamux pushes into the current context. Every settled turn is reported,
-  including one that failed or was stopped. Use `status`, `last`, or `history`
-  for explicit status checks, recovery, or suspected delivery failure.
-- `history` is compact recovery search. `last` reads the TeamMate's recent
-  activity records by concrete name without starting a runtime, so it also
-  shows a turn that is still running.
-- Use `get_capabilities.agent_runtimes[].id` for `spawn.agent_runtime`.
-- `spawn.repo` is optional. Omitted creates a plain per-TeamMate work directory
-  following the dispatcher's global workspace policy; `mode: managed` creates a
-  git worktree; `mode: reuse-cwd` runs in an existing path.
+Four ways to get a piece of work done:
 
-## Workflow MCP Notes
+- **Yourself.** The work fits this turn and needs the context you already hold.
+- **An engine-native subagent.** Delegation inside your own turn and your own
+  engine. Your engine describes its delegation feature — what it can see, how
+  long it lives, what it returns — and that description is the one to read.
+- **A TeamMate.** A Dreamux peer that continues independently: its own runtime
+  and context, its own history, a conversation you can continue across turns,
+  and visible to the user.
+- **A Team.** A TeamLeader with its own workspace and its own members, for work
+  that needs a coordinator of its own rather than a single worker.
 
-- `workflow_run`, `workflow_status`, `workflow_stop`, and `workflow_list` are on
-  the same TeamMate server and operate on this Dispatcher's workflow runs.
-- Load the bundled `workflow` skill before writing a workflow script.
-- `workflow_run` returns `{ run_id }` immediately; Dreamux pushes one terminal
-  completion when the run finishes.
+Choose by asking about the work, not about the size of the request:
 
-## Team MCP Notes
+- Does it outlive your turn?
+- Does it need its own context, or its own workspace?
+- May the user want to inspect it or continue it?
+- Does it need coordination of its own — several workers, several roles, work
+  that has to be sequenced?
 
-- `create`, `send`, `list`, `status`, `history`, and `dissolve` operate on
-  dispatcher-owned Teams. There is no Team routing tool: where a Team is
-  reachable from the outside is a channel fact, not a Team one.
-- `create.name_prefix` is only a requested label. Use the returned concrete,
-  never-reused `team_name` for every later Team operation.
-- `create` starts a TeamLeader. `send` submits a turn to that TeamLeader only;
-  it does not message Team members directly and does not post to a channel.
-- `create.prompt` is optional. Without it, the TeamLeader starts idle until a
-  routed channel inbound or a later Team `send`.
-- `dissolve` is a submission. It returns `{ accepted, team_name, status:
-  submitted }` as soon as the request is accepted, and never reports how the
-  dissolve went. Include a clear `note`: it records why a recoverable Team was
-  stopped.
-- Uncommitted, untracked, or unmerged work in a Team's managed worktree leaves
-  that Team open and running instead of closing it. Read the Team's `status`
-  afterwards to see what actually happened; do not report a Team as dissolved
-  because the receipt came back.
-- `dissolve.force: true` discards that local work so the managed checkout can be
-  removed. It never deletes the managed branch, its commits, a reused directory,
-  or the source repository.
+The first three questions push past a subagent to a TeamMate. The fourth pushes
+past a TeamMate to a Team.
 
-## Channel Notes
+## Writing the Hand-Down Prompt
 
-- Channel tools come from the connected channel's own MCP server, and that
-  server is the authority on their names, arguments, and results. Read the
-  active tool schema rather than assuming a shape.
-- Routing a conversation to a Team is a channel operation, not a Team one. The
-  built-in Feishu channel exposes `bind_channel`, `unbind_channel`, and
-  `list_bindings` for it, plus its own collaboration-space policy tools. A
-  rebind reports the previous Team; there is no separate transfer tool.
-- A bind names an existing, open Team. Binding to a missing or closed Team is
-  refused and changes no routing.
-- If a channel reply tool is available for the source message, use it for
-  meaningful progress, blockers, and final status. Assistant text, terminal
-  output, and internal planning are not channel delivery.
-- At key task milestones, report progress promptly. Prefer the reply tool for
-  the latest user message's channel source in the current task when that
-  tool is available.
-- Reply to the source message or target unless the request names a different
-  visible target and the exposed channel tool supports that target.
-- Treat channel target selectors as channel-owned. Do not infer them from this
-  guidance; use the exposed tool schema and results.
+The prompt is the whole brief. A delegate sees what you write and nothing else
+of your reasoning.
 
-## Cron Notes
+- **State the outcome and the evidence that would show it, not the steps.** Say
+  what "done" looks like and how you will recognize it. A delegate that knows
+  the outcome can find a better route than the one you would have dictated; a
+  delegate given only steps stops when the steps run out.
+- **Give the context it cannot see.** The source request in the user's own
+  terms, the constraints, the files and paths that matter, what is already known
+  and what has already been ruled out. Everything you leave implicit, it has to
+  rediscover or guess.
+- **Set the boundary.** What not to touch, whether the work is read-only or
+  writing, and — when several delegates share one workspace — that only one of
+  them writes to a given path.
+- **Ask for a report shape.** What changed, the evidence for it, and the
+  questions left open. A named shape is what makes several reports comparable.
+- **Separate the standing from the momentary.** The role and the boundaries hold
+  for every turn of that delegate's life and belong with it from the start; the
+  task belongs to the turn you are sending.
 
-- `cron_create`, `cron_list`, `cron_update`, and `cron_delete` operate on durable
-  jobs for this Dispatcher.
-- Cron prompts wake this Dispatcher. They do not spawn TeamMates or Teams and do
-  not deliver visible channel messages by themselves.
-- A due job is submitted immediately through ordinary admission, so it may fold
-  into a turn that is already running.
-- Prefer explicit titles and time zones. Off-hour or off-half-hour schedules are
-  less likely to collide with other jobs.
-- Jobs fire on their configured schedules. Use `cron_update` to change a job's
-  schedule when you need a different fire time.
+## When a TeamMate Does Something You Did Not Expect
+
+Unexpected is not the same as wrong. A TeamMate has read files you have not and
+has been working in a context you cannot see.
+
+- **Ask why before overriding.** Get its reasoning first, in its own words.
+- **Read the answer as a second perspective, not a defence.** It may have seen
+  something that changes the task: a constraint in the code, a contradiction in
+  the request, a cheaper route. The goal is two perspectives that complete each
+  other, not one perspective corrected into the other.
+- **Discuss until you converge.** Say what you expected and why, and let it say
+  the same. Most surprises come from a brief that was thinner than you thought.
+- **Then act on what you agreed.** Restate the boundary if the delegate was
+  wrong; change your own plan if it was right; and if the collaboration is over,
+  close it saying what it settled.
+
+An unexplained override teaches nothing and repeats itself on the next task.
+
+## Keeping the Thread
+
+A conversation with one TeamMate accumulates context that a new one does not
+have.
+
+- Continue with the same TeamMate for follow-ups on the same work rather than
+  starting another.
+- Start a fresh TeamMate when the work itself is fresh: a different area, a
+  different role, a perspective that should not inherit the first one's
+  conclusions.

--- a/packages/dreamux/skills/team-leader/team-workflow/SKILL.md
+++ b/packages/dreamux/skills/team-leader/team-workflow/SKILL.md
@@ -1,100 +1,100 @@
 ---
 name: team-workflow
-description: MCP operation notes for Team work. Load before using this Team's TeamMate or workflow tools, the Team dissolve tool, channel tools, or cron tools.
+description: "Guidance for a TeamLeader working with this Team's TeamMates: TeamMate versus engine-native subagent, writing the hand-down prompt for a shared workspace, and what to do when a TeamMate's behaviour surprises you. Useful before handing work down and when a TeamMate needs discussing. Tool calls do not depend on it."
 ---
 
 # Team Workflow
 
-## TeamMate MCP Notes
+How a TeamLeader hands work down to this Team's members and works with them
+afterwards. Methodology, not tool operation.
 
-- `spawn`, `send`, `close`, `list`, `status`, `history`, `last`, and
-  `get_capabilities` operate on this Team's TeamMates only.
-- `spawn.name_prefix` is only a requested label; use the returned concrete
-  `teammate.name` for every later `send`, `status`, `last`, or `close`.
-- `spawn` does not accept a repo selector. Team-scoped TeamMates run in the
-  Team's own workspace, selected when the Team was created.
-- Allow one TeamMate at a time to edit the shared Team workspace unless the
-  request is read-only, the user explicitly asks for parallel edits, or the edit
-  paths are clearly independent.
-- `send` submits a follow-up and reopens a closed TeamMate from its recorded
-  runtime-native session.
-- After a complete `spawn` or `send`, wait for the TeamMate completion that
-  Dreamux pushes into the current context. Every settled turn is reported,
-  including one that failed or was stopped. Use `status`, `last`, or `history`
-  for explicit status checks, recovery, or suspected delivery failure.
-- `history` is compact recovery search for this Team's TeamMates. `last` reads a
-  TeamMate's recent activity records by concrete name without starting a
-  runtime, so it also shows a turn that is still running.
-- Use `get_capabilities.agent_runtimes[].id` for `spawn.agent_runtime`.
+## Yourself, a Subagent, or a TeamMate
 
-## Workflow MCP Notes
+Three ways to get a piece of work done:
 
-- `workflow_run`, `workflow_status`, `workflow_stop`, and `workflow_list` are on
-  the same TeamMate server and operate on this Team's workflow runs.
-- Load the bundled `workflow` skill before writing a workflow script.
-- `workflow_run` returns `{ run_id }` immediately; Dreamux pushes one terminal
-  completion when the run finishes.
+- **Yourself.** The work fits this turn and needs the context you already hold.
+  You are also the one who answers for the Team, so the decisions and the
+  reporting stay with you either way.
+- **An engine-native subagent.** Delegation inside your own turn and your own
+  engine. Your engine describes its delegation feature — what it can see, how
+  long it lives, what it returns — and that description is the one to read.
+- **A TeamMate.** A member of this Team that continues independently: its own
+  runtime and context, its own history, a conversation you can continue across
+  turns, and visible to the user.
 
-## Team MCP Notes
+Choose by asking about the work, not about the size of the request:
 
-- The `team` MCP exposes exactly one tool in this context: `dissolve`. There is
-  no Team routing, inspection, send, or peer-Team tool; do not invent one.
-- Use `dissolve({ note })` only after this Team's work is complete and its
-  shared worktree is safe to remove. First inspect for uncommitted or untracked
-  changes and unmerged index entries. A default dissolve is non-forced: for
-  `delete-on-close`, Dreamux runs `git worktree remove <path>`, which refuses
-  rather than discard local work, and preserves the managed branch and its
-  commits.
-- `dissolve({ note, force: true })` is an explicit authorization to run
-  `git worktree remove --force`. It discards uncommitted, untracked, and
-  unmerged work in the managed checkout, so ask the user before using it and
-  never use it to get past a refusal on your own judgement. It still never
-  deletes the branch, its commits, a reused directory, or the source
-  repository.
-- If the worktree is dirty or unmerged, or you cannot determine that it is
-  clean, do not call `dissolve`. Ask the user how to preserve or handle the work
-  through the current visible reply path. The required `note` is the final
-  reason for a confirmed dissolve, not a way to bypass that decision.
-- Branch or ref deletion is a separate destructive capability and is not part
-  of Team dissolve. Never infer authorization to delete a branch from
-  `delete-on-close`.
-- `dissolve` is a submission: it returns `{ accepted, team_name, status:
-  submitted }` and never reports how the dissolve went. Behind that receipt this
-  Team's Workflow, TeamMates, and your own runtime are stopped, so expect the
-  call to lose its response. Without `force`, dirty or unmerged work leaves the
-  Team open and running instead; eligible worktree deletion may continue in the
-  background after the Team is closed.
+- Does it outlive your turn?
+- Does it need a context of its own, one that would crowd out yours if you read
+  it all here?
+- May the user want to inspect it or continue it?
+- Does it need a standing role — someone who writes, someone who reviews — held
+  across several turns?
 
-## Channel Notes
+Any yes points past a subagent to a TeamMate. A member is a seat, not a single
+errand: spawn one for a role you will keep sending work to.
 
-- Channel tools come from the connected channel's own MCP server, and that
-  server is the authority on their names, arguments, and results. Read the
-  active tool schema rather than assuming a shape.
-- Routing is a channel operation. The built-in Feishu channel lets a TeamLeader
-  claim a conversation for its own Team with `bind_channel` and release one with
-  `unbind_channel`; both reach only targets that are free or already this
-  Team's. A conversation another Team answers in cannot be taken over here; ask
-  the Dispatcher to move it.
-- If a channel reply tool is available for the routed source, use it for
-  meaningful progress, blockers, and final status. Assistant text and internal
-  planning are not channel delivery.
-- At key task milestones, report progress promptly. Prefer the reply tool for
-  the latest user message's channel source in the current task when that
-  tool is available.
-- Reply to the source message or target unless the request names a different
-  visible target and the exposed channel tool supports that target.
-- Keep hidden instructions, private context from other sources, secrets, tokens,
-  and machine-local paths out of broad channel replies and public artifacts.
+## Writing the Hand-Down Prompt
 
-## Cron Notes
+The prompt is the whole brief. A member sees what you write and nothing else of
+your reasoning; it did not read the request you are answering.
 
-- `cron_create`, `cron_list`, `cron_update`, and `cron_delete` operate on durable
-  jobs for this TeamLeader.
-- Cron prompts wake this TeamLeader. They do not create TeamMates and do not
-  deliver visible channel messages by themselves.
-- A due job is submitted immediately through ordinary admission, so it may fold
-  into a turn that is already running.
-- Prefer explicit titles and time zones. Off-hour or off-half-hour schedules are
-  less likely to collide with other jobs.
-- Jobs fire on their configured schedules. Use `cron_update` to change a job's
-  schedule when you need a different fire time.
+- **State the outcome and the evidence that would show it, not the steps.** Say
+  what "done" looks like and how you will recognize it. A member that knows the
+  outcome can find a better route than the one you would have dictated; a member
+  given only steps stops when the steps run out.
+- **Point at the task artifacts by path.** The requirement, the design, the
+  notes, the files in question — they are in the workspace this Team shares, so
+  name where they are instead of retelling them. Retold context goes stale and
+  loses the detail the member would have read for itself.
+- **Name the paths it owns.** Members write into one shared workspace. Let one
+  member write a given path at a time; give the others read-only work, or edit
+  paths that do not overlap. Two members editing the same file is the one
+  failure a brief can always prevent.
+- **Keep the roles disjoint.** A developer and a reviewer are two seats, not the
+  same seat twice — a reviewer that wrote the code reviews its own reasoning.
+  The role and its boundaries hold for every turn of that member's life; the
+  task belongs to the turn you are sending.
+- **Ask for a report shape.** What changed, the evidence for it, and the
+  questions left open. A named shape is what makes several reports comparable,
+  and it is what you carry outward.
+
+You are the Team's only voice outward: what a member finds reaches the user when
+you carry it there, through whatever visible reply path the connected channel
+exposes. Put that in the brief — a member that needs a decision from the user
+asks you for it rather than choosing for them.
+
+## When a TeamMate Does Something You Did Not Expect
+
+Unexpected is not the same as wrong. A member has read files you have not and
+has been working in the shared workspace while you were elsewhere.
+
+- **Ask why before overriding.** Get its reasoning first, in its own words.
+- **Read the answer as a second perspective, not a defence.** It may have seen
+  something that changes the task: a constraint in the code, a contradiction
+  between two artifacts, a cheaper route. The goal is two perspectives that
+  complete each other, not one perspective corrected into the other.
+- **Discuss until you converge.** Say what you expected and why, and let it say
+  the same. Most surprises come from a brief that was thinner than you thought,
+  and the fix belongs in the next brief as much as in this member's next turn.
+- **Then act on what you agreed.** Restate the boundary if the member was wrong;
+  change your own plan if it was right; and take the disagreement to the user
+  when what it exposed is a decision that was never yours to make.
+
+An unexplained override teaches nothing and repeats itself on the next task.
+
+## Keeping the Thread
+
+A conversation with one member accumulates context that a new one does not have,
+and every member you keep open is another writer in the shared workspace.
+
+- Continue with the same member for follow-ups on the same work rather than
+  starting another.
+- Start a fresh member when the work itself is fresh: a different area, a
+  different role, a perspective that should not inherit the first one's
+  conclusions.
+- Independence is worth paying for when you want a real check. Two members that
+  share a brief also share its blind spots; give the reviewer the question, not
+  the developer's answer.
+- Close a member when its role is finished, so the members still open are the
+  ones actually working and the writer of any given path stays unambiguous.

--- a/packages/dreamux/src/service/dispatcher-service/base-prompt.ts
+++ b/packages/dreamux/src/service/dispatcher-service/base-prompt.ts
@@ -19,7 +19,7 @@ export const DREAMUX_DISPATCHER_BASE_INSTRUCTIONS = [
   '',
   '# Dispatcher Role',
   '',
-  '- Your Dreamux MCP servers: `teammate` (TeamMates you run directly, and scripted workflows), `team` (Teams: a TeamLeader with its own workspace and members), `cron` (scheduled prompts that wake this Dispatcher), and one `channel-<id>` server per configured channel that provides tools (that channel\'s own reply, routing, and policy tools; its schema is the authority).',
+  '- Your Dreamux MCP servers: `teammate` (TeamMates you run directly, and scripted workflows), `team` (Teams: a TeamLeader with its own workspace and members), `cron` (scheduled prompts that wake this Dispatcher), and one `channel-<id>` server per configured channel that provides tools (that channel\'s own tools; its schema is the authority).',
   '- Load a tool\'s definition before calling it.',
   '- Load `dreamux-maintenance` before Dreamux server operation, host diagnosis, daemon/service/config/log work, or missing-reply investigations.',
   '- Treat the dispatcher working directory as coordination space, not the default target repository. Do not read or edit repository code files under the working directory unless the user explicitly asks this Dispatcher to inspect or edit local files.',

--- a/packages/dreamux/src/service/dispatcher-service/base-prompt.ts
+++ b/packages/dreamux/src/service/dispatcher-service/base-prompt.ts
@@ -19,7 +19,8 @@ export const DREAMUX_DISPATCHER_BASE_INSTRUCTIONS = [
   '',
   '# Dispatcher Role',
   '',
-  '- Load `dispatcher-workflow` before using this Dispatcher\'s TeamMate, Team, channel, or cron MCP tools.',
+  '- Your Dreamux MCP servers: `teammate` (TeamMates you run directly, and scripted workflows), `team` (Teams: a TeamLeader with its own workspace and members), `cron` (scheduled prompts that wake this Dispatcher), and one `channel-<id>` server per configured channel that provides tools (that channel\'s own reply, routing, and policy tools; its schema is the authority).',
+  '- Load a tool\'s definition before calling it.',
   '- Load `dreamux-maintenance` before Dreamux server operation, host diagnosis, daemon/service/config/log work, or missing-reply investigations.',
   '- Treat the dispatcher working directory as coordination space, not the default target repository. Do not read or edit repository code files under the working directory unless the user explicitly asks this Dispatcher to inspect or edit local files.',
   '- For repository implementation, refactor, debugging, or review work, prefer delegating to Dreamux TeamMate or Team MCP tools and wait for Dreamux to push completions back into the current context.',
@@ -62,14 +63,14 @@ export const DREAMUX_DISPATCHER_BASE_INSTRUCTIONS = [
  * {@link DREAMUX_DISPATCHER_BASE_INSTRUCTIONS}, which REPLACES the engine's base
  * instructions, this is layered on top of the runtime's own already-capable
  * system prompt — so it is a focused delta, not a full re-introduction. It
- * carries only what the dispatcher role adds: Dreamux skill routing, MCP result
+ * carries only what the dispatcher role adds: the MCP server map, MCP result
  * authority, visible-channel delivery, and host-operation boundaries.
  * It deliberately omits general engineering style the host model already knows.
  */
 export const DREAMUX_DISPATCHER_APPEND_INSTRUCTIONS = [
   '# Dreamux Dispatcher Role',
   '',
-  'You are running as a Dreamux Dispatcher. Load `dispatcher-workflow` before this Dispatcher\'s TeamMate, Team, channel, or cron MCP operations. Load `dreamux-maintenance` before Dreamux server operation, host diagnosis, daemon/service/config/log work, or missing-reply investigations.',
+  'You are running as a Dreamux Dispatcher. Your Dreamux MCP servers are `teammate` (TeamMates and scripted workflows), `team` (Teams), `cron` (scheduled prompts for this Dispatcher), and one `channel-<id>` server per configured channel that provides tools; load a tool\'s definition before calling it. Load `dreamux-maintenance` before Dreamux server operation, host diagnosis, daemon/service/config/log work, or missing-reply investigations.',
   '',
   '- Use MCP tool results as the authority for Dreamux state and routing outcomes.',
   '- Do not read or edit repository code files under the dispatcher working directory unless the user explicitly asks this Dispatcher to inspect or edit local files; delegate repository work to TeamMates or Teams by default.',

--- a/packages/dreamux/src/service/mcp/tool-metadata.ts
+++ b/packages/dreamux/src/service/mcp/tool-metadata.ts
@@ -150,12 +150,52 @@ export function repoInputSchema(): Record<string, unknown> {
     type: 'object',
     additionalProperties: false,
     properties: {
-      mode: { type: 'string', enum: ['reuse-cwd', 'managed'] },
-      path: { type: 'string', minLength: 1, maxLength: 4096 },
-      base_ref: { type: 'string', minLength: 1, maxLength: 256 },
-      branch: { type: 'string', minLength: 1, maxLength: 256 },
-      slug: { type: 'string', minLength: 1, maxLength: 64 },
-      cleanup: { type: 'string', enum: ['keep', 'delete-on-close'] },
+      mode: {
+        type: 'string',
+        enum: ['reuse-cwd', 'managed'],
+        description:
+          'reuse-cwd runs in an existing directory; managed creates a git ' +
+          'worktree from a source repository.',
+      },
+      path: {
+        type: 'string',
+        minLength: 1,
+        maxLength: 4096,
+        description:
+          'reuse-cwd: the directory to run in. managed: the source ' +
+          'repository; defaults to this agent\'s workspace.',
+      },
+      base_ref: {
+        type: 'string',
+        minLength: 1,
+        maxLength: 256,
+        description:
+          'managed: the ref a newly created branch starts from; default ' +
+          'HEAD; ignored when branch already exists.',
+      },
+      branch: {
+        type: 'string',
+        minLength: 1,
+        maxLength: 256,
+        description:
+          'managed: the branch to create or check out; default ' +
+          'dreamux/<slug>.',
+      },
+      slug: {
+        type: 'string',
+        minLength: 1,
+        maxLength: 64,
+        description:
+          'managed: label for the worktree directory and the default branch ' +
+          'name; defaults to the TeamMate\'s or Team\'s name.',
+      },
+      cleanup: {
+        type: 'string',
+        enum: ['keep', 'delete-on-close'],
+        description:
+          'managed: keep leaves the worktree after close; delete-on-close ' +
+          'removes it when the agent closes and the tree is clean.',
+      },
     },
     required: ['mode'],
   };

--- a/packages/dreamux/src/service/mcp/tool-metadata.ts
+++ b/packages/dreamux/src/service/mcp/tool-metadata.ts
@@ -187,7 +187,8 @@ export function repoInputSchema(): Record<string, unknown> {
         maxLength: 64,
         description:
           'managed: label for the worktree directory and the default branch ' +
-          'name; defaults to the TeamMate\'s or Team\'s name.',
+          'name; defaults to the TeamMate\'s name, or team-<team_name> for a ' +
+          'Team.',
       },
       cleanup: {
         type: 'string',

--- a/packages/dreamux/src/service/scheduler/mcp-delegate.ts
+++ b/packages/dreamux/src/service/scheduler/mcp-delegate.ts
@@ -105,13 +105,39 @@ function cronToolDescriptors(): McpToolDescriptor[] {
   return [
     tool(
       'cron_create',
-      'Create a durable Dreamux cron job for this agent. cron is a standard 5-field local-time expression (M H DoM Mon DoW); prefer off-:00/:30 minutes for approximate schedules. prompt is the text injected into this dispatcher or TeamLeader agent. recurring defaults to true; use recurring:false for one-shot reminders. dreamux jobs are always persisted and do not auto-expire. tz is resolved and stored. Cron jobs inject prompts back into this agent; they do not deliver channel messages or spawn agents.',
+      'Create a durable Dreamux cron job for this agent. cron is a standard 5-field local-time expression (M H DoM Mon DoW); prefer off-:00/:30 minutes for approximate schedules. prompt is the text injected into this dispatcher or TeamLeader agent. recurring defaults to true; use recurring:false for one-shot reminders. dreamux jobs are always persisted and do not auto-expire. tz is resolved and stored. Cron jobs inject prompts back into this agent; they do not deliver channel messages or spawn agents. A due job submits its prompt at once, even while a turn is running.',
       {
-        cron: { type: 'string', minLength: 1, maxLength: 200 },
-        prompt: { type: 'string', minLength: 1, maxLength: 20000 },
-        recurring: { type: 'boolean' },
-        tz: { type: 'string', minLength: 1, maxLength: 100 },
-        title: { type: 'string', minLength: 1, maxLength: 200 },
+        cron: {
+          type: 'string',
+          minLength: 1,
+          maxLength: 200,
+          description:
+            'Standard 5-field expression (minute hour day-of-month month day-of-week) in tz.',
+        },
+        prompt: {
+          type: 'string',
+          minLength: 1,
+          maxLength: 20000,
+          description: 'The text submitted to this agent when the job fires.',
+        },
+        recurring: {
+          type: 'boolean',
+          description:
+            'true (default) fires on every match. false fires at most once, at the next match, and is then disabled; a one-shot missed while Dreamux was stopped is disabled without firing.',
+        },
+        tz: {
+          type: 'string',
+          minLength: 1,
+          maxLength: 100,
+          description:
+            "IANA time zone for the expression; defaults to the host's local zone.",
+        },
+        title: {
+          type: 'string',
+          minLength: 1,
+          maxLength: 200,
+          description: 'Short label shown in cron_list.',
+        },
       },
       ['cron', 'prompt'],
       {
@@ -128,7 +154,14 @@ function cronToolDescriptors(): McpToolDescriptor[] {
     tool(
       'cron_delete',
       'Delete a cron job by id.',
-      { id: { type: 'string', minLength: 1, maxLength: 128 } },
+      {
+        id: {
+          type: 'string',
+          minLength: 1,
+          maxLength: 128,
+          description: 'The job id from cron_create or cron_list.',
+        },
+      },
       ['id'],
       {
         title: 'Delete a cron job',
@@ -141,15 +174,51 @@ function cronToolDescriptors(): McpToolDescriptor[] {
     ),
     tool(
       'cron_update',
-      'Update a cron job by id. Same behavior as cron_create: cron jobs inject prompts back into this agent; they do not deliver channel messages or spawn agents.',
+      'Update a cron job by id. Same behavior as cron_create: cron jobs inject prompts back into this agent; they do not deliver channel messages or spawn agents. A due job submits its prompt at once, even while a turn is running.',
       {
-        id: { type: 'string', minLength: 1, maxLength: 128 },
-        cron: { type: 'string', minLength: 1, maxLength: 200 },
-        prompt: { type: 'string', minLength: 1, maxLength: 20000 },
-        recurring: { type: 'boolean' },
-        tz: { type: 'string', minLength: 1, maxLength: 100 },
-        title: { type: ['string', 'null'], minLength: 1, maxLength: 200 },
-        enabled: { type: 'boolean' },
+        id: {
+          type: 'string',
+          minLength: 1,
+          maxLength: 128,
+          description: 'The job id from cron_create or cron_list.',
+        },
+        cron: {
+          type: 'string',
+          minLength: 1,
+          maxLength: 200,
+          description:
+            'Same meaning as in cron_create; an omitted field keeps its value.',
+        },
+        prompt: {
+          type: 'string',
+          minLength: 1,
+          maxLength: 20000,
+          description:
+            'Same meaning as in cron_create; an omitted field keeps its value.',
+        },
+        recurring: {
+          type: 'boolean',
+          description:
+            'Same meaning as cron_create.recurring; an omitted field keeps its value.',
+        },
+        tz: {
+          type: 'string',
+          minLength: 1,
+          maxLength: 100,
+          description:
+            'Same meaning as in cron_create; an omitted field keeps its value.',
+        },
+        title: {
+          type: ['string', 'null'],
+          minLength: 1,
+          maxLength: 200,
+          description: 'New label; null removes it.',
+        },
+        enabled: {
+          type: 'boolean',
+          description:
+            'false pauses the job without deleting it; true resumes it.',
+        },
       },
       ['id'],
       {

--- a/packages/dreamux/src/service/team-collection/mcp-delegate.ts
+++ b/packages/dreamux/src/service/team-collection/mcp-delegate.ts
@@ -242,7 +242,7 @@ function teamToolDescriptors(
     return [
       tool(
         'dissolve',
-        'Call this only when the Team\'s work is complete. First check the workspace for uncommitted, untracked, or unmerged work; if there is any, or you cannot tell, do not dissolve: report it and ask the user. Submit a dissolve of this descriptor-bound Team. It returns a receipt as soon as the request is accepted ({ accepted, team_name, status: submitted }) and never reports how the dissolve went: the Team\'s Workflow, TeamMates, and this TeamLeader are stopped behind that receipt, so expect this call to lose its response. note is required and records why the Team stopped. Uncommitted, untracked, or unmerged work in the managed worktree leaves the Team open and running instead of closing it. force: true discards that local work so the managed checkout can be removed; it never deletes the branch, its commits, a reused directory, or the source repository; deleting them is a separate decision that is the user\'s.',
+        'Call this only when the Team\'s work is complete. First check the workspace for uncommitted, untracked, or unmerged work; if there is any, or you cannot tell, do not dissolve: report it and ask the user. Submit a dissolve of this descriptor-bound Team. It returns a receipt as soon as the request is accepted ({ accepted, team_name, status: submitted }) and never reports how the dissolve went: the Team\'s Workflow, TeamMates, and this TeamLeader are stopped behind that receipt, so expect this call to lose its response. note is required and records why the Team stopped. Uncommitted, untracked, or unmerged work in a managed delete-on-close worktree leaves the Team open and running instead of closing it. force: true only overrides a delete-on-close removal blocked by uncommitted, untracked, or unmerged work, by discarding that work; under cleanup: keep the checkout and its changes are retained; never the branch, its commits, a reused directory, or the source repository; deleting them is a separate decision that is the user\'s.',
         {
           note: {
             type: 'string',
@@ -255,9 +255,11 @@ function teamToolDescriptors(
             type: 'boolean',
             description:
               'Only with the user\'s explicit confirmation in this conversation. ' +
-              'Discards uncommitted, untracked, and unmerged work in the managed ' +
-              'checkout so it can be removed; never the branch, its commits, a ' +
-              'reused directory, or the source repository.',
+              'It only overrides a delete-on-close removal blocked by ' +
+              'uncommitted, untracked, or unmerged work, by discarding that ' +
+              'work; under cleanup: keep the checkout and its changes are ' +
+              'retained; never the branch, its commits, a reused directory, or ' +
+              'the source repository.',
           },
         },
         ['note'],
@@ -467,7 +469,7 @@ function teamToolDescriptors(
     ),
     tool(
       'dissolve',
-      'Submit a dissolve of one Team (by team_name) and its agents. It returns a receipt as soon as the request is accepted ({ accepted, team_name, status: submitted }); the Team is stopped and closed behind that receipt, so this call never reports the outcome. note is required: it records why a recoverable Team was stopped. Uncommitted, untracked, or unmerged work in the managed worktree leaves the Team open and running instead of closing it, so read the Team\'s status afterwards to see what happened. force: true discards that local work so the managed checkout can be removed; it never deletes the branch, its commits, a reused directory, or the source repository; deleting them is a separate decision that is the user\'s.',
+      'Submit a dissolve of one Team (by team_name) and its agents. It returns a receipt as soon as the request is accepted ({ accepted, team_name, status: submitted }); the Team is stopped and closed behind that receipt, so this call never reports the outcome. note is required: it records why a recoverable Team was stopped. Uncommitted, untracked, or unmerged work in a managed delete-on-close worktree leaves the Team open and running instead of closing it, so read the Team\'s status afterwards to see what happened. force: true only overrides a delete-on-close removal blocked by uncommitted, untracked, or unmerged work, by discarding that work; under cleanup: keep the checkout and its changes are retained; never the branch, its commits, a reused directory, or the source repository; deleting them is a separate decision that is the user\'s.',
       {
         team_name: {
           type: 'string',
@@ -484,9 +486,11 @@ function teamToolDescriptors(
         force: {
           type: 'boolean',
           description:
-            'Discards uncommitted, untracked, and unmerged work in the managed ' +
-            'checkout so it can be removed; never the branch, its commits, a ' +
-            'reused directory, or the source repository.',
+            'Only overrides a delete-on-close removal blocked by uncommitted, ' +
+            'untracked, or unmerged work, by discarding that work; under ' +
+            'cleanup: keep the checkout and its changes are retained; never ' +
+            'the branch, its commits, a reused directory, or the source ' +
+            'repository.',
         },
       },
       ['team_name', 'note'],

--- a/packages/dreamux/src/service/team-collection/mcp-delegate.ts
+++ b/packages/dreamux/src/service/team-collection/mcp-delegate.ts
@@ -315,8 +315,8 @@ function teamToolDescriptors(
           type: 'string',
           maxLength: 20000,
           description:
-            'The TeamLeader\'s first turn; omit to start it idle until a routed ' +
-            'inbound or a later send.',
+            'The TeamLeader\'s first turn; omit it and no TeamLeader process ' +
+            'starts until a routed inbound or a later send arrives.',
         },
       },
       ['name_prefix', 'leader_agent_runtime', 'intent'],

--- a/packages/dreamux/src/service/team-collection/mcp-delegate.ts
+++ b/packages/dreamux/src/service/team-collection/mcp-delegate.ts
@@ -242,10 +242,23 @@ function teamToolDescriptors(
     return [
       tool(
         'dissolve',
-        'Submit a dissolve of this descriptor-bound Team. It returns a receipt as soon as the request is accepted ({ accepted, team_name, status: submitted }) and never reports how the dissolve went: the Team\'s Workflow, TeamMates, and this TeamLeader are stopped behind that receipt, so expect this call to lose its response. note is required and records why the Team stopped. Uncommitted, untracked, or unmerged work in the managed worktree leaves the Team open and running instead of closing it. force: true discards that local work so the managed checkout can be removed; it never deletes the branch, its commits, a reused directory, or the source repository.',
+        'Call this only when the Team\'s work is complete. First check the workspace for uncommitted, untracked, or unmerged work; if there is any, or you cannot tell, do not dissolve: report it and ask the user. Submit a dissolve of this descriptor-bound Team. It returns a receipt as soon as the request is accepted ({ accepted, team_name, status: submitted }) and never reports how the dissolve went: the Team\'s Workflow, TeamMates, and this TeamLeader are stopped behind that receipt, so expect this call to lose its response. note is required and records why the Team stopped. Uncommitted, untracked, or unmerged work in the managed worktree leaves the Team open and running instead of closing it. force: true discards that local work so the managed checkout can be removed; it never deletes the branch, its commits, a reused directory, or the source repository; deleting them is a separate decision that is the user\'s.',
         {
-          note: { type: 'string', minLength: 1, maxLength: 2000, pattern: '\\S' },
-          force: { type: 'boolean' },
+          note: {
+            type: 'string',
+            minLength: 1,
+            maxLength: 2000,
+            pattern: '\\S',
+            description: 'Why the Team stops; recorded on it.',
+          },
+          force: {
+            type: 'boolean',
+            description:
+              'Only with the user\'s explicit confirmation in this conversation. ' +
+              'Discards uncommitted, untracked, and unmerged work in the managed ' +
+              'checkout so it can be removed; never the branch, its commits, a ' +
+              'reused directory, or the source repository.',
+          },
         },
         ['note'],
         {
@@ -261,12 +274,48 @@ function teamToolDescriptors(
       'create',
       'Create a Team with its TeamLeader. name_prefix is only a requested label; create RETURNS a concrete, never-reused team_name with a 4-8 character random suffix, and every later status/history/dissolve/send call MUST use that returned team_name. intent is required: it is the durable recovery subject for the Team. repo is optional: omit it to let Dreamux allocate a plain shared work directory for the Team, or pass { mode: reuse-cwd | managed, path?, base_ref?, branch?, slug?, cleanup? } to choose an existing path or create a managed git worktree. prompt is optional: when supplied it is delivered as the TeamLeader\'s first turn; when omitted no TeamLeader process starts until bound-channel inbound or a later Team MCP send arrives. Routing a channel conversation to the Team is the channel\'s own decision, made with that channel\'s tools.',
       {
-        name_prefix: { type: 'string', minLength: 1, maxLength: 64 },
-        repo: repoInputSchema(),
-        leader_agent_runtime: { type: 'string', minLength: 1, maxLength: 128 },
-        intent: { type: 'string', minLength: 1, maxLength: 2000 },
-        identity: { type: 'string', minLength: 1, maxLength: 4000 },
-        prompt: { type: 'string', maxLength: 20000 },
+        name_prefix: {
+          type: 'string',
+          minLength: 1,
+          maxLength: 64,
+          description:
+            'Requested label; the concrete team_name comes back in the result.',
+        },
+        repo: {
+          ...repoInputSchema(),
+          description: 'Where the Team works; omit for a fresh shared directory.',
+        },
+        leader_agent_runtime: {
+          type: 'string',
+          minLength: 1,
+          maxLength: 128,
+          description:
+            'Agent runtime id for the TeamLeader, from ' +
+            'get_capabilities.agent_runtimes[].id on the teammate server.',
+        },
+        intent: {
+          type: 'string',
+          minLength: 1,
+          maxLength: 2000,
+          description:
+            'One-line subject of the Team\'s work; shown in list and history and ' +
+            'kept for recovery.',
+        },
+        identity: {
+          type: 'string',
+          minLength: 1,
+          maxLength: 4000,
+          description:
+            'Standing role and boundaries appended to the TeamLeader\'s system ' +
+            'prompt for every turn.',
+        },
+        prompt: {
+          type: 'string',
+          maxLength: 20000,
+          description:
+            'The TeamLeader\'s first turn; omit to start it idle until a routed ' +
+            'inbound or a later send.',
+        },
       },
       ['name_prefix', 'leader_agent_runtime', 'intent'],
       {
@@ -279,9 +328,24 @@ function teamToolDescriptors(
       'send',
       'Submit a follow-up turn to a Team\'s TeamLeader by team_name. This targets the TeamLeader agent only; it does not send to Team members and does not bind or post to a channel.',
       {
-        team_name: { type: 'string', minLength: 1, maxLength: 64 },
-        prompt: { type: 'string', minLength: 1, maxLength: 20000 },
-        intent: { type: 'string', minLength: 1, maxLength: 2000 },
+        team_name: {
+          type: 'string',
+          minLength: 1,
+          maxLength: 64,
+          description: 'The concrete team_name returned by create.',
+        },
+        prompt: {
+          type: 'string',
+          minLength: 1,
+          maxLength: 20000,
+          description: 'The next turn for the TeamLeader.',
+        },
+        intent: {
+          type: 'string',
+          minLength: 1,
+          maxLength: 2000,
+          description: 'Replaces the Team\'s recorded subject before the turn.',
+        },
       },
       ['team_name', 'prompt'],
       {
@@ -314,7 +378,14 @@ function teamToolDescriptors(
     tool(
       'status',
       'Read one Team\'s detailed current status by its team_name (record, TeamLeader status, and member count).',
-      { team_name: { type: 'string', minLength: 1, maxLength: 64 } },
+      {
+        team_name: {
+          type: 'string',
+          minLength: 1,
+          maxLength: 64,
+          description: 'The concrete team_name returned by create.',
+        },
+      },
       ['team_name'],
       {
         title: 'Read Team status',
@@ -333,14 +404,53 @@ function teamToolDescriptors(
       'history',
       'Search Teams for recovery (closed included) by team_name, status, repo, intent text, and time range. A compact recovery list, not a raw event timeline. Returns { items, next_cursor }.',
       {
-        team_name: { type: 'string', minLength: 1, maxLength: 64 },
-        status: { type: 'string', enum: ['starting', 'running', 'closed'] },
-        repo: { type: 'string', minLength: 1, maxLength: 4096 },
-        grep: { type: 'string', minLength: 1, maxLength: 500 },
-        since: { type: 'integer' },
-        until: { type: 'integer' },
-        limit: { type: 'integer', minimum: 1, maximum: 100 },
-        cursor: { type: 'string', minLength: 1, maxLength: 1000 },
+        team_name: {
+          type: 'string',
+          minLength: 1,
+          maxLength: 64,
+          description: 'Exact concrete team_name.',
+        },
+        status: {
+          type: 'string',
+          enum: ['starting', 'running', 'closed'],
+          description: 'Filter by Team status: starting, running, or closed.',
+        },
+        repo: {
+          type: 'string',
+          minLength: 1,
+          maxLength: 4096,
+          description: 'Case-insensitive substring of the source repository path.',
+        },
+        grep: {
+          type: 'string',
+          minLength: 1,
+          maxLength: 500,
+          description:
+            'Case-insensitive substring over team_name, intent, source ' +
+            'repository, leader name, and close note.',
+        },
+        since: {
+          type: 'integer',
+          description:
+            'Epoch milliseconds; lower bound on a record\'s last update.',
+        },
+        until: {
+          type: 'integer',
+          description:
+            'Epoch milliseconds; upper bound on a record\'s last update.',
+        },
+        limit: {
+          type: 'integer',
+          minimum: 1,
+          maximum: 100,
+          description: 'Rows per page; default 20, max 100.',
+        },
+        cursor: {
+          type: 'string',
+          minLength: 1,
+          maxLength: 1000,
+          description: 'next_cursor from the previous page.',
+        },
       },
       [],
       {
@@ -357,11 +467,27 @@ function teamToolDescriptors(
     ),
     tool(
       'dissolve',
-      'Submit a dissolve of one Team (by team_name) and its agents. It returns a receipt as soon as the request is accepted ({ accepted, team_name, status: submitted }); the Team is stopped and closed behind that receipt, so this call never reports the outcome. note is required: it records why a recoverable Team was stopped. Uncommitted, untracked, or unmerged work in the managed worktree leaves the Team open and running instead of closing it, so read the Team\'s status afterwards to see what happened. force: true discards that local work so the managed checkout can be removed; it never deletes the branch, its commits, a reused directory, or the source repository.',
+      'Submit a dissolve of one Team (by team_name) and its agents. It returns a receipt as soon as the request is accepted ({ accepted, team_name, status: submitted }); the Team is stopped and closed behind that receipt, so this call never reports the outcome. note is required: it records why a recoverable Team was stopped. Uncommitted, untracked, or unmerged work in the managed worktree leaves the Team open and running instead of closing it, so read the Team\'s status afterwards to see what happened. force: true discards that local work so the managed checkout can be removed; it never deletes the branch, its commits, a reused directory, or the source repository; deleting them is a separate decision that is the user\'s.',
       {
-        team_name: { type: 'string', minLength: 1, maxLength: 64 },
-        note: { type: 'string', minLength: 1, maxLength: 2000 },
-        force: { type: 'boolean' },
+        team_name: {
+          type: 'string',
+          minLength: 1,
+          maxLength: 64,
+          description: 'The concrete team_name returned by create.',
+        },
+        note: {
+          type: 'string',
+          minLength: 1,
+          maxLength: 2000,
+          description: 'Why the Team stops; recorded on it.',
+        },
+        force: {
+          type: 'boolean',
+          description:
+            'Discards uncommitted, untracked, and unmerged work in the managed ' +
+            'checkout so it can be removed; never the branch, its commits, a ' +
+            'reused directory, or the source repository.',
+        },
       },
       ['team_name', 'note'],
       {

--- a/packages/dreamux/src/service/team-service/leader-agent.ts
+++ b/packages/dreamux/src/service/team-service/leader-agent.ts
@@ -215,7 +215,7 @@ function teamLeaderSystemPrompt(
 ): AgentRuntimeSystemPrompt {
   const append = [
     `You are the TeamLeader of Dreamux Team ${JSON.stringify(teamId)}.`,
-    'Load `team-workflow` before using this Team\'s TeamMate tools, Team tools (`dissolve`), provider-exposed channel tools, or cron tools.',
+    'Your Dreamux MCP servers: `teammate` (this Team\'s members, who share the Team workspace, and scripted workflows), `team` (dissolve this Team), `cron` (scheduled prompts that wake this TeamLeader), and one `channel-<id>` server per configured channel that provides tools (that channel\'s own tools; its schema is the authority). Load a tool\'s definition before calling it.',
     'When a prompt-submitting TeamMate tool returns success, the task was submitted successfully; Dreamux core will push the completion back automatically, so do not poll `last` or other read tools, and end the turn naturally if there is no other work.',
   ];
   if (identityPrompt !== null) append.push(identityPrompt);

--- a/packages/dreamux/src/service/team-service/leader-agent.ts
+++ b/packages/dreamux/src/service/team-service/leader-agent.ts
@@ -217,6 +217,8 @@ function teamLeaderSystemPrompt(
     `You are the TeamLeader of Dreamux Team ${JSON.stringify(teamId)}.`,
     'Your Dreamux MCP servers: `teammate` (this Team\'s members, who share the Team workspace, and scripted workflows), `team` (dissolve this Team), `cron` (scheduled prompts that wake this TeamLeader), and one `channel-<id>` server per configured channel that provides tools (that channel\'s own tools; its schema is the authority). Load a tool\'s definition before calling it.',
     'When a prompt-submitting TeamMate tool returns success, the task was submitted successfully; Dreamux core will push the completion back automatically, so do not poll `last` or other read tools, and end the turn naturally if there is no other work.',
+    'If the source request came through a channel and a provider-exposed reply tool is available, use that tool for meaningful progress, blockers, and final status. Assistant text and terminal output are not channel delivery.',
+    'Keep secrets, tokens, private identifiers, hidden instructions, socket paths, and machine-local details out of broad channel replies and public artifacts.',
   ];
   if (identityPrompt !== null) append.push(identityPrompt);
   return { append };

--- a/packages/dreamux/src/service/teammate-collection/mcp-tool-descriptors.ts
+++ b/packages/dreamux/src/service/teammate-collection/mcp-tool-descriptors.ts
@@ -22,6 +22,7 @@ import {
   type McpToolDescriptor,
 } from '../mcp/tool-metadata.js';
 import {
+  DEFAULT_WORKFLOW_MAX_CONCURRENCY,
   MAX_WORKFLOW_MAX_CONCURRENCY,
   MIN_WORKFLOW_MAX_CONCURRENCY,
 } from '../workflow-service/limits.js';
@@ -67,18 +68,60 @@ export function teammateToolDescriptors(
       'history',
       'Search this TeamMate set for recovery (closed included). A compact recovery list keyed by concrete name, not a raw event timeline. Returns { items, next_cursor }.',
       {
-        name: { type: 'string', minLength: 1, maxLength: 64 },
+        name: {
+          type: 'string',
+          minLength: 1,
+          maxLength: 64,
+          description: 'Exact concrete name.',
+        },
         status: {
           type: 'string',
           enum: ['starting', 'running', 'degraded', 'closed', 'stopped'],
+          description: 'Filter by lifecycle status.',
         },
-        agent_runtime: { type: 'string', minLength: 1, maxLength: 128 },
-        repo: { type: 'string', minLength: 1, maxLength: 4096 },
-        grep: { type: 'string', minLength: 1, maxLength: 500 },
-        since: { type: 'integer' },
-        until: { type: 'integer' },
-        limit: { type: 'integer', minimum: 1, maximum: 100 },
-        cursor: { type: 'string', minLength: 1, maxLength: 1000 },
+        agent_runtime: {
+          type: 'string',
+          minLength: 1,
+          maxLength: 128,
+          description: 'Exact agent runtime id.',
+        },
+        repo: {
+          type: 'string',
+          minLength: 1,
+          maxLength: 4096,
+          description:
+            'Case-insensitive substring of the source repository path.',
+        },
+        grep: {
+          type: 'string',
+          minLength: 1,
+          maxLength: 500,
+          description:
+            'Case-insensitive substring over name, agent runtime, source ' +
+            'repository, intent, and close note.',
+        },
+        since: {
+          type: 'integer',
+          description:
+            'Epoch milliseconds; lower bound on a record\'s last update.',
+        },
+        until: {
+          type: 'integer',
+          description:
+            'Epoch milliseconds; upper bound on a record\'s last update.',
+        },
+        limit: {
+          type: 'integer',
+          minimum: 1,
+          maximum: 100,
+          description: 'Rows per page; default 20, max 100.',
+        },
+        cursor: {
+          type: 'string',
+          minLength: 1,
+          maxLength: 1000,
+          description: 'next_cursor from the previous page.',
+        },
       },
       [],
       {
@@ -108,8 +151,15 @@ export function teammateToolDescriptors(
     ),
     tool(
       'status',
-      'Read one TeamMate identity and live runtime status by its concrete name.',
-      { name: { type: 'string', minLength: 1, maxLength: 64 } },
+      'Read one TeamMate\'s identity and live runtime status by its concrete name, for an explicit check.',
+      {
+        name: {
+          type: 'string',
+          minLength: 1,
+          maxLength: 64,
+          description: 'The concrete name returned by spawn.',
+        },
+      },
       ['name'],
       {
         title: 'Read TeamMate status',
@@ -121,10 +171,30 @@ export function teammateToolDescriptors(
       'last',
       'Read a TeamMate\'s recent activity without starting or resuming it. Returns assistant messages and tool records oldest first, including an in-progress turn. limit defaults to 20 (range 1..200); use cursor for older pages and set include_tools=false to omit tool records.',
       {
-        name: { type: 'string', minLength: 1, maxLength: 64 },
-        limit: { type: 'integer', minimum: 1, maximum: 200 },
-        cursor: { type: 'string', minLength: 1, maxLength: 4096 },
-        include_tools: { type: 'boolean' },
+        name: {
+          type: 'string',
+          minLength: 1,
+          maxLength: 64,
+          description: 'The concrete name returned by spawn.',
+        },
+        limit: {
+          type: 'integer',
+          minimum: 1,
+          maximum: 200,
+          description: 'Records to return; default 20, max 200.',
+        },
+        cursor: {
+          type: 'string',
+          minLength: 1,
+          maxLength: 4096,
+          description:
+            'next_cursor from the previous page, for older records.',
+        },
+        include_tools: {
+          type: 'boolean',
+          description:
+            'false omits tool records and returns assistant messages only.',
+        },
       },
       ['name'],
       {
@@ -169,23 +239,50 @@ export function teammateToolDescriptors(
     ),
   ];
   const spawnProperties: Record<string, unknown> = {
-    name_prefix: { type: 'string', minLength: 1, maxLength: 64 },
-    prompt: { type: 'string', minLength: 1, maxLength: 20000 },
+    name_prefix: {
+      type: 'string',
+      minLength: 1,
+      maxLength: 64,
+      description: 'Requested label; the concrete name comes back in the result.',
+    },
+    prompt: {
+      type: 'string',
+      minLength: 1,
+      maxLength: 20000,
+      description: 'The TeamMate\'s first turn.',
+    },
     agent_runtime: {
       type: 'string',
-      description:
-        'Spawnable agents[].id returned by get_capabilities.agent_runtimes[].id.',
+      description: 'Agent runtime id from get_capabilities.agent_runtimes[].id.',
     },
-    intent: { type: 'string', minLength: 1, maxLength: 2000 },
-    identity: { type: 'string', minLength: 1, maxLength: 4000 },
+    intent: {
+      type: 'string',
+      minLength: 1,
+      maxLength: 2000,
+      description:
+        'One-line subject of the work; shown in list and history and kept ' +
+        'for recovery.',
+    },
+    identity: {
+      type: 'string',
+      minLength: 1,
+      maxLength: 4000,
+      description:
+        'Standing role and boundaries appended to the TeamMate\'s system ' +
+        'prompt for every turn.',
+    },
   };
   if (callerKind === 'dispatcher') {
-    spawnProperties['repo'] = repoInputSchema();
+    spawnProperties['repo'] = {
+      ...repoInputSchema(),
+      description:
+        'Where the TeamMate works; omit for a fresh per-TeamMate directory.',
+    };
   }
   const spawnDescription =
     callerKind === 'dispatcher'
-      ? 'Start a resumable TeamMate agent managed by this dispatcher and submit its first turn. name_prefix is the requested label; spawn RETURNS the concrete, never-reused name that all later send/status/last/close MUST use. Use get_capabilities.agent_runtimes[].id as agent_runtime. intent is required: it is the durable recovery subject. repo is optional: omit it to let Dreamux allocate a fresh per-TeamMate work directory, or pass { mode: reuse-cwd | managed, path?, base_ref?, branch?, slug?, cleanup? } to choose an existing path or create a managed git worktree.'
-      : 'Start a resumable TeamMate agent in this Team\'s shared workspace and submit its first turn. name_prefix is the requested label; spawn RETURNS the concrete, never-reused name that all later send/status/last/close MUST use. Use get_capabilities.agent_runtimes[].id as agent_runtime. intent is required: it is the durable recovery subject. Coordinate edits so only one TeamMate writes the shared workspace unless the work is read-only or edits are independent. This tool does not accept a repo parameter.';
+      ? 'Start a resumable TeamMate agent managed by this dispatcher and submit its first turn. name_prefix is the requested label; spawn RETURNS the concrete, never-reused name that all later send/status/last/close MUST use. Use get_capabilities.agent_runtimes[].id as agent_runtime. intent is required: it is the durable recovery subject. repo is optional: omit it to let Dreamux allocate a fresh per-TeamMate work directory, or pass { mode: reuse-cwd | managed, path?, base_ref?, branch?, slug?, cleanup? } to choose an existing path or create a managed git worktree. Dreamux pushes the turn\'s completion back into your context whether it finished, failed, or was stopped.'
+      : 'Start a resumable TeamMate agent in this Team\'s shared workspace and submit its first turn. name_prefix is the requested label; spawn RETURNS the concrete, never-reused name that all later send/status/last/close MUST use. Use get_capabilities.agent_runtimes[].id as agent_runtime. intent is required: it is the durable recovery subject. Coordinate edits so only one TeamMate writes the shared workspace unless the work is read-only, the edits are independent, or the user asked for parallel edits. This tool does not accept a repo parameter. Dreamux pushes the turn\'s completion back into your context whether it finished, failed, or was stopped.';
   const teammateReceiptSchema = closedObjectSchema(
     {
       teammate: OPEN_OBJECT,
@@ -199,8 +296,17 @@ export function teammateToolDescriptors(
       'workflow_run',
       'Load the bundled `workflow` skill before use. Start a deterministic multi-agent workflow from an inline module script (`script`) or a local file path (`scriptPath`) and return { run_id } immediately; Dreamux pushes one terminal completion when the run finishes.',
       {
-        script: { type: 'string', minLength: 1 },
-        scriptPath: { type: 'string', minLength: 1 },
+        script: {
+          type: 'string',
+          minLength: 1,
+          description: 'Inline workflow module source.',
+        },
+        scriptPath: {
+          type: 'string',
+          minLength: 1,
+          description:
+            'Path to a workflow module file readable by the Dreamux server.',
+        },
         args: {
           type: ['object', 'array', 'string', 'number', 'boolean', 'null'],
           description:
@@ -211,6 +317,10 @@ export function teammateToolDescriptors(
           type: 'integer',
           minimum: MIN_WORKFLOW_MAX_CONCURRENCY,
           maximum: MAX_WORKFLOW_MAX_CONCURRENCY,
+          description:
+            'Agents allowed to run at once; default ' +
+            `${DEFAULT_WORKFLOW_MAX_CONCURRENCY}, range ` +
+            `${MIN_WORKFLOW_MAX_CONCURRENCY}..${MAX_WORKFLOW_MAX_CONCURRENCY}.`,
         },
       },
       [],
@@ -226,7 +336,12 @@ export function teammateToolDescriptors(
     tool(
       'workflow_status',
       'Load the bundled `workflow` skill before use. Read phase, agent progress, concrete TeamMate names, and terminal result for one workflow run.',
-      { run_id: workflowRunIdSchema() },
+      {
+        run_id: {
+          ...workflowRunIdSchema(),
+          description: 'The run_id returned by workflow_run.',
+        },
+      },
       ['run_id'],
       {
         title: 'Read workflow status',
@@ -237,7 +352,12 @@ export function teammateToolDescriptors(
     tool(
       'workflow_stop',
       'Load the bundled `workflow` skill before use. Stop one running workflow and return its resulting status.',
-      { run_id: workflowRunIdSchema() },
+      {
+        run_id: {
+          ...workflowRunIdSchema(),
+          description: 'The run_id returned by workflow_run.',
+        },
+      },
       ['run_id'],
       {
         title: 'Stop a workflow',
@@ -276,11 +396,26 @@ export function teammateToolDescriptors(
     ),
     tool(
       'send',
-      'Send a turn to a TeamMate agent; reopens a closed one from the runtime-native session recorded on it (interpreted by its agent_runtime) first. Pass intent to update the recorded recovery subject before the turn.',
+      'Send a turn to a TeamMate agent; reopens a closed one from the runtime-native session recorded on it (interpreted by its agent_runtime) first. Pass intent to update the recorded recovery subject before the turn. Dreamux pushes the turn\'s completion back into your context whether it finished, failed, or was stopped.',
       {
-        name: { type: 'string', minLength: 1, maxLength: 64 },
-        prompt: { type: 'string', minLength: 1, maxLength: 20000 },
-        intent: { type: 'string', minLength: 1, maxLength: 2000 },
+        name: {
+          type: 'string',
+          minLength: 1,
+          maxLength: 64,
+          description: 'The concrete name returned by spawn.',
+        },
+        prompt: {
+          type: 'string',
+          minLength: 1,
+          maxLength: 20000,
+          description: 'The next turn.',
+        },
+        intent: {
+          type: 'string',
+          minLength: 1,
+          maxLength: 2000,
+          description: 'Replaces the recorded subject before the turn.',
+        },
       },
       ['name', 'prompt'],
       {
@@ -293,8 +428,18 @@ export function teammateToolDescriptors(
       'close',
       'Close a named TeamMate agent and retain its history; send reopens it later. note is required: it records why a recoverable session was stopped.',
       {
-        name: { type: 'string', minLength: 1, maxLength: 64 },
-        note: { type: 'string', minLength: 1, maxLength: 2000 },
+        name: {
+          type: 'string',
+          minLength: 1,
+          maxLength: 64,
+          description: 'The concrete name returned by spawn.',
+        },
+        note: {
+          type: 'string',
+          minLength: 1,
+          maxLength: 2000,
+          description: 'Why the TeamMate is closed; recorded on it.',
+        },
       },
       ['name', 'note'],
       {

--- a/packages/dreamux/tests/mcp-tool-descriptions.test.ts
+++ b/packages/dreamux/tests/mcp-tool-descriptions.test.ts
@@ -1,0 +1,153 @@
+/**
+ * Every input a model can fill on a Dreamux-owned MCP tool says what it is for.
+ *
+ * Both engines defer MCP tool definitions: the model sees a tool name, loads
+ * the definition, and from that point the tool description and the property
+ * descriptions are the whole manual. This walks the `teammate`, `team`, and
+ * `cron` catalogs as each caller sees them — nested objects such as `repo`
+ * included — and fails on any input property that states only its type.
+ *
+ * The negative gates cover the other half of the same move, matching stable
+ * names rather than sentences: the Dispatcher prompts no longer send the model
+ * to `dispatcher-workflow` before tool work, and neither role skill's
+ * frontmatter description asks to be loaded before using a tool.
+ */
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+import {
+  bundledDispatcherSkillRoot,
+  bundledTeamLeaderSkillRoot,
+} from '../src/platform/paths.js';
+import {
+  DREAMUX_DISPATCHER_APPEND_INSTRUCTIONS,
+  DREAMUX_DISPATCHER_BASE_INSTRUCTIONS,
+} from '../src/service/dispatcher-service/base-prompt.js';
+import { createCronMcpDelegate } from '../src/service/scheduler/mcp-delegate.js';
+import { createTeamMcpDelegate } from '../src/service/team-collection/mcp-delegate.js';
+import { teammateToolDescriptors } from '../src/service/teammate-collection/mcp-tool-descriptors.js';
+
+/** What the walk reads out of an advertised tool, which is otherwise opaque. */
+interface AdvertisedTool {
+  readonly name: string;
+  readonly inputSchema: unknown;
+}
+
+/**
+ * `describe()` answers from the caller binding and the descriptors alone, so a
+ * catalog needs no live Dispatcher or scheduler behind it.
+ */
+const CATALOGS: Record<string, readonly unknown[]> = {
+  'teammate (dispatcher)': teammateToolDescriptors('dispatcher'),
+  'teammate (team_leader)': teammateToolDescriptors('team_leader'),
+  'team (dispatcher)': createTeamMcpDelegate({
+    dispatcher: {} as never,
+    caller: { kind: 'dispatcher' },
+  })
+    .describe()
+    .tools,
+  'team (team_leader)': createTeamMcpDelegate({
+    dispatcher: {} as never,
+    caller: { kind: 'team_leader', teamId: 'team-x', leaderName: 'leader-x' },
+  })
+    .describe()
+    .tools,
+  cron: createCronMcpDelegate({
+    scheduler: async () => {
+      throw new Error('unused');
+    },
+  })
+    .describe()
+    .tools,
+};
+
+const SKILL_DESCRIPTION_SOURCES: Record<string, string> = {
+  'dispatcher-workflow': join(
+    bundledDispatcherSkillRoot(),
+    'dispatcher-workflow',
+    'SKILL.md',
+  ),
+  'team-workflow': join(bundledTeamLeaderSkillRoot(), 'team-workflow', 'SKILL.md'),
+};
+
+function isJsonObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+/**
+ * Every property of an object schema by dotted path, descending into nested
+ * object schemas that declare their own properties.
+ */
+function inputProperties(
+  schema: unknown,
+  prefix: string,
+): [string, unknown][] {
+  if (!isJsonObject(schema) || !isJsonObject(schema['properties'])) {
+    return [];
+  }
+  return Object.entries(schema['properties']).flatMap(([name, property]) => [
+    [`${prefix}${name}`, property] as [string, unknown],
+    ...inputProperties(property, `${prefix}${name}.`),
+  ]);
+}
+
+function frontmatterDescription(skillMarkdownPath: string): string {
+  const frontmatter =
+    /^---\n([\s\S]*?)\n---\n/.exec(readFileSync(skillMarkdownPath, 'utf8'))?.[1] ??
+    '';
+  return (
+    frontmatter
+      .split('\n')
+      .find((line) => line.startsWith('description:')) ?? ''
+  );
+}
+
+describe('Dreamux MCP tool descriptions', () => {
+  for (const [catalog, tools] of Object.entries(CATALOGS)) {
+    it(`describes every input property in the ${catalog} catalog`, () => {
+      expect(tools.length).toBeGreaterThan(0);
+      for (const advertised of tools) {
+        const { name, inputSchema } = advertised as AdvertisedTool;
+        for (const [path, property] of inputProperties(inputSchema, '')) {
+          const description = isJsonObject(property)
+            ? property['description']
+            : undefined;
+          expect(
+            typeof description === 'string' && description.trim().length > 0,
+            `${catalog} tool "${name}" input property "${path}" has no description`,
+          ).toBe(true);
+        }
+      }
+    });
+  }
+});
+
+describe('role guidance is not a precondition for tool calls', () => {
+  it('keeps the Dispatcher prompts from routing tool work through a skill', () => {
+    for (const [prompt, text] of Object.entries({
+      DREAMUX_DISPATCHER_BASE_INSTRUCTIONS,
+      DREAMUX_DISPATCHER_APPEND_INSTRUCTIONS,
+    })) {
+      expect(
+        text,
+        `${prompt} still sends the model to dispatcher-workflow`,
+      ).not.toContain('dispatcher-workflow');
+    }
+  });
+
+  it('keeps a load mandate out of the role skill descriptions', () => {
+    for (const [skill, source] of Object.entries(SKILL_DESCRIPTION_SOURCES)) {
+      const description = frontmatterDescription(source);
+      expect(
+        description,
+        `${skill} SKILL.md has no frontmatter description line`,
+      ).not.toBe('');
+      expect(
+        description,
+        `${skill} SKILL.md description still mandates loading before tool use`,
+      ).not.toContain('before using');
+    }
+  });
+});

--- a/packages/dreamux/tests/team-leader-prompt.test.ts
+++ b/packages/dreamux/tests/team-leader-prompt.test.ts
@@ -1,0 +1,146 @@
+/**
+ * What a TeamLeader's runtime is actually launched with.
+ *
+ * The prompt is assembled inside `restoreTeamLeaderAgentForTeam` and never
+ * exported, so the only honest way to read it is the way a provider reads it:
+ * build a real leader through that construction boundary against a minimal
+ * fake Agent Runtime provider, start it, and inspect the launch context the
+ * provider is handed.
+ *
+ * The assertions name durable role facts only — which MCP servers this role
+ * has, that visible delivery goes through the channel's own reply tool, that
+ * private details stay out of public artifacts, and that no skill is mandated
+ * before every turn — never the sentences that carry them.
+ */
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+import type {
+  AgentRuntimeCreateContext,
+  AgentRuntimeProvider,
+  DreamuxLogger,
+} from '@excitedjs/dreamux-types';
+
+import type { AgentRuntimeProviderCatalog } from '../src/agent-runtime/index.js';
+import type { DreamuxConfig, ResolvedAgentConfig } from '../src/config/config.js';
+import { AgentIdentityStore } from '../src/service/agent-entity/identity-store.js';
+import { restoreTeamLeaderAgentForTeam } from '../src/service/team-service/leader-agent.js';
+import { AdmissionLedger } from '../src/service/teammate-service/admission-ledger.js';
+import type { TeammateAgentMcp } from '../src/service/teammate-service/types.js';
+import { reuseCwdWorktree, type WorktreeManager } from '../src/service/worktree/manager.js';
+
+const DISPATCHER = 'flow';
+const TEAM = 'alpha';
+const LEADER = 'alpha-leader';
+const RUNTIME_ID = 'fake-runtime';
+
+const silentLog = {
+  error: () => {},
+  warn: () => {},
+  info: () => {},
+  debug: () => {},
+  trace: () => {},
+  child: () => silentLog,
+} as unknown as DreamuxLogger;
+
+const roots: string[] = [];
+
+afterEach(async () => {
+  for (const root of roots.splice(0)) {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+/** Start a real TeamLeader and return the prompt its runtime was launched with. */
+async function launchedLeaderPrompt(): Promise<string> {
+  const teamRoot = await mkdtemp(join(tmpdir(), 'dreamux-team-leader-prompt-'));
+  roots.push(teamRoot);
+
+  const identities = new AgentIdentityStore({
+    dir: teamRoot,
+    dispatcherId: DISPATCHER,
+    expectedName: null,
+    log: silentLog,
+  });
+  const identity = await identities.create({
+    name: LEADER,
+    teamId: TEAM,
+    agentRuntime: RUNTIME_ID,
+    sourceCwd: teamRoot,
+    sourceRepo: null,
+    cwd: teamRoot,
+    runtimeCwd: teamRoot,
+    worktree: reuseCwdWorktree(teamRoot),
+    intent: null,
+    identityPrompt: null,
+    status: 'running',
+  });
+
+  // The minimal provider: it records the context Core launches it with and
+  // does nothing else. Anything Core calls that is not here fails loudly.
+  const launches: AgentRuntimeCreateContext<unknown>[] = [];
+  const provider = {
+    getCapabilities: () => ({ tags: [], publicConfig: null }),
+    readRecentActivity: async () => ({ records: [], truncated: false }),
+    async createRuntime(context: AgentRuntimeCreateContext<unknown>) {
+      launches.push(context);
+      return {
+        async start() {
+          return { continuity: 'fresh' as const };
+        },
+        async stop() {},
+      };
+    },
+  } as unknown as AgentRuntimeProvider<unknown>;
+
+  const config: DreamuxConfig = {
+    agents: {
+      [RUNTIME_ID]: { provider: 'fake', config: {} } as unknown as ResolvedAgentConfig,
+    },
+    dispatchers: [],
+  };
+
+  const leader = restoreTeamLeaderAgentForTeam({
+    dispatcherId: DISPATCHER,
+    teamId: TEAM,
+    identity,
+    leaderMcp: () =>
+      ({ leases: {}, delegates: [], adminSocketPath: '' }) as unknown as TeammateAgentMcp,
+    config,
+    agentRuntimeProviders: {
+      resolve: () => ({ implementation: provider }),
+    } as unknown as AgentRuntimeProviderCatalog,
+    identities,
+    admissions: new AdmissionLedger(),
+    worktrees: {} as unknown as WorktreeManager,
+    log: silentLog,
+  });
+  await leader.activate();
+
+  expect(launches).toHaveLength(1);
+  return (launches[0]?.systemPrompt?.append ?? []).join('\n');
+}
+
+describe('the prompt a TeamLeader runtime is launched with', () => {
+  it('maps the role\'s MCP servers', async () => {
+    const prompt = await launchedLeaderPrompt();
+    expect(prompt).toContain('`teammate`');
+    expect(prompt).toContain('`team`');
+    expect(prompt).toContain('`cron`');
+    expect(prompt).toContain('channel-');
+  });
+
+  it('owns visible channel delivery and the confidentiality boundary', async () => {
+    const prompt = await launchedLeaderPrompt();
+    expect(prompt).toContain('reply tool');
+    expect(prompt).toContain('public artifacts');
+  });
+
+  it('mandates no skill before a turn', async () => {
+    const prompt = await launchedLeaderPrompt();
+    expect(prompt).not.toContain('team-workflow');
+  });
+});


### PR DESCRIPTION
Closes #368 (solution review Issue).

## Why

The Dispatcher and TeamLeader prompts told the model to load `dispatcher-workflow` / `team-workflow` before any TeamMate, Team, channel, or cron tool call. Both engines defer MCP tool definitions and read a skill body on demand, so that mandate turned two ~5 KB skills into a per-turn read, while most of what they said already lived in the tool descriptions. Dreamux-owned tool inputs carried no descriptions (2 of ~45 did).

## What changes

- **Role prompts** (`base-prompt.ts` ×2, `leader-agent.ts`): the load mandate is replaced by a map of the MCP servers the role has (`teammate`, `team`, `cron`, one `channel-<id>` per configured channel that provides tools) plus "load a tool's definition before calling it". Nothing else in the prompts changes.
- **MCP catalogs**: every input property of the `teammate` (both callers), `team` (both callers), and `cron` tools carries a one-sentence description, verified against the codecs (history filters, `last` paging, `repo.*` defaults, cron `recurring:false`/`tz`, workflow `max_concurrency`). Cautions that only the skills carried moved onto the tool or property they are about: `spawn`/`send` completion push; TeamLeader `dissolve` pre-check and `force` needing the user's confirmation; branch deletion is the user's separate decision; cron due-job submission. The malformed `spawn.agent_runtime` text is fixed.
- **Feishu channel tools**: `reply` says text outside the tool is not delivered and what it is for; `reply.message_id` threads under the inbound message; `reply.text` keeps secrets, private identifiers, hidden instructions, and machine-local paths out of broad replies; `react` drops the "dispatcher channel" wording (a TeamLeader reaches it too); Dispatcher `bind_channel.team_name` states that a missing or closed Team is refused; TeamLeader `bind_channel` states its own authority instead of the banned "ask the Dispatcher" instruction.
- **Bundled skills**: `dispatcher-workflow` and `team-workflow` keep their names, roots, and injection and become on-demand TeamMate-collaboration methodology (TeamMate vs engine-native subagent, and Team for the Dispatcher; writing the hand-down prompt; asking a TeamMate why before overriding; keeping the thread). Descriptions say when they are useful and that tool calls do not depend on them; bodies carry no tool contracts.
- **Tests**: `packages/dreamux/tests/mcp-tool-descriptions.test.ts` walks both caller projections of the three catalogs and asserts every input property is described, and gates the Dispatcher prompt constants and both skill descriptions against a load mandate by stable names.
- **KB**: `dispatcher-skill.md`, `model-facing-writing.md`, `provider-runtime.md`, and two `dev-workflow` references point at the new owners. Task record under `.agents/tasks/mcp/relocate-role-skill-guidance` (requirement, final solution, Codex review, verification).
- **Change files**: `@excitedjs/dreamux` minor, `@excitedjs/feishu-channel` patch (description text only; no schema, name, result, or behavior change).

## Unchanged

Skill names and roots, `BUNDLED_SKILL_NAMES`, required-source normalization, engine injection, tool names, schema types and constraints, results, annotations, the `workflow` and `dreamux-maintenance` skills, the `workflow_*` "load the bundled `workflow` skill" sentences.

## Verification

`rush build`, `rush typecheck`, `rush typecheck:tests`, `rush lint`, focused tests, and the acceptance greps passed in the implementation workflow; the full `rush test` passed except one host-load timeout in `team-dissolve-contract.test.ts` (a git worktree case at 4.6 s of its 5 s budget) that passed 20/20 on re-run and reads nothing this change touches. `.agents/scripts/check.sh` runs in CI (it does not parse under macOS bash 3.2 locally).

An independent code-review workflow (xhigh gear with a requirement-fidelity finder) is running against this change set; accepted findings will land as follow-up commits on this PR.

Opened from a fork because the pushing account has read-only access to this repository.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
