### PR TITLE
feat(channel): support dispatcher-scoped commands

### DIFF
--- a/.agents/domains/channel.md
+++ b/.agents/domains/channel.md
@@ -11,11 +11,13 @@ selection, or the Core event source a Channel subscribes to.
 ## Ownership
 
 A Channel provider owns platform I/O, inbound normalization, target resolution,
-provider-specific tools, message ownership facts, and **routing**: which
-conversation reaches which Team, and what a Collaboration Space is. Dreamux core
-owns Channel session lifetime, the Command port a Channel invokes, the scoped
-Core event source it subscribes to, and generic MCP forwarding. Core holds no
-binding table, no target model, and no Collaboration Space container.
+provider-specific tools, its own Command definitions, message ownership facts,
+and **routing**: which conversation reaches which Team, and what a Collaboration
+Space is. Dreamux core owns Channel session lifetime, the Command port a Channel
+invokes, the registration and admission lifecycle of the Commands a Channel
+serves, the scoped Core event source it subscribes to, and generic MCP
+forwarding. Core holds no binding table, no target model, and no Collaboration
+Space container.
 
 The built-in Feishu provider lives outside the host package:
 
@@ -69,10 +71,41 @@ Command invoker and one read-only, dispatcher-scoped event source. A Channel
 names a Command, hands it a payload, and gets one answer; both public adapters
 bind the same registry, so a Channel gets no smaller catalog and no private door.
 
+A `ChannelInstance` may also expose `commands.definitions()`. Each definition
+owns one stable `local_name`, version-1 input/output schemas, parsing, execution,
+and business outcomes; Core derives the public
+`channel.<encoded channel_id>.<local_name>` name and serves it through that same
+Command registry. The catalog is immutable for the instance's lifetime. Core
+registers every built Channel as one dispatcher-scoped atomic batch, including
+Channels whose catalogs are empty, so the batch is the complete registration
+lease and two dispatchers may independently use the same channel id and local
+names. A channel id keeps its existing arbitrary non-empty-string contract: Core
+encodes unsafe UTF-16 code units as fixed-width `%XXXX` sequences rather than
+narrowing provider configuration.
+
+Business refusals are declared output values. A provider authored against the
+declaration-only types package has no host error class to construct; an
+unrecognized throw is an implementation fault and Core reports it as
+`INTERNAL`. Registration precedes session initialization, but each Channel's own admission
+opens only after that session's `start()` returns. A registered definition whose
+session is starting or closing fails as `CHANNEL_COMMAND_UNAVAILABLE`; once the
+batch is revoked it fails as an unknown Command. Stop and failed-start rollback
+fence every registration synchronously, drain already admitted calls before
+closing their sessions, and revoke the batch only after session teardown.
+`dispatcher.status.channel_descriptors` is the non-sensitive read model for this
+lifecycle: `{ channel_id, provider, identity, commands, status }`, with status
+`starting | ready | closing | closed`. Dormant reads project configured Channels
+as `closed` without materializing a dispatcher, and the descriptor can never
+carry parsed or raw Channel configuration.
+
 Source:
 
 - `/packages/dreamux/src/service/dispatcher-service/index.ts`
+- `/packages/dreamux/src/service/dispatcher-service/input-source-lifecycle.ts`
+- `/packages/dreamux/src/service/dispatcher-service/channel-descriptor.ts`
 - `/packages/dreamux/src/service/channel-service/index.ts`
+- `/packages/dreamux/src/command/channel-commands.ts`
+- `/packages/dreamux/src/command/registry.ts`
 - `/packages/channel/feishu-channel/src/feishu-channel.ts`
 - `/packages/channel/feishu-channel/src/bot.ts`
 - `/packages/channel/feishu-transport/`

--- a/.agents/domains/current-architecture.md
+++ b/.agents/domains/current-architecture.md
@@ -61,9 +61,10 @@ load through the same path):
   (replace/append), bundled-skill injection, and disabled runtime features.
 - **Channel** — a provider implements session lifecycle, calls Core through
   one `invoke(command, payload)` port, subscribes to a dispatcher-scoped
-  read-only event source, and may publish its own MCP tools. Message parsing,
-  routing, binding, targets, Collaboration Spaces, and presentation are all
-  Channel-internal. Owner: [Channel](channel.md).
+  read-only event source, may publish its own MCP tools, and may serve its own
+  Commands into the one registry. Message parsing, routing, binding, targets,
+  Collaboration Spaces, and presentation are all Channel-internal. Owner:
+  [Channel](channel.md).
 
 Key source: `/packages/dreamux/src/registry/`,
 `/packages/dreamux/src/agent-runtime/catalog.ts`,
@@ -74,14 +75,41 @@ Key source: `/packages/dreamux/src/registry/`,
 One `CoreCommandRegistry` holds every Command definition; the owner-only local
 `admin.sock` and a Channel's in-process `invoke` port are transport adapters
 over the same registry — no per-adapter table, allowlist, or exposure flag.
-Namespaces: `teammate.*`, `team.*`, `workflow.*`, `dispatcher.*`,
+Core namespaces: `teammate.*`, `team.*`, `workflow.*`, `dispatcher.*`,
 `scheduler.cron.*`, plus the transport Commands `mcp.describe` / `mcp.toolcall`.
 Admin callers may pass validated `skill_sources` on `teammate.spawn` /
 `team.create`; bundled role skills cannot be shadowed. The remaining
 control-plane slices (events, protocol baseline, introspection, authentication)
 are the one [active proposal](../proposals/admin-control-plane-surface.md).
 
+`channel.*` is the one dynamic namespace. A Channel may serve Commands of its
+own, and the same registry resolves them: same bounds, same input/output schema
+validation, and same canonicalization. Channel-owned business refusals are
+declared output values; an unrecognized throw remains an implementation fault
+reported as `INTERNAL`, so Core owns no provider business-error vocabulary. It is partitioned by
+dispatcher, because two dispatchers may configure the same dispatcher-local
+`channel_id`. A registered name is
+`channel.<encoded channel_id>.<local_name>`, where the Channel declares only the
+single `local_name` segment and Core derives the rest — so a Channel can occupy
+neither a Core name nor another Channel's namespace. The id is percent-encoded
+per UTF-16 code unit at fixed width (`%XXXX`, including `%` itself), which is
+injective, so two distinct ids can never collide on one name.
+
+Registration is a dispatcher act, not a caller act: a dispatcher registers all
+of its Channels' catalogs as one atomic `ChannelCommandBatch`, and that batch
+*is* the registration lease — an empty catalog still holds it, and only the
+batch's own identity releases it. Registration therefore bypasses the
+process-level admission fence in `CoreCommandPort` (composing the process is not
+reaching into it), while every invocation passes through it. Each Channel's
+registration additionally carries its own admission lease, opened when that
+session's `start()` opens external I/O and fenced before teardown, so a name can
+be resolvable while its Channel is not yet or no longer serving. That window
+answers `CHANNEL_COMMAND_UNAVAILABLE` — a retryable `StatedFailure` — which is
+deliberately distinct from `UNKNOWN_METHOD` for a name that does not exist in
+this dispatcher's partition at all.
+
 Key source: `/packages/dreamux/src/command/`,
+`/packages/dreamux/src/command/channel-commands.ts`,
 `/packages/dreamux/src/admin/socket.ts`.
 
 ## MCP Protocol Boundary

--- a/common/changes/@excitedjs/dreamux-types/feat-channel-commands_2026-09-02-22-55.json
+++ b/common/changes/@excitedjs/dreamux-types/feat-channel-commands_2026-09-02-22-55.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Channel providers may now serve their own Commands. A ChannelInstance can compose an optional ChannelCommandCapability beside its session, whose definitions() returns ChannelCommandDefinition values authored like host Commands but naming only a single stable local_name; the host encodes the channel id and derives the registered name channel.<encoded channel_id>.<local_name> from it. Both types are additive and optional, so an existing Channel provider compiles unchanged.",
+      "type": "minor",
+      "packageName": "@excitedjs/dreamux-types"
+    }
+  ],
+  "packageName": "@excitedjs/dreamux-types",
+  "email": "053700@gmail.com"
+}

--- a/common/changes/@excitedjs/dreamux/feat-channel-commands_2026-09-02-22-55.json
+++ b/common/changes/@excitedjs/dreamux/feat-channel-commands_2026-09-02-22-55.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Dreamux now registers Channel-served Commands. Each dispatcher registers its Channels' catalogs as one atomic batch and serves them from the existing Command registry under channel.<encoded channel_id>.<local_name>, where the host percent-encodes the dispatcher-local channel id, over the same admin socket and in-process adapters as built-in Commands. A Command whose Channel has not finished starting, or has begun stopping, is refused as retryable CHANNEL_COMMAND_UNAVAILABLE rather than as an unknown method. dispatcher status now also reports each configured Channel's registered Command names, declared identity, and lifecycle state, and never any Channel configuration value.",
+      "type": "minor",
+      "packageName": "@excitedjs/dreamux"
+    }
+  ],
+  "packageName": "@excitedjs/dreamux",
+  "email": "053700@gmail.com"
+}

--- a/packages/dreamux-types/README.md
+++ b/packages/dreamux-types/README.md
@@ -31,9 +31,11 @@ shared structural types.
   packages;
 - Channel provider/session contracts, target shapes, inbound envelope shapes,
   tool descriptor/call shapes, config/session contexts, optional strict
-  collaboration operations, and dispatcher-scoped read-only core event DTOs.
-  Channel delivery receipts are status-only and the core event surface carries
-  no service Turn submitted/settled events;
+  collaboration operations, optional Channel-owned Command definitions
+  (`ChannelCommandDefinition` / `ChannelCommandCapability`), and
+  dispatcher-scoped read-only core event DTOs. Channel delivery receipts are
+  status-only and the core event surface carries no service Turn
+  submitted/settled events;
 - a minimal public logger type (`DreamuxLogger`).
 
 It does **not** export runtime implementations, default loggers, loader logic,
