### PR TITLE
chore(feishu-channel): remove dead FeishuBot.inviteMembers pass-through

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -214,8 +214,11 @@ needed, and contain no `Rebuild:` instruction.
 While a package stays on the 0.x version line, its change files must never
 use type `major` — Rush bumps a 0.x package straight to 1.0.0 on a pending
 major. Record breaking changes for 0.x packages as type `minor` with the
-`BREAKING:` note leading. Packages already past 1.0.0 (for example
-`@excitedjs/feishu-channel`) use real semver majors. CI enforces the 0.x rule
+`BREAKING:` note leading. Packages already past 1.0.0 that are consumed outside
+Dreamux use real semver majors. Packages consumed only by Dreamux itself (for
+example `@excitedjs/feishu-channel`, whose `FeishuBot` contract is Dreamux-internal)
+record incompatible changes as type `minor` with a plain note instead.
+CI enforces the 0.x rule
 (`ci.yml`, "Forbid major change files on the 0.x line"); the operator decides
 when a package leaves 0.x.
 

--- a/common/changes/@excitedjs/dreamux/chore-remove-dead-feishu-bot-invite-members_2026-09-07-08-46.json
+++ b/common/changes/@excitedjs/dreamux/chore-remove-dead-feishu-bot-invite-members_2026-09-07-08-46.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Drop the unused `inviteMembers` fake from the Feishu bot test helper.",
+      "type": "none",
+      "packageName": "@excitedjs/dreamux"
+    }
+  ],
+  "packageName": "@excitedjs/dreamux",
+  "email": "hvjfccdy6s@privaterelay.appleid.com"
+}

--- a/common/changes/@excitedjs/feishu-channel/chore-remove-dead-feishu-bot-invite-members_2026-09-07-08-46.json
+++ b/common/changes/@excitedjs/feishu-channel/chore-remove-dead-feishu-bot-invite-members_2026-09-07-08-46.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Remove the dead `FeishuBot.inviteMembers` pass-through and its test fakes. The method was added for the dispatcher-only `team.create_group` flow and has had no caller since that flow was retired in the #182 PR-8 cleanup; `FeishuBot` is a Dreamux-internal contract. The Feishu transport `createGroup`/`inviteMembers` wrappers and their exported types are intentionally kept.",
+      "type": "minor",
+      "packageName": "@excitedjs/feishu-channel"
+    }
+  ],
+  "packageName": "@excitedjs/feishu-channel",
+  "email": "hvjfccdy6s@privaterelay.appleid.com"
+}

--- a/packages/channel/feishu-channel/src/bot.ts
+++ b/packages/channel/feishu-channel/src/bot.ts
@@ -45,14 +45,6 @@ import {
   type OutboundTarget,
   type TransportLogger,
 } from '@excitedjs/feishu-transport';
-import type {
-  FeishuInviteMembersInput,
-  FeishuInviteMembersResult,
-} from '@excitedjs/feishu-transport';
-export type {
-  FeishuInviteMembersInput,
-  FeishuInviteMembersResult,
-} from '@excitedjs/feishu-transport';
 
 /** The Feishu event_type carrying inbound chat messages. */
 const IM_MESSAGE_EVENT_TYPE = 'im.message.receive_v1';
@@ -162,7 +154,6 @@ export interface FeishuBot extends FeishuMessageResourceFetcher {
     card: unknown,
     options?: Pick<FeishuSendOptions, 'signal'>,
   ): Promise<FeishuSendResult>;
-  inviteMembers(input: FeishuInviteMembersInput): Promise<FeishuInviteMembersResult>;
   /** Optional for externally supplied bots; absence disables topic projection. */
   getChatMode?(chatId: string): Promise<FeishuChatMode | undefined>;
   addReaction(messageId: string, emoji: string): Promise<string>;
