### PR TITLE
Resolve the upgrade target and launcher before touching the prefix

### DIFF
--- a/.agents/product/README.md
+++ b/.agents/product/README.md
@@ -161,6 +161,18 @@ the same change that touches it.
 
 ## Local state and upgrades
 
+- **A resumed upgrade reports itself in the conversation that asked for it.** An
+  explicit upgrade request resolves the managed service's own launcher, resolves
+  the exact target before installing anything, applies the changelog's config
+  migrations, repairs until `doctor` passes, and only then restarts with a
+  resume notice. Once the Dispatcher resumes, the operator sees old and new
+  versions, the migrations done, the doctor result, and the restart outcome. An
+  upgrade that cannot get doctor to pass, that resolves to a target at or below
+  the installed version, or that finds the managed launcher and the shell's
+  `dreamux` are different installs reports that and stops before restarting.
+  Past the restart the caller may already be gone, so a Dispatcher that never
+  resumes reports nothing at all.
+  (Decision: [adopt-lean-self-upgrade-sop](/.agents/tasks/builtin-skills/adopt-lean-self-upgrade-sop/README.md).)
 - **Local runtime state is disposable; upgrades fail loudly.** Team, Agent, and
   Dispatcher operational state is rebuildable operational data, not a protected
   asset. On the 0.x line an incompatible shape is handled by fail-loud plus

--- a/.agents/tasks/builtin-skills/adopt-lean-self-upgrade-sop/README.md
+++ b/.agents/tasks/builtin-skills/adopt-lean-self-upgrade-sop/README.md
@@ -6,9 +6,12 @@
 - State: `done`
 - Requirement: [Current requirement](/.agents/tasks/builtin-skills/adopt-lean-self-upgrade-sop/requirement.md)
 - Final solution: [Final technical solution](/.agents/tasks/builtin-skills/adopt-lean-self-upgrade-sop/technical-design/final.md)
