### PR TITLE
Keep the spacing of a plain-text tool output on a COT card

### DIFF
--- a/.agents/domains/channel.md
+++ b/.agents/domains/channel.md
@@ -781,7 +781,18 @@ truncated into one pill rather than folded into that count, per 「按照单条�
 than by how long it is: a value that parses as a JSON object or array is
 pretty-printed (`JSON.stringify(value, null, 2)`) in a `json` code segment,
 anything else is a plain `text` segment (「文本的输出，就按文本输出。能解析成JSON
-的再放进代码段」, 2026-09-04). That rule replaced, within one day, both #347's
+的再放进代码段」, 2026-09-04). The text segment travels with each space that
+begins a line, or sits in a run of two or more, turned into a no-break space
+(U+00A0, `preserveSpacing` in `feishu-cot-presentation.ts`): the client
+collapses a run of ordinary spaces and drops a leading one, so a Bash
+output's indentation and column alignment were lost (「这里头的空格都没了」,
+2026-09-04). A probe card the same day settled the client facts: a raw run
+collapses; U+00A0, U+2002 and the `&nbsp;` entity all keep it; a `<pre>`
+wrapper is shown as literal text with its spaces still collapsed; and an
+entity inside a row `title` is decoded too — tags are escaped, entities are
+decoded. The character was chosen over the entity for costing two bytes of
+the event budget rather than six, and a single inner space stays ordinary so
+a long line still wraps. A code segment keeps its own spaces. That rule replaced, within one day, both #347's
 inline exception for a one-line output under 120 bytes and the all-code rule
 that lasted one commit (「全都给他们包到代码块里面」), once MCP rows made the
 mix of boxed and unboxed outputs visible. A code segment spells its body in

--- a/.agents/product/README.md
+++ b/.agents/product/README.md
@@ -130,7 +130,10 @@ the same change that touches it.
   — today every MCP tool, the Channel's own reply/react/list_chat_bots
   included — shows its tool name behind a generic app icon with its arguments
   hidden; its output still expands. An output that parses as JSON is
-  pretty-printed in a json code segment; any other output is plain text.
+  pretty-printed in a json code segment; any other output is plain text
+  that keeps its indentation and column alignment (each space that begins
+  a line or sits in a run is sent as a no-break space, because the client
+  collapses ordinary runs; single spaces between words still wrap).
   Every card string is cut only at Feishu's own per-event limit, never
   earlier in Core. Raw
   JSON arguments appear nowhere on the card. Codex web searches are rows too.

--- a/common/changes/@excitedjs/feishu-channel/fix-cot-text-indentation_2026-09-04-11-00.json
+++ b/common/changes/@excitedjs/feishu-channel/fix-cot-text-indentation_2026-09-04-11-00.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@excitedjs/feishu-channel",
+      "comment": "A plain-text tool output on a COT card keeps its indentation and column alignment: each space that begins a line or sits in a run of two or more is sent as a no-break space, because the Feishu client collapses ordinary runs. Single spaces between words are unchanged, and so are JSON code segments.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@excitedjs/feishu-channel"
+}