@@ -82,6 +84,36 @@ A provider implements the full contract against this package only — see
 > `packages/dreamux/src/agent-runtime/types.ts`) is the runtime-split slice's job
 > (issue #209 slice 3). The public target published here is already stable for
 > external and built-in runtime/channel packages to author against.
+
+## Channel Command contract
+
+A Channel may serve Commands of its own by composing an optional
+`ChannelCommandCapability` beside its session, exactly the way it composes
+`mcp` — a Channel with no Commands omits the member rather than returning an
+empty catalog. `definitions()` is read once per created instance, so a catalog
+is immutable for the life of that instance.
+
+A `ChannelCommandDefinition` is authored like a Core one — `version`,
+`input`/`output` JSON schemas, `parse`, `execute` — with one difference: it
+declares a single stable `local_name` segment and the host derives the
+registered name from it by encoding the dispatcher-local channel id, so a
+Channel can occupy neither a host name nor another Channel's namespace. The host
+applies the same payload bounds, schema validation, and result canonicalization
+it applies to its own Commands.
+
+A business refusal belongs in the declared `output` schema, not in a thrown
+error. This package is declaration-only and exports no error base a provider
+could construct, and the host classifies any unrecognized throw from a handler
+as `INTERNAL` with no stated next step — so a refusal a caller is meant to read
+and act on must be a value `execute` returns and `output` declares. Reserve
+throwing for genuine implementation faults.
+
+The host also owns when those Commands answer. They become resolvable when the
+dispatcher registers the session's catalog and start accepting calls only once
+that session's `start()` has opened external I/O; between those points, and
+again from the moment teardown fences admission, a call is refused with the
+retryable `CHANNEL_COMMAND_UNAVAILABLE` rather than reported as an unknown
+method.
 
 ## Build / test
 

--- a/packages/dreamux-types/src/channel.ts
+++ b/packages/dreamux-types/src/channel.ts
@@ -18,8 +18,9 @@
  * only and must not import `@excitedjs/dreamux`.
  */
 import type { DreamuxLogger } from './logger.js';
+import type { CoreCommandContext } from './command.js';
 import type { JsonInvokeResult, JsonInvoker } from './invoke.js';
-import type { JsonValue } from './json.js';
+import type { JsonSchema, JsonValue } from './json.js';
 import type {
   DreamuxEnvironment,
   ProviderBinCheck,
@@ -254,12 +255,62 @@ export type ChannelMcpToolOutcome = JsonInvokeResult<
 >;
 
 /**
- * What `createSession` produced. MCP is composed outside the base session, so a
- * Channel with no tools simply omits it rather than implementing fake members.
+ * One Channel-owned Command, authored exactly like a Core one.
+ *
+ * The only difference from {@link CoreCommandDefinition} is the name: a Channel
+ * declares a `local_name` — a single stable segment — and Core derives the full
+ * registered name from it. A Channel therefore cannot occupy a Core name or
+ * another Channel's namespace, and no caller has to assemble an unverified
+ * string.
+ *
+ * Everything else is deliberately identical, because the invocation is
+ * identical: the same registry resolves it, the same bounds and input schema
+ * validate the payload, and the same canonicalization and output schema check
+ * the result. There is no second call result and no Channel-specific adapter.
+ *
+ * A refusal the caller is meant to read belongs in `output`, not in a throw.
+ * This package is declaration-only, so a Channel authored against it alone has
+ * no Core error base to construct; Core classifies an unrecognized throw as
+ * `INTERNAL` with no stated next step, which is right for an implementation
+ * fault and wrong for a business answer. So a Channel that must say "this chat
+ * is not bindable" declares that outcome in its own output schema and returns
+ * it.
+ */
+export interface ChannelCommandDefinition<Input = unknown, Output = unknown> {
+  /**
+   * A single stable segment, unique within the Channel that declares it. Core
+   * rejects a name it cannot register unambiguously rather than encoding it.
+   */
+  readonly local_name: string;
+  readonly version: 1;
+  readonly input: JsonSchema;
+  readonly output: JsonSchema;
+  parse(payload: JsonValue): Input;
+  execute(context: CoreCommandContext, input: Input): Promise<Output>;
+}
+
+/**
+ * Optional Channel Command composition, declared beside the session because the
+ * handlers need the live session and the Channel-owned state it loaded.
+ *
+ * Core composes the returned definitions and owns none of them: not their
+ * schemas, not their business meaning, and not the outcomes they report. It is
+ * read once per instance, so a catalog is immutable for the life of that
+ * instance — the same rule {@link ChannelMcpCapability} follows.
+ */
+export interface ChannelCommandCapability {
+  definitions(): readonly ChannelCommandDefinition[];
+}
+
+/**
+ * What `createSession` produced. MCP and Commands are composed outside the base
+ * session, so a Channel with neither simply omits them rather than implementing
+ * fake members.
  */
 export interface ChannelInstance {
   readonly session: ChannelSession;
   readonly mcp?: ChannelSessionMcpCapability;
+  readonly commands?: ChannelCommandCapability;
 }
 
 export interface ChannelConfigContext {

--- a/packages/dreamux-types/src/index.ts
+++ b/packages/dreamux-types/src/index.ts
@@ -127,6 +127,8 @@ export type {
 } from './teammate.js';
 export type {
   ChannelBinCheck,
+  ChannelCommandCapability,
+  ChannelCommandDefinition,
   ChannelConfigCapability,
   ChannelConfigContext,
   ChannelCorePort,

--- a/packages/dreamux-types/tests/channel-provider-contract.test.ts
+++ b/packages/dreamux-types/tests/channel-provider-contract.test.ts
@@ -13,6 +13,8 @@
 import { describe, expect, it } from 'vitest';
 
 import type {
+  ChannelCommandCapability,
+  ChannelCommandDefinition,
   ChannelCorePort,
   ChannelCoreEvent,
   ChannelEventSource,
@@ -123,8 +125,8 @@ describe('ChannelEventSource / ChannelEventSubscription stay minimal', () => {
   });
 });
 
-describe('ChannelInstance composes MCP as optional, never a required fake member', () => {
-  it('a minimal Channel with no tools omits mcp entirely and still satisfies ChannelInstance', () => {
+describe('ChannelInstance composes MCP and Commands as optional, never required fake members', () => {
+  it('a minimal Channel with no tools and no Commands omits both and still satisfies ChannelInstance', () => {
     const session: ChannelSession = {
       async initialize(): Promise<void> {},
       async start(): Promise<void> {},
@@ -133,11 +135,61 @@ describe('ChannelInstance composes MCP as optional, never a required fake member
     const instance: ChannelInstance = { session };
 
     expect(instance.mcp).toBeUndefined();
+    expect(instance.commands).toBeUndefined();
     expect(Object.keys(instance)).toEqual(['session']);
   });
 
-  it('ChannelInstance has exactly session and the optional mcp — nothing else', () => {
-    assertType<Equal<keyof ChannelInstance, 'session' | 'mcp'>>();
+  it('ChannelInstance has exactly session and the optional mcp/commands — nothing else', () => {
+    assertType<Equal<keyof ChannelInstance, 'session' | 'mcp' | 'commands'>>();
+  });
+
+  it('a Channel that declares Commands composes them beside the session, authored like a Core one', async () => {
+    const session: ChannelSession = {
+      async initialize(): Promise<void> {},
+      async start(): Promise<void> {},
+      async close(): Promise<void> {},
+    };
+    // A Channel-owned Command is a whole definition, not a handler reference:
+    // it declares its own schemas and parses its own payload, which is what
+    // lets Core validate it through the identical path a Core Command takes.
+    const bind: ChannelCommandDefinition<{ chat: string }, { bound: boolean }> = {
+      local_name: 'bind_channel',
+      version: 1,
+      input: {
+        type: 'object',
+        additionalProperties: false,
+        properties: { chat: { type: 'string' } },
+        required: ['chat'],
+      },
+      output: {
+        type: 'object',
+        additionalProperties: false,
+        properties: { bound: { type: 'boolean' } },
+        required: ['bound'],
+      },
+      parse(payload) {
+        return { chat: (payload as { chat: string }).chat };
+      },
+      async execute() {
+        return { bound: true };
+      },
+    };
+    const commands: ChannelCommandCapability = {
+      definitions: () => [bind as ChannelCommandDefinition],
+    };
+    const instance: ChannelInstance = { session, commands };
+
+    expect(instance.commands?.definitions()).toHaveLength(1);
+    expect(instance.commands?.definitions()[0]?.local_name).toBe('bind_channel');
+    // The whole capability is one method: Core reads a catalog, it never asks
+    // a Channel to add, remove, or re-describe one Command at a time.
+    assertType<Equal<keyof ChannelCommandCapability, 'definitions'>>();
+    assertType<
+      Equal<
+        keyof ChannelCommandDefinition,
+        'local_name' | 'version' | 'input' | 'output' | 'parse' | 'execute'
+      >
+    >();
   });
 });
 

--- a/packages/dreamux/README.md
+++ b/packages/dreamux/README.md
@@ -71,6 +71,18 @@ Design background:
   changed through that provider's own MCP tools. Dreamux Core has no binding
   table and no Collaboration Space container; a Channel names a Team when it
   submits, and Core takes it from there.
+- **A Channel may serve Commands, not just call them.** A Channel provider can
+  compose optional Command definitions beside its session, each naming one
+  stable local name; Core registers them per dispatcher as
+  `channel.<encoded channel_id>.<local_name>` — the dispatcher-local channel id
+  is percent-encoded so no id can collide with another — and serves them from
+  the same registry as its own Commands, over the same admin socket and
+  in-process ports. Core owns only when they answer, never what they mean: a
+  registered Command whose Channel has not finished starting, or has begun
+  stopping, is refused as retryable rather than reported as unknown. `dreamux
+  dispatcher status --id <ID>` reports each configured Channel's registered
+  Command names, its operator-declared identity, and its lifecycle state — and
+  no Channel configuration value.
 - **TeamMate is server-hosted.** `spawn` starts a named, semi-resident TeamMate
   and returns its concrete name; `send` submits follow-up turns and reopens a
   closed TeamMate. `last` reads the provider's recent Activity Records — bounded

--- a/packages/dreamux/src/command/channel-commands.ts
+++ b/packages/dreamux/src/command/channel-commands.ts
@@ -1,0 +1,468 @@
+/**
+ * The dispatcher-scoped half of the one Command registry.
+ *
+ * Core Commands are process-level and fixed at composition. A Channel's
+ * Commands are neither: the instance that serves them is built per dispatcher,
+ * per start, and it stops. So they are held here, keyed by the dispatcher that
+ * built them, and reached through the same {@link CoreCommands} entry point —
+ * there is no second registry, no second invoke path, and no second result.
+ *
+ * Two scopes, for two different reasons. The `channel.<channel_id>.` namespace
+ * keeps two Channels of one dispatcher from colliding; the dispatcher partition
+ * lets two dispatchers configure the same channel id without either seeing the
+ * other's handler.
+ *
+ * A registration is also the admission fence for what it registered. A
+ * definition exists from the moment its dispatcher's catalog is registered —
+ * before any session has started — so that a caller never depends on channel
+ * start order. Until the owning session is live, and again once it is closing,
+ * the Command answers {@link ChannelCommandUnavailableError}, which says
+ * "known, not serving now" rather than "no such Command".
+ */
+import type {
+  ChannelCommandDefinition,
+  CoreCommandContext,
+  JsonValue,
+} from '@excitedjs/dreamux-types';
+
+import { validateDispatcherId } from '../state/dispatcher-id.js';
+import { StatedFailure, ValidationError, throwCallerMistake } from './errors.js';
+
+/**
+ * The namespace Core reserves for Channel-registered Commands. No Core Command
+ * may live under it, which is what makes the two halves of the registry
+ * distinguishable by name alone.
+ */
+export const CHANNEL_COMMAND_PREFIX = 'channel.';
+
+/**
+ * One name segment: no dot, so `channel.<channel_id>.<local_name>` parses back
+ * to exactly one channel id and one local name.
+ *
+ * This is the syntax a Channel package authors its `local_name` in. It is a
+ * rule on new code — a package chooses its own Command names — so Core rejects
+ * a `local_name` it cannot register verbatim rather than rewriting it into
+ * something the package never wrote.
+ */
+const NAME_SEGMENT = /^[A-Za-z0-9][A-Za-z0-9_-]*$/;
+
+const NAME_SEGMENT_RULE =
+  'start with an ASCII letter or digit and contain only ASCII letters, ' +
+  'digits, underscore, or dash';
+
+/** Code units a channel id may carry into a command name unencoded. */
+const CHANNEL_ID_SAFE = /^[A-Za-z0-9_-]$/;
+
+/**
+ * Encode one channel id into a single unambiguous name segment.
+ *
+ * A channel id is operator config, and its contract is "non-empty, unique
+ * within its dispatcher" — dots, colons, slashes, and non-ASCII are all legal
+ * today. Rejecting them here would narrow a config contract Core already
+ * accepted, so the id is encoded rather than refused.
+ *
+ * The encoding is per UTF-16 code unit, not per code point: an unsafe unit
+ * becomes `%` followed by exactly four upper-case hex digits. A JS string is a
+ * code-unit sequence and config only promises "non-empty string", so it may
+ * hold an unpaired surrogate; a UTF-8 encoder would fold every such unit onto
+ * U+FFFD and make two distinct legal ids collide. Encoding the units keeps the
+ * map injective over every string the config contract admits.
+ *
+ * `%` is itself unsafe, so it is encoded too (`a.b` → `a%002Eb`, the literal id
+ * `a%002Eb` → `a%0025002Eb`), the fixed width makes the encoding readable back
+ * one unit at a time, and the segment contains no dot — so the full name still
+ * splits into exactly three parts.
+ */
+export function encodeChannelId(channelId: string): string {
+  let encoded = '';
+  for (let index = 0; index < channelId.length; index += 1) {
+    const unit = channelId[index] as string;
+    if (CHANNEL_ID_SAFE.test(unit)) {
+      encoded += unit;
+      continue;
+    }
+    const code = channelId.charCodeAt(index);
+    encoded += `%${code.toString(16).toUpperCase().padStart(4, '0')}`;
+  }
+  return encoded;
+}
+
+/** The full registered name of one Channel Command. */
+export function channelCommandName(
+  channelId: string,
+  localName: string,
+): string {
+  return `${CHANNEL_COMMAND_PREFIX}${encodeChannelId(channelId)}.${localName}`;
+}
+
+/**
+ * The Command is registered, but the Channel instance behind it is not serving:
+ * its dispatcher has not started it yet, or it is closing.
+ *
+ * Retryable by construction — the caller's request was well-formed and the name
+ * is real — which is why it is not an `UNKNOWN_METHOD` and not an internal
+ * defect.
+ */
+export class ChannelCommandUnavailableError extends StatedFailure {
+  constructor(name: string) {
+    super(
+      'CHANNEL_COMMAND_UNAVAILABLE',
+      `channel command '${name}' is registered but its channel is not serving requests`,
+      'Retry once the channel is running; the command name is correct.',
+    );
+  }
+}
+
+/** What the registry keeps for one registered definition. */
+interface ChannelCommandEntry {
+  readonly name: string;
+  readonly definition: ChannelCommandDefinition;
+  readonly registration: ChannelCommandRegistration;
+}
+
+/**
+ * One Channel's registered catalog, and the admission fence over it.
+ *
+ * It tracks its own accepted invocations because draining is per-Channel: a
+ * closing session must let the calls it already accepted finish before its
+ * definitions go away, while the rest of the dispatcher keeps serving.
+ */
+export class ChannelCommandRegistration {
+  private admitting = false;
+  private readonly inFlight = new Set<Promise<unknown>>();
+
+  constructor(
+    readonly dispatcherId: string,
+    readonly channelId: string,
+    readonly names: readonly string[],
+  ) {}
+
+  /** Serve requests. Called once the owning session's own start has returned. */
+  openAdmission(): void {
+    this.admitting = true;
+  }
+
+  /** Refuse further requests. Synchronous and idempotent, like every fence. */
+  closeAdmission(): void {
+    this.admitting = false;
+  }
+
+  get accepting(): boolean {
+    return this.admitting;
+  }
+
+  /** Await every invocation admitted before the fence closed. */
+  async drain(): Promise<void> {
+    while (this.inFlight.size > 0) {
+      await Promise.allSettled([...this.inFlight]);
+    }
+  }
+
+  /**
+   * Admit one invocation and run it, as a single indivisible step.
+   *
+   * Checking the fence, joining the drain set, and starting the handler cannot
+   * be three separate statements. The handler is Channel-owned code: it may
+   * synchronously reach back into its own session and close it — a bind that
+   * fails its precondition and tears the session down does exactly that — and
+   * if the fence closed and drained in the window between "admitted" and
+   * "tracked", the session would be closed and its definitions revoked while
+   * this call was still running. So the drain entry is registered *before* the
+   * handler is invoked, and it is a separate promise from the handler's own
+   * result so a rejection cannot escape the drain set unobserved.
+   *
+   * Returns `null` when the fence is closed; the caller turns that into the
+   * retryable unavailable failure. It is the only way in, so there is no path
+   * that runs a handler without being drained.
+   *
+   * `run()` is called inside a `try` because a function declared to return a
+   * promise can still throw before producing one, and this method is reachable
+   * by any holder of a registration. A throw that escaped between the drain
+   * entry and the settlement wiring below would leave an entry nothing ever
+   * removes, and {@link drain} — which shutdown awaits before closing the
+   * session — would never return. The failure is re-raised unchanged; only the
+   * bookkeeping is undone.
+   */
+  admit(run: () => Promise<JsonValue>): Promise<JsonValue> | null {
+    if (!this.admitting) return null;
+    let settle!: () => void;
+    const tracked = new Promise<void>((resolve) => {
+      settle = resolve;
+    });
+    const release = (): void => {
+      this.inFlight.delete(tracked);
+      settle();
+    };
+    this.inFlight.add(tracked);
+    let result: Promise<JsonValue>;
+    try {
+      result = run();
+    } catch (error) {
+      release();
+      throw error;
+    }
+    void result.catch(() => {}).finally(release);
+    return result;
+  }
+}
+
+/**
+ * Everything one dispatcher registered in a single atomic step, and the only
+ * handle that can take it back.
+ *
+ * The batch is the unit because the catalog is validated as a whole: a
+ * dispatcher whose second Channel declares a colliding name registers neither,
+ * so a failed start never leaves half a catalog behind. It is also the
+ * dispatcher's registration lease — while it is live no other batch may
+ * register for that dispatcher, whether or not it named a single Command.
+ */
+export class ChannelCommandBatch {
+  constructor(
+    private readonly owner: ChannelCommands,
+    readonly dispatcherId: string,
+    private readonly registrations: ReadonlyMap<
+      string,
+      ChannelCommandRegistration
+    >,
+  ) {}
+
+  /** The registration for one channel of this batch, or `null`. */
+  get(channelId: string): ChannelCommandRegistration | null {
+    return this.registrations.get(channelId) ?? null;
+  }
+
+  /** Every registered name, keyed by channel. Read-only projection. */
+  namesByChannel(): ReadonlyMap<string, readonly string[]> {
+    return new Map(
+      [...this.registrations].map(([channelId, registration]) => [
+        channelId,
+        registration.names,
+      ]),
+    );
+  }
+
+  closeAdmission(): void {
+    for (const registration of this.registrations.values()) {
+      registration.closeAdmission();
+    }
+  }
+
+  async drain(): Promise<void> {
+    for (const registration of this.registrations.values()) {
+      await registration.drain();
+    }
+  }
+
+  /**
+   * Remove every definition this batch registered and release the dispatcher.
+   * Idempotent, and the only way the next start gets to register.
+   */
+  unregister(): void {
+    for (const registration of this.registrations.values()) {
+      this.owner.revoke(registration);
+    }
+    this.owner.release(this);
+  }
+}
+
+/** What one Channel instance contributed to a dispatcher's catalog. */
+export interface ChannelCommandSource {
+  readonly channelId: string;
+  readonly definitions: readonly ChannelCommandDefinition[];
+}
+
+/**
+ * The registration half of the Command port, as a dispatcher sees it.
+ *
+ * A dispatcher registers and revokes its Channels' catalogs; it never reaches
+ * the registry to invoke one. Naming that as its own interface keeps the
+ * lifecycle's dependency exactly as wide as what it does.
+ */
+export interface ChannelCommandRegistrar {
+  registerChannelCommands(
+    dispatcherId: string,
+    sources: readonly ChannelCommandSource[],
+  ): ChannelCommandBatch;
+  channelCommandNames(dispatcherId: string): readonly string[];
+}
+
+export class ChannelCommands {
+  /** dispatcher id → full command name → entry. */
+  private readonly byDispatcher = new Map<
+    string,
+    Map<string, ChannelCommandEntry>
+  >();
+  /**
+   * dispatcher id → the batch that currently owns its catalog.
+   *
+   * Separate from the map above because the two are not the same fact: a
+   * dispatcher whose Channels declare no Commands registers an empty catalog
+   * and still owns its registration, and only its own batch may give it back.
+   */
+  private readonly owners = new Map<string, ChannelCommandBatch>();
+
+  /**
+   * Validate and register one dispatcher's whole Channel catalog.
+   *
+   * Nothing is inserted until every definition in every source has passed, so a
+   * rejected catalog leaves the registry exactly as it was. Registrations start
+   * closed: the definitions are resolvable immediately — that is the point, a
+   * caller must not have to know channel start order — but they do not serve
+   * until their session is live.
+   *
+   * One batch owns a dispatcher's whole catalog, so a dispatcher that already
+   * has one cannot register a second: the batch is what closes, drains, and
+   * revokes, and two of them would each hold half of a lifecycle neither can
+   * complete. One source per channel id, and no empty id, for the same reason.
+   */
+  register(
+    dispatcherId: string,
+    sources: readonly ChannelCommandSource[],
+    assertUnreserved: (name: string) => void,
+  ): ChannelCommandBatch {
+    const staged = new Map<string, ChannelCommandEntry>();
+    const registrations = new Map<string, ChannelCommandRegistration>();
+    if (this.owners.has(dispatcherId)) {
+      throw new Error(
+        `dispatcher ${JSON.stringify(dispatcherId)} already has a registered ` +
+          'channel command catalog; revoke it before registering another',
+      );
+    }
+    for (const source of sources) {
+      if (source.channelId === '') {
+        // An empty id would encode to an empty segment, so `channel..name`
+        // would name a channel that cannot be identified — and the batch could
+        // not report which channel to close. Config forbids it; the registry
+        // says so itself rather than trusting its caller.
+        throw new Error(
+          `dispatcher ${JSON.stringify(dispatcherId)} registered channel ` +
+            'commands for an empty channel id',
+        );
+      }
+      if (registrations.has(source.channelId)) {
+        // One registration per channel is what makes the batch a complete
+        // handle: a second source for the same id would leave the first
+        // source's entries owned by a registration the batch no longer holds,
+        // so nothing could close, drain, or revoke them.
+        throw new Error(
+          `dispatcher ${JSON.stringify(dispatcherId)} registered channel ` +
+            `commands for ${JSON.stringify(source.channelId)} twice`,
+        );
+      }
+      const names: string[] = [];
+      const registration = new ChannelCommandRegistration(
+        dispatcherId,
+        source.channelId,
+        names,
+      );
+      for (const definition of source.definitions) {
+        const name = validatedName(source.channelId, definition);
+        assertUnreserved(name);
+        if (staged.has(name)) {
+          // Two owners for one name would mean two authorities for one action —
+          // the same rule the Core half enforces at composition.
+          throw new Error(
+            `channel command ${JSON.stringify(name)} is registered twice in ` +
+              `dispatcher ${JSON.stringify(dispatcherId)}`,
+          );
+        }
+        staged.set(name, { name, definition, registration });
+        names.push(name);
+      }
+      registrations.set(source.channelId, registration);
+    }
+    // An all-empty catalog leaves no entry behind: a dispatcher whose Channels
+    // declare no Commands must look exactly like one that registered nothing.
+    // It still takes the registration lease below — owning nothing is not the
+    // same as owning no lifecycle.
+    if (staged.size > 0) this.byDispatcher.set(dispatcherId, staged);
+    const batch = new ChannelCommandBatch(this, dispatcherId, registrations);
+    this.owners.set(dispatcherId, batch);
+    return batch;
+  }
+
+  /**
+   * Give the dispatcher's registration back, if this batch still holds it.
+   *
+   * Guarded by identity rather than by id so a late `unregister()` from a
+   * superseded batch cannot release the run that replaced it.
+   */
+  release(batch: ChannelCommandBatch): void {
+    if (this.owners.get(batch.dispatcherId) === batch) {
+      this.owners.delete(batch.dispatcherId);
+    }
+  }
+
+  /** Remove everything one registration owns. Idempotent. */
+  revoke(registration: ChannelCommandRegistration): void {
+    const commands = this.byDispatcher.get(registration.dispatcherId);
+    if (commands === undefined) return;
+    for (const name of registration.names) {
+      if (commands.get(name)?.registration === registration) {
+        commands.delete(name);
+      }
+    }
+    if (commands.size === 0) this.byDispatcher.delete(registration.dispatcherId);
+  }
+
+  resolve(
+    dispatcherId: string,
+    name: string,
+  ): ChannelCommandEntry | undefined {
+    return this.byDispatcher.get(dispatcherId)?.get(name);
+  }
+
+  /** Every registered name for one dispatcher. Diagnostics only. */
+  names(dispatcherId: string): readonly string[] {
+    return [...(this.byDispatcher.get(dispatcherId)?.keys() ?? [])];
+  }
+}
+
+function validatedName(
+  channelId: string,
+  definition: ChannelCommandDefinition,
+): string {
+  if (!NAME_SEGMENT.test(definition.local_name)) {
+    throw new Error(
+      `channel command local_name ${JSON.stringify(definition.local_name)} ` +
+        `cannot be part of a command name; it must ${NAME_SEGMENT_RULE}`,
+    );
+  }
+  if (definition.version !== 1) {
+    throw new Error(
+      `channel command ${JSON.stringify(definition.local_name)} declares ` +
+        `version ${JSON.stringify(definition.version)}; only version 1 exists`,
+    );
+  }
+  return channelCommandName(channelId, definition.local_name);
+}
+
+/**
+ * Read the dispatcher a Channel Command invocation is scoped to.
+ *
+ * Addressing is validated exactly as it is for a Core dispatcher-scoped
+ * Command — the same id rule, the same `RuleViolation` → `BAD_REQUEST`
+ * narrowing — so a malformed `dispatcher_id` is the caller's mistake here too
+ * rather than falling through to `UNKNOWN_METHOD`, which would tell the caller
+ * the Command does not exist when the real fault is the address. What it
+ * deliberately does not do is look the dispatcher up: a Channel Command is
+ * resolved in the partition its own registration created, so it needs no host.
+ */
+export function channelCommandDispatcher(
+  context: CoreCommandContext,
+  name: string,
+): string {
+  const id = context.dispatcher_id;
+  if (id === undefined) {
+    throw new ValidationError(
+      `channel command '${name}' is dispatcher-scoped and the caller supplied ` +
+        'no dispatcher_id',
+    );
+  }
+  try {
+    return validateDispatcherId(id);
+  } catch (error) {
+    // The id rule speaks in its own words; only its type becomes the caller's.
+    throwCallerMistake(error);
+  }
+}

--- a/packages/dreamux/src/command/host.ts
+++ b/packages/dreamux/src/command/host.ts
@@ -8,6 +8,7 @@
  */
 import type { DispatcherRow } from '../state/dispatcher-store.js';
 import type { DispatcherService } from '../service/dispatcher-service/index.js';
+import type { ChannelDescriptor } from '../service/dispatcher-service/channel-descriptor.js';
 import type {
   DispatcherRuntimeStatus,
   DispatcherSummary,
@@ -25,6 +26,15 @@ export interface CoreCommandHost {
   dispatcherRow(dispatcherId: string): DispatcherRow | null;
   /** The current runtime projection of one dispatcher, live or persisted. */
   dispatcherRuntimeStatus(dispatcherId: string): Promise<DispatcherRuntimeStatus>;
+  /**
+   * The non-sensitive description of one dispatcher's configured Channels.
+   *
+   * A Channel's Commands are registered dynamically, so their names are a
+   * runtime fact no caller can derive from config. This is where a caller reads
+   * them, together with the identification and lifecycle facts that make them
+   * actionable. It carries no Channel configuration, raw or parsed.
+   */
+  dispatcherChannels(dispatcherId: string): ChannelDescriptor[];
   /** Get-or-build the per-dispatcher aggregate. */
   dispatcher(dispatcherId: string): DispatcherService;
   /**

--- a/packages/dreamux/src/command/port.ts
+++ b/packages/dreamux/src/command/port.ts
@@ -17,10 +17,16 @@ import type {
   JsonValue,
 } from '@excitedjs/dreamux-types';
 
+import type {
+  ChannelCommandBatch,
+  ChannelCommandRegistrar,
+  ChannelCommandSource,
+} from './channel-commands.js';
 import { ServerShuttingDownError } from './errors.js';
 import type { CoreCommands } from './registry.js';
 
-export class CoreCommandPort implements CoreCommandRegistry {
+export class CoreCommandPort
+implements CoreCommandRegistry, ChannelCommandRegistrar {
   private accepting = true;
   private readonly inFlight = new Set<Promise<unknown>>();
 
@@ -29,6 +35,26 @@ export class CoreCommandPort implements CoreCommandRegistry {
   /** Every registered name, in registration order. Diagnostics only. */
   names(): readonly string[] {
     return this.registry.names();
+  }
+
+  /**
+   * Register one dispatcher's Channel catalog.
+   *
+   * Registration is not an invocation, so it does not pass the admission fence
+   * above: a dispatcher composing its own Channels is the process building
+   * itself, not a caller reaching in. What the registration produces is fenced
+   * by its own per-Channel admission.
+   */
+  registerChannelCommands(
+    dispatcherId: string,
+    sources: readonly ChannelCommandSource[],
+  ): ChannelCommandBatch {
+    return this.registry.registerChannelCommands(dispatcherId, sources);
+  }
+
+  /** Every Channel Command name registered for one dispatcher. */
+  channelCommandNames(dispatcherId: string): readonly string[] {
+    return this.registry.channelCommandNames(dispatcherId);
   }
 
   invoke(

--- a/packages/dreamux/src/command/registry.ts
+++ b/packages/dreamux/src/command/registry.ts
@@ -26,6 +26,7 @@
  * pagination owned by the domain that produces it.
  */
 import type {
+  ChannelCommandDefinition,
   CoreCommandContext,
   CoreCommandDefinition,
   CoreCommandRegistry,
@@ -38,6 +39,14 @@ import {
   JSON_VALUE_UNBOUNDED,
   type JsonValueBounds,
 } from '../platform/json-value.js';
+import {
+  ChannelCommands,
+  ChannelCommandUnavailableError,
+  channelCommandDispatcher,
+  CHANNEL_COMMAND_PREFIX,
+  type ChannelCommandBatch,
+  type ChannelCommandSource,
+} from './channel-commands.js';
 import {
   InternalError,
   UnknownCommandError,
@@ -72,8 +81,21 @@ const EMPTY_PAYLOAD: JsonValue = canonicalJsonValue({}, COMMAND_PAYLOAD_BOUNDS);
 /** A definition erased to what the registry itself needs to know. */
 export type AnyCoreCommand = CoreCommandDefinition<string, unknown, unknown>;
 
+/**
+ * The part of a definition the shared validation steps read. Both halves of the
+ * registry satisfy it, which is what lets one set of steps serve both: a
+ * Channel Command differs only in how its name was derived.
+ */
+type SchemaOwner = Pick<AnyCoreCommand, 'input' | 'output'>;
+
 export class CoreCommands implements CoreCommandRegistry {
   private readonly commands = new Map<string, AnyCoreCommand>();
+  /**
+   * The dispatcher-scoped half. Core Commands are fixed at composition; a
+   * Channel's are registered when its dispatcher builds it and revoked when
+   * that dispatcher stops, so they cannot live in the map above.
+   */
+  private readonly channelCommands = new ChannelCommands();
 
   constructor(definitions: readonly AnyCoreCommand[]) {
     for (const definition of definitions) {
@@ -81,6 +103,14 @@ export class CoreCommands implements CoreCommandRegistry {
         // Two owners for one name would mean two authorities for one action.
         throw new Error(
           `core command ${JSON.stringify(definition.name)} is registered twice`,
+        );
+      }
+      if (definition.name.startsWith(CHANNEL_COMMAND_PREFIX)) {
+        // The prefix is what makes the two halves distinguishable by name
+        // alone; a Core Command inside it would make resolution ambiguous.
+        throw new Error(
+          `core command ${JSON.stringify(definition.name)} uses the reserved ` +
+            `${JSON.stringify(CHANNEL_COMMAND_PREFIX)} namespace`,
         );
       }
       // Every declared branch is proven here, not on the first invocation that
@@ -97,24 +127,97 @@ export class CoreCommands implements CoreCommandRegistry {
     return [...this.commands.keys()];
   }
 
+  /**
+   * Register one dispatcher's whole Channel catalog, atomically.
+   *
+   * Validation matches the Core half exactly — malformed schemas and duplicate
+   * names are composition errors that fail the caller's start, not request
+   * errors discovered later.
+   */
+  registerChannelCommands(
+    dispatcherId: string,
+    sources: readonly ChannelCommandSource[],
+  ): ChannelCommandBatch {
+    for (const source of sources) {
+      for (const definition of source.definitions) {
+        assertChannelSchemaDefinition(source.channelId, definition, 'input');
+        assertChannelSchemaDefinition(source.channelId, definition, 'output');
+      }
+    }
+    return this.channelCommands.register(dispatcherId, sources, (name) => {
+      if (this.commands.has(name)) {
+        throw new Error(
+          `channel command ${JSON.stringify(name)} collides with a core command`,
+        );
+      }
+    });
+  }
+
+  /** Every Channel Command name registered for one dispatcher. */
+  channelCommandNames(dispatcherId: string): readonly string[] {
+    return this.channelCommands.names(dispatcherId);
+  }
+
   async invoke(
     context: CoreCommandContext,
     name: string,
     payload: JsonValue,
   ): Promise<JsonValue> {
+    if (name.startsWith(CHANNEL_COMMAND_PREFIX)) {
+      return this.invokeChannelCommand(context, name, payload);
+    }
     const definition = this.commands.get(name);
     if (definition === undefined) {
       throw new UnknownCommandError(name);
     }
     const bounded = boundedPayload(payload);
-    validateInput(definition, bounded);
+    validateInput(definition, bounded, name);
     const input = definition.parse(bounded);
     const output = await definition.execute(context, input);
     // Canonicalize before validating, so the schema checks the value adapters
     // actually receive rather than the pre-serialization object graph.
-    const result = canonicalResult(definition, output);
-    validateOutput(definition, result);
+    const result = canonicalResult(output, name);
+    validateOutput(definition, result, name);
     return result;
+  }
+
+  /**
+   * One Channel Command, through the identical path.
+   *
+   * The only two additions are the ones a dynamic registration requires: the
+   * dispatcher partition it resolves in, and the admission fence that separates
+   * "registered but not serving" from "no such Command". Bounding, validation,
+   * parsing, canonicalization, and output checking are the same steps, in the
+   * same order, so a Channel Command answers exactly as a Core one does.
+   *
+   * Everything from `parse` onward runs inside the registration's `admit`,
+   * because all of it is Channel-owned code that may synchronously close its
+   * own session. Admission and the drain entry are taken together there, so no
+   * accepted call can be missed by the drain that precedes session close.
+   */
+  private async invokeChannelCommand(
+    context: CoreCommandContext,
+    name: string,
+    payload: JsonValue,
+  ): Promise<JsonValue> {
+    const dispatcherId = channelCommandDispatcher(context, name);
+    const entry = this.channelCommands.resolve(dispatcherId, name);
+    if (entry === undefined) {
+      throw new UnknownCommandError(name);
+    }
+    const bounded = boundedPayload(payload);
+    validateInput(entry.definition, bounded, name);
+    const admitted = entry.registration.admit(async () => {
+      const input = entry.definition.parse(bounded);
+      const output = await entry.definition.execute(context, input);
+      const result = canonicalResult(output, name);
+      validateOutput(entry.definition, result, name);
+      return result;
+    });
+    if (admitted === null) {
+      throw new ChannelCommandUnavailableError(name);
+    }
+    return admitted;
   }
 }
 
@@ -158,6 +261,33 @@ function assertSchemaDefinition(
 }
 
 /**
+ * The same composition-time schema proof, for a Channel-authored definition.
+ *
+ * A Channel package is a separate package on its own release line, so a
+ * malformed schema is exactly as much a composition error as a Core one — it
+ * fails the dispatcher start that tried to register it, naming the channel and
+ * the local name an operator can act on.
+ */
+function assertChannelSchemaDefinition(
+  channelId: string,
+  definition: ChannelCommandDefinition,
+  side: 'input' | 'output',
+): void {
+  try {
+    validateSchemaDefinition(definition[side]);
+  } catch (error) {
+    if (error instanceof SchemaViolation) {
+      throw new Error(
+        `channel ${JSON.stringify(channelId)} command ` +
+          `${JSON.stringify(definition.local_name)} declares a malformed ` +
+          `${side} schema — ${error.message}`,
+      );
+    }
+    throw error;
+  }
+}
+
+/**
  * Put one result through Core's JSON boundary.
  *
  * A schema check alone cannot make a result safe to hand an adapter: an open
@@ -172,13 +302,13 @@ function assertSchemaDefinition(
  * produces an arbitrarily large one, so a generic limit here would only be an
  * arbitrary cutoff. Domain-owned pagination is the answer when one is needed.
  */
-function canonicalResult(definition: AnyCoreCommand, output: unknown): JsonValue {
+function canonicalResult(output: unknown, name: string): JsonValue {
   try {
     return canonicalJsonValue(output, JSON_VALUE_UNBOUNDED);
   } catch (error) {
     if (error instanceof JsonValueError) {
       throw new InternalError(
-        `${definition.name} produced a result that is not JSON-representable ` +
+        `${name} produced a result that is not JSON-representable ` +
           `— ${error.message}`,
       );
     }
@@ -186,13 +316,17 @@ function canonicalResult(definition: AnyCoreCommand, output: unknown): JsonValue
   }
 }
 
-function validateInput(definition: AnyCoreCommand, payload: JsonValue): void {
+function validateInput(
+  definition: SchemaOwner,
+  payload: JsonValue,
+  name: string,
+): void {
   try {
     validateJsonSchema(payload, definition.input);
   } catch (error) {
     if (error instanceof SchemaViolation) {
       throw new ValidationError(
-        `invalid ${definition.name} payload — ${error.message}`,
+        `invalid ${name} payload — ${error.message}`,
       );
     }
     throw error;
@@ -206,13 +340,17 @@ function validateInput(definition: AnyCoreCommand, payload: JsonValue): void {
  * path. The check covers what the Command declares — an open `OBJECT` is
  * checked as an object, deliberately not field by field.
  */
-function validateOutput(definition: AnyCoreCommand, output: JsonValue): void {
+function validateOutput(
+  definition: SchemaOwner,
+  output: JsonValue,
+  name: string,
+): void {
   try {
     validateJsonSchema(output, definition.output);
   } catch (error) {
     if (error instanceof SchemaViolation) {
       throw new InternalError(
-        `${definition.name} produced a result that violates its declared ` +
+        `${name} produced a result that violates its declared ` +
           `output schema — ${error.message}`,
       );
     }

--- a/packages/dreamux/src/server.ts
+++ b/packages/dreamux/src/server.ts
@@ -211,6 +211,7 @@ export class Server {
       summarize: () => this.summarize(),
       dispatcherRow: (id) => this.repos.dispatchers.get(id),
       dispatcherRuntimeStatus: (id) => this.dispatchers.status(id),
+      dispatcherChannels: (id) => this.dispatchers.channelDescriptors(id),
       dispatcher: (id) => this.getDispatcher(id),
       mcpLeases: this.mcpLeases,
     };
@@ -230,6 +231,7 @@ export class Server {
       channelProviders: this.channelProviders,
       mcpLeases: this.mcpLeases,
       commands: this.commands,
+      channelCommands: this.commands,
       homePathPrefixes,
       adminSocketPath: this.opts.adminSocketPath ?? adminSocketPath(),
       channelLoggerFactory: this.channelLoggerFactory,

--- a/packages/dreamux/src/service/channel-service/index.ts
+++ b/packages/dreamux/src/service/channel-service/index.ts
@@ -150,6 +150,22 @@ export class ChannelService {
   }
 
   /**
+   * How far one configured channel has got, in the only three states this
+   * service distinguishes.
+   *
+   * `running` means its session started and was adopted; `built` means its
+   * instance exists but its external I/O is not open yet; `stopped` means there
+   * is no instance at all. It reads both maps because they answer different
+   * questions — the same reason {@link sessionMcp} reads the built one — and it
+   * exposes nothing but that distinction, never the channel's config.
+   */
+  channelStatus(channelId: string): 'running' | 'built' | 'stopped' {
+    if (this.sessions?.has(channelId) === true) return 'running';
+    if (this.built?.has(channelId) === true) return 'built';
+    return 'stopped';
+  }
+
+  /**
    * The MCP capability this channel's created instance composed, or `null` when
    * there is no instance or it composed no session tools.
    *

--- a/packages/dreamux/src/service/dispatcher-service/channel-descriptor.ts
+++ b/packages/dreamux/src/service/dispatcher-service/channel-descriptor.ts
@@ -1,0 +1,110 @@
+/**
+ * The non-sensitive, read-only description of one configured Channel.
+ *
+ * It exists because a Channel's Commands are registered dynamically: a caller
+ * that can invoke `channel.<id>.<name>` has no other way to learn the name, and
+ * `dispatcher.list`/`dispatcher.status` are already the read model for "what is
+ * this dispatcher". Everything here is either operator-declared identification
+ * or a Core-owned lifecycle fact.
+ *
+ * What it deliberately never carries is the Channel's configuration. `identity`
+ * is the opaque string the provider's own {@link ChannelIdentityCapability}
+ * produced at config load — Core stores and repeats it without interpreting it,
+ * so nothing here has to name a provider config field — and no other config
+ * value, raw or parsed, is reachable from this shape.
+ */
+
+/**
+ * How far one Channel has got, in the four states a caller can act on.
+ *
+ * `starting` means the instance exists but its external I/O is not open, so its
+ * Commands answer `CHANNEL_COMMAND_UNAVAILABLE`; `ready` means it is serving;
+ * `closing` means admission is fenced and what was accepted is draining, with
+ * the Commands still resolvable; `closed` means nothing of this Channel is
+ * registered any more and its names no longer resolve at all. The distinction
+ * between `starting` and `closing` is exactly the one a retrying caller needs:
+ * the first will become `ready`, the second will not.
+ */
+export type ChannelDescriptorStatus =
+  | 'starting'
+  | 'ready'
+  | 'closing'
+  | 'closed';
+
+export interface ChannelDescriptor {
+  readonly channel_id: string;
+  readonly provider: string;
+  /** The provider-neutral opaque identity, or `null` when it declared none. */
+  readonly identity: string | null;
+  /** Every Command name Core registered for this Channel, fully qualified. */
+  readonly commands: readonly string[];
+  readonly status: ChannelDescriptorStatus;
+}
+
+/**
+ * One configured Channel, as the config loader recorded it. Narrower than
+ * `DispatcherChannelConfig` on purpose: the two config members this shape does
+ * not name are `config` and `rawConfig`, so nothing here can reach them.
+ */
+export interface ConfiguredChannelFacts {
+  readonly id: string;
+  readonly provider: string;
+  readonly identity?: string;
+}
+
+/**
+ * Project one dispatcher's configured Channels.
+ *
+ * The registration, not the session map, is what decides whether a Channel is
+ * `closed`. The two do not fall away together: `ChannelService.closeAll()`
+ * detaches its session maps before it awaits a single `session.close()`, so
+ * between the fence and the batch's revocation the sessions read as stopped
+ * while every name still resolves — and answers the retryable unavailable
+ * failure rather than `UNKNOWN_METHOD`. Reading liveness first would publish
+ * `closed` alongside a non-empty `commands` list for that whole window, which
+ * is precisely the pair a caller uses to decide the Channel is gone.
+ *
+ * So the two facts a caller acts on are derived from one source: while this
+ * dispatcher's batch still holds a registration for the Channel, its names are
+ * reported and its state is `closing` from the instant admission is fenced;
+ * once the batch is revoked — after the sessions closed, or after a close that
+ * failed — it is `closed` with no names at all.
+ */
+export function channelDescriptors(input: {
+  configured: readonly ConfiguredChannelFacts[];
+  /** Whether this dispatcher's live batch still holds this Channel. */
+  registered: (channelId: string) => boolean;
+  liveStatus: (channelId: string) => 'running' | 'built' | 'stopped';
+  admissionFenced: boolean;
+  commandNames: (channelId: string) => readonly string[];
+}): ChannelDescriptor[] {
+  return input.configured.map((channel) => {
+    const registered = input.registered(channel.id);
+    return {
+      channel_id: channel.id,
+      provider: channel.provider,
+      // An empty identity is the loader's "this provider declared none", not a
+      // real value, so it is reported as absent rather than as an empty string.
+      identity:
+        channel.identity === undefined || channel.identity === ''
+          ? null
+          : channel.identity,
+      commands: registered ? [...input.commandNames(channel.id)] : [],
+      status: registered
+        ? servingStatus(input.liveStatus(channel.id), input.admissionFenced)
+        : 'closed',
+    };
+  });
+}
+
+/** The state of a Channel whose registration is still live. */
+function servingStatus(
+  live: 'running' | 'built' | 'stopped',
+  admissionFenced: boolean,
+): ChannelDescriptorStatus {
+  // The fence is published synchronously, before any awaited teardown, so a
+  // registered Channel that is no longer admitting is stated as closing from
+  // the same instant a caller starts being refused.
+  if (admissionFenced) return 'closing';
+  return live === 'running' ? 'ready' : 'starting';
+}

--- a/packages/dreamux/src/service/dispatcher-service/index.ts
+++ b/packages/dreamux/src/service/dispatcher-service/index.ts
@@ -43,6 +43,7 @@ import { SchedulerService } from '../scheduler/service.js';
 import type { SchedulerCommands } from '../scheduler/types.js';
 import { CronJobStore } from '../scheduler/store.js';
 import { ChannelService } from '../channel-service/index.js';
+import type { ChannelDescriptor } from './channel-descriptor.js';
 import { DispatcherCoreEventBus } from '../dispatcher-core-events/index.js';
 import type {
   TeamCreateInput,
@@ -272,6 +273,7 @@ export class DispatcherService {
         }),
       }),
       commands: opts.commands,
+      channelCommands: opts.channelCommands,
       coreEvents: this.coreEvents,
       scheduler: this.scheduler_,
       teams: this.teams,
@@ -357,6 +359,11 @@ export class DispatcherService {
       // They are revoked once, here, immediately before the sessions holding
       // them are closed.
       this.coreEvents.revokeSources();
+      // Everything Core already accepted through a Channel Command settles
+      // before the sessions it is running against are closed. The fence itself
+      // was published synchronously back in `stop`/`beginShutdown`.
+      await collectShutdownFailure(failures, () =>
+        this.inputSources.drainChannelCommands());
       await collectShutdownFailure(failures, () =>
         this.channels.closeAll(this.log));
       await collectShutdownFailure(failures, () =>
@@ -396,6 +403,17 @@ export class DispatcherService {
 
   runtimeStatus(): DispatcherRuntimeStatus {
     return dispatcherRuntimeStatus(this.inputSources.agent);
+  }
+
+  /**
+   * The non-sensitive read model of this dispatcher's configured Channels.
+   *
+   * A live aggregate is the only place that knows which Commands are currently
+   * registered and how far each session has got, so the read model is asked of
+   * it rather than reconstructed from config by a caller.
+   */
+  channelDescriptors(): ChannelDescriptor[] {
+    return this.inputSources.channelDescriptors();
   }
 
   liveRuntimeStatus(): LiveDispatcherRuntimeStatus | null {

--- a/packages/dreamux/src/service/dispatcher-service/input-source-lifecycle.ts
+++ b/packages/dreamux/src/service/dispatcher-service/input-source-lifecycle.ts
@@ -6,6 +6,11 @@ import type {
 
 import type { AgentRuntimeProviderCatalog } from '../../agent-runtime/index.js';
 import type { ChannelProviderCatalog } from '../../channel/catalog.js';
+import type {
+  ChannelCommandBatch,
+  ChannelCommandRegistrar,
+  ChannelCommandSource,
+} from '../../command/channel-commands.js';
 import type { ConversationProjection } from '../../channel/conversation-projection.js';
 import {
   createChannelCorePort,
@@ -25,6 +30,10 @@ import type { TeammateCollection } from '../teammate-collection/index.js';
 import type { TeammateService } from '../teammate-service/index.js';
 import type { TeammateAgentMcp } from '../teammate-service/types.js';
 import { collectShutdownFailure } from '../shutdown-errors.js';
+import {
+  channelDescriptors,
+  type ChannelDescriptor,
+} from './channel-descriptor.js';
 import type { DispatcherWorkflows } from './dispatcher-workflows.js';
 import { createDispatcherAgent } from './agent.js';
 import { ensureDispatcherRootIdentity } from './identity.js';
@@ -58,6 +67,13 @@ interface DispatcherInputSourceLifecycleOptions {
    * the raw registry.
    */
   commands: CoreCommandRegistry;
+  /**
+   * The registration half of that same port. A dispatcher owns the lifetime of
+   * its Channels' Commands — it registers the whole catalog when it builds
+   * them and revokes it when it stops — while a Channel session only ever
+   * invokes through the narrow provider-facing registry above.
+   */
+  channelCommands: ChannelCommandRegistrar;
   coreEvents: DispatcherCoreEventBus;
   scheduler: SchedulerService;
   teams: TeamCollection;
@@ -81,6 +97,19 @@ export class DispatcherInputSourceLifecycle {
    * — rather than relying on each provider to stop calling.
    */
   private readonly channelPorts: ChannelCorePortLease[] = [];
+  /**
+   * The Channel Command catalog this run registered, or `null` when nothing is
+   * registered. One batch per dispatcher run: it is registered whole once the
+   * Channels are built, and it is the only handle that can fence, drain, and
+   * revoke what it registered.
+   */
+  private channelCommands: ChannelCommandBatch | null = null;
+  /**
+   * Whether Channel admission has been fenced for this run. Read only to
+   * describe a channel as `closing` rather than `ready`; the fence itself is
+   * the port lease's and the registration's, not a flag anything consults.
+   */
+  private admissionFenced = false;
   private started = false;
   private cleanupPending = false;
 
@@ -128,12 +157,63 @@ export class DispatcherInputSourceLifecycle {
    * Fence Channel Command admission, synchronously and idempotently.
    *
    * Published before any awaited teardown so an initialized session cannot
-   * enter Core while shutdown is converging what it already accepted. Event
+   * enter Core while shutdown is converging what it already accepted. Both
+   * halves are fenced together because they are the same doorway seen from two
+   * sides: the port lease refuses a Channel's outbound Command, the
+   * registration refuses an inbound call to a Channel's own. Event
    * subscriptions deliberately outlive this: a stopping runtime still settles,
    * and those facts are worth delivering.
    */
   closeChannelPortAdmission(): void {
+    this.admissionFenced = true;
     for (const lease of this.channelPorts) lease.closeAdmission();
+    this.channelCommands?.closeAdmission();
+  }
+
+  /**
+   * Await every Channel Command call admitted before the fence closed.
+   *
+   * Separate from the fence because the two happen at different times: the
+   * fence is synchronous and precedes all teardown, while this must finish
+   * before the sessions those calls are running against are closed. A caller
+   * that closes a session first would tear down the Channel state a call it
+   * already accepted is still using.
+   */
+  async drainChannelCommands(): Promise<void> {
+    this.closeChannelPortAdmission();
+    await this.channelCommands?.drain();
+  }
+
+  /**
+   * Remove this run's whole Channel Command catalog. Idempotent, and only ever
+   * after the sessions behind it are closed.
+   */
+  private unregisterChannelCommands(): void {
+    this.channelCommands?.unregister();
+    this.channelCommands = null;
+  }
+
+  /** Every Command name registered for one of this dispatcher's channels. */
+  channelCommandNames(channelId: string): readonly string[] {
+    return this.channelCommands?.get(channelId)?.names ?? [];
+  }
+
+  /**
+   * The non-sensitive read model of this dispatcher's configured Channels.
+   *
+   * Liveness alone would misreport the teardown window — see
+   * {@link channelDescriptors} — so the registration this run holds is what
+   * decides whether a Channel is still being described at all.
+   */
+  channelDescriptors(): ChannelDescriptor[] {
+    return channelDescriptors({
+      configured: this.opts.channels.configuredChannels(),
+      registered: (channelId) =>
+        this.channelCommands?.get(channelId) != null,
+      liveStatus: (channelId) => this.opts.channels.channelStatus(channelId),
+      admissionFenced: this.admissionFenced,
+      commandNames: (channelId) => this.channelCommandNames(channelId),
+    });
   }
 
   /**
@@ -144,16 +224,22 @@ export class DispatcherInputSourceLifecycle {
    * it built them, so closing them without clearing would leave a torn-down
    * channel still answering "yes, I can serve a session tool", and an
    * initialized session holds a live subscription nothing else would revoke.
+   *
+   * The Command catalog these instances registered is fenced and drained
+   * before they are closed, and revoked only after: a call Core already
+   * accepted runs against Channel state that must still exist, and a name must
+   * not resolve to an instance that is gone.
    */
   private async discardPreparedChannels(
     sessions: Map<string, ChannelInstance>,
   ): Promise<void> {
-    this.closeChannelPortAdmission();
+    await this.drainChannelCommands();
     this.channelPorts.length = 0;
     this.opts.coreEvents.revokeSources();
     try {
       await closeAllBuilt(sessions);
     } finally {
+      this.unregisterChannelCommands();
       this.opts.channels.clear();
     }
   }
@@ -164,6 +250,10 @@ export class DispatcherInputSourceLifecycle {
     // initializes new ones. Keeping the old objects would fence nothing and
     // would grow with every restart.
     this.channelPorts.length = 0;
+    // Same for the catalog: those definitions are served by instances this run
+    // built and this stop closed. A later start registers the catalog its own
+    // instances declare.
+    this.unregisterChannelCommands();
   }
 
   markCleanupPending(): void {
@@ -198,7 +288,25 @@ export class DispatcherInputSourceLifecycle {
     // would serve it exists. Building is also the step that can fail, so nothing
     // else is committed until it has.
     const sessions = await this.opts.channels.build();
+    // Building is awaited, so a shutdown may have begun while it ran. Registering
+    // after that fence would put a catalog into the registry that this run will
+    // never open and that the shutdown already past this point will never revoke.
     try {
+      this.assertAvailable();
+    } catch (error) {
+      await closeAllBuilt(sessions);
+      this.opts.channels.clear();
+      throw error;
+    }
+    try {
+      // The whole dispatcher catalog, registered in one atomic step before any
+      // session is initialized. Before initialization, because a session may
+      // invoke Core as soon as it has its port, and a Channel that reaches its
+      // own sibling's Command must not depend on build order. Atomic, because a
+      // colliding name in the second Channel means this dispatcher has no valid
+      // catalog at all — registering half of one would leave the failed start
+      // to unwind names that are already resolvable.
+      this.registerChannelCommands(sessions);
       const agent = createDispatcherAgent({
         id: this.opts.dispatcherId,
         config: this.opts.config,
@@ -219,6 +327,44 @@ export class DispatcherInputSourceLifecycle {
       await this.discardPreparedChannels(sessions);
       throw error;
     }
+  }
+
+  /**
+   * Register what every built Channel declared, as one catalog.
+   *
+   * A Channel with no Commands contributes an empty source rather than being
+   * skipped, so the batch holds one registration per built channel and the
+   * lifecycle has a fence to open and close for each — including the channels
+   * that only ever invoke.
+   *
+   * Collection and registration are two steps with an availability fence
+   * between them because `definitions()` is Channel-owned code running
+   * synchronously inside this call: it can reach back into the dispatcher and
+   * begin a stop before the last source is even assembled. Re-checking after
+   * the last provider frame returns is what keeps a catalog from landing in the
+   * registry behind a fence that has already passed the point of revoking it.
+   */
+  private registerChannelCommands(
+    sessions: Map<string, ChannelInstance>,
+  ): void {
+    const sources: ChannelCommandSource[] = [];
+    for (const [channelId, instance] of sessions) {
+      sources.push({
+        channelId,
+        definitions: instance.commands?.definitions() ?? [],
+      });
+    }
+    this.assertAvailable();
+    this.channelCommands = this.opts.channelCommands.registerChannelCommands(
+      this.opts.dispatcherId,
+      sources,
+    );
+    // A fence belongs to the run whose registrations it closed. This run has
+    // just registered its own, and it could only reach here past
+    // `assertAvailable`, so the previous run's fence stops describing these
+    // channels as closing. Reset here rather than in `markStopped` so a
+    // prepare-only teardown followed by a retry still reports honestly.
+    this.admissionFenced = false;
   }
 
   /**
@@ -289,6 +435,11 @@ export class DispatcherInputSourceLifecycle {
       const rollbackFailures: unknown[] = [];
       await collectShutdownFailure(rollbackFailures, () =>
         this.opts.workflows.rollbackStart());
+      // Everything Core already accepted through a Channel Command settles
+      // before the rollback below closes the sessions those calls are running
+      // against.
+      await collectShutdownFailure(rollbackFailures, () =>
+        this.drainChannelCommands());
       await collectShutdownFailure(rollbackFailures, () =>
         rollbackFailedInputSourceStart({
           dispatcherId: this.opts.dispatcherId,
@@ -302,6 +453,10 @@ export class DispatcherInputSourceLifecycle {
           agent: this.agent_,
           log: this.opts.log,
         }));
+      // Last, and unconditionally: the whole batch this start registered goes
+      // away with the instances that served it, whether or not the rest of the
+      // rollback proved release.
+      this.unregisterChannelCommands();
       this.preparedChannels = null;
       this.channelPorts.length = 0;
       this.started = false;
@@ -336,6 +491,10 @@ export class DispatcherInputSourceLifecycle {
    * and what it does with external traffic — routing, binding, presentation —
    * is the Channel's own. A session is published as live only after its own
    * start returns.
+   *
+   * Its Commands begin serving at exactly the same point, and only its own:
+   * before that the definitions resolve but answer `CHANNEL_COMMAND_UNAVAILABLE`,
+   * because a handler needs the state the session's own start established.
    */
   private async startPreparedChannels(
     sessions: Map<string, ChannelInstance>,
@@ -344,6 +503,7 @@ export class DispatcherInputSourceLifecycle {
     for (const [channelId, instance] of sessions) {
       await instance.session.start();
       this.assertAvailable();
+      this.channelCommands?.get(channelId)?.openAdmission();
       liveChannels.set(channelId, instance);
       this.opts.channels.adopt(liveChannels);
     }

--- a/packages/dreamux/src/service/dispatcher-service/types.ts
+++ b/packages/dreamux/src/service/dispatcher-service/types.ts
@@ -6,6 +6,7 @@ import type {
 
 import type { AgentRuntimeProviderCatalog } from '../../agent-runtime/index.js';
 import type { ChannelProviderCatalog } from '../../channel/catalog.js';
+import type { ChannelCommandRegistrar } from '../../command/channel-commands.js';
 import type { DreamuxConfig } from '../../config/config.js';
 import type { DispatcherStore } from '../../state/dispatcher-store.js';
 import type { AgentEntityIdentityStatus } from '../agent-entity/types.js';
@@ -25,6 +26,15 @@ export interface DispatcherServiceOptions {
    * validation, and shutdown fence rather than getting a second surface.
    */
   commands: CoreCommandRegistry;
+  /**
+   * The registration half of the same port, which is Core-internal.
+   *
+   * A dispatcher registers its Channels' Commands and revokes them when it
+   * stops; a Channel only ever invokes. Carrying registration as its own field
+   * — rather than widening `commands` — keeps the provider-facing
+   * {@link CoreCommandRegistry} exactly as narrow as it is today.
+   */
+  channelCommands: ChannelCommandRegistrar;
   /** Host home prefixes resolved by Server before this aggregate is built. */
   homePathPrefixes: readonly string[];
   adminSocketPath?: string;

--- a/packages/dreamux/src/service/dispatchers/commands.ts
+++ b/packages/dreamux/src/service/dispatchers/commands.ts
@@ -20,8 +20,10 @@ import {
   OBJECT,
   STRING,
   arrayOf,
+  enumOf,
   objectSchema,
 } from '../../command/schema.js';
+import type { ChannelDescriptor } from '../dispatcher-service/channel-descriptor.js';
 import type { DispatcherSummary } from '../dispatcher-service/types.js';
 
 interface DispatcherListResult {
@@ -34,7 +36,28 @@ interface DispatcherStatusResult {
   status: string;
   session_id: string | null;
   last_error: string | null;
+  channel_descriptors: ChannelDescriptor[];
 }
+
+/**
+ * The closed shape of one Channel description.
+ *
+ * Declared here rather than left an open `OBJECT` — the treatment the rich
+ * evolving DTOs above get — precisely because this one must not evolve
+ * silently: it is the read model that faces a Channel's own callers, and a
+ * closed schema makes an undeclared field a loud Core defect instead of a quiet
+ * leak of whatever produced it.
+ */
+const CHANNEL_DESCRIPTOR = objectSchema(
+  {
+    channel_id: STRING,
+    provider: STRING,
+    identity: NULLABLE_STRING,
+    commands: arrayOf(STRING),
+    status: enumOf(['starting', 'ready', 'closing', 'closed']),
+  },
+  ['channel_id', 'provider', 'identity', 'commands', 'status'],
+);
 
 interface DispatcherStartResult {
   dispatcher_id: string;
@@ -77,8 +100,16 @@ export function dispatcherCommands(
         status: STRING,
         session_id: NULLABLE_STRING,
         last_error: NULLABLE_STRING,
+        channel_descriptors: arrayOf(CHANNEL_DESCRIPTOR),
       },
-      ['dispatcher_id', 'channel_identity', 'status', 'session_id', 'last_error'],
+      [
+        'dispatcher_id',
+        'channel_identity',
+        'status',
+        'session_id',
+        'last_error',
+        'channel_descriptors',
+      ],
     ),
     parse(payload) {
       commandPayload(payload);
@@ -93,6 +124,7 @@ export function dispatcherCommands(
         status: runtime.status ?? 'stopped',
         session_id: runtime.sessionId,
         last_error: runtime.lastError,
+        channel_descriptors: host.dispatcherChannels(id),
       };
     },
   };

--- a/packages/dreamux/src/service/dispatchers/index.ts
+++ b/packages/dreamux/src/service/dispatchers/index.ts
@@ -1,5 +1,6 @@
 import type { AgentRuntimeProviderCatalog } from '../../agent-runtime/index.js';
 import type { ChannelProviderCatalog } from '../../channel/catalog.js';
+import type { ChannelCommandRegistrar } from '../../command/channel-commands.js';
 import type { DreamuxConfig } from '../../config/config.js';
 import type { RestartIntentConsumer } from '../../daemon/restart-intent.js';
 import type { DispatcherStore } from '../../state/dispatcher-store.js';
@@ -10,6 +11,10 @@ import type {
 import { AgentIdentityStore } from '../agent-entity/identity-store.js';
 import { dispatcherDir } from '../../platform/paths.js';
 import { DispatcherService } from '../dispatcher-service/index.js';
+import {
+  channelDescriptors,
+  type ChannelDescriptor,
+} from '../dispatcher-service/channel-descriptor.js';
 import type {
   DispatcherRuntimeStatus,
   DispatcherServiceOptions,
@@ -28,6 +33,11 @@ export interface DispatchersOptions {
   mcpLeases: McpLeaseRegistry;
   /** The process-wide admitted Command port every Channel session invokes through. */
   commands: CoreCommandRegistry;
+  /**
+   * The registration half of that same port. Core-internal: dispatchers
+   * register their Channels' Commands through it, and no provider sees it.
+   */
+  channelCommands: ChannelCommandRegistrar;
   homePathPrefixes: readonly string[];
   adminSocketPath?: string;
   channelLoggerFactory: (dispatcherId: string) => DreamuxLogger;
@@ -50,6 +60,7 @@ export class Dispatchers {
   private readonly channelProviders: ChannelProviderCatalog;
   private readonly mcpLeases: McpLeaseRegistry;
   private readonly commands: CoreCommandRegistry;
+  private readonly channelCommands: ChannelCommandRegistrar;
   private readonly homePathPrefixes: readonly string[];
   private readonly adminSocketPath: string | undefined;
   private readonly channelLoggerFactory: (dispatcherId: string) => DreamuxLogger;
@@ -75,6 +86,7 @@ export class Dispatchers {
     this.channelProviders = opts.channelProviders;
     this.mcpLeases = opts.mcpLeases;
     this.commands = opts.commands;
+    this.channelCommands = opts.channelCommands;
     this.homePathPrefixes = opts.homePathPrefixes;
     this.adminSocketPath = opts.adminSocketPath;
     this.channelLoggerFactory = opts.channelLoggerFactory;
@@ -154,6 +166,30 @@ export class Dispatchers {
     };
   }
 
+  /**
+   * The non-sensitive Channel read model of one dispatcher.
+   *
+   * A materialized aggregate answers for itself, because only it knows which
+   * Commands are registered and how far each session has got. For a dispatcher
+   * this process never materialized the answer is its configured Channels with
+   * no Commands and `closed` status — a plain read, never a reason to build an
+   * aggregate, exactly like {@link status} above.
+   */
+  channelDescriptors(id: string): ChannelDescriptor[] {
+    const service = this.services.get(id);
+    if (service !== undefined) return service.channelDescriptors();
+    const configured =
+      this.config.dispatchers.find((dispatcher) => dispatcher.id === id)
+        ?.channels ?? [];
+    return channelDescriptors({
+      configured,
+      registered: () => false,
+      liveStatus: () => 'stopped',
+      admissionFenced: false,
+      commandNames: () => [],
+    });
+  }
+
   async shutdown(): Promise<void> {
     this.beginShutdown();
     const results = await Promise.allSettled(
@@ -177,6 +213,7 @@ export class Dispatchers {
       channelProviders: this.channelProviders,
       mcpLeases: this.mcpLeases,
       commands: this.commands,
+      channelCommands: this.channelCommands,
       homePathPrefixes: this.homePathPrefixes,
       ...(this.adminSocketPath !== undefined
         ? { adminSocketPath: this.adminSocketPath }

--- a/packages/dreamux/tests/channel-command-adapters.test.ts
+++ b/packages/dreamux/tests/channel-command-adapters.test.ts
@@ -1,0 +1,344 @@
+/**
+ * Adapter equivalence for the dispatcher-scoped half of the registry.
+ *
+ * A Channel Command is registered by a dispatcher and served by a Channel, but
+ * it is still a Command in the one registry — so the `admin.sock` NDJSON server
+ * and the in-process Channel invoker must answer it identically, including its
+ * two failures that have no Core analogue (`CHANNEL_COMMAND_UNAVAILABLE`, and a
+ * name that resolves only inside its own dispatcher partition).
+ *
+ * Both adapters here are the real production objects over one shared
+ * `CoreCommandPort`, exactly as `core-command-adapters.test.ts` builds them for
+ * the Core half.
+ */
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { readFileSync } from 'node:fs';
+
+import type { ChannelCommandBatch } from '../src/command/channel-commands.js';
+import {
+  externalBindCommand,
+  externalFaultingCommand,
+} from './fixtures/external-channel-command.js';
+import {
+  createCommandHarness,
+  createHarnessChannelInvoker,
+  fakeChannelCommand,
+  startHarnessAdminSocket,
+  HARNESS_CHANNEL_ID,
+  HARNESS_DISPATCHER_ID,
+  type CommandHarness,
+  type HarnessAdminSocket,
+} from './helpers/command-harness.js';
+
+const NAME = `channel.${HARNESS_CHANNEL_ID}.ping`;
+
+/** Register one open Channel Command into a harness's real registry. */
+function registerPing(
+  harness: CommandHarness,
+  overrides: Parameters<typeof fakeChannelCommand>[1] = {},
+): ChannelCommandBatch {
+  const batch = harness.port.registerChannelCommands(HARNESS_DISPATCHER_ID, [
+    {
+      channelId: HARNESS_CHANNEL_ID,
+      definitions: [fakeChannelCommand('ping', overrides)],
+    },
+  ]);
+  batch.get(HARNESS_CHANNEL_ID)?.openAdmission();
+  return batch;
+}
+
+describe('a Channel Command answers identically through both adapters', () => {
+  let admin: HarnessAdminSocket | null = null;
+  let batch: ChannelCommandBatch | null = null;
+
+  afterEach(async () => {
+    batch?.unregister();
+    batch = null;
+    if (admin !== null) {
+      await admin.close();
+      admin = null;
+    }
+  });
+
+  it('returns the same result to an admin.sock caller and to the Channel invoker', async () => {
+    const harness = createCommandHarness();
+    batch = registerPing(harness);
+    admin = await startHarnessAdminSocket(harness);
+    const lease = createHarnessChannelInvoker(harness);
+
+    // The admin caller states the dispatcher in its envelope; the Channel
+    // invoker bound it once at construction. Both address the same partition.
+    const viaAdmin = await admin.send(NAME, {
+      dispatcher_id: HARNESS_DISPATCHER_ID,
+      note: 'hello',
+    });
+    const viaChannel = await lease.port.invoke.invoke(NAME, { note: 'hello' });
+
+    expect(viaAdmin.ok).toBe(true);
+    expect((viaAdmin as { result: unknown }).result).toEqual(viaChannel);
+    expect(viaChannel).toEqual({ echoed: 'hello' });
+  });
+
+  it('rejects an invalid payload as BAD_REQUEST on both, without the Channel handler running', async () => {
+    const execute = vi.fn(async () => ({ echoed: 'never' }));
+    const harness = createCommandHarness();
+    batch = registerPing(harness, { execute });
+    admin = await startHarnessAdminSocket(harness);
+    const lease = createHarnessChannelInvoker(harness);
+
+    const viaAdmin = await admin.send(NAME, { dispatcher_id: HARNESS_DISPATCHER_ID });
+    expect(viaAdmin.ok).toBe(false);
+    expect((viaAdmin as { error: { code: string } }).error.code).toBe('BAD_REQUEST');
+
+    await expect(lease.port.invoke.invoke(NAME, {})).rejects.toMatchObject({
+      code: 'BAD_REQUEST',
+    });
+    expect(execute).not.toHaveBeenCalled();
+  });
+
+  it('reports CHANNEL_COMMAND_UNAVAILABLE on both while the registration is fenced', async () => {
+    const harness = createCommandHarness();
+    batch = registerPing(harness);
+    admin = await startHarnessAdminSocket(harness);
+    const lease = createHarnessChannelInvoker(harness);
+
+    batch.closeAdmission();
+
+    const viaAdmin = await admin.send(NAME, {
+      dispatcher_id: HARNESS_DISPATCHER_ID,
+      note: 'x',
+    });
+    expect(viaAdmin.ok).toBe(false);
+    expect((viaAdmin as { error: { code: string; action?: string } }).error).toMatchObject({
+      code: 'CHANNEL_COMMAND_UNAVAILABLE',
+      action: expect.stringContaining('Retry'),
+    });
+
+    await expect(lease.port.invoke.invoke(NAME, { note: 'x' })).rejects.toMatchObject({
+      code: 'CHANNEL_COMMAND_UNAVAILABLE',
+    });
+  });
+
+  it('reports UNKNOWN_METHOD on both once the batch is revoked', async () => {
+    const harness = createCommandHarness();
+    const registered = registerPing(harness);
+    admin = await startHarnessAdminSocket(harness);
+    const lease = createHarnessChannelInvoker(harness);
+
+    registered.unregister();
+
+    const viaAdmin = await admin.send(NAME, {
+      dispatcher_id: HARNESS_DISPATCHER_ID,
+      note: 'x',
+    });
+    expect((viaAdmin as { error: { code: string } }).error.code).toBe('UNKNOWN_METHOD');
+    await expect(lease.port.invoke.invoke(NAME, { note: 'x' })).rejects.toMatchObject({
+      code: 'UNKNOWN_METHOD',
+    });
+  });
+
+  it('answers BAD_REQUEST on an admin call that names no dispatcher, and UNKNOWN_METHOD on one that names another', async () => {
+    // The Channel invoker cannot produce either case — it binds its own
+    // dispatcher at construction and never reads one from the caller — so this
+    // is where the two adapters legitimately differ in what they can express,
+    // and the admin half must still classify both correctly.
+    const harness = createCommandHarness();
+    batch = registerPing(harness);
+    admin = await startHarnessAdminSocket(harness);
+
+    const missing = await admin.send(NAME, { note: 'x' });
+    expect((missing as { error: { code: string } }).error.code).toBe('BAD_REQUEST');
+
+    const malformed = await admin.send(NAME, {
+      dispatcher_id: 'not a valid id',
+      note: 'x',
+    });
+    expect((malformed as { error: { code: string } }).error.code).toBe('BAD_REQUEST');
+
+    const otherDispatcher = await admin.send(NAME, {
+      dispatcher_id: 'some-other-dispatcher',
+      note: 'x',
+    });
+    expect((otherDispatcher as { error: { code: string } }).error.code).toBe(
+      'UNKNOWN_METHOD',
+    );
+  });
+
+  it('carries a Channel-authored refusal as an ordinary result on both adapters', async () => {
+    // A refusal a caller acts on is a declared *output*, not a throw: an
+    // external Channel imports `@excitedjs/dreamux-types` only, and that
+    // package is declaration-only — there is no Core error base for it to
+    // construct. So this is the whole refusal mechanism a real provider has,
+    // and both adapters must carry it unchanged.
+    const harness = createCommandHarness();
+    const registered = harness.port.registerChannelCommands(HARNESS_DISPATCHER_ID, [
+      {
+        channelId: HARNESS_CHANNEL_ID,
+        definitions: [
+          externalBindCommand({
+            localName: 'bind',
+            refuse: (input) =>
+              input.chat_id === 'p2p-chat' ? 'a p2p chat is never bindable' : null,
+          }),
+        ],
+      },
+    ]);
+    registered.get(HARNESS_CHANNEL_ID)?.openAdmission();
+    batch = registered;
+    admin = await startHarnessAdminSocket(harness);
+    const lease = createHarnessChannelInvoker(harness);
+    const bind = `channel.${HARNESS_CHANNEL_ID}.bind`;
+
+    const refusedViaAdmin = await admin.send(bind, {
+      dispatcher_id: HARNESS_DISPATCHER_ID,
+      chat_id: 'p2p-chat',
+    });
+    expect(refusedViaAdmin.ok).toBe(true);
+    expect((refusedViaAdmin as { result: unknown }).result).toEqual({
+      bound: false,
+      reason: 'a p2p chat is never bindable',
+    });
+    await expect(lease.port.invoke.invoke(bind, { chat_id: 'p2p-chat' })).resolves.toEqual(
+      { bound: false, reason: 'a p2p chat is never bindable' },
+    );
+
+    const acceptedViaAdmin = await admin.send(bind, {
+      dispatcher_id: HARNESS_DISPATCHER_ID,
+      chat_id: 'oc-group',
+    });
+    expect((acceptedViaAdmin as { result: unknown }).result).toEqual({
+      bound: true,
+      reason: null,
+    });
+    await expect(lease.port.invoke.invoke(bind, { chat_id: 'oc-group' })).resolves.toEqual(
+      { bound: true, reason: null },
+    );
+  });
+
+  it('reports an ordinary throw from a Channel handler as INTERNAL on both adapters', async () => {
+    // The most an externally-authored handler can express by throwing, since
+    // it has no Core failure class: a plain `Error`. Core does not invent a
+    // next step for it — it is an unclassified implementation fault, and both
+    // adapters say exactly that.
+    const harness = createCommandHarness();
+    const registered = harness.port.registerChannelCommands(HARNESS_DISPATCHER_ID, [
+      {
+        channelId: HARNESS_CHANNEL_ID,
+        definitions: [externalFaultingCommand('bind')],
+      },
+    ]);
+    registered.get(HARNESS_CHANNEL_ID)?.openAdmission();
+    batch = registered;
+    admin = await startHarnessAdminSocket(harness);
+    const lease = createHarnessChannelInvoker(harness);
+    const bind = `channel.${HARNESS_CHANNEL_ID}.bind`;
+
+    const viaAdmin = await admin.send(bind, {
+      dispatcher_id: HARNESS_DISPATCHER_ID,
+      chat_id: 'oc-group',
+    });
+    expect((viaAdmin as { error: unknown }).error).toEqual({
+      code: 'INTERNAL',
+      message: 'the channel provider hit an unhandled condition',
+    });
+    await expect(
+      lease.port.invoke.invoke(bind, { chat_id: 'oc-group' }),
+    ).rejects.toMatchObject({
+      message: 'the channel provider hit an unhandled condition',
+    });
+  });
+
+  it('refuses a result its own declared output schema does not admit', async () => {
+    // The counterpart guarantee to "a refusal is a declared output": the
+    // declaration is enforced, so a Channel cannot smuggle an undeclared shape
+    // through the same door.
+    const harness = createCommandHarness();
+    const registered = harness.port.registerChannelCommands(HARNESS_DISPATCHER_ID, [
+      {
+        channelId: HARNESS_CHANNEL_ID,
+        definitions: [
+          {
+            ...externalBindCommand({ localName: 'bind' }),
+            async execute() {
+              return { bound: false, reason: null, internal_detail: 'leaked' };
+            },
+          },
+        ],
+      },
+    ]);
+    registered.get(HARNESS_CHANNEL_ID)?.openAdmission();
+    batch = registered;
+    const lease = createHarnessChannelInvoker(harness);
+
+    await expect(
+      lease.port.invoke.invoke(`channel.${HARNESS_CHANNEL_ID}.bind`, {
+        chat_id: 'oc-group',
+      }),
+    ).rejects.toMatchObject({ code: 'INTERNAL' });
+  });
+
+  it('the external fixture depends on @excitedjs/dreamux-types alone', () => {
+    // The guarantee the two tests above rest on. If this fixture ever reaches
+    // into the host package, they stop proving anything about what an external
+    // Channel can do — so the import restriction is asserted, not assumed.
+    const fixture = readFileSync(
+      new URL('./fixtures/external-channel-command.ts', import.meta.url),
+      'utf8',
+    );
+    const imports = [...fixture.matchAll(/from\s+'([^']+)'/g)].map(
+      (match) => match[1],
+    );
+    expect(imports).toEqual(['@excitedjs/dreamux-types']);
+  });
+
+  it('is refused by the process shutdown fence on both adapters, before the Channel handler', async () => {
+    const execute = vi.fn(async () => ({ echoed: 'never' }));
+    const harness = createCommandHarness();
+    batch = registerPing(harness, { execute });
+    admin = await startHarnessAdminSocket(harness);
+    const lease = createHarnessChannelInvoker(harness);
+
+    harness.port.closeAdmission();
+
+    const viaAdmin = await admin.send(NAME, {
+      dispatcher_id: HARNESS_DISPATCHER_ID,
+      note: 'x',
+    });
+    expect((viaAdmin as { error: { code: string } }).error.code).toBe(
+      'SERVER_SHUTTING_DOWN',
+    );
+    await expect(lease.port.invoke.invoke(NAME, { note: 'x' })).rejects.toMatchObject({
+      code: 'SERVER_SHUTTING_DOWN',
+    });
+    expect(execute).not.toHaveBeenCalled();
+  });
+
+  it('applies the same payload bounds a Core Command gets', async () => {
+    const harness = createCommandHarness();
+    batch = registerPing(harness);
+    const lease = createHarnessChannelInvoker(harness);
+    const { COMMAND_PAYLOAD_BOUNDS } = await import('../src/command/registry.js');
+
+    await expect(
+      lease.port.invoke.invoke(NAME, {
+        note: 'x'.repeat(COMMAND_PAYLOAD_BOUNDS.maxBytes + 1_024),
+      }),
+    ).rejects.toMatchObject({ code: 'BAD_REQUEST' });
+  });
+
+  it('registration reaches the registry only through the port, and the port never fences it', () => {
+    // Registration is the process composing itself, not a caller reaching in,
+    // so it is deliberately outside the admission fence — otherwise a
+    // dispatcher could never register after any prior shutdown fenced the port.
+    const harness = createCommandHarness();
+    harness.port.closeAdmission();
+
+    const registered = harness.port.registerChannelCommands('late-dispatcher', [
+      { channelId: 'c1', definitions: [fakeChannelCommand('ping')] },
+    ]);
+    expect(harness.port.channelCommandNames('late-dispatcher')).toEqual([
+      'channel.c1.ping',
+    ]);
+    registered.unregister();
+  });
+});

--- a/packages/dreamux/tests/channel-command-registry.test.ts
+++ b/packages/dreamux/tests/channel-command-registry.test.ts
@@ -1,0 +1,701 @@
+/**
+ * The dispatcher-scoped half of the one Command registry: name encoding, whole
+ * catalog atomicity, the registration lease, and the admission fence.
+ *
+ * Everything here drives the real `CoreCommands` — through the real
+ * `CoreCommandPort` wherever a dispatcher would reach it — rather than a model
+ * of it, because the properties under test are exactly the ones a description
+ * would get wrong: whether a rejected catalog left residue, whether a name a
+ * caller can address resolves to the registration that owns it, and whether a
+ * fence and a drain are one indivisible step.
+ */
+import { describe, expect, it, vi } from 'vitest';
+
+import type { ChannelCommandDefinition } from '@excitedjs/dreamux-types';
+
+import {
+  channelCommandName,
+  encodeChannelId,
+  ChannelCommandRegistration,
+  type ChannelCommandSource,
+} from '../src/command/channel-commands.js';
+import { CoreCommandPort } from '../src/command/port.js';
+import { CoreCommands } from '../src/command/registry.js';
+import { NO_INPUT, objectSchema } from '../src/command/schema.js';
+import type { AnyCoreCommand } from '../src/command/registry.js';
+import { fakeChannelCommand } from './helpers/command-harness.js';
+
+const DISPATCHER = 'flow';
+
+/** One empty registry behind the real admitted port, as `Server` composes it. */
+function port(coreDefinitions: readonly AnyCoreCommand[] = []): CoreCommandPort {
+  return new CoreCommandPort(new CoreCommands(coreDefinitions));
+}
+
+function source(
+  channelId: string,
+  ...definitions: readonly ChannelCommandDefinition[]
+): ChannelCommandSource {
+  return { channelId, definitions };
+}
+
+function channelContext(channelId = 'primary', dispatcherId = DISPATCHER) {
+  return {
+    source: 'channel' as const,
+    dispatcher_id: dispatcherId,
+    channel_id: channelId,
+  };
+}
+
+describe('channel id encoding is injective over every id config admits', () => {
+  it('leaves an already-safe id verbatim, so the common name is readable', () => {
+    expect(encodeChannelId('primary')).toBe('primary');
+    expect(encodeChannelId('feishu-bot_2')).toBe('feishu-bot_2');
+    expect(channelCommandName('primary', 'bind_channel')).toBe(
+      'channel.primary.bind_channel',
+    );
+  });
+
+  it('encodes a dot so the full name still splits into exactly three parts', () => {
+    // `a.b` unencoded would make `channel.a.b.cmd` parse as channel `a` with
+    // local name `b.cmd` — two readings of one name.
+    expect(encodeChannelId('a.b')).toBe('a%002Eb');
+    expect(channelCommandName('a.b', 'cmd')).toBe('channel.a%002Eb.cmd');
+    expect(channelCommandName('a.b', 'cmd').split('.')).toHaveLength(3);
+  });
+
+  it('encodes the escape character itself, so an id that spells an encoding is distinct from what it spells', () => {
+    // The collision this rules out: id `a.b` and the literal id `a%002Eb` must
+    // not produce the same segment.
+    expect(encodeChannelId('a%002Eb')).toBe('a%0025002Eb');
+    expect(encodeChannelId('a%002Eb')).not.toBe(encodeChannelId('a.b'));
+  });
+
+  it('encodes non-ASCII per UTF-16 code unit, keeping a surrogate pair distinct from its parts', () => {
+    // U+1F600 is one code point stored as the surrogate pair D83D DE00.
+    expect(encodeChannelId('\u{1F600}')).toBe('%D83D%DE00');
+    expect(encodeChannelId('中')).toBe('%4E2D');
+    expect(encodeChannelId('\uD83D')).toBe('%D83D');
+    expect(encodeChannelId('\uDE00')).toBe('%DE00');
+  });
+
+  it('keeps two lone surrogates distinct — a UTF-8 encoder would fold both onto U+FFFD', () => {
+    // This is why the encoding is per code unit. Config promises "non-empty
+    // string", and a JS string may hold an unpaired surrogate; folding them
+    // together would let two legal, distinct ids register the same name.
+    const first = encodeChannelId('\uD800');
+    const second = encodeChannelId('\uDC00');
+    const replacement = encodeChannelId('�');
+    expect(first).not.toBe(second);
+    expect(first).not.toBe(replacement);
+    expect(second).not.toBe(replacement);
+  });
+
+  it('registers two ids that differ only by an encoded character as two distinct names', () => {
+    const registrar = port();
+    const batch = registrar.registerChannelCommands(DISPATCHER, [
+      source('a.b', fakeChannelCommand('ping')),
+      source('a%002Eb', fakeChannelCommand('ping')),
+    ]);
+    expect([...registrar.channelCommandNames(DISPATCHER)].sort()).toEqual([
+      'channel.a%0025002Eb.ping',
+      'channel.a%002Eb.ping',
+    ]);
+    batch.unregister();
+  });
+});
+
+describe('registration is whole-catalog and atomic', () => {
+  it('refuses an empty channel id rather than registering an unaddressable name', () => {
+    const registrar = port();
+    expect(() =>
+      registrar.registerChannelCommands(DISPATCHER, [
+        source('', fakeChannelCommand('ping')),
+      ]),
+    ).toThrow(/empty channel id/);
+    expect(registrar.channelCommandNames(DISPATCHER)).toEqual([]);
+  });
+
+  it('refuses two sources for one channel id, which would orphan the first registration', () => {
+    const registrar = port();
+    expect(() =>
+      registrar.registerChannelCommands(DISPATCHER, [
+        source('primary', fakeChannelCommand('ping')),
+        source('primary', fakeChannelCommand('pong')),
+      ]),
+    ).toThrow(/registered channel commands for "primary" twice/);
+    expect(registrar.channelCommandNames(DISPATCHER)).toEqual([]);
+  });
+
+  it('lets two channels of one dispatcher declare the same local_name, because the id segment separates them', async () => {
+    // Encoding is injective, so two distinct channel ids can never produce one
+    // name. This is the property that makes a per-Channel `local_name` the
+    // Channel's own choice rather than a dispatcher-wide namespace to police.
+    const registrar = port();
+    const batch = registrar.registerChannelCommands(DISPATCHER, [
+      source('primary', fakeChannelCommand('ping')),
+      source('secondary', fakeChannelCommand('ping')),
+    ]);
+    expect([...registrar.channelCommandNames(DISPATCHER)].sort()).toEqual([
+      'channel.primary.ping',
+      'channel.secondary.ping',
+    ]);
+    batch.unregister();
+  });
+
+  it('refuses a name one channel declares twice, and leaves nothing behind', () => {
+    const registrar = port();
+    expect(() =>
+      registrar.registerChannelCommands(DISPATCHER, [
+        source('primary', fakeChannelCommand('ping'), fakeChannelCommand('ping')),
+      ]),
+    ).toThrow(/"channel\.primary\.ping" is registered twice/);
+    // The whole point of atomicity: the first, valid definition of the pair is
+    // not left resolvable by the failure that rejected the second.
+    expect(registrar.channelCommandNames(DISPATCHER)).toEqual([]);
+  });
+
+  it('rejects the whole catalog when a LATER channel fails, leaving the earlier channel unregistered', async () => {
+    const registrar = port();
+    expect(() =>
+      registrar.registerChannelCommands(DISPATCHER, [
+        source('primary', fakeChannelCommand('alpha')),
+        source('secondary', fakeChannelCommand('beta')),
+        // The third channel's own declaration is the one that fails; the first
+        // two were perfectly valid and must not survive it.
+        source('tertiary', fakeChannelCommand('has.dot')),
+      ]),
+    ).toThrow(/cannot be part of a command name/);
+    expect(registrar.channelCommandNames(DISPATCHER)).toEqual([]);
+    // And nothing is invocable, not merely unlisted.
+    await expect(
+      registrar.invoke(channelContext(), 'channel.primary.alpha', { note: 'x' }),
+    ).rejects.toMatchObject({ code: 'UNKNOWN_METHOD' });
+    // The rejected attempt also took no lease, so the dispatcher can retry.
+    expect(() =>
+      registrar.registerChannelCommands(DISPATCHER, [
+        source('primary', fakeChannelCommand('alpha')),
+      ]),
+    ).not.toThrow();
+  });
+
+  it('rejects a malformed Channel-declared schema at registration, naming the channel and local name', () => {
+    const registrar = port();
+    const malformed = fakeChannelCommand('broken', {
+      input: { type: 'not-a-real-type' } as never,
+    });
+    expect(() =>
+      registrar.registerChannelCommands(DISPATCHER, [source('primary', malformed)]),
+    ).toThrow(/channel "primary" command "broken" declares a malformed input schema/);
+    expect(registrar.channelCommandNames(DISPATCHER)).toEqual([]);
+  });
+
+  it('rejects a malformed declared OUTPUT schema too, before any invocation could reach it', () => {
+    const registrar = port();
+    const malformed = fakeChannelCommand('broken', {
+      output: { type: 'object', unsupported: true } as never,
+    });
+    expect(() =>
+      registrar.registerChannelCommands(DISPATCHER, [source('primary', malformed)]),
+    ).toThrow(/channel "primary" command "broken" declares a malformed output schema/);
+  });
+
+  it('rejects a local_name that cannot be one name segment', () => {
+    const registrar = port();
+    for (const bad of ['has.dot', '_leading', 'has space', '', 'ünicode']) {
+      expect(() =>
+        registrar.registerChannelCommands(DISPATCHER, [
+          source('primary', fakeChannelCommand(bad)),
+        ]),
+        `local_name ${JSON.stringify(bad)} must be refused`,
+      ).toThrow(/cannot be part of a command name/);
+    }
+    expect(registrar.channelCommandNames(DISPATCHER)).toEqual([]);
+  });
+
+  it('rejects a version other than 1, because only version 1 exists', () => {
+    const registrar = port();
+    expect(() =>
+      registrar.registerChannelCommands(DISPATCHER, [
+        source('primary', fakeChannelCommand('ping', { version: 2 as never })),
+      ]),
+    ).toThrow(/only version 1 exists/);
+  });
+
+  it('rejects a Channel name that would collide with a Core Command', () => {
+    // A Core Command may not live under `channel.`, so the only way to collide
+    // is for a Core Command to be named one — which construction already
+    // refuses. Both halves of that rule are proven here.
+    expect(
+      () =>
+        new CoreCommands([
+          {
+            name: 'channel.primary.ping',
+            version: 1,
+            input: NO_INPUT,
+            output: objectSchema({}),
+            parse: (payload) => payload,
+            execute: async () => ({}),
+          } as AnyCoreCommand,
+        ]),
+    ).toThrow(/reserved "channel\." namespace/);
+  });
+});
+
+describe('one batch per dispatcher is the registration lease', () => {
+  it('refuses a second batch while the first is live', () => {
+    const registrar = port();
+    registrar.registerChannelCommands(DISPATCHER, [
+      source('primary', fakeChannelCommand('ping')),
+    ]);
+    expect(() =>
+      registrar.registerChannelCommands(DISPATCHER, [
+        source('other', fakeChannelCommand('pong')),
+      ]),
+    ).toThrow(/already has a registered channel command catalog/);
+    // The live catalog is untouched by the rejected attempt.
+    expect(registrar.channelCommandNames(DISPATCHER)).toEqual(['channel.primary.ping']);
+  });
+
+  it('an all-empty catalog registers no name but still holds the lease', () => {
+    const registrar = port();
+    const batch = registrar.registerChannelCommands(DISPATCHER, [source('primary')]);
+    expect(registrar.channelCommandNames(DISPATCHER)).toEqual([]);
+    // Owning nothing is not the same as owning no lifecycle: this dispatcher
+    // still has a registration, and only its own batch may give it back.
+    expect(() =>
+      registrar.registerChannelCommands(DISPATCHER, [source('primary')]),
+    ).toThrow(/already has a registered channel command catalog/);
+    batch.unregister();
+    expect(() =>
+      registrar.registerChannelCommands(DISPATCHER, [
+        source('primary', fakeChannelCommand('ping')),
+      ]),
+    ).not.toThrow();
+  });
+
+  it('unregister releases the lease and removes every name it registered', async () => {
+    const registrar = port();
+    const batch = registrar.registerChannelCommands(DISPATCHER, [
+      source('primary', fakeChannelCommand('ping')),
+      source('secondary', fakeChannelCommand('pong')),
+    ]);
+    batch.get('primary')?.openAdmission();
+    expect(registrar.channelCommandNames(DISPATCHER)).toHaveLength(2);
+
+    batch.unregister();
+
+    expect(registrar.channelCommandNames(DISPATCHER)).toEqual([]);
+    await expect(
+      registrar.invoke(channelContext(), 'channel.primary.ping', { note: 'x' }),
+    ).rejects.toMatchObject({ code: 'UNKNOWN_METHOD' });
+  });
+
+  it('unregister is idempotent and a superseded batch cannot release the run that replaced it', () => {
+    const registrar = port();
+    const first = registrar.registerChannelCommands(DISPATCHER, [
+      source('primary', fakeChannelCommand('ping')),
+    ]);
+    first.unregister();
+    const second = registrar.registerChannelCommands(DISPATCHER, [
+      source('primary', fakeChannelCommand('pong')),
+    ]);
+
+    // A late `unregister()` from the superseded batch must not revoke the run
+    // that replaced it, nor release its lease.
+    first.unregister();
+
+    expect(registrar.channelCommandNames(DISPATCHER)).toEqual(['channel.primary.pong']);
+    expect(() =>
+      registrar.registerChannelCommands(DISPATCHER, [source('primary')]),
+    ).toThrow(/already has a registered channel command catalog/);
+    second.unregister();
+  });
+
+  it('scopes names per dispatcher: two dispatchers may configure the same channel id', async () => {
+    const registrar = port();
+    const executeA = vi.fn(async () => ({ echoed: 'a' }));
+    const executeB = vi.fn(async () => ({ echoed: 'b' }));
+    const a = registrar.registerChannelCommands('alpha', [
+      source('primary', fakeChannelCommand('ping', { execute: executeA })),
+    ]);
+    const b = registrar.registerChannelCommands('beta', [
+      source('primary', fakeChannelCommand('ping', { execute: executeB })),
+    ]);
+    a.get('primary')?.openAdmission();
+    b.get('primary')?.openAdmission();
+
+    await registrar.invoke(
+      channelContext('primary', 'alpha'),
+      'channel.primary.ping',
+      { note: 'x' },
+    );
+
+    expect(executeA).toHaveBeenCalledTimes(1);
+    expect(executeB).not.toHaveBeenCalled();
+
+    // And revoking one dispatcher's batch leaves the other's resolvable.
+    a.unregister();
+    expect(registrar.channelCommandNames('alpha')).toEqual([]);
+    expect(registrar.channelCommandNames('beta')).toEqual(['channel.primary.ping']);
+    await expect(
+      registrar.invoke(channelContext('primary', 'beta'), 'channel.primary.ping', {
+        note: 'x',
+      }),
+    ).resolves.toEqual({ echoed: 'b' });
+    b.unregister();
+  });
+});
+
+describe('addressing a Channel Command is validated exactly as a Core one is', () => {
+  it('a missing dispatcher_id is BAD_REQUEST, not a silent default', async () => {
+    const registrar = port();
+    const batch = registrar.registerChannelCommands(DISPATCHER, [
+      source('primary', fakeChannelCommand('ping')),
+    ]);
+    batch.get('primary')?.openAdmission();
+
+    await expect(
+      registrar.invoke({ source: 'admin_socket' }, 'channel.primary.ping', {
+        note: 'x',
+      }),
+    ).rejects.toMatchObject({ code: 'BAD_REQUEST' });
+    batch.unregister();
+  });
+
+  it('a malformed dispatcher_id is BAD_REQUEST, never UNKNOWN_METHOD', async () => {
+    // Falling through to UNKNOWN_METHOD would tell the caller the Command does
+    // not exist when the real fault is the address it used.
+    const registrar = port();
+    const batch = registrar.registerChannelCommands(DISPATCHER, [
+      source('primary', fakeChannelCommand('ping')),
+    ]);
+    batch.get('primary')?.openAdmission();
+
+    for (const malformed of ['-leading-dash', 'has space', 'a'.repeat(65), '']) {
+      await expect(
+        registrar.invoke(
+          { source: 'admin_socket', dispatcher_id: malformed },
+          'channel.primary.ping',
+          { note: 'x' },
+        ),
+        `dispatcher_id ${JSON.stringify(malformed)} must be a caller mistake`,
+      ).rejects.toMatchObject({ code: 'BAD_REQUEST' });
+    }
+    batch.unregister();
+  });
+
+  it('a well-formed dispatcher_id that registered nothing is UNKNOWN_METHOD', async () => {
+    const registrar = port();
+    const batch = registrar.registerChannelCommands(DISPATCHER, [
+      source('primary', fakeChannelCommand('ping')),
+    ]);
+    batch.get('primary')?.openAdmission();
+
+    await expect(
+      registrar.invoke(
+        { source: 'admin_socket', dispatcher_id: 'some-other-dispatcher' },
+        'channel.primary.ping',
+        { note: 'x' },
+      ),
+    ).rejects.toMatchObject({ code: 'UNKNOWN_METHOD' });
+    batch.unregister();
+  });
+
+  it('a valid dispatcher_id resolves and executes', async () => {
+    const registrar = port();
+    const batch = registrar.registerChannelCommands(DISPATCHER, [
+      source('primary', fakeChannelCommand('ping')),
+    ]);
+    batch.get('primary')?.openAdmission();
+
+    await expect(
+      registrar.invoke(
+        { source: 'admin_socket', dispatcher_id: DISPATCHER },
+        'channel.primary.ping',
+        { note: 'hello' },
+      ),
+    ).resolves.toEqual({ echoed: 'hello' });
+    batch.unregister();
+  });
+});
+
+describe('a Channel Command answers through the identical validation path', () => {
+  it('validates the Channel-declared input before the handler runs', async () => {
+    const registrar = port();
+    const execute = vi.fn(async () => ({ echoed: 'never' }));
+    const batch = registrar.registerChannelCommands(DISPATCHER, [
+      source('primary', fakeChannelCommand('ping', { execute })),
+    ]);
+    batch.get('primary')?.openAdmission();
+
+    await expect(
+      registrar.invoke(channelContext(), 'channel.primary.ping', { wrong: 1 }),
+    ).rejects.toMatchObject({ code: 'BAD_REQUEST' });
+    expect(execute).not.toHaveBeenCalled();
+    batch.unregister();
+  });
+
+  it('reports a Channel result that violates its own declared output as INTERNAL, not the caller mistake', async () => {
+    const registrar = port();
+    const batch = registrar.registerChannelCommands(DISPATCHER, [
+      source(
+        'primary',
+        fakeChannelCommand('ping', { execute: async () => ({}) as never }),
+      ),
+    ]);
+    batch.get('primary')?.openAdmission();
+
+    await expect(
+      registrar.invoke(channelContext(), 'channel.primary.ping', { note: 'x' }),
+    ).rejects.toMatchObject({ code: 'INTERNAL' });
+    batch.unregister();
+  });
+
+  it('reports a non-JSON-representable Channel result as INTERNAL', async () => {
+    const registrar = port();
+    const batch = registrar.registerChannelCommands(DISPATCHER, [
+      source(
+        'primary',
+        fakeChannelCommand('ping', {
+          execute: async () => ({ echoed: () => {} }) as never,
+        }),
+      ),
+    ]);
+    batch.get('primary')?.openAdmission();
+
+    await expect(
+      registrar.invoke(channelContext(), 'channel.primary.ping', { note: 'x' }),
+    ).rejects.toMatchObject({ code: 'INTERNAL' });
+    batch.unregister();
+  });
+
+  it('passes the caller context through untouched, so a handler reads who called it', async () => {
+    const registrar = port();
+    const seen: unknown[] = [];
+    const batch = registrar.registerChannelCommands(DISPATCHER, [
+      source(
+        'primary',
+        fakeChannelCommand('ping', {
+          async execute(context, input) {
+            seen.push(context);
+            return { echoed: input.note };
+          },
+        }),
+      ),
+    ]);
+    batch.get('primary')?.openAdmission();
+
+    await registrar.invoke(channelContext('primary'), 'channel.primary.ping', {
+      note: 'x',
+    });
+
+    expect(seen).toEqual([
+      { source: 'channel', dispatcher_id: DISPATCHER, channel_id: 'primary' },
+    ]);
+    batch.unregister();
+  });
+});
+
+describe('the admission fence separates "not serving" from "no such Command"', () => {
+  it('a registered but never-opened Command answers CHANNEL_COMMAND_UNAVAILABLE, retryably', async () => {
+    const registrar = port();
+    const execute = vi.fn(async () => ({ echoed: 'never' }));
+    const batch = registrar.registerChannelCommands(DISPATCHER, [
+      source('primary', fakeChannelCommand('ping', { execute })),
+    ]);
+
+    await expect(
+      registrar.invoke(channelContext(), 'channel.primary.ping', { note: 'x' }),
+    ).rejects.toMatchObject({
+      code: 'CHANNEL_COMMAND_UNAVAILABLE',
+      action: expect.stringContaining('Retry'),
+    });
+    // Never reached the Channel's own handler, so nothing partial happened.
+    expect(execute).not.toHaveBeenCalled();
+    batch.unregister();
+  });
+
+  it('opens per registration, not per batch: one channel serving does not open its sibling', async () => {
+    const registrar = port();
+    const batch = registrar.registerChannelCommands(DISPATCHER, [
+      source('primary', fakeChannelCommand('ping')),
+      source('secondary', fakeChannelCommand('pong')),
+    ]);
+
+    batch.get('primary')?.openAdmission();
+
+    await expect(
+      registrar.invoke(channelContext(), 'channel.primary.ping', { note: 'x' }),
+    ).resolves.toEqual({ echoed: 'x' });
+    await expect(
+      registrar.invoke(channelContext('secondary'), 'channel.secondary.pong', {
+        note: 'x',
+      }),
+    ).rejects.toMatchObject({ code: 'CHANNEL_COMMAND_UNAVAILABLE' });
+    batch.unregister();
+  });
+
+  it('a fenced Command answers unavailable rather than unknown, because the name is still real', async () => {
+    const registrar = port();
+    const batch = registrar.registerChannelCommands(DISPATCHER, [
+      source('primary', fakeChannelCommand('ping')),
+    ]);
+    batch.get('primary')?.openAdmission();
+    batch.closeAdmission();
+
+    await expect(
+      registrar.invoke(channelContext(), 'channel.primary.ping', { note: 'x' }),
+    ).rejects.toMatchObject({ code: 'CHANNEL_COMMAND_UNAVAILABLE' });
+    // Still listed: fenced is not revoked.
+    expect(registrar.channelCommandNames(DISPATCHER)).toEqual(['channel.primary.ping']);
+    batch.unregister();
+  });
+
+  it('closeAdmission is idempotent and openAdmission after it serves again', async () => {
+    const registrar = port();
+    const batch = registrar.registerChannelCommands(DISPATCHER, [
+      source('primary', fakeChannelCommand('ping')),
+    ]);
+    const registration = batch.get('primary')!;
+    registration.closeAdmission();
+    registration.closeAdmission();
+    expect(registration.accepting).toBe(false);
+    registration.openAdmission();
+    expect(registration.accepting).toBe(true);
+
+    await expect(
+      registrar.invoke(channelContext(), 'channel.primary.ping', { note: 'x' }),
+    ).resolves.toEqual({ echoed: 'x' });
+    batch.unregister();
+  });
+});
+
+describe('drain converges what admission already accepted', () => {
+  it('a handler that closes its own session synchronously is still drained', async () => {
+    // The race `admit` exists for: a bind that fails its precondition tears its
+    // session down from inside the handler. If the fence-check and the drain
+    // entry were separate statements, this call would be running against state
+    // that shutdown believed it had already converged.
+    const registrar = port();
+    let batchRef: { closeAdmission(): void } | null = null;
+    let handlerFinished = false;
+    let release!: () => void;
+    const gate = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    const batch = registrar.registerChannelCommands(DISPATCHER, [
+      source(
+        'primary',
+        fakeChannelCommand('bind', {
+          async execute(_context, input) {
+            // Synchronously, before its first await: exactly the reentry the
+            // indivisible admit step has to survive.
+            batchRef?.closeAdmission();
+            await gate;
+            handlerFinished = true;
+            return { echoed: input.note };
+          },
+        }),
+      ),
+    ]);
+    batchRef = batch;
+    batch.get('primary')?.openAdmission();
+
+    const inFlight = registrar.invoke(channelContext(), 'channel.primary.bind', {
+      note: 'x',
+    });
+    // The fence the handler itself closed is already refusing the next caller.
+    await expect(
+      registrar.invoke(channelContext(), 'channel.primary.bind', { note: 'y' }),
+    ).rejects.toMatchObject({ code: 'CHANNEL_COMMAND_UNAVAILABLE' });
+
+    const drained = batch.drain().then(() => {
+      // Drain must not resolve before the accepted call finished.
+      expect(handlerFinished).toBe(true);
+    });
+    release();
+    await Promise.all([inFlight, drained]);
+    batch.unregister();
+  });
+
+  it('drain returns even when the admitted handler rejects', async () => {
+    const registrar = port();
+    const batch = registrar.registerChannelCommands(DISPATCHER, [
+      source(
+        'primary',
+        fakeChannelCommand('ping', {
+          async execute() {
+            throw new Error('channel handler blew up');
+          },
+        }),
+      ),
+    ]);
+    batch.get('primary')?.openAdmission();
+
+    const rejected = registrar.invoke(channelContext(), 'channel.primary.ping', {
+      note: 'x',
+    });
+    await expect(rejected).rejects.toThrow(/channel handler blew up/);
+    // A rejection that escaped the drain set unobserved would hang this await.
+    await expect(batch.drain()).resolves.toBeUndefined();
+    batch.unregister();
+  });
+
+  it('a run that throws synchronously leaves no entry the drain would wait on forever', async () => {
+    // `admit` takes the drain entry before it calls `run`, so a `run` that
+    // throws before ever producing a promise must still release that entry.
+    // Driven directly against the registration because the registry always
+    // hands `admit` an async function; this proves the primitive itself.
+    const registration = new ChannelCommandRegistration(DISPATCHER, 'primary', []);
+    registration.openAdmission();
+
+    expect(() =>
+      registration.admit((): Promise<never> => {
+        throw new Error('synchronous handler failure');
+      }),
+    ).toThrow(/synchronous handler failure/);
+
+    await expect(registration.drain()).resolves.toBeUndefined();
+  });
+
+  it('a run that returns an already-rejected promise is likewise released', async () => {
+    const registration = new ChannelCommandRegistration(DISPATCHER, 'primary', []);
+    registration.openAdmission();
+
+    const admitted = registration.admit(() =>
+      Promise.reject(new Error('already rejected')),
+    );
+    await expect(admitted).rejects.toThrow(/already rejected/);
+
+    await expect(registration.drain()).resolves.toBeUndefined();
+  });
+
+  it('drain on a fence that never admitted anything returns immediately', async () => {
+    const registration = new ChannelCommandRegistration(DISPATCHER, 'primary', []);
+    expect(registration.admit(async () => null)).toBeNull();
+    await expect(registration.drain()).resolves.toBeUndefined();
+  });
+});
+
+describe('the batch is a read model of what it registered', () => {
+  it('reports names per channel, and nothing for a channel it does not hold', () => {
+    const registrar = port();
+    const batch = registrar.registerChannelCommands(DISPATCHER, [
+      source('primary', fakeChannelCommand('ping'), fakeChannelCommand('pong')),
+      source('quiet'),
+    ]);
+
+    expect(batch.get('primary')?.names).toEqual([
+      'channel.primary.ping',
+      'channel.primary.pong',
+    ]);
+    expect(batch.get('quiet')?.names).toEqual([]);
+    expect(batch.get('never-configured')).toBeNull();
+    expect([...batch.namesByChannel()]).toEqual([
+      ['primary', ['channel.primary.ping', 'channel.primary.pong']],
+      ['quiet', []],
+    ]);
+    batch.unregister();
+  });
+});

--- a/packages/dreamux/tests/channel-descriptor.test.ts
+++ b/packages/dreamux/tests/channel-descriptor.test.ts
@@ -1,0 +1,303 @@
+/**
+ * The Channel read model: `channelDescriptors()` and the `dispatcher.status`
+ * result that carries it.
+ *
+ * Two things are under test here and they fail in different ways. The
+ * projection decides *what* a caller is told about a Channel — and in
+ * particular that "gone" and "still named" are one decision, taken from the
+ * registration rather than from liveness. The Command's declared output decides
+ * what may reach a caller at all: it is a closed schema precisely so an
+ * undeclared field — a provider config value most of all — is a loud Core
+ * defect instead of a quiet leak.
+ */
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { AgentRuntimeProviderCatalog } from '../src/agent-runtime/index.js';
+import { ChannelProviderCatalog } from '../src/channel/catalog.js';
+import { CoreCommandPort } from '../src/command/port.js';
+import { CoreCommands } from '../src/command/registry.js';
+import type { DreamuxConfig } from '../src/config/config.js';
+import { ProviderRegistry } from '../src/registry/registry.js';
+import { McpLeaseRegistry } from '../src/service/mcp/leases.js';
+import { Dispatchers } from '../src/service/dispatchers/index.js';
+import {
+  channelDescriptors,
+  type ChannelDescriptor,
+} from '../src/service/dispatcher-service/channel-descriptor.js';
+import { DispatcherStore } from '../src/state/dispatcher-store.js';
+import type { CoreCommandContext, DreamuxLogger } from '@excitedjs/dreamux-types';
+import {
+  adminContext,
+  createCommandHarness,
+  HARNESS_DISPATCHER_ID,
+} from './helpers/command-harness.js';
+
+function silentLogger(): DreamuxLogger {
+  const noop = () => {};
+  return { error: noop, warn: noop, info: noop, debug: noop, trace: noop };
+}
+
+/** The five fields a descriptor is allowed to have, and nothing else. */
+const DESCRIPTOR_KEYS = [
+  'channel_id',
+  'commands',
+  'identity',
+  'provider',
+  'status',
+];
+
+describe('channelDescriptors(): the registration decides what a caller is told', () => {
+  const configured = [
+    { id: 'primary', provider: 'npm:@example/chan#create', identity: 'chat-7788' },
+  ];
+
+  it('reports a configured Channel this run never registered as closed, with no commands', () => {
+    expect(
+      channelDescriptors({
+        configured,
+        registered: () => false,
+        liveStatus: () => 'stopped',
+        admissionFenced: false,
+        commandNames: () => ['channel.primary.ping'],
+      }),
+    ).toEqual([
+      {
+        channel_id: 'primary',
+        provider: 'npm:@example/chan#create',
+        identity: 'chat-7788',
+        commands: [],
+        status: 'closed',
+      },
+    ]);
+  });
+
+  it('walks closed -> starting -> ready -> closing -> closed as registration, liveness, and the fence move', () => {
+    const state = {
+      registered: false,
+      live: 'stopped' as 'running' | 'built' | 'stopped',
+      fenced: false,
+    };
+    const read = (): ChannelDescriptor =>
+      channelDescriptors({
+        configured,
+        registered: () => state.registered,
+        liveStatus: () => state.live,
+        admissionFenced: state.fenced,
+        commandNames: () => ['channel.primary.ping'],
+      })[0] as ChannelDescriptor;
+
+    const seen: Array<{ status: string; commands: readonly string[] }> = [];
+    const observe = () => {
+      const descriptor = read();
+      seen.push({ status: descriptor.status, commands: descriptor.commands });
+    };
+
+    observe(); // nothing registered yet
+    state.registered = true;
+    state.live = 'built';
+    observe(); // catalog registered, session not started
+    state.live = 'running';
+    observe(); // session started and adopted
+    state.fenced = true;
+    observe(); // admission fenced, still draining
+    // `ChannelService.closeAll()` detaches its maps before awaiting a single
+    // close, so liveness reads `stopped` here while the batch is still live —
+    // and the names must still be reported for exactly that window.
+    state.live = 'stopped';
+    observe();
+    state.registered = false;
+    observe(); // batch revoked
+
+    expect(seen).toEqual([
+      { status: 'closed', commands: [] },
+      { status: 'starting', commands: ['channel.primary.ping'] },
+      { status: 'ready', commands: ['channel.primary.ping'] },
+      { status: 'closing', commands: ['channel.primary.ping'] },
+      { status: 'closing', commands: ['channel.primary.ping'] },
+      { status: 'closed', commands: [] },
+    ]);
+  });
+
+  it('reports the identity the provider declared, and null when it declared none', () => {
+    const [declared, empty, absent] = channelDescriptors({
+      configured: [
+        { id: 'a', provider: 'p', identity: 'chat-7788' },
+        // The config loader writes '' when a provider has no identity
+        // capability; that is its "none", not a value to repeat back.
+        { id: 'b', provider: 'p', identity: '' },
+        { id: 'c', provider: 'p' },
+      ],
+      registered: () => false,
+      liveStatus: () => 'stopped',
+      admissionFenced: false,
+      commandNames: () => [],
+    });
+    expect(declared?.identity).toBe('chat-7788');
+    expect(empty?.identity).toBeNull();
+    expect(absent?.identity).toBeNull();
+  });
+
+  it('carries nothing from the Channel config but the id, the provider ref, and the opaque identity', () => {
+    // The projection input is typed to `ConfiguredChannelFacts`, but the value
+    // production passes is the whole `DispatcherChannelConfig` — parsed config,
+    // raw config and all. So the guarantee that matters is behavioural: what
+    // comes out carries none of it.
+    const [descriptor] = channelDescriptors({
+      configured: [
+        {
+          id: 'primary',
+          provider: 'npm:@example/chan#create',
+          identity: 'chat-7788',
+          config: { app_secret: 'sekret-value', allow_chats: ['oc_1'] },
+          rawConfig: { app_secret: '${env:CHAN_SECRET}' },
+        } as never,
+      ],
+      registered: () => true,
+      liveStatus: () => 'running',
+      admissionFenced: false,
+      commandNames: () => ['channel.primary.bind'],
+    });
+    expect(Object.keys(descriptor as object).sort()).toEqual(DESCRIPTOR_KEYS);
+    expect(JSON.stringify(descriptor)).not.toContain('sekret-value');
+    expect(JSON.stringify(descriptor)).not.toContain('CHAN_SECRET');
+    expect(JSON.stringify(descriptor)).not.toContain('oc_1');
+  });
+});
+
+describe('dispatcher.status carries the Channel read model under a closed schema', () => {
+  function descriptor(overrides: Partial<ChannelDescriptor> = {}): ChannelDescriptor {
+    return {
+      channel_id: 'primary',
+      provider: 'npm:@example/chan#create',
+      identity: 'chat-7788',
+      commands: ['channel.primary.bind'],
+      status: 'ready',
+      ...overrides,
+    };
+  }
+
+  async function status(
+    harness: ReturnType<typeof createCommandHarness>,
+    context: CoreCommandContext = adminContext(HARNESS_DISPATCHER_ID),
+  ) {
+    return harness.port.invoke(context, 'dispatcher.status', {});
+  }
+
+  it('returns each configured Channel with its registered command names', async () => {
+    const harness = createCommandHarness({
+      dispatcherChannels: () => [descriptor()],
+    });
+    const result = (await status(harness)) as { channel_descriptors: unknown[] };
+    expect(result.channel_descriptors).toEqual([descriptor()]);
+  });
+
+  it('refuses to publish a descriptor field Core never declared, as an INTERNAL defect', async () => {
+    const harness = createCommandHarness({
+      // Exactly the leak the closed schema exists to stop: a future edit that
+      // hands the read model the whole config object instead of the three
+      // facts it is allowed to repeat.
+      dispatcherChannels: () =>
+        [{ ...descriptor(), config: { app_secret: 'sekret-value' } }] as never,
+    });
+    await expect(status(harness)).rejects.toMatchObject({ code: 'INTERNAL' });
+  });
+
+  it('refuses a status word outside the four a caller can act on', async () => {
+    const harness = createCommandHarness({
+      dispatcherChannels: () =>
+        [{ ...descriptor(), status: 'draining' }] as never,
+    });
+    await expect(status(harness)).rejects.toMatchObject({ code: 'INTERNAL' });
+  });
+
+  it('is addressed by the caller context, and asks for exactly the dispatcher named', async () => {
+    const asked: string[] = [];
+    const harness = createCommandHarness({
+      dispatcherChannels: (id) => {
+        asked.push(id);
+        return [];
+      },
+    });
+    await status(harness);
+    expect(asked).toEqual([HARNESS_DISPATCHER_ID]);
+  });
+});
+
+describe('Dispatchers.channelDescriptors(): a read never materializes a dormant dispatcher', () => {
+  let dispatchers: Dispatchers | null = null;
+
+  afterEach(() => {
+    dispatchers = null;
+  });
+
+  function build(): Dispatchers {
+    const config: DreamuxConfig = {
+      agents: { flow: { provider: 'builtin:codex', config: {} } },
+      dispatchers: [
+        {
+          id: 'flow',
+          cwd: null,
+          enabled: true,
+          workspace: { enabled: true },
+          channels: [
+            {
+              id: 'primary',
+              provider: 'npm:@example/chan#create',
+              identity: 'chat-7788',
+              config: { app_secret: 'sekret-value' },
+              rawConfig: { app_secret: '${env:CHAN_SECRET}' },
+            },
+          ],
+          agentRuntime: 'flow',
+          runtime: { provider: 'builtin:codex', config: {} },
+        },
+      ],
+    };
+    return new Dispatchers({
+      config,
+      dispatchers: new DispatcherStore(config),
+      agentRuntimeProviders: new AgentRuntimeProviderCatalog({
+        registry: new ProviderRegistry(),
+      }),
+      channelProviders: new ChannelProviderCatalog({ registry: new ProviderRegistry() }),
+      mcpLeases: new McpLeaseRegistry(),
+      commands: new CoreCommandPort(new CoreCommands([])),
+      channelCommands: new CoreCommandPort(new CoreCommands([])),
+      homePathPrefixes: [],
+      channelLoggerFactory: () => silentLogger(),
+      log: silentLogger(),
+    });
+  }
+
+  it('answers from config alone — closed, no commands, and no aggregate built', () => {
+    dispatchers = build();
+
+    expect(dispatchers.channelDescriptors('flow')).toEqual([
+      {
+        channel_id: 'primary',
+        provider: 'npm:@example/chan#create',
+        identity: 'chat-7788',
+        commands: [],
+        status: 'closed',
+      },
+    ]);
+
+    // Proof the read built nothing: `get()` refuses to construct once the
+    // collection stops accepting, so a dispatcher that answers here would have
+    // to be one this read had already cached.
+    dispatchers.beginShutdown();
+    expect(() => dispatchers?.get('flow')).toThrow(/shutting down/);
+  });
+
+  it('repeats no config value from the dormant read either', () => {
+    dispatchers = build();
+    const json = JSON.stringify(dispatchers.channelDescriptors('flow'));
+    expect(json).not.toContain('sekret-value');
+    expect(json).not.toContain('CHAN_SECRET');
+  });
+
+  it('reports an unconfigured dispatcher as having no Channels at all', () => {
+    dispatchers = build();
+    expect(dispatchers.channelDescriptors('no-such-dispatcher')).toEqual([]);
+  });
+});

--- a/packages/dreamux/tests/fixtures/external-channel-command.ts
+++ b/packages/dreamux/tests/fixtures/external-channel-command.ts
@@ -1,0 +1,103 @@
+/**
+ * A Channel Command authored the way an external provider must author one:
+ * importing `@excitedjs/dreamux-types` and nothing else.
+ *
+ * That single import restriction is the point of this file, and
+ * `channel-command-adapters.test.ts` asserts it by reading this source back.
+ * An external Channel package may not depend on `@excitedjs/dreamux`, and the
+ * types package is declaration-only — it publishes no error base, no registry,
+ * and no value at all — so anything this fixture can do is exactly what a real
+ * external Channel can do, and anything it cannot do is a capability Core would
+ * be pretending to offer.
+ *
+ * The consequence this fixture exists to pin down is how a refusal is reported.
+ * A provider here has no Core failure class to construct, so a business outcome
+ * a caller is meant to read and act on is a *value* the handler returns and the
+ * declared output schema admits. Throwing is left for what it actually means:
+ * an implementation fault nobody classified.
+ */
+import type {
+  ChannelCommandDefinition,
+  JsonValue,
+} from '@excitedjs/dreamux-types';
+
+interface BindInput {
+  readonly chat_id: string;
+}
+
+/**
+ * The refusal shape, declared in the schema like any other answer.
+ *
+ * `bound: false` with a provider-owned `reason` is how this Channel says no.
+ * A caller branches on the field rather than on an error class it could not
+ * import anyway, and the value survives both adapters unchanged because it is
+ * an ordinary successful result.
+ */
+interface BindOutput {
+  readonly bound: boolean;
+  readonly reason: string | null;
+}
+
+/**
+ * One Command that answers, and refuses, entirely through its own output.
+ *
+ * `refuse` decides which of the two declared answers this instance gives, so a
+ * test can drive the refusal path without the fixture needing a second
+ * definition or any Core-owned vocabulary.
+ */
+export function externalBindCommand(options: {
+  localName: string;
+  refuse?: (input: BindInput) => string | null;
+}): ChannelCommandDefinition {
+  const definition: ChannelCommandDefinition<BindInput, BindOutput> = {
+    local_name: options.localName,
+    version: 1,
+    input: {
+      type: 'object',
+      additionalProperties: false,
+      properties: { chat_id: { type: 'string' } },
+      required: ['chat_id'],
+    },
+    output: {
+      type: 'object',
+      additionalProperties: false,
+      properties: {
+        bound: { type: 'boolean' },
+        reason: { type: ['string', 'null'] },
+      },
+      required: ['bound', 'reason'],
+    },
+    parse(payload: JsonValue): BindInput {
+      return { chat_id: (payload as { chat_id: string }).chat_id };
+    },
+    async execute(_context, input): Promise<BindOutput> {
+      const reason = options.refuse?.(input) ?? null;
+      return reason === null
+        ? { bound: true, reason: null }
+        : { bound: false, reason };
+    },
+  };
+  return definition as ChannelCommandDefinition;
+}
+
+/**
+ * The other half of the contract: a handler that genuinely breaks.
+ *
+ * A provider authored against the types package alone can only throw an
+ * ordinary `Error`, so this is the most a real external Channel can express by
+ * throwing — and the test pins what Core makes of it.
+ */
+export function externalFaultingCommand(
+  localName: string,
+): ChannelCommandDefinition {
+  const definition: ChannelCommandDefinition<BindInput, BindOutput> = {
+    ...(externalBindCommand({ localName }) as ChannelCommandDefinition<
+      BindInput,
+      BindOutput
+    >),
+    async execute(): Promise<BindOutput> {
+      throw new Error('the channel provider hit an unhandled condition');
+    },
+  };
+  return definition as ChannelCommandDefinition;
+}

--- a/packages/dreamux/tests/helpers/command-harness.ts
+++ b/packages/dreamux/tests/helpers/command-harness.ts
@@ -22,6 +22,7 @@ import { join } from 'node:path';
 import { createConnection, createServer, type Socket } from 'node:net';
 
 import type {
+  ChannelCommandDefinition,
   ChannelEventSource,
   CoreCommandContext,
   JsonValue,
@@ -41,6 +42,7 @@ import type {
   McpServerDelegate,
 } from '../../src/service/mcp/types.js';
 import type { DispatcherService } from '../../src/service/dispatcher-service/index.js';
+import type { ChannelDescriptor } from '../../src/service/dispatcher-service/channel-descriptor.js';
 import type { DispatcherRow } from '../../src/state/dispatcher-store.js';
 import type { DreamuxLogger } from '@excitedjs/dreamux-types';
 import type {
@@ -204,6 +206,11 @@ export interface HarnessOptions {
   /** Override `host.summarize()`, used by `server.status` and `dispatcher.list`. */
   summarize?: () => Promise<DispatcherSummary[]>;
   dispatcherRuntimeStatus?: () => Promise<DispatcherRuntimeStatus>;
+  /**
+   * Override `host.dispatcherChannels()`, the non-sensitive Channel read model
+   * `dispatcher.status` carries. Defaults to none configured.
+   */
+  dispatcherChannels?: (dispatcherId: string) => ChannelDescriptor[];
 }
 
 export interface CommandHarness {
@@ -215,7 +222,6 @@ export interface CommandHarness {
   /** Every call `host.dispatcher(id)` made, for tests that assert a call count. */
   readonly dispatcherLookups: string[];
 }
-
 /** Build one full harness: host, registry, and the admitted port, wired together exactly as `Server` wires them. */
 export function createCommandHarness(options: HarnessOptions = {}): CommandHarness {
   const dispatcher = createFakeDispatcher(options.dispatcherOverrides);
@@ -229,6 +235,7 @@ export function createCommandHarness(options: HarnessOptions = {}): CommandHarne
     dispatcherRuntimeStatus:
       options.dispatcherRuntimeStatus ??
       (async () => ({ status: 'running', sessionId: null, lastError: null })),
+    dispatcherChannels: options.dispatcherChannels ?? (() => []),
     dispatcher: (id: string) => {
       dispatcherLookups.push(id);
       return dispatcher;
@@ -466,6 +473,46 @@ export function hostileDeepPayload(depth: number): JsonValue {
     value = { nested: value };
   }
   return value as JsonValue;
+}
+
+/**
+ * One minimal, valid Channel-owned Command definition.
+ *
+ * Authored exactly as a Channel package would write one — closed input and
+ * output schemas, its own `parse`, its own `execute` — because the whole point
+ * of the registration path under test is that Core validates a Channel's
+ * definition through the identical steps it applies to a Core one. A test that
+ * needs a specific behaviour overrides `execute`; everything else stays the
+ * shape a real Channel ships.
+ */
+export function fakeChannelCommand(
+  localName: string,
+  overrides: Partial<ChannelCommandDefinition<{ note: string }, { echoed: string }>> = {},
+): ChannelCommandDefinition {
+  const definition: ChannelCommandDefinition<{ note: string }, { echoed: string }> = {
+    local_name: localName,
+    version: 1,
+    input: {
+      type: 'object',
+      additionalProperties: false,
+      properties: { note: { type: 'string' } },
+      required: ['note'],
+    },
+    output: {
+      type: 'object',
+      additionalProperties: false,
+      properties: { echoed: { type: 'string' } },
+      required: ['echoed'],
+    },
+    parse(payload) {
+      return { note: (payload as { note: string }).note };
+    },
+    async execute(_context, input) {
+      return { echoed: input.note };
+    },
+    ...overrides,
+  };
+  return definition as ChannelCommandDefinition;
 }
 
 export type { AdminResponse };

--- a/packages/dreamux/tests/helpers/fake-channel-provider.ts
+++ b/packages/dreamux/tests/helpers/fake-channel-provider.ts
@@ -14,6 +14,8 @@
  * tools".
  */
 import type {
+  ChannelCommandCapability,
+  ChannelCommandDefinition,
   ChannelCoreEvent,
   ChannelCorePort,
   ChannelEventSubscription,
@@ -84,6 +86,33 @@ export interface FakeChannelProviderOptions {
    */
   mutationTail?: () => Promise<void>;
   /**
+   * Runs inside `createSession`, before the instance is returned. A test uses
+   * it to make something happen while the host is still awaiting `build()` —
+   * a concurrent shutdown, most usefully.
+   */
+  onCreateSession?: (channelId: string) => void | Promise<void>;
+  /**
+   * Runs inside `start()`, before this session is recorded as started. The
+   * interleaving point a test needs to observe what is true *while* one
+   * session is opening: the host starts sessions one at a time, so a hook here
+   * sees every earlier session already live and every later one not yet built
+   * into the live map.
+   */
+  onStart?: (channelId: string) => void | Promise<void>;
+  /**
+   * Channel-owned Command definitions this session composes, or a thunk that
+   * decides them when Core reads the catalog. A Channel with no Commands omits
+   * this entirely, so no `ChannelCommandCapability` object exists on the
+   * instance at all — the same present-or-absent rule `mcp` follows.
+   *
+   * The thunk form is what lets a test drive the hostile case: `definitions()`
+   * is Channel-owned code Core runs synchronously, so a test can make it reach
+   * back into the dispatcher before the catalog is even assembled.
+   */
+  commands?:
+    | readonly ChannelCommandDefinition[]
+    | (() => readonly ChannelCommandDefinition[]);
+  /**
    * Optional Channel MCP composition. Omitted entirely (not present-but-empty)
    * when a test's Channel has no tools, matching `ChannelProvider.mcp?`.
    */
@@ -138,6 +167,10 @@ export function createFakeChannelProvider(
       };
       sessions.set(context.channel_id, handle);
       record(`channel:${context.channel_id}:create`);
+      // Awaited here, while the host is still inside `build()`: a test that
+      // wants a shutdown to land mid-build gets a real interleaving point
+      // rather than a timer it hopes is long enough.
+      await options.onCreateSession?.(context.channel_id);
 
       const session = {
         async initialize(port: ChannelCorePort): Promise<void> {
@@ -155,6 +188,7 @@ export function createFakeChannelProvider(
           record(`channel:${context.channel_id}:initialize`);
         },
         async start(): Promise<void> {
+          await options.onStart?.(context.channel_id);
           if (options.failStart) {
             record(`channel:${context.channel_id}:start:fail`);
             throw options.failStart();
@@ -181,12 +215,13 @@ export function createFakeChannelProvider(
         },
       };
 
-      const instance: ChannelInstance = options.mcp
-        ? {
-            session,
-            mcp: buildSessionMcp(options.mcp),
-          }
-        : { session };
+      const instance: ChannelInstance = {
+        session,
+        ...(options.mcp ? { mcp: buildSessionMcp(options.mcp) } : {}),
+        ...(options.commands !== undefined
+          ? { commands: buildCommands(options.commands) }
+          : {}),
+      };
       return instance;
     },
     ...(options.mcp
@@ -197,6 +232,15 @@ export function createFakeChannelProvider(
   };
 
   return { provider, sessions };
+}
+
+function buildCommands(
+  commands: NonNullable<FakeChannelProviderOptions['commands']>,
+): ChannelCommandCapability {
+  return {
+    definitions: () =>
+      typeof commands === 'function' ? commands() : commands,
+  };
 }
 
 function buildSessionMcp(

--- a/packages/dreamux/tests/input-source-lifecycle.test.ts
+++ b/packages/dreamux/tests/input-source-lifecycle.test.ts
@@ -40,6 +40,8 @@ import type { DispatcherChannelConfig, DreamuxConfig } from '../src/config/confi
 import { AgentRuntimeProviderCatalog } from '../src/agent-runtime/index.js';
 import { ChannelProviderCatalog } from '../src/channel/catalog.js';
 import { createConversationProjection } from '../src/channel/conversation-projection.js';
+import { CoreCommandPort } from '../src/command/port.js';
+import { CoreCommands } from '../src/command/registry.js';
 import { ServerShuttingDownError } from '../src/platform/errors.js';
 import { ProviderRegistry } from '../src/registry/registry.js';
 import { parseProviderRef } from '../src/registry/provider-ref.js';
@@ -59,6 +61,7 @@ import {
   createFakeChannelProvider,
   type FakeChannelProviderResult,
 } from './helpers/fake-channel-provider.js';
+import { fakeChannelCommand } from './helpers/command-harness.js';
 
 function silentLogger(): DreamuxLogger {
   const noop = () => {};
@@ -98,6 +101,10 @@ interface Harness {
   coreEvents: DispatcherCoreEventBus;
   admittedTasks: DispatcherTaskDrain;
   commands: { context: CoreCommandContext; name: string; payload: JsonValue }[];
+  /** The real admitted port this lifecycle registers its Channel catalog into. */
+  channelCommandPort: CoreCommandPort;
+  /** Flip what `isUnavailable()` answers, as a real shutdown fence would. */
+  setUnavailable: (value: boolean) => void;
   fakeChannel: FakeChannelProviderResult;
   extraChannel: FakeChannelProviderResult | null;
   teams: TeamCollection;
@@ -124,6 +131,7 @@ async function buildHarness(options: {
 
   const recorder: string[] = [];
   const record = (label: string) => recorder.push(label);
+  let unavailable = false;
 
   const fakeChannel = createFakeChannelProvider({
     record,
@@ -187,6 +195,11 @@ async function buildHarness(options: {
       return { ok: true } as JsonValue;
     },
   };
+  // The registration half is the real one, behind the real admitted port, so
+  // the names these tests resolve are the names an admin.sock caller would.
+  // Only the invoke half above is a fake, because these tests order the
+  // lifecycle rather than exercise the Core catalog.
+  const channelCommandPort = new CoreCommandPort(new CoreCommands([]));
 
   const teams = {
     async recoverWorktreeCleanup() {
@@ -268,13 +281,14 @@ async function buildHarness(options: {
     agentMcp: () =>
       ({ leases: {}, delegates: [], adminSocketPath: '' }) as unknown as TeammateAgentMcp,
     commands: commandRegistry,
+    channelCommands: channelCommandPort,
     coreEvents,
     scheduler,
     teams,
     teammates,
     admittedTasks,
     workflows,
-    isUnavailable: () => false,
+    isUnavailable: () => unavailable,
     restartIntent: () => null,
   });
 
@@ -290,6 +304,10 @@ async function buildHarness(options: {
     coreEvents,
     admittedTasks,
     commands,
+    channelCommandPort,
+    setUnavailable: (value: boolean) => {
+      unavailable = value;
+    },
     fakeChannel,
     extraChannel: extraChannelResult,
     teams,
@@ -652,5 +670,351 @@ describe('DispatcherInputSourceLifecycle: shutdown/rollback ordering and fencing
     // must not itself touch the Channel session (that already happened via
     // closePreparedChannels/rollback in a real stop sequence).
     expect(() => harness.lifecycle.markStopped()).not.toThrow();
+  });
+});
+
+/** A promise a test settles by hand, to hold a Command handler open. */
+function deferred(): { promise: Promise<void>; resolve: () => void } {
+  let resolve!: () => void;
+  const promise = new Promise<void>((res) => {
+    resolve = res;
+  });
+  return { promise, resolve };
+}
+
+const CHANNEL_CALLER: CoreCommandContext = {
+  source: 'channel',
+  dispatcher_id: 'flow',
+  channel_id: 'primary',
+};
+
+/** Invoke one Channel Command through the same admitted port an admin caller uses. */
+function invokeChannelCommand(
+  harness: Harness,
+  name: string,
+  payload: JsonValue = { note: 'x' },
+  context: CoreCommandContext = CHANNEL_CALLER,
+): Promise<JsonValue> {
+  return harness.channelCommandPort.invoke(context, name, payload);
+}
+
+/** Whether the dispatcher currently holds a registration lease at all. */
+function leaseIsFree(harness: Harness): boolean {
+  try {
+    harness.channelCommandPort.registerChannelCommands('flow', []).unregister();
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+describe('DispatcherInputSourceLifecycle: Channel Command registration lifecycle', () => {
+  let harness: Harness;
+
+  afterEach(async () => {
+    if (harness) await teardown(harness);
+  });
+
+  it('registers the whole catalog when Channels are built, and serves nothing until each session has started', async () => {
+    harness = await buildHarness({
+      channelOptions: { commands: [fakeChannelCommand('ping')] },
+    });
+
+    await harness.lifecycle.prepareChannels();
+
+    // Resolvable immediately: a caller must not have to know channel start
+    // order to learn the name exists.
+    expect(harness.channelCommandPort.channelCommandNames('flow')).toEqual([
+      'channel.primary.ping',
+    ]);
+    expect(harness.lifecycle.channelCommandNames('primary')).toEqual([
+      'channel.primary.ping',
+    ]);
+    await expect(invokeChannelCommand(harness, 'channel.primary.ping')).rejects.toMatchObject(
+      { code: 'CHANNEL_COMMAND_UNAVAILABLE' },
+    );
+
+    await harness.lifecycle.start();
+    await expect(invokeChannelCommand(harness, 'channel.primary.ping')).resolves.toEqual({
+      echoed: 'x',
+    });
+  });
+
+  it('opens admission per registration, at the moment that session own start returns', async () => {
+    const observed: string[] = [];
+    harness = await buildHarness({
+      channelOptions: { commands: [fakeChannelCommand('ping')] },
+      extraChannel: {
+        id: 'secondary',
+        ref: 'npm:@example/second#create',
+        options: {
+          commands: [fakeChannelCommand('ping')],
+          // Runs inside `secondary.start()`, i.e. after primary started and
+          // before secondary is published as live. Exactly the window where
+          // "one registration at a time" is observable.
+          onStart: async () => {
+            observed.push(
+              await invokeChannelCommand(harness, 'channel.primary.ping')
+                .then(() => 'primary:served')
+                .catch((error: { code?: string }) => `primary:${error.code}`),
+            );
+            observed.push(
+              await invokeChannelCommand(
+                harness,
+                'channel.secondary.ping',
+                { note: 'x' },
+                { source: 'channel', dispatcher_id: 'flow', channel_id: 'secondary' },
+              )
+                .then(() => 'secondary:served')
+                .catch((error: { code?: string }) => `secondary:${error.code}`),
+            );
+          },
+        },
+      },
+    });
+
+    await harness.lifecycle.start();
+
+    expect(observed).toEqual([
+      'primary:served',
+      'secondary:CHANNEL_COMMAND_UNAVAILABLE',
+    ]);
+    // Both serve once the whole start returned.
+    await expect(
+      invokeChannelCommand(
+        harness,
+        'channel.secondary.ping',
+        { note: 'x' },
+        { source: 'channel', dispatcher_id: 'flow', channel_id: 'secondary' },
+      ),
+    ).resolves.toEqual({ echoed: 'x' });
+  });
+
+  it('an ordinary stop fences admission, drains what it accepted, closes the sessions, and only then revokes the catalog', async () => {
+    const held = deferred();
+    let record!: (label: string) => void;
+    harness = await buildHarness({
+      channelOptions: {
+        commands: [
+          fakeChannelCommand('slow', {
+            async execute(_context, input) {
+              record('command:slow:begin');
+              await held.promise;
+              record('command:slow:end');
+              return { echoed: input.note };
+            },
+          }),
+        ],
+      },
+    });
+    record = harness.record;
+
+    await harness.lifecycle.start();
+    const inFlight = invokeChannelCommand(harness, 'channel.primary.slow');
+    // Let the handler reach its await before the fence closes, so this is a
+    // genuinely accepted call rather than one refused at the door.
+    await Promise.resolve();
+    expect(harness.recorder).toContain('command:slow:begin');
+
+    // The stop sequence `DispatcherService.doStop` runs, in its order.
+    let drained = false;
+    const draining = harness.lifecycle.drainChannelCommands().then(() => {
+      drained = true;
+    });
+    // Fenced synchronously: a call arriving now is refused, and the descriptor
+    // says `closing` rather than `ready` from that same instant.
+    await expect(invokeChannelCommand(harness, 'channel.primary.slow')).rejects.toMatchObject(
+      { code: 'CHANNEL_COMMAND_UNAVAILABLE' },
+    );
+    expect(harness.lifecycle.channelDescriptors()).toEqual([
+      {
+        channel_id: 'primary',
+        provider: 'npm:@example/chan#create',
+        identity: null,
+        commands: ['channel.primary.slow'],
+        status: 'closing',
+      },
+    ]);
+    await Promise.resolve();
+    expect(drained).toBe(false);
+
+    held.resolve();
+    await draining;
+    await expect(inFlight).resolves.toEqual({ echoed: 'x' });
+
+    await harness.channels.closeAll(silentLogger());
+    await harness.lifecycle.closePreparedChannels();
+    harness.lifecycle.markStopped();
+
+    // The accepted call finished before the session it ran against closed, and
+    // the names went away only after that.
+    const order = (label: string) => harness.recorder.indexOf(label);
+    expect(order('command:slow:end')).toBeGreaterThan(order('command:slow:begin'));
+    expect(order('channel:primary:close')).toBeGreaterThan(order('command:slow:end'));
+    expect(harness.channelCommandPort.channelCommandNames('flow')).toEqual([]);
+    await expect(invokeChannelCommand(harness, 'channel.primary.slow')).rejects.toMatchObject(
+      { code: 'UNKNOWN_METHOD' },
+    );
+    expect(harness.lifecycle.channelDescriptors()).toEqual([
+      {
+        channel_id: 'primary',
+        provider: 'npm:@example/chan#create',
+        identity: null,
+        commands: [],
+        status: 'closed',
+      },
+    ]);
+    expect(leaseIsFree(harness)).toBe(true);
+  });
+
+  it('a prepare-only teardown revokes the catalog it registered, in the same order', async () => {
+    harness = await buildHarness({
+      channelOptions: { commands: [fakeChannelCommand('ping')] },
+    });
+    await harness.lifecycle.prepareChannels();
+    expect(harness.channelCommandPort.channelCommandNames('flow')).toEqual([
+      'channel.primary.ping',
+    ]);
+
+    await harness.lifecycle.closePreparedChannels();
+
+    expect(harness.channelCommandPort.channelCommandNames('flow')).toEqual([]);
+    expect(leaseIsFree(harness)).toBe(true);
+    expect(harness.lifecycle.channelDescriptors()[0]?.status).toBe('closed');
+  });
+
+  it('a failed start revokes the whole batch, including the Channel that had already started', async () => {
+    harness = await buildHarness({
+      channelOptions: { commands: [fakeChannelCommand('ping')] },
+      extraChannel: {
+        id: 'secondary',
+        ref: 'npm:@example/second#create',
+        options: {
+          commands: [fakeChannelCommand('ping')],
+          failStart: () => new Error('secondary channel start failed'),
+        },
+      },
+    });
+
+    await expect(harness.lifecycle.start()).rejects.toThrow(
+      /secondary channel start failed/,
+    );
+
+    expect(harness.channelCommandPort.channelCommandNames('flow')).toEqual([]);
+    await expect(invokeChannelCommand(harness, 'channel.primary.ping')).rejects.toMatchObject(
+      { code: 'UNKNOWN_METHOD' },
+    );
+    // The lease went with it, so the retry a failed start invites can register.
+    expect(leaseIsFree(harness)).toBe(true);
+    expect(harness.lifecycle.channelDescriptors().map((c) => c.status)).toEqual([
+      'closed',
+      'closed',
+    ]);
+  });
+
+  it('a shutdown that lands while build() is still running registers no catalog at all', async () => {
+    harness = await buildHarness({
+      channelOptions: {
+        commands: [fakeChannelCommand('ping')],
+        onCreateSession: () => {
+          harness.setUnavailable(true);
+        },
+      },
+    });
+
+    await expect(harness.lifecycle.prepareChannels()).rejects.toThrow(/shutting down/);
+
+    expect(harness.channelCommandPort.channelCommandNames('flow')).toEqual([]);
+    harness.setUnavailable(false);
+    expect(leaseIsFree(harness)).toBe(true);
+  });
+
+  it('a definitions() call that synchronously begins a shutdown leaves no catalog and no lease', async () => {
+    // `definitions()` is Channel-owned code Core runs synchronously while
+    // assembling the catalog: it can reach back into its own dispatcher and
+    // start a stop before the last source is even collected.
+    harness = await buildHarness({
+      channelOptions: {
+        commands: () => {
+          harness.setUnavailable(true);
+          return [fakeChannelCommand('ping')];
+        },
+      },
+    });
+
+    await expect(harness.lifecycle.prepareChannels()).rejects.toThrow(/shutting down/);
+
+    expect(harness.channelCommandPort.channelCommandNames('flow')).toEqual([]);
+    harness.setUnavailable(false);
+    expect(leaseIsFree(harness)).toBe(true);
+  });
+
+  it('a definitions() call that begins a shutdown asynchronously has its already-registered catalog revoked', async () => {
+    // The harder half of the same hazard: the fence lands *after* the catalog
+    // is in the registry, so correctness depends on the failed prepare
+    // unwinding what it registered rather than on the fence arriving in time.
+    harness = await buildHarness({
+      channelOptions: {
+        commands: () => {
+          queueMicrotask(() => harness.setUnavailable(true));
+          return [fakeChannelCommand('ping')];
+        },
+      },
+    });
+
+    await expect(harness.lifecycle.prepareChannels()).rejects.toThrow(/shutting down/);
+
+    expect(harness.channelCommandPort.channelCommandNames('flow')).toEqual([]);
+    harness.setUnavailable(false);
+    expect(leaseIsFree(harness)).toBe(true);
+    expect(harness.fakeChannel.sessions.get('primary')?.closeCalled).toBe(true);
+  });
+
+  it('a Channel that declares no Commands still gets a registration, so it has a fence of its own', async () => {
+    harness = await buildHarness();
+    await harness.lifecycle.prepareChannels();
+
+    expect(harness.channelCommandPort.channelCommandNames('flow')).toEqual([]);
+    // Registered-but-empty is not the same as unregistered: the descriptor
+    // still describes a live Channel rather than a closed one.
+    expect(harness.lifecycle.channelDescriptors()[0]).toEqual({
+      channel_id: 'primary',
+      provider: 'npm:@example/chan#create',
+      identity: null,
+      commands: [],
+      status: 'starting',
+    });
+    expect(leaseIsFree(harness)).toBe(false);
+  });
+
+  it('a retry after a fenced prepare registers a fresh catalog and stops reporting the previous fence', async () => {
+    // The retryable teardown this lifecycle actually supports: a prepare that
+    // never got as far as adopting an Agent. It fenced admission on the way
+    // out, so the fence must belong to the run that closed it — not to the one
+    // that registers next.
+    let refuse = true;
+    harness = await buildHarness({
+      channelOptions: {
+        commands: () => {
+          if (refuse) harness.setUnavailable(true);
+          return [fakeChannelCommand('ping')];
+        },
+      },
+    });
+    await expect(harness.lifecycle.prepareChannels()).rejects.toThrow(/shutting down/);
+    expect(harness.channelCommandPort.channelCommandNames('flow')).toEqual([]);
+    expect(harness.lifecycle.channelDescriptors()[0]?.status).toBe('closed');
+
+    refuse = false;
+    harness.setUnavailable(false);
+    await harness.lifecycle.start();
+
+    expect(harness.channelCommandPort.channelCommandNames('flow')).toEqual([
+      'channel.primary.ping',
+    ]);
+    expect(harness.lifecycle.channelDescriptors()[0]?.status).toBe('ready');
+    await expect(invokeChannelCommand(harness, 'channel.primary.ping')).resolves.toEqual({
+      echoed: 'x',
+    });
   });
 });

--- a/packages/dreamux/tests/mcp-delegate-catalog.test.ts
+++ b/packages/dreamux/tests/mcp-delegate-catalog.test.ts
@@ -254,6 +254,9 @@ function stubHost(): CoreCommandHost {
     dispatcherRuntimeStatus: () => {
       throw new Error('mcpCommands must not call dispatcherRuntimeStatus()');
     },
+    dispatcherChannels: () => {
+      throw new Error('mcpCommands must not call dispatcherChannels()');
+    },
     dispatcher: () => {
       throw new Error('mcpCommands must not call dispatcher()');
     },

--- a/packages/dreamux/tests/package-boundary-guards.test.ts
+++ b/packages/dreamux/tests/package-boundary-guards.test.ts
@@ -350,6 +350,8 @@ describe('each package\'s index.ts re-export set is an intentional, pinned surfa
         'AgentRuntimeSystemPrompt',
         'BuiltinProviderRef',
         'ChannelBinCheck',
+        'ChannelCommandCapability',
+        'ChannelCommandDefinition',
         'ChannelCommandError',
         'ChannelCommandRetryableErrorCode',
         'ChannelConfigCapability',


### PR DESCRIPTION
## Summary

- allow Channel providers to declare immutable, dispatcher-scoped command catalogs
- register those commands in the canonical Core command registry with shared input/output validation, canonicalization, and adapter behavior
- add per-channel admission, draining, rollback, and revocation across Channel lifecycle transitions
- expose non-sensitive Channel command descriptors through `dispatcher.status` without materializing dormant dispatchers

## External provider contract

External Channel providers depend only on `@excitedjs/dreamux-types`. A Channel-authored business refusal is represented by the command's declared output schema and returned as an ordinary result. A thrown error is an implementation fault and is normalized to `INTERNAL`; Core does not define or import Channel-specific business error vocabularies.

Command names use `channel.<encoded channel_id>.<local_name>`, where the host applies the documented injective channel-id encoding. Registration is atomic per Channel catalog, and stopping or rolling back a Channel closes admission before draining in-flight executions and unregistering definitions.

## Validation

- `rush build`
- `rush lint`
- `rush typecheck`
- `rush typecheck:tests`
- `DREAMUX_SKIP_LIVE_CODEX=1 rush test`
- Dreamux package tests: 68 files passed, 1045 passed, 1 skipped
- `rush smoke-built-cli`
- `.agents/scripts/check.sh`
- `rush change --verify --target-branch origin/next --no-fetch`
- `git diff --check`

The live Codex compatibility test was intentionally skipped by `DREAMUX_SKIP_LIVE_CODEX=1`; the non-live suite and both admin-socket/in-process Channel command adapters passed.