-- Solution review Issue: Not applicable; the operator ruled this onto the minimal-change fast path.
+- Solution review Issue: Not applicable for the first slice (minimal-change fast
+  path). The follow-up slice is specified by
+  [issue #374](https://github.com/excitedjs/dreamux/issues/374), authored by the
+  operator.
 - Blockers: None.
-- Next action: Commit the reviewed workspace and open the PR against `next`.
+- Next action: Await merge of the issue #374 follow-up PR; it closes that issue.
 - Verification: [Verification record](/.agents/tasks/builtin-skills/adopt-lean-self-upgrade-sop/verification.md)
 - Related tasks: None.
 
@@ -22,10 +25,17 @@
 - Boundary extension: on 2026-09-02 the operator answered "1" to the reviewer's
   second blocker, adding `.agents/scripts/check.sh` to the writable set so the
   required knowledge gate could be made runnable on stock macOS bash.
+- Follow-up slice approved on 2026-09-04 with "开一个新的 pr ，修一下这个issue 的
+  问题，pr 合入后给 issue 关掉", against the scenarios and non-goals in issue #374
+  and the plan played back to the operator beforehand. Boundary:
+  `references/self-upgrade.md`, `.agents/product/README.md`, this task record,
+  and one Rush change file.
 
 ## Delivery
 
-- Pull request / CI / merge: Not started.
+- Pull request / CI / merge: PR #370 merged into `next` as `4561f52`. Follow-up
+  slice for issue #374 in progress; it opens a second PR from the same fork,
+  because the pushing account has read-only access to the upstream repository.
 - Knowledge closeout: Complete. Owners touched and results:
   - `.agents/tasks/**` — this task record is the decision record: requirement,
     final solution, operator rulings, and verification.
@@ -33,9 +43,10 @@
     — updated to the four-step contract.
   - `CLAUDE.md` — maintenance-synchronization clause updated to the installed
     target's changelog.
-  - `.agents/product/README.md` — `N/A`: the catalog's upgrade entry owns
-    fail-loud state handling on the 0.x line, which this change does not touch.
-    The self-upgrade SOP is model-facing guidance, not a catalogued behavior.
+  - `.agents/product/README.md` — updated by the follow-up slice. The first
+    slice recorded this as `N/A` on the reasoning that the SOP is model-facing
+    guidance; issue #374 overrode that, and the Channel-visible upgrade outcome
+    is now a catalog entry pointing back here.
   - `.agents/glossary.md` — `N/A`: no overloaded term added or redefined.
   - `.agents/root.md` — `N/A`: routing is unchanged; the existing row already
     lists the two live domain owners ahead of the archived specification.

--- a/.agents/tasks/builtin-skills/adopt-lean-self-upgrade-sop/requirement.md
+++ b/.agents/tasks/builtin-skills/adopt-lean-self-upgrade-sop/requirement.md
@@ -147,3 +147,66 @@ The bundled self-upgrade reference states one runnable four-step procedure:
   omission of a private registry flag are required substitutions under the
   repository's public-repo red line, not a partial adoption of the ruling.
 - Blocking unknowns: none.
+
+
+## Follow-up slice: harden the lean SOP (issue #374)
+
+After PR #370 merged, the operator filed
+[issue #374](https://github.com/excitedjs/dreamux/issues/374) with three named
+scenarios and an explicit non-goal list. The lean four-step shape is confirmed
+correct; only the smallest textual corrections inside those steps are in scope.
+
+### Confirmed scenarios and their evidence
+
+1. **The SOP could upgrade one install and restart another.** Onboarding
+   defaults the service launcher to whichever launcher ran it
+   (`packages/dreamux/src/onboard/wizard.ts` resolves `dreamuxBin` from
+   `process.env['DREAMUX_BIN'] ?? process.argv[1]`, and
+   `packages/dreamux/src/onboard/service.ts` writes that absolute path into
+   `ExecStart` / `ProgramArguments`). A service pinned to an npx or local-checkout
+   launcher therefore need not be the `dreamux` this shell resolves. The SOP read
+   `oldVersion` from the shell's `dreamux`, installed into the shell's global
+   prefix, restarted the service, received the service's resume notice, and
+   reported the other copy's version as success.
+2. **The SOP installed before it compared.** The target was only known after
+   `npm install --global` had already changed the live prefix. A named selector,
+   or `latest` while the installed copy is a newer prerelease, resolves at or
+   below `oldVersion` — and this repository publishes a beta prerelease on every
+   merge to `next`, so being ahead of `latest` is ordinary, not exotic. The
+   `(oldVersion, targetVersion]` range in step 2 is then empty or inverted.
+3. **The no-notice instruction had no executing actor.** The resume notice is
+   injected into a Dispatcher as it comes up
+   (`packages/dreamux/src/daemon/restart-intent.ts`). If resume or startup fails,
+   no turn exists, so no model is present to observe that the notice never
+   arrived. `Use the root skill's Service lifecycle route if ... the notice does
+   not arrive` promised an action nobody could take.
+
+### Desired outcome
+
+- Step 1 resolves the managed launcher and its environment once from
+  `doctor --json`, reads `oldVersion` from that launcher, and stops on a
+  launcher / PATH / global-prefix mismatch.
+- Step 1 resolves the exact target with `npm view` before installing; equal is a
+  reported no-op, lower is refused, only higher installs. The post-install check
+  requires the managed launcher to report the resolved target.
+- Step 4 keeps Service lifecycle routing only for a synchronous restart failure
+  while the caller is still alive, and drops the unreachable no-notice promise.
+- `.agents/product/README.md` carries the Channel-visible upgrade outcome with a
+  pointer to this task record.
+
+### Non-goals (operator's list, verbatim in effect)
+
+No package staging or `npm pack`, no dependency rehearsal prefixes, no
+backup/artifact matrices, no rollback protocols, no independent
+controller/recovery actor, and no new persisted state, timers, retry loops, or
+recovery mechanisms. If a fix would materially expand the SOP, the scenario is
+left fail-loud instead.
+
+### Acknowledged direction change
+
+Scenario 1's fix restores a narrow piece of the launcher/prefix identity proof
+that PR #370 deleted. This is deliberate and was surfaced to the operator before
+implementation: the deleted version proved identity across staged artifacts and
+rehearsal prefixes, while this one resolves the launcher once and stops on a
+mismatch. The scenario is named and reachable, which is what the deleted version
+lacked.

--- a/.agents/tasks/builtin-skills/adopt-lean-self-upgrade-sop/technical-design/final.md
+++ b/.agents/tasks/builtin-skills/adopt-lean-self-upgrade-sop/technical-design/final.md
@@ -165,3 +165,26 @@ Two blockers were accepted and applied; both are recorded with evidence in
    macOS bash 3.2. One `case` inside a process substitution became a
    parameter-expansion prefix test. The operator extended the implementation
    boundary to cover this file.
+
+
+## Follow-up slice: issue #374 corrections
+
+Path: minimal-change fast path, same as the parent slice.
+
+- `references/self-upgrade.md` step 1 — resolve the managed service once from
+  `doctor --json`, take `service.execStart[0]` as the launcher and its captured
+  environment as the environment, read `oldVersion` from that launcher, stop on a
+  launcher / `PATH` / `npm prefix -g` mismatch, resolve the exact target with
+  `npm view` before installing, treat equal as a reported no-op and lower as a
+  refusal, and require the managed launcher to report the resolved target after
+  install.
+- `references/self-upgrade.md` step 4 — Service lifecycle routing applies only to
+  a synchronous restart failure while the caller survives; the unreachable
+  no-notice promise is deleted.
+- `.agents/product/README.md` — one entry under `Local state and upgrades` for
+  the Channel-visible upgrade outcome, pointing at this task record.
+- One Rush change file, `patch`.
+
+Everything on the operator's non-goal list stays absent. No CLI, daemon, config,
+or state behavior changes; `doctor --json`, `npm view`, and `npm prefix -g` are
+existing surfaces this guide composes.

--- a/.agents/tasks/builtin-skills/adopt-lean-self-upgrade-sop/verification.md
+++ b/.agents/tasks/builtin-skills/adopt-lean-self-upgrade-sop/verification.md
@@ -92,3 +92,67 @@ change file were each checked and reported clean. The reviewer confirmed no
 - The lean SOP has no rollback step. That is the accepted consequence of the
   operator's ruling, not an oversight: a failed install is diagnosed before any
   restart, and doctor must pass before the daemon is restarted at all.
+
+
+# Verification — follow-up slice (issue #374)
+
+## TeamLeader pre-review
+
+| Command | Result |
+|---|---|
+| `rush build` | SUCCESS |
+| `rush lint` | SUCCESS |
+| `rush test` | SUCCESS, no failure |
+| `rush typecheck:tests` | SUCCESS |
+| `.agents/scripts/check.sh` | `KB OK`, exit 0 |
+| `init_task.py check` | Task record OK |
+| `gitleaks protect --staged` | no leaks found |
+| `common/scripts/check-internal-content.sh` | exit 0 |
+
+The anti-leak gate was run by hand. This machine sets `core.hooksPath` to an
+external security-hook directory, so the repository's own
+`common/git-hooks/pre-commit` never fires and the mandatory gate is silently
+inert. Nothing about the machine's git configuration was changed; the hook's two
+checks were executed directly against the staged content instead. This is a
+repository-level gap — the gate CLAUDE.md calls mandatory can be bypassed by a
+setting the repository never inspects — and was reported to the operator rather
+than worked around quietly.
+
+## Independent implementation review
+
+One read-only reviewer, minimal-change fast path, one turn. One blocker, no
+improvements. Accepted.
+
+### Blocker — the product catalog re-promised a delivery the system cannot make
+
+The first draft of the catalog entry said an upgrade "reports itself" and that
+"the operator sees ... the restart outcome". That is the exact guarantee issue
+#374's third scenario removed from the SOP.
+
+`packages/dreamux/src/service/dispatcher-service/restart-notice.ts` returns early
+unless `startContinuity() === 'resumed'`, and an injection failure only warns to
+the log. So when resume or startup fails there is no turn, no notice, and no
+Channel delivery. A catalog entry claiming otherwise would invite a future
+implementer to satisfy it by adding the timer, retry, or recovery actor this task
+exists to keep out.
+
+Fix: the entry now names a *resumed* upgrade, qualifies the operator-visible
+report with "Once the Dispatcher resumes", and states plainly that a Dispatcher
+which never resumes reports nothing at all.
+
+### Reviewer findings with no defect
+
+All three named scenarios were walked against the new text and confirmed closed
+before any mutation: scenario 1 halts on the launcher/PATH/prefix mismatch before
+install, scenario 2 halts on the pre-install `npm view` comparison, and scenario
+3's actor-less instruction is gone. No non-goal was reintroduced. Every command
+and field the guide names was verified against current source, including
+`service.execStart` and `service.environment` in the doctor JSON. The SOP is 86
+lines and still four steps. Public-repository safety and the Rush change file
+were clean.
+
+## Residual risk
+
+- A Dispatcher that never resumes after the restart reports nothing. That is the
+  accepted fail-loud boundary named in issue #374, now stated in the product
+  catalog rather than papered over.

--- a/common/changes/@excitedjs/dreamux/fix-self-upgrade-launcher-and-target_2026-09-04-16-10.json
+++ b/common/changes/@excitedjs/dreamux/fix-self-upgrade-launcher-and-target_2026-09-04-16-10.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@excitedjs/dreamux",
+      "comment": "Harden the bundled self-upgrade guide: resolve the managed launcher and the exact target before installing, refuse an equal or lower target, and drop the unreachable no-notice routing promise.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@excitedjs/dreamux"
+}

--- a/packages/dreamux/skills/dispatcher/dreamux-maintenance/references/self-upgrade.md
+++ b/packages/dreamux/skills/dispatcher/dreamux-maintenance/references/self-upgrade.md
@@ -8,19 +8,36 @@ external stop/start and is not covered here.
 ### 1. Install the requested version
 
 Confirm the current Dispatcher id and retain the originating Channel message and
-provider reply tool for the resumed report. Record the current `dreamux
---version` as `oldVersion`.
+provider reply tool for the resumed report.
 
-Use the same Node/npm environment and global prefix as the managed service. When
-the operator does not name a version, use `latest`:
+Resolve the managed service once with `dreamux doctor --json`. Treat
+`service.execStart[0]` as the launcher the service actually runs, use its
+captured environment for every later command, and record that launcher's
+`--version` as `oldVersion`. Stop and report when that launcher, the `dreamux`
+on this shell's `PATH`, and the package under `npm prefix -g` are not the same
+install: onboarding pins the service to whichever launcher ran it, so upgrading
+one copy and restarting another would report a version that is not running.
+
+Resolve the exact target before changing anything. When the operator does not
+name a version, use `latest`:
 
 ```text
-npm install --global @excitedjs/dreamux@<requested-or-latest>
+npm view @excitedjs/dreamux@<requested-or-latest> version
 ```
 
-Require the install to succeed, then run `dreamux --version` again and record the
-installed result as `targetVersion`. If installation or version resolution
-fails, diagnose and fix it before continuing. Do not restart.
+Compare the resolved target with `oldVersion`. Equal is a no-op: report it and
+stop. Lower is a downgrade this guide does not perform — report it and stop,
+because the forward changelog range in step 2 would be empty and meaningless.
+Only a higher target continues:
+
+```text
+npm install --global @excitedjs/dreamux@<resolved-target>
+```
+
+Require the install to succeed, then re-read the managed launcher's `--version`,
+require it to equal the resolved target, and record it as `targetVersion`. If
+installation or version resolution fails, diagnose and fix it before continuing.
+Do not restart.
 
 ### 2. Read changelog and migrate config
 
@@ -63,5 +80,7 @@ with the provider reply tool. Report `oldVersion`, `targetVersion`, the changelo
 actions and config migrations completed, the passing doctor result, and the
 restart result. Assistant text alone is not Channel delivery.
 
-Use the root skill's Service lifecycle route if restart fails or the notice does
-not arrive. Do not claim upgrade success without the resumed notice.
+If the restart command itself fails while this turn is still alive, route to the
+root skill's Service lifecycle entry. Once the restart is in flight this caller
+may be reaped, so it claims nothing: the resumed notice is what reports the
+upgrade.


### PR DESCRIPTION
Closes #374.

Follow-up to #370, which replaced the staged self-upgrade procedure with a runnable four-step guide. Three scenarios that guide could still reach — each named in the issue, each confirmed against current source before writing a line.

## 1. The guide could upgrade one install and restart another

Onboarding pins the managed service to whichever launcher ran it: `onboard/wizard.ts` takes `dreamuxBin` from `DREAMUX_BIN ?? process.argv[1]`, and `onboard/service.ts` writes that absolute path into `ExecStart` / `ProgramArguments`. A service onboarded through npx or a local checkout is therefore not necessarily the `dreamux` a later shell resolves.

The guide read `oldVersion` from the shell's copy, installed into the shell's global prefix, restarted the service, received the *service's* resume notice, and reported the other copy's version as a successful upgrade.

**Step 1** now resolves the service once with `doctor --json`, treats `service.execStart[0]` as the launcher and its captured environment as the environment, reads `oldVersion` from that launcher, and stops when the launcher, the shell's `dreamux`, and the package under `npm prefix -g` are not one install.

## 2. The guide installed before it compared

The target was only known after `npm install --global` had already changed the live prefix. A named selector — or `latest` while the installed copy is a newer prerelease, which is ordinary here because every merge to `next` publishes a beta — resolves at or below `oldVersion`, leaving step 2's `(oldVersion, targetVersion]` range empty or inverted.

**Step 1** now resolves the exact target with `npm view` first: equal is a reported no-op, lower is refused, only higher installs. The post-install check requires the *managed launcher* to report the resolved target.

## 3. The no-notice instruction had no actor

`restart-notice.ts` returns early unless `startContinuity() === 'resumed'`, and logs rather than replies when injection fails. If resume or startup fails there is no turn — so nothing was executing to notice that the notice never arrived.

**Step 4** now keeps Service lifecycle routing for a synchronous restart failure while the caller is still alive, and claims nothing past that point.

## Product catalog

The Channel-visible outcome is now a catalog entry. It names a **resumed** upgrade deliberately: a Dispatcher that never resumes reports nothing at all, and saying so keeps the next reader from closing that gap with a timer or a recovery actor. Caught in review of the first draft, which had promised the report unconditionally — the exact guarantee scenario 3 removes.

## Non-goals honoured

Nothing from the issue's list returns: no staging or `npm pack`, no rehearsal prefixes, no backup/artifact matrix, no rollback protocol, no independent controller, no new persisted state, timers, or retry loops. The guide is 86 lines (from 67) and still four steps; the added lines pay for the two named scenarios and nothing else.

## Validation

| Gate | Result |
|---|---|
| `rush build` / `lint` / `test` / `typecheck:tests` | all SUCCESS, no failure |
| `.agents/scripts/check.sh` | `KB OK (153 files reachable from root.md)` |
| `init_task.py check` | Task record OK |
| gitleaks + `check-internal-content.sh` over staged | clean |
| `git diff --cached --check` | clean |

Documentation and bundled skill text only — no `packages/*/src` and no test file is touched. Change file is `patch` for `@excitedjs/dreamux`.

One note for maintainers: the mandatory anti-leak pre-commit gate does not fire on a machine that sets `core.hooksPath` elsewhere, because git then ignores `common/git-hooks/`. Both of the hook's checks were run directly against the staged content instead. Nothing in the repository currently detects that the gate is inert.

Task record: `.agents/tasks/builtin-skills/adopt-lean-self-upgrade-sop`

🤖 Generated with [Claude Code](https://claude.com/claude-code)