--- a/packages/channel/feishu-channel/src/feishu-cot-events.ts
+++ b/packages/channel/feishu-channel/src/feishu-cot-events.ts
@@ -11,6 +11,7 @@ import type { FeishuCotEventInput } from '@excitedjs/feishu-transport';
 import {
   escapedBytes,
   nonEmpty,
+  preserveSpacing,
   toolPresentation,
   truncateEscaped,
   TRUNCATION_MARKER,
@@ -262,6 +263,8 @@ export interface ToolResultParts {
  * a `json` code segment, anything else as plain text (operator ruling,
  * 2026-09-04: 「文本的输出，就按文本输出。能解析成JSON的再放进代码段」). The whole
  * text is parsed first and cut last, so a cut never decides what a value was.
+ * Plain text keeps its spacing the way the client keeps it (`preserveSpacing`),
+ * before the cut is measured; a code segment keeps its own spaces.
  */
 export interface ToolResultOutput {
   readonly kind: 'json' | 'text';
@@ -279,7 +282,7 @@ export function toolResultOutput(resultJson: string | null): ToolResultOutput | 
   } catch {
     // Not JSON: the runtime's own text, shown as text.
   }
-  return { kind: 'text', text };
+  return { kind: 'text', text: preserveSpacing(text) };
 }
 
 export function assembleToolResultContent(parts: ToolResultParts): unknown {

--- a/packages/channel/feishu-channel/src/feishu-cot-presentation.ts
+++ b/packages/channel/feishu-channel/src/feishu-cot-presentation.ts
@@ -165,6 +165,23 @@ export function nonEmpty(value: string | null): string | null {
   return value === null || value === '' ? null : value;
 }
 
+const NO_BREAK_SPACE = '\u00a0';
+
+/**
+ * A `text` segment as the Feishu client keeps its spacing. The client
+ * collapses a run of ordinary spaces to one and drops the run that begins a
+ * line, so a text output lost its indentation and its column alignment; a
+ * no-break space stays where it was (probe card, 2026-09-04: raw spaces
+ * collapsed, U+00A0 and the `&nbsp;` entity both kept the indentation, a
+ * `<pre>` wrapper was shown as literal text). Each space that begins a line,
+ * or sits in a run of two or more, becomes U+00A0; a single space between
+ * words stays a space, so a long line still wraps there. The character, not
+ * the entity: two bytes of the event budget instead of six.
+ */
+export function preserveSpacing(text: string): string {
+  return text.replace(/^ +| {2,}/gmu, (run) => NO_BREAK_SPACE.repeat(run.length));
+}
+
 export function truncateEscaped(value: string, maxBytes: number): string {
   const valueBytes = escapedBytes(value);
   if (valueBytes <= maxBytes) return value;

--- a/packages/channel/feishu-channel/tests/feishu-cot-tool-rows.test.ts
+++ b/packages/channel/feishu-channel/tests/feishu-cot-tool-rows.test.ts
@@ -143,12 +143,52 @@ describe('runtime-labelled tool rows', () => {
       role: 'tool',
       content: [
         { type: 'code', language: 'bash', code: 'git status --short' },
-        { type: 'text', text: ' M src/a.ts\n?? src/b.ts' },
+        // The leading space is a no-break space: the client drops an ordinary one.
+        { type: 'text', text: '\u00a0M src/a.ts\n?? src/b.ts' },
       ],
     });
   });
 
-  it('pretty-prints an output that parses as JSON in a json code segment', () => {
+  it('keeps the indentation and column alignment of a text output with no-break spaces', () => {
+    const [result] = toolCallResultEvents(toolCall({
+      status: 'completed',
+      result_json: [
+        'DIST_TAGS={',
+        '  "latest": "0.23.0"',
+        '}',
+        'drwxr-xr-x  2 me  4096 src',
+        'a single space between words stays a space',
+      ].join('\n'),
+    }));
+    // Each space that begins a line or sits in a run of two or more becomes
+    // U+00A0; the single spaces stay, so a long line still wraps at them.
+    expect(result!.content).toMatchObject({
+      content: {
+        type: 'text',
+        text: [
+          'DIST_TAGS={',
+          '\u00a0\u00a0"latest": "0.23.0"',
+          '}',
+          'drwxr-xr-x\u00a0\u00a02 me\u00a0\u00a04096 src',
+          'a single space between words stays a space',
+        ].join('\n'),
+      },
+    });
+  });
+
+  it('measures the cut after the spaces were converted', () => {
+    const [result] = toolCallResultEvents(toolCall({
+      status: 'completed',
+      result_json: '  x\n'.repeat(3_000),
+    }));
+    const shown = (result!.content as { content: { type: string; text: string } }).content;
+    expect(shown.text.startsWith('\u00a0\u00a0x\n')).toBe(true);
+    expect(shown.text.endsWith('… (truncated)')).toBe(true);
+    // Two bytes per converted space, counted inside the event limit.
+    expect(Buffer.byteLength(JSON.stringify(result!.content), 'utf8')).toBeLessThanOrEqual(4_096);
+  });
+
+  it('pretty-prints an output that parses as JSON in a json code segment, its spaces untouched', () => {
     const [result] = toolCallResultEvents(toolCall({
       tool_name: 'mcp__teammate__spawn',
       tool_action: null,


### PR DESCRIPTION
## Why

A Bash row's plain-text output lost its indentation on the COT card: the Feishu client collapses a run of ordinary spaces in a `text` segment to one and drops the run that begins a line (operator, 2026-09-04: 「这里头的空格都没了」).

A probe card sent the same day settled the client facts:

- a raw run of spaces collapses;
- U+00A0, U+2002 and the `&nbsp;` entity all keep the indentation;
- a `<pre>` wrapper is shown as literal text with its spaces still collapsed;
- an entity inside a row `title` is decoded too — tags are escaped, entities are decoded.

## What

- `preserveSpacing` in `feishu-cot-presentation.ts`: each space that begins a line, or sits in a run of two or more, becomes a no-break space (U+00A0). A single space between words stays ordinary so a long line still wraps.
- Applied on the `text` branch of `toolResultOutput`, before the event budget is measured, so the cut counts the converted bytes. JSON code segments are untouched.
- The character rather than the entity: two bytes of the 4,096-byte event budget instead of six; the probe showed both render the same.
- Tests: indentation and column alignment kept, single spaces untouched, JSON output unaffected, the cut measured after conversion.
- Product README, `channel.md` (probe facts), and a `patch` change file for `@excitedjs/feishu-channel`.

## Gates

`rush build`, `lint`, `test`, `typecheck:tests` from `@excitedjs/feishu-channel`: green. `.agents/scripts/check.sh`: KB OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01THnULV9wt1Ew4TNg6bJAz6