@@ -290,10 +281,6 @@ export function createFeishuBot(
     ): Promise<FeishuSendResult> {
       const { messageIds } = await transport.sendCard(target, card, options);
       return { messageIds };
-    },
-
-    inviteMembers(input: FeishuInviteMembersInput): Promise<FeishuInviteMembersResult> {
-      return transport.inviteMembers(input);
     },
 
     getChatMode(chatId: string): Promise<FeishuChatMode | undefined> {

--- a/packages/channel/feishu-channel/tests/helpers/fake-feishu-bot.ts
+++ b/packages/channel/feishu-channel/tests/helpers/fake-feishu-bot.ts
@@ -3,8 +3,6 @@ import type {
   FeishuBotMemberAddedEvent,
   FeishuChatMode,
   FeishuCotClient,
-  FeishuInviteMembersInput,
-  FeishuInviteMembersResult,
   FeishuMessageResourceRequest,
   FeishuMessageResourceResponse,
   FeishuMessageReadMode,
@@ -152,9 +150,6 @@ export function createFakeFeishuBot(appId: string = 'fake-bot'): FakeFeishuBot {
       sentCards.push(entry);
       await waitForSendCardDelay(sendCardDelay, options?.signal);
       return { messageIds: [id] };
-    },
-    async inviteMembers(input: FeishuInviteMembersInput): Promise<FeishuInviteMembersResult> {
-      return { addedOpenIds: input.userOpenIds };
     },
     async getChatMode(chatId: string): Promise<FeishuChatMode | undefined> {
       chatModeRequests.push(chatId);

--- a/packages/dreamux/tests/helpers/fake-feishu-bot.ts
+++ b/packages/dreamux/tests/helpers/fake-feishu-bot.ts
@@ -31,8 +31,6 @@ import type { FeishuBot, FeishuInboundEvent } from '@excitedjs/feishu-channel';
 type FeishuInboundRoutes = Parameters<FeishuBot['start']>[0];
 type FeishuOutboundTarget = Parameters<FeishuBot['send']>[0];
 type FeishuSendResult = Awaited<ReturnType<FeishuBot['send']>>;
-type FeishuInviteMembersInput = Parameters<FeishuBot['inviteMembers']>[0];
-type FeishuInviteMembersResult = Awaited<ReturnType<FeishuBot['inviteMembers']>>;
 type FeishuMessageResourceRequest = Parameters<
   FeishuBot['fetchMessageResource']
 >[0];
@@ -107,12 +105,6 @@ export function createFakeFeishuBot(appId = 'fake-bot'): FakeFeishuBot {
       // assert on a card the user stopped seeing.
       const sent = sentCards.find((entry) => entry.messageIds.includes(messageId));
       if (sent !== undefined) sent.card = card;
-    },
-
-    async inviteMembers(
-      input: FeishuInviteMembersInput,
-    ): Promise<FeishuInviteMembersResult> {
-      return { addedOpenIds: input.userOpenIds };
     },
 
     async addReaction(messageId: string, emoji: string): Promise<string> {


### PR DESCRIPTION
Remove the unused `FeishuBot.inviteMembers` delegation, its type imports/re-exports, and the two matching bot fakes. The method was added for the dispatcher-only `team.create_group` flow, retired in the #182 PR-8 cleanup, and has no remaining source callers. This aligns the bot cleanup with the FlowX fork. The Feishu transport `createGroup`/`inviteMembers` wrappers, their exported types, and the package-boundary guards are intentionally kept.

Versioning: feishu-channel is Dreamux-internal; operator ruled minor. A separate policy commit scopes real semver majors to externally consumed packages and records incompatible Dreamux-internal changes as `minor` with a plain note. Root `AGENTS.md` is a symlink to `CLAUDE.md`, so the policy edit is in `CLAUDE.md` and preserves the symlink.

The original deletion list also named the methods in `tests/feishu-bot.test.ts`. That object is actually `FakeTransport implements FeishuTransport`, whose preserved interface requires both methods. This PR retains that transport fake and its imports to preserve type correctness.

Changed files:

- `packages/channel/feishu-channel/src/bot.ts`
- `packages/channel/feishu-channel/tests/helpers/fake-feishu-bot.ts`
- `packages/dreamux/tests/helpers/fake-feishu-bot.ts`
- `CLAUDE.md` (policy only, separate commit)
- `common/changes/@excitedjs/feishu-channel/chore-remove-dead-feishu-bot-invite-members_2026-09-07-08-46.json` — `minor`
- `common/changes/@excitedjs/dreamux/chore-remove-dead-feishu-bot-invite-members_2026-09-07-08-46.json` — `none`

Rush 5.140 has no project selector for `change --bulk`. The two change files were generated by separate non-interactive runs using the operator-supplied messages, with only the corresponding package's changes staged for each run: `--bulk --bump-type minor` and `--bulk --bump-type none`, both with `--target-branch origin/next --no-fetch`. No generated JSON was edited. The initial unstaged invocation was a no-op; generation succeeded after staging.

Verification (all listed gates passed):

| Working directory | Command | Result |
| --- | --- | --- |
| Repository root | `node common/scripts/install-run-rush.js install` | Passed |
| Repository root | `node common/scripts/install-run-rush.js build --to @excitedjs/feishu-channel --to @excitedjs/dreamux` | 8 operations passed |
| `packages/channel/feishu-channel` | `node ../../../common/scripts/install-run-rushx.js test` | 24 files, 384 tests passed |
| `packages/dreamux` | `node ../../common/scripts/install-run-rushx.js test --exclude tests/codex-live.test.ts` | 71 files, 1007 tests passed; live integration excluded |
| `packages/channel/feishu-channel` | `node ../../../common/scripts/install-run-rushx.js typecheck:tests` | Passed; existing configuration excludes tests |
| `packages/dreamux` | `node ../../common/scripts/install-run-rushx.js typecheck:tests` | Passed |
| `packages/channel/feishu-channel` | `node ../../../common/scripts/install-run-rushx.js lint` | Passed |
| `packages/dreamux` | `node ../../common/scripts/install-run-rushx.js lint` | Passed |
| Repository root | `bash .agents/scripts/check.sh` | 167 files reachable; passed |
| Repository root | `node common/scripts/install-run-rush.js change --verify --target-branch origin/next --no-fetch` | Passed after both commits; both change files found |
| Repository root | `git diff origin/next...HEAD --check` | Passed |

The Dreamux test run includes `feishu-allow-chats-release-contract.test.ts`, which reads the root policy. Both commits passed the installed pre-commit gates, including gitleaks and internal-content checks. A separate `rushx typecheck:tests --listFilesOnly` inspection confirmed that feishu-channel's existing inherited `exclude: ["tests"]` leaves zero test files in that check; this PR does not change that configuration. Rush emitted its Node 22.16.0 compatibility warning; all invoked gate commands above exited 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
