### PR TITLE
Refine Feishu COT and route cards

### DIFF
--- a/.agents/domains/channel.md
+++ b/.agents/domains/channel.md
@@ -482,8 +482,9 @@ one, and send the notification card.
 
 Refusing to route to a Team that cannot answer is the one moment the question can
 be asked: `team.status` is invoked before the row is written and before the
-conversation is told, and only a definite answer refuses — `TEAM_NOT_FOUND`,
-`TEAM_CLOSED`, or a `closed` status. A Team that dissolves afterwards converges
+conversation is told. A nonexistent Team throws Core's `TEAM_NOT_FOUND`
+unchanged; a closed Team is a successful status response whose `team.status` is
+`closed`, which the Channel rejects. A Team that dissolves afterwards converges
 through the `team.state` event instead.
 
 What Core owns is the lease scope. Every Channel MCP call carries a
@@ -529,10 +530,13 @@ provisioning begins on first accepted topic inbound.
 The run order is the one that degrades honestly — create the Team, commit the
 route, announce it, deliver the message — and every exit before `team.submit`
 answers `unsubmitted`, so the message it was carrying goes to the Dispatcher
-Agent like any other message this Channel could not hand to a Team. Failing to
-provision is not a reason to drop what somebody wrote. A failure after
-`team.create` leaves an ordinary Team nothing routes to: an accepted orphan an
-operator can see and use, deliberately not compensated.
+Agent like any other message this Channel could not hand to a Team. The
+`team.create` receipt carries the created Team's leader name, configured runtime
+ID, and runtime cwd, so the Channel can render the route card without an
+immediate `team.status` round trip. Failing to provision is not a reason to drop
+what somebody wrote. A failure after `team.create` leaves an ordinary Team
+nothing routes to: an accepted orphan an operator can see and use, deliberately
+not compensated.
 
 Idempotency comes from one choice with several consequences: the `team.create`
 `request_id` is the inbound message id, used bare.
@@ -583,23 +587,30 @@ Routing notification cards are rendered from this Channel's own records, at the
 moment this Channel changes them, and no Core event is involved — Core publishes
 no binding fact, because it holds none.
 
-There are four renderers, and their field sets are the content contract:
+There are six renderers, and their field sets are the content contract:
 
 - **route bound** (manual bind, or an automatic provisioning announcement):
-  target display, binding kind (topic or group), Team name, and the space name
-  when the row was installed for a Space;
-- **route unbound** (manual unbind, and every route a closing Team gives up):
-  target display, Team name, and a status line;
+  target display, binding kind (topic or group), Team name, TeamLeader name,
+  configured Agent Runtime ID, and runtime cwd;
+- **route unbound** (manual Channel MCP unbind): target display, binding kind,
+  Team name, and an explicit statement that only the route was removed and the
+  Team remains active;
+- **Team dissolved** (routes removed after final `team.state(status: 'closed')`):
+  target display, binding kind, Team name, and the confirmed Team-closure cause;
+- **route ended** (early route removal after an inbound `TEAM_CLOSED` rejection):
+  target display, binding kind, Team name, and cause-neutral wording because
+  dissolution may still be in progress and may be refused;
 - **space bound**: space name, container group display, TeamLeader runtime, the
   workspace — which renders the configured repository path when the policy has
   one — base ref, and a note that new topics get their own Team;
 - **space unbound**: space name, container group display, and a status line
   saying provisioning stopped while existing Teams and bindings are unchanged.
 
-Cards use Feishu `plain_text` elements only and render display fields, Team
-facts, and the Space's own policy without rendering prompts or raw errors. The
-repository path is deliberately visible to the members of the bound conversation;
-the user-visible half of that disclosure is
+The three route lifecycle cards use Card 2.0 with English fixed copy and literal
+`plain_text` dynamic values. Collaboration Space cards keep their existing
+schema. Cards render display fields, Team facts, and the Space's own policy
+without rendering prompts or raw errors. The repository path is deliberately
+visible to the members of the bound conversation; the user-visible half of that disclosure is
 [`/.agents/product/README.md`](/.agents/product/README.md).
 
 Where a card goes follows the target. A route card for a topic replies under the

--- a/.agents/domains/channel.md
+++ b/.agents/domains/channel.md
@@ -606,11 +606,12 @@ There are six renderers, and their field sets are the content contract:
 - **space unbound**: space name, container group display, and a status line
   saying provisioning stopped while existing Teams and bindings are unchanged.
 
-The three route lifecycle cards use Card 2.0 with English fixed copy and literal
-`plain_text` dynamic values. Collaboration Space cards keep their existing
-schema. Cards render display fields, Team facts, and the Space's own policy
-without rendering prompts or raw errors. The repository path is deliberately
-visible to the members of the bound conversation; the user-visible half of that disclosure is
+The route-bound, route-unbound, and Team-dissolved cards use Card 2.0 with
+English fixed copy and literal `plain_text` dynamic values. The cause-neutral
+route-ended card and Collaboration Space cards keep their existing schema.
+Cards render display fields, Team facts, and the Space's own policy without
+rendering prompts or raw errors. The repository path is deliberately visible
+to the members of the bound conversation; the user-visible half of that disclosure is
 [`/.agents/product/README.md`](/.agents/product/README.md).
 
 Where a card goes follows the target. A route card for a topic replies under the

--- a/.agents/product/README.md
+++ b/.agents/product/README.md
@@ -55,7 +55,11 @@ the same change that touches it.
   When a chat, topic, or space binding changes, the built-in Feishu channel
   posts a confirmation card: space-bound shows the space name, TeamLeader
   runtime, and repo policy; route-bound shows the binding kind, Team name,
-  TeamLeader name, runtime, and runtime cwd; unbinding is a one-liner. The
+  TeamLeader name, configured runtime ID, and runtime cwd. Explicit Channel MCP
+  unbind says that only the route was removed and the Team remains active; final
+  Team dissolution says that Team closure removed all of that Team's routes; an
+  early route removal on `TEAM_CLOSED` stays cause-neutral until closure is
+  final. The selected route lifecycle cards use English Card 2.0 copy. The
   absolute repo cwd and runtime working directory are **deliberately**
   disclosed to the bound conversation's members — an explicit operator ruling
   that narrowed the earlier disclosure allowlist. Delivery is best-effort with
@@ -150,7 +154,10 @@ the same change that touches it.
   that keeps its indentation and column alignment (each space that begins
   a line or sits in a run is sent as a no-break space, because the client
   collapses ordinary runs; single spaces between words still wrap).
-  Every card string is cut only at Feishu's own per-event limit, never
+  A non-JSON tool result keeps its first ten content lines and gains the English
+  truncation marker when an eleventh line exists; a terminal LF or CRLF does not
+  invent another content line. A JSON object or array bypasses that line rule.
+  Every card string is still finally bounded by Feishu's per-event limit, never
   earlier in Core. Raw
   JSON arguments appear nowhere on the card. Codex web searches are rows too.
   The card's own words — row verbs (Read, Edit, Search, List), the Completed and
@@ -184,6 +191,9 @@ the same change that touches it.
   (Requirement: 「CoT需要真实反映agent provider现在正在发生的事情」 and the
   2026-09-03 ruling on display state in
   [split-streaming-display-from-pushback](/.agents/tasks/architecture/split-streaming-display-from-pushback/requirement.md).)
+  When a newer inbound anchor supersedes an open card, that old presentation
+  closes successfully and activity continues on the new anchor; route release,
+  Team or session close, and runtime interruption remain interrupted.
 
 ## Failures the model sees
 

--- a/.agents/product/README.md
+++ b/.agents/product/README.md
@@ -59,8 +59,9 @@ the same change that touches it.
   unbind says that only the route was removed and the Team remains active; final
   Team dissolution says that Team closure removed all of that Team's routes; an
   early route removal on `TEAM_CLOSED` stays cause-neutral until closure is
-  final. The selected route lifecycle cards use English Card 2.0 copy. The
-  absolute repo cwd and runtime working directory are **deliberately**
+  final. The route-bound, route-unbound, and Team-dissolved cards use English
+  Card 2.0 copy; the cause-neutral route-ended card keeps its existing schema.
+  The absolute repo cwd and runtime working directory are **deliberately**
   disclosed to the bound conversation's members — an explicit operator ruling
   that narrowed the earlier disclosure allowlist. Delivery is best-effort with
   one retry; a failed card never affects the binding change it reports.

--- a/.agents/tasks/channel/README.md
+++ b/.agents/tasks/channel/README.md
@@ -20,3 +20,4 @@
 - [Feishu Access Foundation Records](/.agents/tasks/channel/feishu-access-foundations/README.md) — `done`: Preserve the Feishu access decisions: pairing access V3, allow_chats trust semantics, and inbound attachments.
 
 - [Feishu conversation-of-thought cards](/.agents/tasks/channel/feishu-cot-conversation-cards/README.md) — `done`: Render dispatcher and TeamLeader conversations as conversation-anchored Feishu COT cards through a neutral, display-only core projection.
+- [Refine Feishu COT and binding cards](/.agents/tasks/channel/refine-feishu-cot-and-binding-cards/README.md) — `review`: Bound plain-text COT tool results by line count, restore Team runtime context on binding cards, distinguish route-removal notifications, and complete superseded COT cards successfully

--- a/.agents/tasks/channel/refine-feishu-cot-and-binding-cards/README.md
+++ b/.agents/tasks/channel/refine-feishu-cot-and-binding-cards/README.md
@@ -1,0 +1,53 @@
+# Refine Feishu COT and binding cards
+
+## Current state
+
+- Goal: Bound plain-text COT tool results by line count, restore Team runtime context on binding cards, and complete superseded COT cards successfully
+- State: `implementation`
+- Requirement: [Current requirement](/.agents/tasks/channel/refine-feishu-cot-and-binding-cards/requirement.md)
+- Final solution:
+  [technical-design/final.md](/.agents/tasks/channel/refine-feishu-cot-and-binding-cards/technical-design/final.md).
+- Solution review Issue:
+  [#383 Solution review: refine Feishu COT and route notification cards](https://github.com/excitedjs/dreamux/issues/383).
+- Solution input revision: Final requirement after the operator selected paired
+  UI set 2, English-only fixed copy, and the same set-2 detail treatment for
+  the route-bound runtime-cwd section.
+- Solution review: Three independent reviews completed. The final solution
+  accepts the terminating-newline finding and the pre-final `TEAM_CLOSED`
+  notification finding; no architecture disagreement remains.
+- Review record:
+  [draft](/.agents/tasks/channel/refine-feishu-cot-and-binding-cards/technical-design/draft.md),
+  [Codex review](/.agents/tasks/channel/refine-feishu-cot-and-binding-cards/technical-design/reviews/review-codex.md),
+  [Codex Ultra review](/.agents/tasks/channel/refine-feishu-cot-and-binding-cards/technical-design/reviews/review-codex-ultra.md), and
+  [Codex Medium review](/.agents/tasks/channel/refine-feishu-cot-and-binding-cards/technical-design/reviews/review-codex-medium.md).
+- Verification:
+  [verification.md](/.agents/tasks/channel/refine-feishu-cot-and-binding-cards/verification.md).
+- Blockers: None.
+- Next action: Open a Draft PR, then complete the full repository gates and
+  independent implementation review on the PR.
+- Related tasks: Builds on
+  [Feishu conversation-of-thought cards](/.agents/tasks/channel/feishu-cot-conversation-cards/README.md).
+
+## Development approval
+
+- Status: Granted on 2026-09-07 by explicit operator approval after playback of
+  the final requirement, solution, implementation boundary, and verification
+  plan.
+- Approved requirement:
+  [requirement.md](/.agents/tasks/channel/refine-feishu-cot-and-binding-cards/requirement.md).
+- Approved solution:
+  [technical-design/final.md](/.agents/tasks/channel/refine-feishu-cot-and-binding-cards/technical-design/final.md).
+- Approved implementation boundary: Feishu COT plain-text result truncation,
+  superseded-anchor completion, canonical route-Team facts, the selected
+  route-bound/unbind/dissolution Card 2.0 presentations, truthful pre-final
+  route-ended notification selection, directly affected tests and knowledge,
+  and required Rush change files. The operator subsequently required extending
+  `team.create` with runtime ID and cwd so automatic provisioning does not issue
+  a redundant `team.status`; no provider contract, persisted routing/config/state
+  schema, Collaboration Space card, or existing route-removal/Dispatcher-
+  fallback behavior changes.
+
+## Delivery
+
+- Pull request / CI / merge: Not started.
+- Knowledge closeout: Pending.

--- a/.agents/tasks/channel/refine-feishu-cot-and-binding-cards/requirement.md
+++ b/.agents/tasks/channel/refine-feishu-cot-and-binding-cards/requirement.md
@@ -1,0 +1,196 @@
+# Requirement
+
+## Initial request
+
+- Operator request, 2026-09-07:
+  - "COT 的 toolresult 截断策略改一下，增加超过 10行截断（已经识别成 json 的不做截断）".
+  - "feishu 的绑定卡片增加显示 agent runtime 和 cwd（这是上次重构丢掉的功能）".
+  - "飞书COT换锚点的时候，老卡的关闭状态改成成功，而不是现在这个任务中断".
+  - "解绑卡片也需要设计一下 这个地方分为解绑和团队解散。如果飞书Channel通过MCP触发了解绑的话，就发解绑卡片。如果是收到团队解散通知，被动触发解绑，就发团队解散卡片。"
+- The operator chose to create a new task rather than reopen the existing
+  Feishu COT conversation-cards task.
+
+## Current alignment
+
+- Status: Final. The operator selected notification-card set 2, required all
+  visible copy to be English, and extended that set's full-width detail-panel
+  treatment to the route-bound card's runtime-cwd section.
+- Confirmed current behavior and evidence:
+  - `toolResultOutput` parses the complete result before choosing its Feishu
+    segment. A JSON object or array becomes pretty-printed JSON; every other
+    non-empty value becomes plain text. Both are currently cut only when the
+    assembled event would exceed Feishu's 4,096-byte content limit.
+  - A route-bound card currently shows target, binding kind, Team, and optional
+    collaboration-space name. Commit `2ed5f5ea` removed the TeamLeader name,
+    Agent Runtime, and runtime cwd that the prior Core binding-event projection
+    supplied. The current product catalog still says a route-bound card names
+    the TeamLeader, runtime, and runtime cwd.
+  - Manual binding already invokes `team.status` before a route is persisted.
+    Its canonical answer includes the Team's `leader_agent_runtime` and the
+    TeamLeader's `repo.path` (the runtime cwd), but the current binding path
+    discards that detail after checking status. Automatic provisioning owns the
+    successful `team.create` receipt, so that receipt must carry the same two
+    facts instead of forcing an immediate second Core query.
+  - Replacing an anchor currently detaches its open card with the
+    `interrupted` terminal. Runtime-reported interruption, route release, Team
+    closure, and Channel-session close also use interruption through distinct
+    lifecycle paths.
+  - Manual/MCP unbind and passive route removal after Team closure currently
+    both call `bindingUnboundCard`, so the conversation cannot tell whether an
+    operator removed only this route or the Team itself ended. The source paths
+    are already distinct: `unbindChannel` owns the former, while
+    `announceTeamClosed` owns the latter.
+  - A Seed UI consultation checked the official Feishu Card 2.0 structure,
+    component-level localization, layout, table, and collapsible-panel
+    documentation, then successfully sent and read back six private rendered
+    candidates. Card 2.0 requires Feishu client 7.20 or newer; older clients
+    show only the title and an upgrade prompt. The table candidate cannot
+    localize its labels because Card 2.0 tables expose raw strings and Card 2.0
+    has no global localization envelope.
+- Desired outcome: Keep routine COT output compact, restore the requested Team
+  runtime context on route-bound cards, and make only anchor replacement close
+  the superseded card successfully.
+- Desired behavior:
+  1. A non-empty plain-text tool result with at most 10 lines is unchanged. A
+     plain-text result with an eleventh line is reduced to its first 10 lines
+     and an explicit truncation marker. The existing Feishu byte-budget cut
+     remains the final bound. A terminal LF or CRLF terminates the tenth line;
+     it does not create an eleventh content line by itself.
+  2. A result recognized as a JSON object or array is exempt from the 10-line
+     rule, including when pretty-printing produces more than 10 lines; it remains
+     subject to Feishu's byte limit. JSON scalars remain plain text and therefore
+     use the line rule.
+  3. A successful route bind shows the Team's Agent Runtime and actual runtime
+     cwd in the confirmation card, using canonical data obtained from Core before
+     the route becomes visible. This applies to manual and automatically
+     provisioned route-bound cards; space-policy cards are not the lost route
+     presentation and retain their current fields.
+     The route-bound card keeps the selected Card 2.0 candidate 4 Team-focus
+     hierarchy: the Team name is the primary heading and target, TeamLeader,
+     and Agent Runtime are three compact facts below it. Its runtime-cwd area
+     adopts the selected unbind set 2 treatment: one full-width tinted detail
+     panel with a static label and a literal dynamic value. The Agent Runtime
+     value is the configured runtime ID (for example `trae-gpt`), never a
+     provider reference such as `builtin:codex`. Dynamic names and paths must
+     remain literal text even when they contain Markdown-significant
+     characters.
+  4. When a new inbound replaces a recipient's current anchor, an open card on
+     the old anchor closes with Feishu's successful `done` terminal. Activity
+     continues on the new anchor as it does today.
+  5. A route removed by the Feishu Channel MCP unbind path sends a distinct
+     active-unbind card. A route removed passively because the Channel received
+     a Team closed/dissolved notification sends a distinct Team-dissolution
+     card. The cards communicate different causes; the passive card must not
+     imply that only the individual conversation route was manually removed.
+     Both use selected UI set 2: a Team-focused hero, a three-column
+     target/binding/Team fact row, and a full-width reason panel. The active
+     unbind card uses neutral grey treatment and says the Team remains active;
+     the Team-dissolution card uses an orange warning accent and says Team
+     closure caused all of that Team's routes to be removed automatically.
+     The Team-dissolution wording is reserved for a final
+     `team.state(status: 'closed')` fact. A route removed early after Core
+     rejects an inbound with `TEAM_CLOSED` keeps a cause-neutral route-ended
+     notification because the same code also means a dissolve is only in
+     progress and may still be refused.
+  6. All fixed user-visible copy in the route-bound, active-unbind, and
+     Team-dissolution cards is English. Preview-only candidate/set labels are
+     absent from production cards. Dynamic target, Team, TeamLeader, runtime ID,
+     and cwd values are shown unchanged rather than translated.
+- Scope: Feishu COT result presentation, Feishu route-bound notification cards,
+  the canonical Core query used during manual route binding, the neutral
+  `team.create` result consumed by automatic provisioning, and directly
+  affected tests and current knowledge.
+- Non-goals:
+  - No Core-side truncation and no line cap for assistant text, tool arguments,
+    item pills, or JSON object/array results.
+  - No persisted routing/config/state format change.
+  - No change to collaboration-space policy cards.
+  - No change to runtime-reported `interrupted`, route release, Team closure, or
+    session shutdown; those cards remain interrupted.
+  - No change to the existing early removal and single Dispatcher fallback for
+    a routed inbound rejected with `TEAM_CLOSED`; only its notification remains
+    factually neutral until final Team closure is published.
+- Constraints and invariants:
+  - JSON recognition still happens before any output truncation.
+  - Core owns Team and Agent runtime facts; the Feishu Channel may display the
+    canonical answer but must not reconstruct those facts from paths or local
+    state.
+  - `team.status` reports a closed Team successfully with `team.status` equal to
+    `closed`; only a nonexistent Team throws `TEAM_NOT_FOUND`. The Channel must
+    not translate that Core failure or invent a thrown `TEAM_CLOSED` status
+    path.
+  - Binding validation, durable route mutation, COT fencing, and best-effort
+    notification ordering must stay intact.
+  - Existing per-event byte limiting remains authoritative after the new
+    plain-text line limiting.
+  - The selected route-bound card uses Card 2.0 and therefore requires Feishu
+    client 7.20 or newer. Selecting candidate 4 after that limitation was
+    presented accepts this client baseline for this notification. Selecting
+    unbind set 2 applies the same Card 2.0 baseline to active-unbind and
+    Team-dissolution notifications. Collaboration-space policy cards remain on
+    their existing schema.
+
+## Acceptance criteria
+
+1. Plain-text results of 0-10 lines render without a line-count marker; an
+   11-line result renders the first 10 lines followed by the existing English
+   truncation marker, within the 4,096-byte event limit.
+2. A JSON object or array whose pretty-printed form exceeds 10 lines is not cut
+   at line 10, but an oversized JSON value is still cut to the event byte limit.
+3. Every successful manual or provisioned route-bound card uses the selected
+   Team-focus Card 2.0 layout, with its runtime cwd in the set-2 full-width
+   tinted detail panel, and displays the bound Team's TeamLeader name,
+   configured Agent Runtime ID, and runtime cwd from Core's canonical status
+   result. It never substitutes the provider reference for the runtime ID.
+4. Three consecutive inbound anchors leave the first two cards closed as
+   `done` and the newest card open. Mid-native-turn replacement continues
+   subsequent activity on the successor card.
+5. A real runtime `interrupted` end, route release, Team closure, or session
+   close still closes the affected open card as interrupted.
+6. An MCP-triggered unbind renders the selected active-unbind card, while each
+   route removed after a Team closed event renders the selected Team-dissolution
+   card. A route removed on a pre-final `TEAM_CLOSED` admission rejection never
+   claims that the Team dissolved. Each flow keeps its existing route mutation,
+   COT fence, and single Dispatcher fallback behavior.
+7. The three route notification cards contain English fixed copy only, have no
+   preview labels, and render dynamic values literally even for Markdown
+   punctuation and long cwd values.
+8. Build, lint, tests, and test typechecking pass.
+
+## Decisions and unknowns
+
+- Confirmed operator decisions:
+  - This is a new task rather than a continuation of the prior COT task.
+  - JSON-recognized tool results are exempt from the 10-line truncation rule.
+  - Anchor replacement closes the old card successfully rather than as
+    interrupted. This ruling is intentionally narrower than other lifecycle
+    terminals.
+  - A Seed TeamMate must research official Feishu card documentation, design
+    5-6 rendered UI candidates, and send them privately to the operator for a
+    direct selection; the source group is not the preview surface.
+  - "先选4吧。运行时填id而不是provider": candidate 4 is selected, and its
+    runtime field is the configured Agent Runtime ID rather than a provider
+    reference.
+  - Active Feishu Channel MCP unbind and passive route removal after a Team
+    dissolution are different user-visible causes and must render different
+    cards.
+  - "选套装2 吧": active-unbind and Team-dissolution cards use paired UI
+    set 2.
+  - "文案都改成英文。": all fixed copy in the selected production cards is
+    English.
+  - "给绑定卡片的那个工作区也改成解绑卡片套装2相同的风格": the
+    route-bound card's runtime-cwd/workspace section uses the same full-width
+    detail-panel visual treatment as unbind set 2.
+  - "返回值这边增加一些字段，本来就可以避免去调用Status": automatic
+    provisioning consumes runtime ID and cwd from `team.create`; it does not
+    follow creation with `team.status`.
+  - "closed 确实是正常状态，调用可以返回出这个 team 的status，调用并不会
+    throw error，但是 TEAM_NOT_FOUND 是团队name 不存在，那接口就应该throw
+    error": manual binding checks `closed` in the successful status response
+    and preserves `TEAM_NOT_FOUND` as the Core-authored thrown failure.
+- Assumptions:
+  - "超过 10 行" means ten lines remain whole and the rule first triggers on
+    line eleven.
+  - "cwd" means the TeamLeader runtime working directory shown by the old
+    route-bound card, not the collaboration-space repository policy.
+- Blocking unknowns: None.

--- a/.agents/tasks/channel/refine-feishu-cot-and-binding-cards/technical-design/draft.md
+++ b/.agents/tasks/channel/refine-feishu-cot-and-binding-cards/technical-design/draft.md
@@ -1,0 +1,197 @@
+# Technical solution draft
+
+## Outcome and boundary
+
+Keep the change inside the Feishu Channel except for consuming the existing
+neutral `team.status` command. Core already owns and returns every Team fact the
+cards need, so no Core contract, persisted record, provider interface, or routing
+document changes. The Channel gains one small route-Team view derived from the
+canonical command response and uses it for both manual and provisioned binding.
+
+The implementation changes five behaviors only:
+
+1. Plain-text tool results keep at most ten source lines before the existing
+   Feishu byte fitting runs. JSON objects and arrays bypass this line rule.
+2. Replacing a non-null COT anchor closes the superseded card as completed.
+   Retiring an anchor to `null`, session close, route release, Team close, and a
+   runtime-reported interruption remain interrupted.
+3. Manual and provisioned route binds obtain the same canonical Team card facts
+   before the route becomes visible.
+4. Route-bound notifications render the selected Team-focused Card 2.0 design.
+5. Explicit MCP unbind and passive Team closure render distinct selected-set-2
+   Card 2.0 notifications.
+
+Collaboration-space policy cards and the general Card 1.0 status-card helper stay
+unchanged.
+
+## 1. Bound plain-text tool results where presentation class is known
+
+Extend `toolResultOutput` in
+`/packages/channel/feishu-channel/src/feishu-cot-events.ts`. It already parses the
+complete result before classifying it, which is the correct ownership point. If
+the parsed value is a non-null object or array, pretty-print it as JSON exactly as
+today and do not count lines. Otherwise scan the original text by LF/CRLF source
+line boundaries. A terminal delimiter ends the preceding line and does not create
+another content line; a delimiter followed by more content, including another
+blank-line delimiter, does. When an eleventh content line exists, keep the first
+ten complete lines, preserve their original line separators, and append the
+existing English `TRUNCATION_MARKER` on a new line. Apply `preserveSpacing` only
+after that source-text line cut.
+
+The existing `assembleToolResultContent` byte-fitting pipeline remains the final
+bound for both classes. No new budget, option, or Core processing is introduced.
+
+## 2. Give anchor replacement its own terminal without widening lifecycle rules
+
+Change `FeishuCotAdapter.advanceAnchor` so the terminal follows the transition:
+
+- old anchor -> new non-null anchor: `completed`;
+- old anchor -> `null`: `interrupted`.
+
+The method already owns both the old presentation and the replacement target, so
+the decision needs no new state or parameter. `finishCard`, `close`, and all route
+and Team fences keep their current explicit terminals. Update the method and
+domain comments that currently say replacement is interruption; do not alter the
+anchor generation, receipt opening, open-tool-call clearing, or serialized I/O.
+
+## 3. Read one canonical route-Team card context
+
+Add one Feishu-local helper module that invokes `team.status` and returns the
+minimum display context:
+
+```ts
+interface FeishuRouteTeamContext {
+  teamName: string;
+  leaderName: string;
+  agentRuntime: string;
+  runtimeCwd: string;
+}
+```
+
+Read `teamName`, `leaderName`, and configured runtime ID from `answer.team`
+(`team_name`, `leader_name`, `leader_agent_runtime`), and the actual runtime cwd
+from `answer.leader.repo.path`. Do not inspect provider references or reconstruct
+paths from a collaboration-space repository policy. A nullable
+`leader.runtime_status` is irrelevant: a lazily started TeamLeader still has a
+durable identity and repo path.
+
+The helper preserves the existing missing/closed-Team public failures. A response
+that cannot supply the four required display facts cannot produce a successful
+route-bound notification and therefore fails before route persistence; this is a
+real reachable state when the canonical Team read cannot load its leader identity.
+It does not start or probe the runtime.
+
+Manual `bindChannel` awaits this context where it currently calls
+`requireRoutableTeam`, then performs the existing durable bind, previous-owner
+release, new-owner claim, notification, and return in the same order.
+
+Automatic provisioning awaits the same context after a successful `team.create`
+and before `routing.bind`. Its order becomes:
+
+```text
+team.create -> team.status -> routing.bind -> COT claim/card -> team.submit
+```
+
+Thus an unavailable canonical status leaves the created Team as the ordinary
+unbound Team the provisioning design already accepts for any pre-bind failure,
+and returns the inbound as `unsubmitted`; no compensation or retry mechanism is
+added. Extend the provisioning announcement input with the resolved context so it
+never performs another read after the route is visible.
+
+## 4. Render the three route notifications directly as Card 2.0
+
+Keep Card 2.0 construction in
+`/packages/channel/feishu-channel/src/feishu-binding-notification-card.ts`. Do not
+change `buildFeishuStatusCard`: collaboration-space cards still use that Card 1.0
+surface, while route cards deliberately adopt the operator-selected Card 2.0
+baseline. Small private builders in this file may express the repeated English
+plain-text, static label, fact-column, and full-width detail-panel shapes without
+creating a repository-wide card abstraction.
+
+Every production route card removes preview tags and uses English fixed copy
+only. Dynamic target, Team, TeamLeader, runtime ID, and cwd values are
+`plain_text`; static colored labels may use the already validated Markdown shape.
+No dynamic string is interpolated into Markdown.
+
+### Route bound
+
+- green header and bound state;
+- Team name as the hero;
+- target, TeamLeader, and configured Agent Runtime ID as three grey fact cells;
+- runtime cwd in one full-width green-tinted detail panel, matching set 2's
+  bottom-panel treatment.
+
+### Explicit MCP unbind: selected set 2
+
+- neutral grey header and unbound state;
+- Team name as the hero;
+- target, binding kind, and Team as three grey fact cells;
+- one full-width grey reason panel stating that Feishu Channel removed this
+  route and the Team remains active.
+
+### Passive Team closure: selected set 2
+
+- neutral header with orange warning icon/tag and orange Team hero;
+- the same three fact cells;
+- one full-width orange reason panel stating that the Team closed and all of its
+  routes were removed automatically.
+
+Split the current shared unbound renderer into three truthful presentations:
+
+- `unbindChannel` calls the explicit-unbind renderer;
+- `announceTeamClosed` calls the Team-dissolution renderer only when invoked
+  after a final `team.state(status: 'closed')` event;
+- the existing inbound fallback after a `TEAM_CLOSED` rejection uses a
+  cause-neutral route-ended renderer, because that error is also raised while a
+  dissolve is merely in progress and the dissolve can still fail.
+
+Make the cause explicit at the existing `forgetTeamRoutes` caller boundary:
+the closed-event caller requests final-dissolution presentation; the admission
+rejection caller requests neutral route-ended presentation. Both still share the
+same one durable `routing.forgetTeam` commit path. Preserve route mutation, COT
+fencing, best-effort notification, and the single Dispatcher fallback. Do not
+change Core's error vocabulary, poll status, add state, or claim that the Team
+remains active in the neutral card.
+
+## Verification
+
+- Extend `feishu-cot-tool-rows.test.ts` with 10-line, LF-terminated 10-line,
+  CRLF-terminated 10-line, 11-line, explicit blank eleventh-line, JSON
+  object/array over ten lines, JSON scalar, and post-line-cut byte-budget cases.
+- Extend `feishu-cot.test.ts` across both TeamLeader and Dispatcher recipients:
+  three successive non-null anchors close the first two cards as `done`; anchor
+  retirement, route release, Team close, session close, and native interruption
+  remain interrupted; mid-native-turn activity continues on the successor.
+- Add focused notification-card tests for schema 2.0, English-only static copy,
+  absent preview labels, selected colors/layout, configured runtime ID, literal
+  Markdown-significant dynamic values, and the full-width bound-cwd/set-2 reason
+  panels.
+- Extend binding-operation tests to assert canonical context is read before bind,
+  manual unbind and Team-close paths choose different renderers, and a lazy
+  leader with `runtime_status: null` remains bindable.
+- Extend session-level tests for the third route-removal cause: an inbound
+  rejected while dissolve is pending keeps the neutral route-ended card, route
+  removal/COT interruption, and one Dispatcher fallback even if dissolve is then
+  refused; only a final closed event emits the Team-dissolution card.
+- Extend provisioning tests to assert `team.create -> team.status -> bind ->
+  announce -> submit`, context propagation, and no route/announcement/submission
+  when status detail cannot be obtained.
+- Update the product catalog and Channel domain to state the three distinct route
+  notifications, canonical runtime context, English Card 2.0 presentation, and
+  successful superseded-anchor terminal. Run `.agents/scripts/check.sh`.
+- Run Rush build, lint, test, and `typecheck:tests`. Add the required
+  `@excitedjs/feishu-channel` change file through `rush change`; this is a
+  user-visible non-breaking notification/presentation fix, with no state rebuild.
+
+## Rejected alternatives
+
+- Do not restore Core binding events. Routing is Channel-owned; the Channel only
+  reads canonical Team facts through the existing neutral command.
+- Do not derive cwd from Space policy or the Team record path: neither is the
+  TeamLeader runtime cwd.
+- Do not display provider refs or require a live `runtime_status`; both contradict
+  the selected runtime-ID behavior and lazy runtime lifecycle.
+- Do not convert collaboration-space cards or the general Card 1.0 helper merely
+  for visual uniformity beyond the operator-selected route cards.
+- Do not add persisted provisioning phases, retries, or compensation for a
+  pre-bind status-read failure.

--- a/.agents/tasks/channel/refine-feishu-cot-and-binding-cards/technical-design/final.md
+++ b/.agents/tasks/channel/refine-feishu-cot-and-binding-cards/technical-design/final.md
@@ -1,0 +1,203 @@
+# Final technical solution
+
+## Outcome and boundary
+
+Keep presentation and routing behavior inside the Feishu Channel while exposing
+the facts already owned by Core through the neutral command that naturally
+produces them. Manual binding consumes `team.status`; automatic provisioning
+consumes `team.create`. The latter result is extended with configured Agent
+Runtime ID and runtime cwd, avoiding an immediate status round trip. This adds
+no provider interface, persisted record, routing schema, or provisioning state.
+
+The implementation changes five user-visible behaviors:
+
+1. Plain-text COT tool results keep at most ten content lines before the
+   existing Feishu byte fitting runs. JSON objects and arrays bypass this line
+   rule.
+2. Replacing a non-null COT anchor closes the superseded card as completed.
+   Retiring an anchor and all genuine lifecycle interruptions remain
+   interrupted.
+3. Manual and provisioned route binds obtain canonical Team card facts before
+   the route becomes visible, without sharing a Channel helper or duplicating a
+   Core read.
+4. Route-bound notifications render the selected Team-focused Card 2.0 design,
+   with the runtime cwd in the selected full-width detail-panel treatment.
+5. Explicit MCP unbind, confirmed Team dissolution, and pre-final route removal
+   each use copy that states only the cause the Channel actually knows.
+
+Collaboration-space policy cards and the general Card 1.0 status-card helper
+remain unchanged.
+
+## 1. Bound plain-text tool results after JSON classification
+
+Extend `toolResultOutput` in
+`/packages/channel/feishu-channel/src/feishu-cot-events.ts`, where the complete
+result is already parsed and classified. If the parsed value is a non-null
+object or array, pretty-print it as JSON exactly as today and do not count its
+lines. Treat JSON scalars and all non-JSON values as plain text.
+
+For plain text, scan the original string by LF and CRLF source boundaries. A
+terminal delimiter terminates the preceding content line but does not create an
+additional line. A delimiter followed by content, including another blank-line
+delimiter, does start another content line. When an eleventh content line
+exists, keep the first ten complete lines, preserve their original separators,
+and append the existing English `TRUNCATION_MARKER` on a new line. Apply
+`preserveSpacing` only after this source-text cut.
+
+The existing `assembleToolResultContent` byte-fitting pipeline remains the
+final bound for JSON and text. This adds no Core processing, configuration, or
+second byte budget.
+
+## 2. Give anchor replacement its own terminal
+
+Change `FeishuCotAdapter.advanceAnchor` so its terminal follows the transition:
+
+- old anchor to a new non-null anchor: `completed`;
+- old anchor to `null`: `interrupted`.
+
+The adapter already owns both the old presentation and the replacement target,
+so this needs no new state or caller parameter. Keep `finishCard`, `close`, route
+release, Team close, session close, runtime-reported interruption, anchor
+generation, receipt opening, open-tool-call clearing, and serialized I/O
+unchanged.
+
+## 3. Return canonical card facts on the producing paths
+
+Extend the neutral `TeamCreateResult` with `leader_agent_runtime` and
+`runtime_cwd`. Core already persists both facts in the accepted Team record, so
+new creation and idempotent `existing` / `closed` replay return the same shape.
+The result is required rather than optional: successful Team creation publishes
+the TeamLeader identity before returning. No new fact or secondary lookup is
+introduced.
+
+Automatic provisioning consumes `leader_name`, `leader_agent_runtime`, and
+`runtime_cwd` directly from that receipt:
+
+```text
+team.create -> routing.bind -> COT claim/card -> team.submit
+```
+
+Manual `bindChannel` still invokes `team.status` once because it binds an
+already-existing Team. It reads the configured runtime ID from
+`answer.team.leader_agent_runtime` and the actual cwd from
+`answer.leader.repo.path`, then preserves the existing bind, previous-owner
+release, new-owner claim, notification, and response order. A nullable runtime
+process status is irrelevant because a lazily started TeamLeader still has a
+durable identity and repo path.
+
+The status semantics stay owned by Core: a nonexistent Team throws
+`TEAM_NOT_FOUND`, which the Channel leaves unchanged; a closed Team is a
+successful status response and the Channel rejects it before route persistence.
+If the successful response lacks the required leader view, binding also fails
+before persistence. No Channel error translation, shared context helper,
+compensation, retry, or persisted phase is added.
+
+## 4. Render selected route notifications as Card 2.0
+
+Keep route-card construction in
+`/packages/channel/feishu-channel/src/feishu-binding-notification-card.ts`. Do
+not change `buildFeishuStatusCard`; Collaboration Space cards retain their
+existing Card 1.0 presentation. Small private builders in the notification-card
+module may share repeated Card 2.0 label, fact-column, and full-width panel
+shapes without introducing a repository-wide card abstraction.
+
+All fixed copy in the three selected production cards is English. Remove every
+preview candidate/set label. Render target, Team, TeamLeader, runtime ID, and cwd
+as `plain_text`; never interpolate dynamic values into Markdown.
+
+### Route bound
+
+- Green header and bound-state tag.
+- Team name as the hero.
+- Target, TeamLeader, and configured Agent Runtime ID as three grey fact cells.
+- Runtime cwd in one full-width green-tinted detail panel matching the selected
+  set-2 bottom-panel treatment.
+
+### Explicit MCP unbind
+
+- Neutral grey header and unbound-state tag.
+- Team name as the hero.
+- Target, binding kind, and Team as three grey fact cells.
+- One full-width grey reason panel stating that Feishu Channel removed this
+  route and the Team remains active.
+
+### Confirmed Team dissolution
+
+- Neutral header with an orange warning icon/tag and orange Team hero.
+- Target, binding kind, and Team as three grey fact cells.
+- One full-width orange reason panel stating that the Team closed and all of its
+  routes were removed automatically.
+
+## 5. Preserve three distinct route-removal facts
+
+Use the existing Channel caller boundary to choose the truthful notification:
+
+- `unbindChannel` uses the explicit-unbind renderer.
+- A final `team.state(status: 'closed')` caller uses the Team-dissolution
+  renderer for every forgotten route.
+- The existing inbound fallback after a `TEAM_CLOSED` admission rejection uses
+  a cause-neutral route-ended renderer. That error also means dissolution is
+  merely in progress, and a non-force dissolve may still be refused. The card
+  must claim neither completed dissolution nor continued Team activity.
+
+Pass this distinction at the existing `forgetTeamRoutes` caller boundary while
+keeping one durable `routing.forgetTeam` mutation path. Preserve COT fencing,
+best-effort notification, and exactly one Dispatcher fallback. Do not change
+Core's error vocabulary, poll Team status, or persist a route-removal reason.
+
+## Verification
+
+- Extend `feishu-cot-tool-rows.test.ts` with 10-line, LF-terminated 10-line,
+  CRLF-terminated 10-line, 11-line, explicit blank eleventh-line, JSON
+  object/array over ten lines, JSON scalar, and post-line-cut byte-budget cases.
+- Extend `feishu-cot.test.ts` across TeamLeader and Dispatcher recipients: three
+  successive non-null anchors close the first two cards as `done`; anchor
+  retirement, route release, Team close, session close, and native interruption
+  remain interrupted; activity continues on the successor mid-native-turn.
+- Add notification-card tests for schema 2.0, English fixed copy, absent preview
+  labels, selected colors/layout, configured runtime ID, literal
+  Markdown-significant dynamic values, and the full-width cwd/reason panels.
+- Extend binding tests to prove canonical context is read before persistence,
+  explicit unbind and final Team close select different renderers, and a leader
+  with `runtime_status: null` remains bindable.
+- Extend session-level tests for the third removal cause: an inbound rejected
+  while dissolve is pending keeps the neutral route-ended card, route removal,
+  COT interruption, and one Dispatcher fallback even if dissolution is refused;
+  only a final closed event emits the dissolution card.
+- Extend provisioning tests to prove `team.create -> bind -> announce ->
+  submit`, direct receipt propagation, and the absence of a redundant
+  `team.status` call.
+- Update the product catalog and Channel domain for the three removal semantics,
+  canonical runtime context, selected Card 2.0 presentation, and successful
+  superseded-anchor terminal; run `.agents/scripts/check.sh`.
+- Add Rush change files for `@excitedjs/feishu-channel`,
+  `@excitedjs/dreamux-types`, and `@excitedjs/dreamux`, then run Rush build,
+  lint, test, and `typecheck:tests`. No state rebuild is needed.
+
+## Review adjudication
+
+Three independent reviews were completed. Two reviewers found the same blocking
+lifecycle ambiguity: `TEAM_CLOSED` can represent an in-progress dissolution that
+later fails. The final solution accepts that finding and reserves dissolution
+copy for final `team.state(status: 'closed')`, while keeping the existing early
+route removal and Dispatcher fallback with neutral copy. The third reviewer found
+that a raw split could misclassify a terminating LF or CRLF as an eleventh line.
+The final solution accepts that finding and defines content-line scanning plus
+explicit regression cases. No material ownership or architecture disagreement
+remains.
+
+## Rejected alternatives
+
+- Do not restore Core binding events. Routing remains Channel-owned; the Channel
+  reads canonical Team facts from the Core command already required by each
+  path.
+- Do not add a shared Channel context helper: after provisioning consumes the
+  create receipt, manual binding is its only possible caller.
+- Do not derive cwd from Space policy or a Team record path; neither is the
+  TeamLeader runtime cwd.
+- Do not display provider refs or require a live `runtime_status`; both
+  contradict the selected runtime-ID behavior and lazy runtime lifecycle.
+- Do not convert Collaboration Space cards or the general Card 1.0 helper merely
+  for visual uniformity outside the selected route cards.
+- Do not add status polling, persisted route-removal causes, provisioning phases,
+  retries, or compensation.

--- a/.agents/tasks/channel/refine-feishu-cot-and-binding-cards/technical-design/reviews/review-codex-medium.md
+++ b/.agents/tasks/channel/refine-feishu-cot-and-binding-cards/technical-design/reviews/review-codex-medium.md
@@ -1,0 +1,34 @@
+# Codex medium review
+
+## Status: NOT READY
+
+## Blocking finding
+
+### B1 — The line-cut rule does not define a terminating newline, so it can truncate a ten-line result that acceptance requires to remain unchanged
+
+**Exact evidence.** The draft says to split the original text on line breaks and
+to cut whenever an eleventh line exists
+([draft.md:29-36](../draft.md#L29-L36)). Current presentation deliberately
+preserves every non-empty source string (`nonEmpty` rejects only `null` and the
+empty string) at
+`packages/channel/feishu-channel/src/feishu-cot-presentation.ts:163-166`, and
+`toolResultOutput` passes that original text to the text presentation path at
+`packages/channel/feishu-channel/src/feishu-cot-events.ts:274-285`. Therefore a
+normal command result such as `line1\\n...\\nline10\\n` reaches the new rule
+with its final delimiter intact. A direct split produces ten content entries
+plus a trailing empty entry, which the draft leaves indistinguishable from an
+actual eleventh blank line.
+
+**Trigger.** A non-JSON tool result has exactly ten content lines and ends with
+the customary final LF (or CRLF).
+
+**Wrong result.** The implementation can treat the split's trailing empty
+entry as line eleven, add `… (truncated)`, and remove the final newline. This
+violates acceptance criterion 1's requirement that a 0–10-line plain-text
+result render unchanged.
+
+**Minimal correction.** Define line counting in the design as source lines,
+not raw `split()` entries: a terminal line delimiter terminates the preceding
+line and does not by itself create another line; an additional empty line does.
+Specify the corresponding helper/algorithm and add LF- and CRLF-terminated
+ten-line regression cases, alongside the existing eleven-line cases.

--- a/.agents/tasks/channel/refine-feishu-cot-and-binding-cards/technical-design/reviews/review-codex-ultra.md
+++ b/.agents/tasks/channel/refine-feishu-cot-and-binding-cards/technical-design/reviews/review-codex-ultra.md
@@ -1,0 +1,134 @@
+# Independent solution review
+
+Verdict: **NOT READY** — one blocking notification-cause mismatch. The other
+proposed mechanisms fit the requirement and current ownership boundaries.
+
+Reviewed source HEAD: `48882651ea09acb87ecaf96ba090bdddb829c613`.
+The sole requirement and solution inputs were this task's `requirement.md` and
+`technical-design/draft.md`, respectively:
+
+- Requirement SHA-256: `f82cbf9145700cbdd03023fc6cd8bdf5cc087646db377a7653fbc6918c0a4864`.
+- Draft SHA-256: `1cb87874954d67041167d1d07be9739f560f416bdbec84c6a831a3df86947ba7`.
+
+No other review file was read. This review follows the engineering whitepaper's
+requirement-driven mechanism and ownership rules. Source references below are
+repository-relative.
+
+## Blocking finding
+
+### B1 — A refused dissolve can produce a card saying the Team dissolved
+
+**Draft location:** `technical-design/draft.md:129-139`, especially the unconditional
+replacement of the renderer called by `announceTeamClosed`.
+
+**Requirement:** `requirement.md:80-89` distinguishes an MCP unbind from removal
+caused by a received Team-closure notification. The latter card asserts that
+the Team closed. Notification ordering and COT fencing must remain intact
+(`requirement.md:109-110`).
+
+**Source evidence:**
+
+- `packages/channel/feishu-channel/src/feishu-channel.ts:286-291` invokes
+  `forgetTeamRoutes(..., 'team_closed')` for a closed `team.state` event, but
+  `:441-454` invokes the same path for a `TEAM_CLOSED` submission rejection.
+  `:330-339` sends both through `announceTeamClosed` after route removal.
+- `packages/dreamux/src/service/team-collection/errors.ts:21-25` explicitly
+  defines `TEAM_CLOSED` to include closing/dissolving. In
+  `packages/dreamux/src/service/team-service/index.ts:433-438`, a non-null
+  `dissolveTask` produces that error before the Team is durably closed.
+- `packages/dreamux/src/service/team-service/closing.ts:93-95,189-192` can refuse
+  a non-force Dispatcher dissolve during the initial worktree assessment.
+  Durable closure occurs later at `:108-117`. On refusal,
+  `packages/dreamux/src/service/team-service/index.ts:479-485` clears the fence;
+  the Team remains open.
+- Today's `bindingUnboundCard` only states that the route no longer routes to a
+  Team (`packages/channel/feishu-channel/src/feishu-binding-notification-card.ts:52-58`).
+  It does not assert that the Team itself ended. The refusal path's existing
+  announcement is covered by
+  `packages/channel/feishu-channel/tests/feishu-channel-session.test.ts:142-179`.
+
+**Trigger:** A Dispatcher requests a non-force dissolve of a Team with a dirty
+managed worktree. An inbound reaches an existing route while the asynchronous
+assessment is pending. Core rejects that submission with `TEAM_CLOSED`; the
+assessment then refuses the dissolve.
+
+**Wrong consequence:** The unchanged rejection cleanup calls the newly selected
+Team-dissolution renderer, telling the conversation that its Team closed even
+though it remains open and can accept work again. The existing route removal is
+not the new defect; changing a factual route-ended announcement into a false
+Team-lifecycle assertion is. Renaming a method does not establish the cause it
+claims to represent.
+
+**Minimal correction:** Account for the submission-rejection caller explicitly
+in the draft. Reserve the confirmed-dissolution copy for the actual closed
+`team.state` notification, and retain a factual route-ended announcement for the
+existing rejection cleanup. Preserve its durable removal, COT release, and single
+Dispatcher fallback. Do not replace that announcement with the MCP-unbind copy
+claiming the Team remains active, or silently remove it. Keep this distinction
+at the existing Channel notification boundary; no Core error-contract change,
+persisted cause, retry, or compensation is needed.
+
+**Verification:** Exercise a real closing fence while worktree assessment is
+pending, then a refused dissolve. Assert that no card claims Team dissolution,
+the route-ended notification still arrives, and cleanup/fallback behavior is
+unchanged. Separately assert the selected dissolution card after a closed
+`team.state` event. Direct tests of `announceTeamClosed` alone miss this caller.
+
+## Ownership, boundary, and trade-offs
+
+- Core already supplies the required card facts. `team.status` reaches
+  `TeamCollection.summary` through
+  `packages/dreamux/src/service/team-collection/commands.ts:330-332` and
+  `packages/dreamux/src/service/dispatcher-service/index.ts:508-509`.
+  `packages/dreamux/src/service/team-service/team-view.ts:5-10` supplies the
+  canonical names and configured runtime ID;
+  `packages/dreamux/src/service/agent-entity/read-helpers.ts:23-43`
+  maps `identity.runtime_cwd` to `leader.repo.path`. The Feishu-local display
+  helper has two real consumers and does not justify a new Core contract.
+- A missing leader and a lazy runtime are different cases. The store-only status
+  path can return `leader: null`
+  (`packages/dreamux/src/service/team-collection/read-model.ts:77-83,142-151`),
+  while a present leader with `runtime_status: null` still carries its cwd.
+  The draft's required-facts check addresses an actual producer state. Retaining
+  lazy startup follows commit `d74142c3` by YourWildDad; binding must not activate
+  the runtime merely to populate the card.
+- Reading status between creation and binding fits the existing failure model:
+  `packages/channel/feishu-channel/src/feishu-provisioning.ts:113-130,145-179`
+  leaves committed Team facts alone on a pre-submit failure, and
+  `packages/channel/feishu-channel/src/feishu-channel.ts:421-456` delivers an
+  `unsubmitted` inbound to the Dispatcher.
+  One additional canonical read on provisioning is the justified cost of the
+  requested facts. No durable provisioning mechanism is warranted.
+- The proposed anchor transition uses facts already owned by the adapter.
+  Non-null replacement enters at
+  `packages/channel/feishu-channel/src/feishu-cot-adapter.ts:185-189`; retirement and
+  lifecycle fences pass null at `:201,291-301`; session close explicitly uses
+  interruption at `:310-317`. Existing `completed` maps to Feishu `done` in
+  `packages/channel/feishu-channel/src/feishu-cot-events.ts:72-87`. No new state
+  or provider behavior is needed.
+- The route-card boundary deliberately follows the Channel ownership introduced
+  by commit `2ed5f5ea` by YourWildDad, while restoring the presentation facts that
+  commit removed. Keeping Card 2.0 construction local avoids changing space-policy
+  cards or the general Card 1.0 helper. The selected client baseline is an
+  explicit requirement trade-off and should be visible in the release note.
+
+## Non-blocking verification notes
+
+1. Preserve meaningful byte-budget coverage. The existing spacing test uses
+   3,000 short lines
+   (`packages/channel/feishu-channel/tests/feishu-cot-tool-rows.test.ts:179-188`),
+   which the new line
+   cap would reduce before it exercises byte fitting. Use at most ten sufficiently
+   long indented lines as well, so NBSP conversion still tests the final byte
+   bound. The draft already calls for post-line-cut byte-budget cases.
+2. Keep fixtures representative of the canonical answer: the current manual-bind
+   fake returns only `{ team: { status } }`
+   (`packages/channel/feishu-channel/tests/feishu-session-bindings.test.ts:81-94`).
+   Extend it with real-shaped Team and
+   leader fields; retain the missing/closed-Team assertions. Distinguish a null
+   leader from a present leader with null runtime status.
+
+Validation performed: source/caller tracing, relevant source history, and existing
+test inspection. No build, lint, tests, live Feishu send, or implementation changes
+were performed. The draft's planned Rush gates remain implementation acceptance
+work; this review does not claim them green.

--- a/.agents/tasks/channel/refine-feishu-cot-and-binding-cards/technical-design/reviews/review-codex.md
+++ b/.agents/tasks/channel/refine-feishu-cot-and-binding-cards/technical-design/reviews/review-codex.md
@@ -1,0 +1,138 @@
+# Independent solution review
+
+Verdict: **NOT READY**.
+
+One blocking finding: the proposed dissolution renderer would also announce a
+Team as dissolved while its dissolve is merely pending and can still be refused.
+The other proposed ownership and presentation changes fit the recorded requirement.
+
+## Review basis and boundary
+
+- Requirement authority: `requirement.md`, SHA-256
+  `f82cbf9145700cbdd03023fc6cd8bdf5cc087646db377a7653fbc6918c0a4864`.
+- Reviewed solution: `technical-design/draft.md`, SHA-256
+  `1cb87874954d67041167d1d07be9739f560f416bdbec84c6a831a3df86947ba7`.
+- Current source: `48882651ea09acb87ecaf96ba090bdddb829c613`.
+- Applied `.agents/skills/engineering-whitepaper/SKILL.md` and the frontend
+  whitepaper's abstraction/layering guidance. History and current knowledge were
+  checked as implementation evidence, not additional requirement input.
+- Only this review file is written. No implementation, tests, requirement, draft,
+  or other task record is changed. No build, test run, or live card delivery was
+  performed; this is a solution review, not implementation validation.
+
+## Blocking finding
+
+### R1 — [P2] An admission rejection does not prove that the Team dissolved
+
+**Draft location:** lines 129-139, especially the unconditional assignment of the
+Team-dissolution renderer to `announceTeamClosed`. The verification list at lines
+153-158 also stops below the session caller that exposes the problem.
+
+**Requirement:** lines 80-89 distinguish explicit MCP unbind from passive removal
+after a Team closure notification. The dissolution card states that Team closure
+caused the routes to be removed. That requires a closure fact.
+
+**Current-source evidence:**
+
+1. `packages/dreamux/src/service/team-service/index.ts:433-439` raises the same
+   `TeamClosedError` both while `dissolveTask` is pending and when the durable Team
+   record is closed. `packages/dreamux/src/service/team-collection/errors.ts:22-28`
+   assigns that error the code `TEAM_CLOSED`.
+2. Dissolve raises its fence before the background operation starts
+   (`team-service/index.ts:457-468`). A non-forced Dispatcher dissolve then awaits
+   the worktree assessment and can refuse a dirty worktree before closing anything
+   (`packages/dreamux/src/service/team-service/closing.ts:91-96,189-193`). On failure,
+   `team-service/index.ts:479-485` clears the fence; the Team need not have closed.
+3. Besides the durable `team.state` event path at
+   `packages/channel/feishu-channel/src/feishu-channel.ts:286-291`, an ordinary
+   inbound rejected with `TEAM_CLOSED` calls `forgetTeamRoutes(..., 'team_closed')`
+   at lines 441-454. That call removes the routes and invokes
+   `announceTeamClosed` at lines 329-339. No closed event or status read is required.
+4. The existing notification is truthful about the route alone:
+   `packages/channel/feishu-channel/src/feishu-binding-notification-card.ts:39-60`
+   says the conversation is no longer routed to a Team. The session regression
+   test at `packages/channel/feishu-channel/tests/feishu-channel-session.test.ts:142-179`
+   explicitly preserves notification and one Dispatcher fallback for this path.
+
+**Triggering flow:** a Dispatcher submits a non-forced dissolve for a Team with a
+dirty managed worktree. While the asynchronous assessment is pending, a message
+arrives on one of its Feishu routes. Admission returns `TEAM_CLOSED`; the Channel
+removes the Team's routes and calls `announceTeamClosed`. The worktree assessment
+then refuses the dissolve and the Team remains open.
+
+**Wrong consequence:** under the draft, the conversation receives an orange card
+stating that its Team closed/dissolved even though the Team is still alive. The
+wrong statement is introduced by the new cause-specific copy; this finding does
+not ask this task to redesign the existing early route removal.
+
+**Smaller correction:** separate the two existing callers' notification meaning
+inside the Channel. Reserve the new dissolution renderer for the confirmed
+`team.state(status: 'closed')` path. Preserve a route-removal-only notification for
+the pre-admission rejection path, without asserting either completed dissolution
+or explicit MCP unbind. The current generic unbound renderer already supplies
+that narrower meaning; keep it for this existing fallback instead of repurposing
+every caller. Preserve route removal, COT release, and one Dispatcher fallback.
+No Core error change, status polling, notification ledger, or persisted phase is
+needed. Include this small session call-site change in the declared boundary.
+
+**Verification:** extend the session-level cases, not only direct binding-operation
+tests. Exercise an inbound during the real dissolve fence with a dirty-worktree
+refusal; assert no dissolution claim, unchanged route removal/COT interruption,
+and exactly one Dispatcher fallback. Separately emit the confirmed closed event
+with multiple remaining routes and assert one dissolution notification per removed
+route. Do not delete the existing rejection-notification assertion to make the
+new renderer pass.
+
+## Supported design choices
+
+- **COT ownership and terminal scope are correct.** `toolResultOutput` classifies
+  the complete value at `feishu-cot-events.ts:274-285`; byte fitting follows at
+  lines 288-320. The proposed line cut belongs only in its text branch. In
+  `feishu-cot-adapter.ts`, inbound supplies a non-null anchor at lines 168-201,
+  Team/route fences supply null at lines 291-301, and session close explicitly
+  uses interruption at lines 310-318. Changing the terminal selected at lines
+  359-370 therefore preserves the requested lifecycle boundary. `completed`
+  already maps to wire `done` at `feishu-cot-events.ts:72-86`.
+- **Canonical Team context needs no new Core capability.** `team.status` invokes
+  `getTeamStatus` at `packages/dreamux/src/service/team-collection/commands.ts:312-333`.
+  `TeamView` exposes the configured runtime ID and leader name at
+  `team-collection/types.ts:231-247`; `agent-entity/read-helpers.ts:23-44` maps
+  `identity.runtime_cwd` to `leader.repo.path`. `team-collection/index.ts:282-294`
+  reads an unmaterialized Team from records, without starting its runtime.
+  `leader: null` is reachable through the record reader
+  (`team-collection/read-model.ts:77-82,142-151`), so refusing a bind when the
+  required cwd cannot be obtained has a concrete producer. It must remain distinct
+  from a valid leader whose `runtime_status` is null.
+- **The helper has two real consumers.** Replace the manual validation read at
+  `feishu-session-bindings.ts:74,116-134`, and add the same read before the durable
+  bind at `feishu-provisioning.ts:145-179`. Carrying only the four display facts
+  avoids a second canonical read during notification. A provisioning failure at
+  that point already has an honest `unsubmitted` outcome at lines 113-129; the
+  session delivers it to the Dispatcher at `feishu-channel.ts:429-456`. The extra
+  query adds latency and a pre-bind failure point, but implements the explicitly
+  required canonical-context ordering without compensation state.
+- **Channel-local rendering follows the ownership history.** Commit `2ed5f5ea`
+  (author: YourWildDad) removed Core binding-event inputs and the old runtime/cwd
+  card fields. The draft correctly restores the presentation through the existing
+  command port instead of restoring Core routing ownership. Keeping the Card 1.0
+  status helper for unchanged space cards and constructing the selected route
+  cards locally avoids widening the abstraction.
+
+## Non-blocking verification notes
+
+1. Add a rendered check of the final production JSON for all three selected cards,
+   including a long cwd and Markdown-significant dynamic text. Requirement lines
+   44-50 record candidate validation, but that does not validate the final English
+   copy and combined detail-panel layout. The transport merely serializes the
+   `unknown` card and checks its size before sending
+   (`packages/channel/feishu-transport/src/transport/feishu.ts:446-459`); unit shape
+   assertions cannot establish client rendering. This review sent nothing.
+2. Make the line-boundary tests explicit about empty output, trailing line breaks,
+   and CRLF. Keep the original text unchanged below the threshold, and test the
+   final emitted event after spacing preservation and byte fitting, rather than
+   only a split helper. The draft already names the main 10/11-line and JSON cases.
+
+The requested Card 2.0 client baseline and best-effort notification delivery are
+accepted trade-offs in the requirement, not reasons to add a compatibility
+fallback or a delivery guarantee. The implementation still needs the four Rush
+gates and knowledge/change-note work listed in the draft after R1 is resolved.

--- a/.agents/tasks/channel/refine-feishu-cot-and-binding-cards/verification.md
+++ b/.agents/tasks/channel/refine-feishu-cot-and-binding-cards/verification.md
@@ -1,0 +1,70 @@
+# Verification
+
+## TeamLeader pre-review
+
+The complete implementation diff was inspected against the approved
+requirement and final technical solution. The first pass found that the route
+cards preserved the selected hierarchy but omitted meaningful details from the
+operator-selected rendered designs: Card 2.0 config and summary, header icons,
+hero subtitles, and the selected unbind/dissolution state wording. The same
+developer corrected those omissions and strengthened the card-shape tests.
+
+The second pass confirmed:
+
+- plain-text COT tool results cut only when an eleventh content line exists,
+  terminal LF/CRLF does not invent a line, JSON objects and arrays bypass the
+  line rule, and Feishu byte fitting remains final;
+- non-null anchor replacement emits `done`, while anchor retirement and all
+  existing runtime, route, Team, and session interruption paths remain
+  interrupted;
+- manual binding reads `team.status` before the route becomes visible, while
+  automatic provisioning consumes the configured runtime ID and cwd directly
+  from `team.create` without a redundant status query;
+- the three selected Card 2.0 notifications preserve their approved English
+  hierarchy, config, summaries, icons, state tags, spacing, fact order, and
+  full-width detail panels, with every dynamic value kept as `plain_text`;
+- explicit MCP unbind, final `team.state(status: 'closed')`, and pre-final
+  `TEAM_CLOSED` rejection select the active, dissolved, and neutral
+  presentations respectively, without changing route mutation, COT fencing, or
+  the single Dispatcher fallback;
+- Collaboration Space cards, provider contracts, and persisted schemas are
+  unchanged. The neutral `team.create` result now exposes the runtime facts its
+  provisioning consumer needs.
+
+## Checks
+
+The TeamLeader reran these checks after the architecture correction:
+
+```text
+node common/scripts/install-run-rush.js build --to @excitedjs/feishu-channel
+PASS
+
+node common/scripts/install-run-rush.js build --to @excitedjs/dreamux
+PASS
+
+node common/scripts/install-run-rush.js test --only @excitedjs/dreamux-types --only @excitedjs/feishu-channel --only @excitedjs/dreamux --verbose
+PARTIAL — dreamux-types passed 106 tests; feishu-channel passed 416 tests;
+dreamux passed 977 deterministic tests and failed 5 live Codex tests because
+the external runtime timed out or produced no mid-turn activity
+
+node common/scripts/install-run-rush.js change --verify --target-branch origin/next --no-fetch
+PASS
+
+.agents/scripts/check.sh
+PASS — 162 files reachable
+
+git diff --check
+PASS
+```
+
+Affected-package lint and test typechecking, the deterministic Dreamux rerun,
+full-repository gates, and independent implementation review remain for the
+Draft PR follow-up.
+
+## Known limitations
+
+- No live Feishu client send was performed after implementation. The selected
+  Card 2.0 component vocabulary was rendered and selected during requirement
+  clarification, and production shape tests now lock its meaningful details.
+- Card 2.0 requires Feishu client 7.20 or newer, an operator-accepted baseline
+  recorded in the approved requirement.

--- a/common/changes/@excitedjs/dreamux-types/dreamux-team-dreamux-trae-gpt-vi8zroza_2026-09-07-07-32.json
+++ b/common/changes/@excitedjs/dreamux-types/dreamux-team-dreamux-trae-gpt-vi8zroza_2026-09-07-07-32.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Expose the created TeamLeader runtime ID and runtime cwd on the canonical team.create result.",
+      "type": "minor",
+      "packageName": "@excitedjs/dreamux-types"
+    }
+  ],
+  "packageName": "@excitedjs/dreamux-types",
+  "email": "hvjfccdy6s@privaterelay.appleid.com"
+}

--- a/common/changes/@excitedjs/dreamux/dreamux-team-dreamux-trae-gpt-vi8zroza_2026-09-07-07-32.json
+++ b/common/changes/@excitedjs/dreamux/dreamux-team-dreamux-trae-gpt-vi8zroza_2026-09-07-07-32.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Return the TeamLeader runtime ID and runtime cwd directly from team.create so callers do not need a follow-up status query.",
+      "type": "minor",
+      "packageName": "@excitedjs/dreamux"
+    }
+  ],
+  "packageName": "@excitedjs/dreamux",
+  "email": "hvjfccdy6s@privaterelay.appleid.com"
+}

--- a/common/changes/@excitedjs/feishu-channel/dreamux-team-dreamux-trae-gpt-vi8zroza_2026-09-06-18-17.json
+++ b/common/changes/@excitedjs/feishu-channel/dreamux-team-dreamux-trae-gpt-vi8zroza_2026-09-06-18-17.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Refine Feishu route cards with canonical Team runtime context and distinct removal reasons; limit plain-text COT results to ten lines and complete superseded cards successfully. Route notifications use Card 2.0 and require Feishu 7.20 or newer. No state rebuild is needed.",
+      "type": "patch",
+      "packageName": "@excitedjs/feishu-channel"
+    }
+  ],
+  "packageName": "@excitedjs/feishu-channel",
+  "email": "hvjfccdy6s@privaterelay.appleid.com"
+}

--- a/packages/channel/feishu-channel/src/feishu-binding-notification-card.ts
+++ b/packages/channel/feishu-channel/src/feishu-binding-notification-card.ts
@@ -4,7 +4,7 @@
  * These cards used to be rendered from Core binding events, which meant Core
  * had to publish a binding fact for a Channel to be able to describe its own
  * state. They are now rendered from this Channel's own records, at the moment
- * this Channel changes them, and no Core event is involved.
+ * this Channel changes them, and no Core binding event is involved.
  */
 import type { FeishuSpaceRecord } from './routing/document.js';
 import { describeTarget, type FeishuTarget } from './routing/target.js';
@@ -17,23 +17,45 @@ export function bindingBoundCard(input: {
   target: FeishuTarget;
   display: string | null;
   teamName: string;
-  /** Set when the binding was installed automatically for a space. */
-  spaceName: string | null;
+  leaderName: string;
+  agentRuntime: string;
+  runtimeCwd: string;
 }): unknown {
-  const topic = input.target.kind === 'topic';
-  return buildFeishuStatusCard({
-    template: 'green',
-    title: topic ? 'Dreamux 话题已绑定' : 'Dreamux 群聊已绑定',
-    enTitle: topic ? 'Dreamux topic bound' : 'Dreamux group bound',
-    fields: [
-      line('目标', 'Target', input.display ?? describeTarget(input.target)),
-      line('绑定类型', 'Binding', topic ? '话题' : '群聊', topic ? 'topic' : 'group'),
-      line('团队', 'Team', input.teamName),
-      ...(input.spaceName !== null
-        ? [line('协作空间', 'Collaboration space', input.spaceName)]
-        : []),
-    ],
-  });
+  const targetDisplay = input.display ?? describeTarget(input.target);
+  const binding = input.target.kind === 'topic' ? 'topic' : 'group';
+  return {
+    schema: '2.0',
+    config: {
+      update_multi: true,
+      width_mode: 'default',
+      summary: { content: `${targetDisplay} bound to Team ${input.teamName}` },
+    },
+    header: {
+      ...routeHeader(`Dreamux ${binding} bound`, 'green', 'Bound', 'green'),
+      icon: { tag: 'standard_icon', token: 'group_outlined', color: 'green' },
+    },
+    body: {
+      direction: 'vertical',
+      padding: '12px 12px 20px 12px',
+      elements: [
+        { ...textBlock(input.teamName, 'heading-2', 'green'), margin: '0px 0px 2px 0px' },
+        {
+          ...textBlock(`Bound to ${targetDisplay} · ${binding}`, 'notation', 'grey'),
+          margin: '0px 0px 12px 0px',
+        },
+        factRow([
+          ['Target', targetDisplay],
+          ['TeamLeader', input.leaderName],
+          ['Agent Runtime', input.agentRuntime],
+        ]),
+        detailPanel(
+          "**<font color='green'>Runtime cwd</font>**",
+          input.runtimeCwd,
+          'green-50',
+        ),
+      ],
+    },
+  };
 }
 
 export function bindingUnboundCard(input: {
@@ -41,24 +63,165 @@ export function bindingUnboundCard(input: {
   display: string | null;
   teamName: string;
 }): unknown {
-  const topic = input.target.kind === 'topic';
+  const targetDisplay = input.display ?? describeTarget(input.target);
+  const binding = input.target.kind === 'topic' ? 'topic' : 'group';
+  return {
+    schema: '2.0',
+    config: {
+      update_multi: true,
+      width_mode: 'default',
+      summary: { content: `${targetDisplay} unbound from Team ${input.teamName}` },
+    },
+    header: {
+      ...routeHeader(`Dreamux ${binding} unbound`, 'grey', 'Unbound', 'neutral'),
+      icon: { tag: 'standard_icon', token: 'close_outlined', color: 'grey' },
+    },
+    body: {
+      direction: 'vertical',
+      padding: '12px 12px 20px 12px',
+      elements: [
+        { ...textBlock(input.teamName, 'heading-2'), margin: '0px 0px 2px 0px' },
+        {
+          ...textBlock(`Unbound from ${targetDisplay}`, 'notation', 'grey'),
+          margin: '0px 0px 12px 0px',
+        },
+        factRow([
+          ['Target', targetDisplay],
+          ['Binding', binding],
+          ['Team', input.teamName],
+        ]),
+        detailPanel(
+          "**<font color='grey'>Why</font>**",
+          'Unbound via Feishu Channel; the Team remains active.',
+          'grey-50',
+        ),
+      ],
+    },
+  };
+}
+
+export function teamDissolvedCard(input: {
+  target: FeishuTarget;
+  display: string | null;
+  teamName: string;
+}): unknown {
+  return {
+    schema: '2.0',
+    config: {
+      update_multi: true,
+      width_mode: 'default',
+      summary: { content: `Team ${input.teamName} dissolved; routes removed` },
+    },
+    header: {
+      ...routeHeader('Dreamux team dissolved', 'grey', 'Team dissolved', 'orange'),
+      icon: { tag: 'standard_icon', token: 'warning_outlined', color: 'orange' },
+    },
+    body: {
+      direction: 'vertical',
+      padding: '12px 12px 20px 12px',
+      elements: [
+        { ...textBlock(input.teamName, 'heading-2', 'orange'), margin: '0px 0px 2px 0px' },
+        {
+          ...textBlock('Team closed; routes removed automatically', 'notation', 'grey'),
+          margin: '0px 0px 12px 0px',
+        },
+        factRow([
+          ['Target', input.display ?? describeTarget(input.target)],
+          ['Binding', input.target.kind === 'topic' ? 'topic' : 'group'],
+          ['Team', input.teamName],
+        ]),
+        detailPanel(
+          "**<font color='orange'>Why</font>**",
+          'Team closed; all of its routes were removed automatically.',
+          'orange-50',
+        ),
+      ],
+    },
+  };
+}
+
+/** Admission can be refused while dissolution is still pending. */
+export function bindingRouteEndedCard(input: {
+  target: FeishuTarget;
+  display: string | null;
+  teamName: string;
+}): unknown {
   return buildFeishuStatusCard({
     template: 'grey',
-    title: topic ? 'Dreamux 话题已解绑' : 'Dreamux 群聊已解绑',
-    enTitle: topic ? 'Dreamux topic unbound' : 'Dreamux group unbound',
+    title: 'Dreamux route ended',
+    enTitle: 'Dreamux route ended',
     fields: [
-      line('目标', 'Target', input.display ?? describeTarget(input.target)),
-      line('团队', 'Team', input.teamName),
-      line(
-        '状态',
-        'Status',
-        topic ? '该话题已不再路由到团队。' : '该群聊已不再路由到团队。',
-        topic
-          ? 'This topic is no longer routed to a Team.'
-          : 'This group is no longer routed to a Team.',
-      ),
+      line('Target', 'Target', input.display ?? describeTarget(input.target)),
+      line('Team', 'Team', input.teamName),
+      line('Status', 'Status', 'This conversation is no longer routed to this Team.'),
     ],
   });
+}
+
+function routeHeader(
+  title: string,
+  template: 'green' | 'grey',
+  status: string,
+  color: 'green' | 'neutral' | 'orange',
+) {
+  return {
+    title: { tag: 'plain_text', content: title },
+    template,
+    text_tag_list: [{ tag: 'text_tag', text: { tag: 'plain_text', content: status }, color }],
+  };
+}
+
+function textBlock(
+  content: string,
+  textSize: 'heading-2' | 'normal' | 'notation',
+  textColor: 'default' | 'grey' | 'green' | 'orange' = 'default',
+  textAlign: 'left' | 'center' = 'left',
+) {
+  return {
+    tag: 'div',
+    text: { tag: 'plain_text', content, text_size: textSize, text_color: textColor, text_align: textAlign },
+  };
+}
+
+function factRow(facts: Array<[string, string]>) {
+  return {
+    tag: 'column_set',
+    flex_mode: 'none',
+    horizontal_spacing: '8px',
+    margin: '0px 0px 12px 0px',
+    columns: facts.map(([label, value]) => ({
+      tag: 'column',
+      width: 'weighted',
+      weight: 1,
+      background_style: 'grey-50',
+      padding: '8px 8px 8px 8px',
+      vertical_spacing: '2px',
+      elements: [
+        textBlock(label, 'notation', 'grey', 'center'),
+        textBlock(value, 'normal', 'default', 'center'),
+      ],
+    })),
+  };
+}
+
+function detailPanel(labelMarkdown: string, value: string, background: string) {
+  return {
+    tag: 'column_set',
+    flex_mode: 'none',
+    margin: '0px',
+    columns: [{
+      tag: 'column',
+      width: 'weighted',
+      weight: 1,
+      background_style: background,
+      padding: '12px 12px 12px 12px',
+      vertical_spacing: '4px',
+      elements: [
+        { tag: 'markdown', content: labelMarkdown },
+        textBlock(value, 'normal'),
+      ],
+    }],
+  };
 }
 
 export function spaceBoundCard(space: FeishuSpaceRecord): unknown {

--- a/packages/channel/feishu-channel/src/feishu-channel.ts
+++ b/packages/channel/feishu-channel/src/feishu-channel.ts
@@ -305,20 +305,17 @@ export class FeishuChannelSession {
   /**
    * Commit the removal of every route to a Team, and say what it removed.
    *
-   * Both reasons reach the same durable change, so they share the one commit
+   * All reasons reach the same durable change, so they share the one commit
    * path the store owns rather than growing a second authority beside it. A
    * commit that fails is logged and nothing more: the route is still live, and
    * the next message to it earns the same rejection and the same attempt.
    *
-   * Only a closed Team is announced. That is a transition the conversation
-   * lived through — it had a Team, and the Team ended — while a stale route is
-   * this Channel correcting its own document on the way to delivering a
-   * message, and telling a group about it would be noise about nothing the
-   * group did.
+   * A final closed event announces dissolution; an admission rejection only
+   * announces that the route ended. A missing Team stays silent.
    */
   private async forgetTeamRoutes(
     teamName: string,
-    reason: 'team_closed' | 'stale_route',
+    reason: 'team_closed' | 'route_ended' | 'stale_route',
   ): Promise<void> {
     const scope = {
       dispatcher_id: this.opts.dispatcherId,
@@ -335,8 +332,8 @@ export class FeishuChannelSession {
       );
       // Past the commit: the rows are gone from disk, and what follows is
       // presentation over what they said.
-      if (reason === 'team_closed') {
-        this.bindings.announceTeamClosed({ teamName, removed });
+      if (reason !== 'stale_route') {
+        this.bindings.announceRoutesRemoved({ teamName, removed, reason });
       }
     } catch (err) {
       this.opts.log.warn(
@@ -439,17 +436,13 @@ export class FeishuChannelSession {
     // proves nothing about whether a turn exists, and nothing is sent twice on
     // a guess.
     if (plan.kind === 'bound') {
-      // Only a rejection can arrive from that branch, and its code says what
-      // kind of evidence removed the row. `TEAM_CLOSED` is the same close the
-      // `team.state` event proves, and it usually arrives here first: dissolve
-      // raises the Team's closing fence before it publishes the final state,
-      // so the message that gets refused precedes the event. It is announced
-      // for that reason. `TEAM_NOT_FOUND` is a row pointing at nothing, which
-      // is this Channel correcting its own document and stays silent.
+      // TEAM_CLOSED also covers a pending dissolve that may still be refused.
+      // Announce only route removal until the final Team state proves closure.
+      // TEAM_NOT_FOUND is silent correction of a row pointing at nothing.
       await this.forgetTeamRoutes(
         plan.teamName,
         outcome.status === 'rejected' && outcome.code === 'TEAM_CLOSED'
-          ? 'team_closed'
+          ? 'route_ended'
           : 'stale_route',
       );
     }

--- a/packages/channel/feishu-channel/src/feishu-cot-adapter.ts
+++ b/packages/channel/feishu-channel/src/feishu-cot-adapter.ts
@@ -362,7 +362,7 @@ export class FeishuCotAdapter {
     anchor: VisibleMessageAnchor | null,
   ): void {
     state.generation += 1;
-    this.detach(key, state, 'interrupted');
+    this.detach(key, state, anchor === null ? 'interrupted' : 'completed');
     state.anchor = anchor;
     if (anchor === null) {
       state.openCalls.clear();
@@ -371,9 +371,8 @@ export class FeishuCotAdapter {
   }
 
   /**
-   * Stop writing to this card and record how it ends. A card retired by a
-   * lifecycle path — a replaced anchor, a closing session — is interrupted
-   * rather than failed, because nothing about it failed.
+   * Stop writing to this card and record how it ends. Anchor replacement
+   * completes the old card; retirement and session closure interrupt it.
    */
   private detach(
     key: string,

--- a/packages/channel/feishu-channel/src/feishu-cot-events.ts
+++ b/packages/channel/feishu-channel/src/feishu-cot-events.ts
@@ -32,8 +32,8 @@ const COT_REQUEST_ENCODING_RESERVE_BYTES = 512;
 /**
  * How a card ends: the same three words the runtime uses for a turn end,
  * because a card's terminal *is* the end of what it was showing. The lifecycle
- * paths that end a card with no runtime saying so — a retired anchor, a session
- * close — are exactly `interrupted`. Wire spelling is this module's business.
+ * paths that retire an anchor or close a session use `interrupted`; replacing
+ * an anchor completes its old card. Wire spelling is this module's business.
  *
  * Feishu documents one more `RUN_FINISHED.status`, `paused`, that nothing here
  * produces: a card is open or ended, never held. The omission is deliberate.
@@ -263,8 +263,9 @@ export interface ToolResultParts {
  * a `json` code segment, anything else as plain text (operator ruling,
  * 2026-09-04: 「文本的输出，就按文本输出。能解析成JSON的再放进代码段」). The whole
  * text is parsed first and cut last, so a cut never decides what a value was.
- * Plain text keeps its spacing the way the client keeps it (`preserveSpacing`),
- * before the cut is measured; a code segment keeps its own spaces.
+ * Plain text keeps ten content lines, then preserves its spacing the way the
+ * client keeps it (`preserveSpacing`) before byte fitting. JSON keeps its lines
+ * and spaces until byte fitting.
  */
 export interface ToolResultOutput {
   readonly kind: 'json' | 'text';
@@ -282,7 +283,17 @@ export function toolResultOutput(resultJson: string | null): ToolResultOutput | 
   } catch {
     // Not JSON: the runtime's own text, shown as text.
   }
-  return { kind: 'text', text: preserveSpacing(text) };
+  let boundary = -1;
+  for (let line = 0; line < 10; line += 1) {
+    boundary = text.indexOf('\n', boundary + 1);
+    if (boundary === -1 || boundary === text.length - 1) {
+      return { kind: 'text', text: preserveSpacing(text) };
+    }
+  }
+  return {
+    kind: 'text',
+    text: preserveSpacing(text.slice(0, boundary + 1) + TRUNCATION_MARKER),
+  };
 }
 
 export function assembleToolResultContent(parts: ToolResultParts): unknown {

--- a/packages/channel/feishu-channel/src/feishu-provisioning.ts
+++ b/packages/channel/feishu-channel/src/feishu-provisioning.ts
@@ -1,10 +1,10 @@
 /**
  * Turning an unrouted Feishu topic into a working Team.
  *
- * This is the Collaboration Space product effect, composed from two generic
+ * This is the Collaboration Space product effect, composed from generic
  * Core Commands. Core is not told that a space exists, that a topic is a child
  * of a group, or that anything is being orchestrated: it is asked to create a
- * Team, and then to accept one submission.
+ * Team and then accept one submission.
  *
  * None of the work is durable. It lives in this process and may be lost with
  * it — there is no record to resume from, and after a restart the next message
@@ -22,7 +22,11 @@
  * operator who rebinds or removes the space meanwhile changes what the next
  * creation sees and nothing about one already under way.
  */
-import type { DreamuxLogger, JsonValue } from '@excitedjs/dreamux-types';
+import type {
+  DreamuxLogger,
+  JsonValue,
+  TeamCreateResult,
+} from '@excitedjs/dreamux-types';
 
 import type { FeishuRouting } from './routing/index.js';
 import type { FeishuSpaceRecord } from './routing/document.js';
@@ -39,12 +43,6 @@ import {
   type FeishuTeamSubmitter,
 } from './feishu-submit.js';
 
-interface TeamCreateResultShape {
-  status: 'created' | 'existing' | 'closed';
-  team_name: string;
-  leader_name: string;
-}
-
 export interface FeishuProvisioningOptions {
   readonly dispatcherId: string;
   readonly channelId: string;
@@ -57,7 +55,9 @@ export interface FeishuProvisioningOptions {
     target: FeishuTarget;
     display: string | null;
     teamName: string;
-    spaceName: string;
+    leaderName: string;
+    agentRuntime: string;
+    runtimeCwd: string;
   }): void;
 }
 
@@ -131,7 +131,7 @@ export class FeishuProvisioning {
   }
 
   /**
-   * Create the Team, commit the route, announce it, deliver the message.
+   * Create the Team, commit the route, announce it, then submit.
    *
    * The order is the one that degrades honestly. A failure before the binding
    * commits leaves an ordinary Team nothing routes to, which an operator can
@@ -139,7 +139,7 @@ export class FeishuProvisioning {
    * compensation ledger for work this design has already declared expendable.
    *
    * Only the last line reaches Core with this message. Every earlier exit is
-   * `unsubmitted`, which is a fact about this run and not a guess: no Command
+   * `unsubmitted`, which is a fact about this run and not a guess: no submission
    * has been sent yet, so the message is still owed a recipient.
    */
   private async run(input: ProvisioningRequest): Promise<FeishuSubmitOutcome> {
@@ -174,7 +174,9 @@ export class FeishuProvisioning {
       target: input.target,
       display: input.display,
       teamName: created.team_name,
-      spaceName: input.space.space_name,
+      leaderName: created.leader_name,
+      agentRuntime: created.leader_agent_runtime,
+      runtimeCwd: created.runtime_cwd,
     });
     return this.opts.submitter.submit(created.team_name, input.submission);
   }
@@ -197,7 +199,7 @@ export class FeishuProvisioning {
 
   private async createTeam(
     input: ProvisioningRequest,
-  ): Promise<TeamCreateResultShape> {
+  ): Promise<TeamCreateResult> {
     const { space, target } = input;
     return (await this.opts.invoke('team.create', {
       // The inbound Feishu message id, used bare: it is globally unique, so it
@@ -252,6 +254,6 @@ export class FeishuProvisioning {
             },
           }
         : {}),
-    } as JsonValue)) as unknown as TeamCreateResultShape;
+    } as JsonValue)) as unknown as TeamCreateResult;
   }
 }

--- a/packages/channel/feishu-channel/src/feishu-session-bindings.ts
+++ b/packages/channel/feishu-channel/src/feishu-session-bindings.ts
@@ -11,13 +11,13 @@
  * lifecycle fence and bounded-send policy, and this module needs neither.
  */
 import type { JsonValue } from '@excitedjs/dreamux-types';
-import { PublicInvokeFailure } from '@excitedjs/dreamux-utils';
-
-import { commandErrorCode } from './feishu-submit.js';
+import { isPlainObject, PublicInvokeFailure } from '@excitedjs/dreamux-utils';
 
 import {
   bindingBoundCard,
   bindingUnboundCard,
+  bindingRouteEndedCard,
+  teamDissolvedCard,
   spaceBoundCard,
   spaceUnboundCard,
 } from './feishu-binding-notification-card.js';
@@ -71,7 +71,27 @@ export class FeishuBindingOperations {
           'group, or a topic inside one.',
       );
     }
-    await this.requireRoutableTeam(input.teamName);
+    const answer = await this.opts.invoke('team.status', { team_name: input.teamName });
+    const team = isPlainObject(answer) ? answer['team'] : null;
+    if (isPlainObject(team) && team['status'] === 'closed') {
+      throw new PublicInvokeFailure(
+        `Team ${JSON.stringify(input.teamName)} is closed and can no longer ` +
+          'answer here. Bind an open Team instead.',
+      );
+    }
+    const leader = isPlainObject(answer) ? answer['leader'] : null;
+    const repo = isPlainObject(leader) ? leader['repo'] : null;
+    if (
+      !isPlainObject(team) ||
+      typeof team['team_name'] !== 'string' || team['team_name'] === '' ||
+      typeof team['leader_name'] !== 'string' || team['leader_name'] === '' ||
+      typeof team['leader_agent_runtime'] !== 'string' || team['leader_agent_runtime'] === '' ||
+      !isPlainObject(repo) || typeof repo['path'] !== 'string' || repo['path'] === ''
+    ) {
+      throw new PublicInvokeFailure(
+        `Team ${JSON.stringify(input.teamName)} has no complete TeamLeader runtime context.`,
+      );
+    }
     const { previousTeamName } = await this.opts.routing.bind({
       target,
       teamName: input.teamName,
@@ -91,46 +111,14 @@ export class FeishuBindingOperations {
       bindingBoundCard({
         target,
         display: input.display,
-        teamName: input.teamName,
-        spaceName: null,
+        teamName: team['team_name'],
+        leaderName: team['leader_name'],
+        agentRuntime: team['leader_agent_runtime'],
+        runtimeCwd: repo['path'],
       }),
       input.teamName,
     );
     return { team_name: input.teamName, previous_team_name: previousTeamName };
-  }
-
-  /**
-   * Refuse to route a conversation to a Team that cannot answer in it.
-   *
-   * Where a message goes is this Channel's own decision, but whether a Team
-   * exists and is open is Core's fact, so it is asked rather than assumed —
-   * before the row is written and before the conversation is told, since a
-   * binding card naming a Team that is gone is worse than no binding at all.
-   * This is the only moment the question can be asked; a Team that dissolves
-   * afterwards still converges through the `team.closed` event.
-   *
-   * Only a definite answer refuses. Core proving the Team missing or closed is
-   * one, and so is a `closed` status; any other reply already proves a Team
-   * answered to that name, whatever else it says.
-   */
-  private async requireRoutableTeam(teamName: string): Promise<void> {
-    let answer: JsonValue;
-    try {
-      answer = await this.opts.invoke('team.status', { team_name: teamName });
-    } catch (error) {
-      const code = commandErrorCode(error);
-      if (code !== 'TEAM_NOT_FOUND' && code !== 'TEAM_CLOSED') throw error;
-      throw new PublicInvokeFailure(
-        `There is no Team named ${JSON.stringify(teamName)} to route this ` +
-          'conversation to. Bind an open Team, or create one first.',
-      );
-    }
-    if (teamStatusOf(answer) === 'closed') {
-      throw new PublicInvokeFailure(
-        `Team ${JSON.stringify(teamName)} is closed and can no longer ` +
-          'answer here. Bind an open Team instead.',
-      );
-    }
   }
 
   async unbindChannel(
@@ -178,22 +166,13 @@ export class FeishuBindingOperations {
     return space;
   }
 
-  /**
-   * A closed Team's routes are gone; announce it where each one served.
-   *
-   * Removal already committed, and this only says so. Every row gets the same
-   * two effects a manual unbind gets — the COT route release and the unbound
-   * card — because to the conversation nothing else happened: it was routed to
-   * a Team, and now it is not. The card falls back to the target description
-   * when the removed row carried no display, exactly as an unbind does.
-   *
-   * Nothing here is awaited or retried. A card that does not arrive leaves the
-   * route removed, which is the fact that mattered.
-   */
-  announceTeamClosed(input: {
+  /** Announce committed route removal using only its confirmed cause. */
+  announceRoutesRemoved(input: {
     teamName: string;
     removed: readonly FeishuRemovedRoute[];
+    reason: 'team_closed' | 'route_ended';
   }): void {
+    const card = input.reason === 'team_closed' ? teamDissolvedCard : bindingRouteEndedCard;
     for (const route of input.removed) {
       this.opts.cot.onRouteReleased({
         teamName: input.teamName,
@@ -201,7 +180,7 @@ export class FeishuBindingOperations {
       });
       this.opts.notify(
         route.target,
-        bindingUnboundCard({
+        card({
           target: route.target,
           display: route.display,
           teamName: input.teamName,
@@ -216,7 +195,9 @@ export class FeishuBindingOperations {
     target: FeishuTarget;
     display: string | null;
     teamName: string;
-    spaceName: string;
+    leaderName: string;
+    agentRuntime: string;
+    runtimeCwd: string;
   }): void {
     this.opts.cot.onRouteClaimed({
       teamName: input.teamName,
@@ -228,24 +209,13 @@ export class FeishuBindingOperations {
         target: input.target,
         display: input.display,
         teamName: input.teamName,
-        spaceName: input.spaceName,
+        leaderName: input.leaderName,
+        agentRuntime: input.agentRuntime,
+        runtimeCwd: input.runtimeCwd,
       }),
       input.teamName,
     );
   }
-}
-
-/** Read the Team status out of a `team.status` answer, if it states one. */
-function teamStatusOf(answer: JsonValue): string | null {
-  if (answer === null || typeof answer !== 'object' || Array.isArray(answer)) {
-    return null;
-  }
-  const team = (answer as Record<string, unknown>)['team'];
-  if (team === null || typeof team !== 'object' || Array.isArray(team)) {
-    return null;
-  }
-  const status = (team as Record<string, unknown>)['status'];
-  return typeof status === 'string' ? status : null;
 }
 
 export function selectorTarget(

--- a/packages/channel/feishu-channel/tests/feishu-binding-notification-card.test.ts
+++ b/packages/channel/feishu-channel/tests/feishu-binding-notification-card.test.ts
@@ -1,0 +1,185 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  bindingBoundCard,
+  bindingRouteEndedCard,
+  bindingUnboundCard,
+  teamDissolvedCard,
+} from '../src/feishu-binding-notification-card.js';
+import { chatTarget, topicTarget } from '../src/routing/target.js';
+
+function nodes(value: unknown): Array<Record<string, unknown>> {
+  if (Array.isArray(value)) return value.flatMap(nodes);
+  if (value === null || typeof value !== 'object') return [];
+  const record = value as Record<string, unknown>;
+  return [record, ...Object.values(record).flatMap(nodes)];
+}
+
+const target = topicTarget('chat-example', 'topic-example');
+const display = '**target** [literal](url)';
+const team = {
+  teamName: '*team* _literal_',
+  leaderName: '`leader` <literal>',
+  agentRuntime: 'trae-gpt',
+  runtimeCwd: `/workspace/[literal]/${'long directory_'.repeat(50)}end`,
+};
+
+// Selected candidate 4 / set 2, with the final English and runtime-cwd refinements.
+const cards = [
+  {
+    name: 'bound',
+    card: bindingBoundCard({ target, display, ...team }),
+    summary: `${display} bound to Team ${team.teamName}`,
+    title: 'Dreamux topic bound',
+    color: 'green',
+    icon: { token: 'group_outlined', color: 'green' },
+    status: 'Bound',
+    statusColor: 'green',
+    heroColor: 'green',
+    subtitle: `Bound to ${display} · topic`,
+    facts: [['Target', display], ['TeamLeader', team.leaderName], ['Agent Runtime', team.agentRuntime]],
+    panel: 'green-50',
+    panelLabel: "**<font color='green'>Runtime cwd</font>**",
+    panelValue: team.runtimeCwd,
+  },
+  {
+    name: 'unbound',
+    card: bindingUnboundCard({ target, display, teamName: team.teamName }),
+    summary: `${display} unbound from Team ${team.teamName}`,
+    title: 'Dreamux topic unbound',
+    color: 'grey',
+    icon: { token: 'close_outlined', color: 'grey' },
+    status: 'Unbound',
+    statusColor: 'neutral',
+    heroColor: 'default',
+    subtitle: `Unbound from ${display}`,
+    facts: [['Target', display], ['Binding', 'topic'], ['Team', team.teamName]],
+    panel: 'grey-50',
+    panelLabel: "**<font color='grey'>Why</font>**",
+    panelValue: 'Unbound via Feishu Channel; the Team remains active.',
+  },
+  {
+    name: 'dissolved',
+    card: teamDissolvedCard({ target, display, teamName: team.teamName }),
+    summary: `Team ${team.teamName} dissolved; routes removed`,
+    title: 'Dreamux team dissolved',
+    color: 'grey',
+    icon: { token: 'warning_outlined', color: 'orange' },
+    status: 'Team dissolved',
+    statusColor: 'orange',
+    heroColor: 'orange',
+    subtitle: 'Team closed; routes removed automatically',
+    facts: [['Target', display], ['Binding', 'topic'], ['Team', team.teamName]],
+    panel: 'orange-50',
+    panelLabel: "**<font color='orange'>Why</font>**",
+    panelValue: 'Team closed; all of its routes were removed automatically.',
+  },
+];
+
+describe('selected route notification cards', () => {
+  it.each(cards)('$name preserves the selected config, English summary, icon and state tag', ({
+    card, summary, title, color, icon, status, statusColor,
+  }) => {
+    expect(card).toMatchObject({
+      schema: '2.0',
+      config: { update_multi: true, width_mode: 'default', summary: { content: summary } },
+      header: {
+        title: { tag: 'plain_text', content: title },
+        template: color,
+        icon: { tag: 'standard_icon', ...icon },
+        text_tag_list: [{ tag: 'text_tag', text: { tag: 'plain_text', content: status }, color: statusColor }],
+      },
+    });
+    expect(nodes(card).filter((node) => node['tag'] === 'text_tag')).toHaveLength(1);
+  });
+
+  it.each(cards)('$name preserves the Team hero, subtitle and selected body spacing', ({ card, heroColor, subtitle }) => {
+    expect(card).toMatchObject({ body: {
+      direction: 'vertical',
+      padding: '12px 12px 20px 12px',
+      elements: [
+        {
+          tag: 'div', margin: '0px 0px 2px 0px',
+          text: { tag: 'plain_text', content: team.teamName, text_size: 'heading-2', text_color: heroColor },
+        },
+        {
+          tag: 'div', margin: '0px 0px 12px 0px',
+          text: { tag: 'plain_text', content: subtitle, text_size: 'notation', text_color: 'grey' },
+        },
+        { tag: 'column_set', margin: '0px 0px 12px 0px' },
+        { tag: 'column_set', margin: '0px' },
+      ],
+    } });
+    const body = nodes(card).find((node) => node['direction'] === 'vertical');
+    expect(body).not.toHaveProperty('vertical_spacing');
+  });
+
+  it.each(cards)('$name keeps the final fact order in compact, centered grey cells', ({ card, facts }) => {
+    const rows = nodes(card).filter((node) => node['tag'] === 'column_set');
+    expect(rows).toHaveLength(2);
+    expect(rows[0]).toMatchObject({
+      flex_mode: 'none', horizontal_spacing: '8px',
+      columns: facts.map(([label, value]) => ({
+        tag: 'column', width: 'weighted', weight: 1,
+        background_style: 'grey-50', padding: '8px 8px 8px 8px', vertical_spacing: '2px',
+        elements: [
+          { text: { tag: 'plain_text', content: label, text_size: 'notation', text_color: 'grey', text_align: 'center' } },
+          { text: { tag: 'plain_text', content: value, text_align: 'center' } },
+        ],
+      })),
+    });
+    expect(rows[0]!['columns']).toHaveLength(3);
+  });
+
+  it.each(cards)('$name keeps its full-width tinted panel with a static label and complete literal value', ({
+    card, panel, panelLabel, panelValue,
+  }) => {
+    const rows = nodes(card).filter((node) => node['tag'] === 'column_set');
+    expect(rows[1]).toMatchObject({
+      flex_mode: 'none', margin: '0px',
+      columns: [{
+        tag: 'column', width: 'weighted', weight: 1,
+        background_style: panel, padding: '12px 12px 12px 12px', vertical_spacing: '4px',
+        elements: [
+          { tag: 'markdown', content: panelLabel },
+          { tag: 'div', text: { tag: 'plain_text', content: panelValue, text_align: 'left' } },
+        ],
+      }],
+    });
+    expect(rows[1]!['columns']).toHaveLength(1);
+  });
+
+  it.each(cards)('$name renders dynamic values literally without preview labels or Chinese fallback copy', ({ card, panelLabel }) => {
+    const all = nodes(card);
+    const text = all.filter((node) => node['tag'] === 'plain_text').map((node) => node['content']);
+    expect(text).toContain(display);
+    expect(text).toContain(team.teamName);
+    expect(all.filter((node) => 'i18n_content' in node)).toEqual([]);
+    // Only the static panel label uses Markdown; names, subtitles and paths do not.
+    expect(all.filter((node) => node['tag'] === 'markdown' || node['tag'] === 'lark_md'))
+      .toEqual([{ tag: 'markdown', content: panelLabel }]);
+    expect(JSON.stringify(card)).not.toMatch(/[\u3400-\u9fff]|candidate|preview|set 2|builtin:codex/iu);
+  });
+
+  it.each([
+    { kind: 'group', route: chatTarget('chat-example', 'group') },
+    { kind: 'topic', route: target },
+  ])('names the $kind in bind/unbind titles and binding facts', ({ kind, route }) => {
+    const bound = bindingBoundCard({ target: route, display, ...team });
+    const unbound = bindingUnboundCard({ target: route, display, teamName: team.teamName });
+    expect(bound).toMatchObject({ header: { title: { content: `Dreamux ${kind} bound` } } });
+    expect(unbound).toMatchObject({ header: { title: { content: `Dreamux ${kind} unbound` } } });
+    expect(nodes(bound)).toContainEqual(expect.objectContaining({
+      tag: 'plain_text', content: `Bound to ${display} · ${kind}`,
+    }));
+    expect(nodes(unbound)).toContainEqual(expect.objectContaining({ tag: 'plain_text', content: kind }));
+  });
+
+  it('keeps pre-final route removal neutral and outside the selected Card 2.0 designs', () => {
+    const card = bindingRouteEndedCard({ target, display, teamName: team.teamName });
+    expect(card).not.toHaveProperty('schema', '2.0');
+    expect(card).toMatchObject({ header: { title: { content: 'Dreamux route ended' } } });
+    expect(JSON.stringify(card)).toContain('This conversation is no longer routed to this Team.');
+    expect(JSON.stringify(card)).not.toMatch(/dissolved|Team closed|remains active/);
+  });
+});

--- a/packages/channel/feishu-channel/tests/feishu-channel-session.test.ts
+++ b/packages/channel/feishu-channel/tests/feishu-channel-session.test.ts
@@ -139,7 +139,7 @@ function readBindings(channelId: string): Array<Record<string, unknown>> {
 }
 
 describe('FeishuChannelSession.deliver — typed pre-admission rejection fallback', () => {
-  it('TEAM_CLOSED: removes the stale binding, announces it, and delivers once to the Dispatcher Agent', async () => {
+  it('TEAM_CLOSED during a refused dissolve: removes the route neutrally and falls back once', async () => {
     const bot = createFakeFeishuBot();
     const channelId = 'chan-closed';
     const session = await newSession(bot, channelId);
@@ -175,8 +175,18 @@ describe('FeishuChannelSession.deliver — typed pre-admission rejection fallbac
     expect(outcome).toEqual({ status: 'submitted', turnId: 'turn-fallback-1' });
     expect(submitCalls).toBe(2);
     expect(session.routing.bindingFor(chatTarget('oc_closed', 'group'))).toBeUndefined();
-    // TEAM_CLOSED is announced: the conversation is told its route ended.
     expect(bot.sentCards).toHaveLength(1);
+    expect(JSON.stringify(bot.sentCards[0]!.card)).toContain('Dreamux route ended');
+    expect(JSON.stringify(bot.sentCards[0]!.card)).not.toMatch(/dissolved|remains active|Team closed/);
+
+    // The pending non-force dissolve is refused; Core still reports an open Team.
+    port.emit({
+      schema_version: 1, kind: 'team.state', occurred_at: Date.now(),
+      team_name: 'closing-team', leader_name: 'leader-1', status: 'running', teammates: [],
+    });
+    expect(bot.sentCards).toHaveLength(1);
+    expect(readBindings(channelId)).toEqual([]);
+    expect(port.calls.map((call) => call.command)).toEqual(['team.submit', 'team.submit']);
 
     await session.close();
   });
@@ -316,6 +326,11 @@ describe('FeishuChannelSession — team.state closed invalidates every binding t
       () => session.routing.bindingFor(chatTarget('oc_x', 'group')) === undefined,
     );
     await waitFor(() => bot.sentCards.length >= 2);
+    for (const { card } of bot.sentCards) {
+      expect(JSON.stringify(card)).toContain('Dreamux team dissolved');
+      expect(JSON.stringify(card)).toContain('all of its routes were removed automatically.');
+      expect(JSON.stringify(card)).not.toContain('remains active');
+    }
 
     await session.close();
 
@@ -360,7 +375,7 @@ describe('FeishuChannelSession — team.state closed invalidates every binding t
     // awaits the store's own commit queue regardless of who queued it.
     expect(readBindings(channelId)).toEqual([]);
 
-    // But no card exists — announceTeamClosed's notify() only reaches the
+    // But no card exists — announceRoutesRemoved's notify() only reaches the
     // network after the write resolves, by which point close() has already
     // aborted this session's fence, and notify() refuses to run past that
     // point. No presentation callback fires after final close.

--- a/packages/channel/feishu-channel/tests/feishu-cot-delivery.test.ts
+++ b/packages/channel/feishu-channel/tests/feishu-cot-delivery.test.ts
@@ -272,7 +272,7 @@ describe('FeishuChannelSession COT — the anchor is the visible inbound message
     await session.close();
   });
 
-  it('interrupts one predecessor and opens exactly one successor for a second inbound', async () => {
+  it('completes one predecessor and opens exactly one successor for a second inbound', async () => {
     let submissionIndex = 0;
     const { session, cot, port } = await harness('chan-cot-successor', async (
       command,
@@ -313,14 +313,14 @@ describe('FeishuChannelSession COT — the anchor is the visible inbound message
       },
     });
     await waitFor(() => cot.cards.length === 2);
-    await waitFor(() => cotTerminal(cot.cards[0]!) === 'interrupted');
+    await waitFor(() => cotTerminal(cot.cards[0]!) === 'done');
 
     expect(cot.cards).toHaveLength(2);
     expect(cot.cards.map((card) => card.originMessageId)).toEqual([
       'message-one',
       'message-two',
     ]);
-    expect(cot.cards.map(cotTerminal)).toEqual(['interrupted', null]);
+    expect(cot.cards.map(cotTerminal)).toEqual(['done', null]);
     expectOpeningTexts(cot.cards[0]!, ['first answer']);
     expectOpeningTexts(cot.cards[1]!, []);
 
@@ -360,12 +360,12 @@ describe('FeishuChannelSession COT — the anchor is the visible inbound message
     const outcome = await session.submit(null, submission);
     expect(outcome).toEqual({ status: 'duplicate' });
     await waitFor(() => cot.cards.length === 2);
-    await waitFor(() => cotTerminal(cot.cards[0]!) === 'interrupted');
+    await waitFor(() => cotTerminal(cot.cards[0]!) === 'done');
     expect(cot.cards.map((card) => card.originMessageId)).toEqual([
       'message-repeat',
       'message-repeat',
     ]);
-    expect(cot.cards.map(cotTerminal)).toEqual(['interrupted', null]);
+    expect(cot.cards.map(cotTerminal)).toEqual(['done', null]);
     expectOpeningTexts(cot.cards[1]!, []);
 
     port.emit(assistantMessage('turn-original', 'dispatcher', 'after repeat'));
@@ -377,12 +377,14 @@ describe('FeishuChannelSession COT — the anchor is the visible inbound message
   });
 
   it('carries the same anchor to the Dispatcher when a proven-stale route falls back', async () => {
-    const { session, cot, port } = await harness('chan-cot-fallback', async (
+    let submitCalls = 0;
+    const { session, cot, port, bot } = await harness('chan-cot-fallback', async (
       command,
       payload,
       emit,
     ) => {
       if (command !== 'team.submit') throw new Error(`unexpected ${command}`);
+      submitCalls += 1;
       const p = payload as Record<string, unknown>;
       // The stored route names a Team that is closed: proven no admission.
       if (p['team_name'] !== undefined) throw teamClosedError();
@@ -422,6 +424,9 @@ describe('FeishuChannelSession COT — the anchor is the visible inbound message
       'om_user_1',
     ]);
     expect(cot.cards.map(cotTerminal)).toEqual(['interrupted', null]);
+    expect(submitCalls).toBe(2);
+    expect(JSON.stringify(bot.sentCards[0]!.card)).toContain('Dreamux route ended');
+    expect(JSON.stringify(bot.sentCards[0]!.card)).not.toContain('dissolved');
     port.emit(assistantMessage('turn-fallback', 'dispatcher', 'dispatcher answered'));
     await waitFor(() => cotTexts(cot.cards[1]!).length === 2);
     expectOpeningTexts(cot.cards[1]!, ['dispatcher answered']);

--- a/packages/channel/feishu-channel/tests/feishu-cot-tool-rows.test.ts
+++ b/packages/channel/feishu-channel/tests/feishu-cot-tool-rows.test.ts
@@ -8,8 +8,8 @@
  * What came back is shown by what it is, not by how long it is: a value that
  * parses as JSON is pretty-printed in a `json` code segment, anything else is
  * plain text (operator ruling, 2026-09-04: 「文本的输出，就按文本输出。能解析成JSON
- * 的再放进代码段」), and a string is cut only where it would exceed Feishu's
- * per-event content limit (「截断长度以飞书平台上给出的最长长度为准」).
+ * 的再放进代码段」). Plain text keeps ten content lines; every result remains
+ * bounded by Feishu's per-event content limit.
  */
 
 import { describe, expect, it } from 'vitest';
@@ -18,6 +18,7 @@ import type { TeammateActivity } from '@excitedjs/dreamux-types';
 
 import {
   toolCallResultEvents,
+  toolResultOutput,
   toolCallStartEvents,
 } from '../src/feishu-cot-events.js';
 
@@ -188,6 +189,50 @@ describe('runtime-labelled tool rows', () => {
     expect(Buffer.byteLength(JSON.stringify(result!.content), 'utf8')).toBeLessThanOrEqual(4_096);
   });
 
+  it.each(['', 'one', ...['\n', '\r\n'].flatMap((separator) => {
+    const ten = Array.from({ length: 10 }, (_, i) => `line-${i}`).join(separator);
+    return [ten, ten + separator];
+  })])('keeps at most ten content lines unchanged: %j', (output) => {
+    expect(toolResultOutput(output)).toEqual(output === '' ? null : { kind: 'text', text: output });
+  });
+
+  it.each(['\n', '\r\n'])('cuts the eleventh content line, including an empty one, with %j', (separator) => {
+    const ten = Array.from({ length: 10 }, (_, i) => `line-${i}`).join(separator);
+    for (const eleventh of ['line-eleven', separator]) {
+      const [event] = toolCallResultEvents(toolCall({
+        status: 'completed', result_json: ten + separator + eleventh,
+      }));
+      expect(event!.content).toMatchObject({
+        content: { type: 'text', text: ten + separator + '… (truncated)' },
+      });
+    }
+  });
+
+  it.each([Array.from({ length: 12 }, (_, i) => i), { values: Array.from({ length: 12 }, (_, i) => i) }])(
+    'keeps all lines of a JSON object or array', (value) => {
+      const [event] = toolCallResultEvents(toolCall({ status: 'completed', result_json: JSON.stringify(value) }));
+      expect(event!.content).toMatchObject({
+        content: { type: 'code', language: 'json', code: JSON.stringify(value, null, 2) },
+      });
+    },
+  );
+
+  it('treats a JSON scalar with multiline whitespace as text and cuts its source lines', () => {
+    const scalar = '42' + '\n'.repeat(11);
+    expect(JSON.parse(scalar)).toBe(42);
+    expect(toolResultOutput(scalar)).toEqual({ kind: 'text', text: '42' + '\n'.repeat(10) + '… (truncated)' });
+  });
+
+  it.each([
+    '  ' + '界'.repeat(2_000) + '\nshort'.repeat(10),
+    JSON.stringify({ values: Array.from({ length: 12 }, () => '界'.repeat(1_000)) }),
+  ])('still applies the event byte limit after classification and line cutting', (output) => {
+    const [event] = toolCallResultEvents(toolCall({ status: 'completed', result_json: output }));
+    const shown = (event!.content as { content: { text?: string; code?: string } }).content;
+    expect(shown.text ?? shown.code).toContain('… (truncated)');
+    expect(Buffer.byteLength(JSON.stringify(event!.content), 'utf8')).toBeLessThanOrEqual(4_096);
+  });
+
   it('pretty-prints an output that parses as JSON in a json code segment, its spaces untouched', () => {
     const [result] = toolCallResultEvents(toolCall({
       tool_name: 'mcp__teammate__spawn',
@@ -219,7 +264,7 @@ describe('runtime-labelled tool rows', () => {
     }
   });
 
-  it("cuts an output only at Feishu's per-event content limit, with the marker", () => {
+  it("cuts a long single-line output at Feishu's per-event content limit, with the marker", () => {
     const [result] = toolCallResultEvents(toolCall({
       status: 'completed',
       result_json: 'x'.repeat(10_000),

--- a/packages/channel/feishu-channel/tests/feishu-cot.test.ts
+++ b/packages/channel/feishu-channel/tests/feishu-cot.test.ts
@@ -304,10 +304,10 @@ describe.each([LEADER, DISPATCHER])(
         'om_2',
         'om_3',
       ]);
-      // Every superseded card was interrupted; exactly one is still open.
+      // Every superseded card completed; exactly one is still open.
       expect(cot.cards.map(cotTerminal)).toEqual([
-        'interrupted',
-        'interrupted',
+        'done',
+        'done',
         null,
       ]);
 
@@ -329,7 +329,7 @@ describe.each([LEADER, DISPATCHER])(
 
       expect(cot.cards).toHaveLength(2);
       const [first, second] = cot.cards as [typeof cot.cards[0], typeof cot.cards[0]];
-      expect(cotTerminal(first)).toBe('interrupted');
+      expect(cotTerminal(first)).toBe('done');
       expectOpeningTexts(first, ['first thought']);
       // The still-running native turn keeps producing, into the card the
       // operator is now looking at.

--- a/packages/channel/feishu-channel/tests/feishu-provisioning.test.ts
+++ b/packages/channel/feishu-channel/tests/feishu-provisioning.test.ts
@@ -15,9 +15,11 @@ import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-import type { DreamuxLogger, JsonValue } from '@excitedjs/dreamux-types';
+import type { DreamuxLogger, JsonValue, TeamCreateResult } from '@excitedjs/dreamux-types';
+
+import { teamCreateResult } from './helpers/team-status.js';
 
 import { FeishuProvisioning } from '../src/feishu-provisioning.js';
 import { FeishuRouting } from '../src/routing/index.js';
@@ -58,8 +60,14 @@ interface Harness {
   provisioning: FeishuProvisioning;
   invokeCalls: Array<{ command: string; payload: JsonValue }>;
   submitCalls: Array<{ teamName: string; sourceId: string }>;
-  announceCalls: Array<{ teamName: string; spaceName: string }>;
-  createResult: { status: 'created' | 'existing' | 'closed'; team_name: string; leader_name: string };
+  announceCalls: Array<{
+    teamName: string;
+    leaderName: string;
+    agentRuntime: string;
+    runtimeCwd: string;
+  }>;
+  trace: string[];
+  createResult: TeamCreateResult;
   createImpl?: (payload: JsonValue) => Promise<JsonValue>;
   submitResult: FeishuSubmitOutcome;
 }
@@ -79,7 +87,8 @@ async function harness(): Promise<Harness> {
     invokeCalls: [],
     submitCalls: [],
     announceCalls: [],
-    createResult: { status: 'created', team_name: 'space-team-1', leader_name: 'leader-1' },
+    trace: [],
+    createResult: teamCreateResult('space-team-1'),
     submitResult: { status: 'submitted', turnId: 'turn-1' },
   };
 
@@ -90,11 +99,13 @@ async function harness(): Promise<Harness> {
     routing,
     submitter: {
       submit: async (teamName, sub) => {
+        state.trace.push('team.submit');
         state.submitCalls.push({ teamName, sourceId: sub.sourceId });
         return state.submitResult;
       },
     },
     invoke: async (command, payload) => {
+      state.trace.push(command);
       state.invokeCalls.push({ command, payload });
       if (command === 'team.create') {
         if (state.createImpl !== undefined) return state.createImpl(payload);
@@ -103,7 +114,13 @@ async function harness(): Promise<Harness> {
       throw new Error(`unexpected command ${command}`);
     },
     announce: (input) => {
-      state.announceCalls.push({ teamName: input.teamName, spaceName: input.spaceName });
+      state.trace.push('announce');
+      state.announceCalls.push({
+        teamName: input.teamName,
+        leaderName: input.leaderName,
+        agentRuntime: input.agentRuntime,
+        runtimeCwd: input.runtimeCwd,
+      });
     },
   });
   state.provisioning = provisioning;
@@ -127,6 +144,11 @@ describe('FeishuProvisioning — happy-path ordering', () => {
     const h = await harness();
     const spaceRecord = await h.routing.bindSpace(space());
     const target = topicTarget('oc_container', 'thread_new');
+    const bind = h.routing.bind.bind(h.routing);
+    vi.spyOn(h.routing, 'bind').mockImplementation(async (input) => {
+      h.trace.push('bind');
+      return bind(input);
+    });
 
     const outcome = await h.provisioning.provisionForInbound({
       space: spaceRecord,
@@ -136,13 +158,13 @@ describe('FeishuProvisioning — happy-path ordering', () => {
     });
 
     expect(outcome).toEqual({ status: 'submitted', turnId: 'turn-1' });
-    expect(h.invokeCalls).toHaveLength(1);
-    expect(h.invokeCalls[0]?.command).toBe('team.create');
+    expect(h.invokeCalls.map((call) => call.command)).toEqual(['team.create']);
     expect(h.routing.bindingFor(target)?.team_name).toBe('space-team-1');
     expect(h.announceCalls).toEqual([
-      { teamName: 'space-team-1', spaceName: 'space-a' },
+      { teamName: 'space-team-1', leaderName: 'space-team-1-leader', agentRuntime: 'trae-gpt', runtimeCwd: '/workspace/space-team-1' },
     ]);
     expect(h.submitCalls).toEqual([{ teamName: 'space-team-1', sourceId: 'msg-1' }]);
+    expect(h.trace).toEqual(['team.create', 'bind', 'announce', 'team.submit']);
   });
 
   it('derives request_id from the inbound message id, so distinct messages get distinct ids', async () => {
@@ -155,7 +177,7 @@ describe('FeishuProvisioning — happy-path ordering', () => {
       display: null,
       submission: submission('m1'),
     });
-    h.createResult = { status: 'created', team_name: 'space-team-2', leader_name: 'leader-2' };
+    h.createResult = teamCreateResult('space-team-2');
     await h.provisioning.provisionForInbound({
       space: spaceRecord,
       target: topicTarget('oc_container', 'thread_2'),
@@ -163,7 +185,7 @@ describe('FeishuProvisioning — happy-path ordering', () => {
       submission: submission('m2'),
     });
 
-    const requestIds = h.invokeCalls.map(
+    const requestIds = h.invokeCalls.filter((c) => c.command === 'team.create').map(
       (c) => (c.payload as Record<string, unknown>)['request_id'],
     );
     // Bare message ids, not a composite: a Feishu message id is already
@@ -185,7 +207,7 @@ describe('FeishuProvisioning — happy-path ordering', () => {
     // The same message arriving again after the binding was lost — the run
     // reaches team.create a second time and must present the same identity.
     await h.routing.unbind(target);
-    h.createResult = { status: 'existing', team_name: 'space-team-1', leader_name: 'leader-1' };
+    h.createResult = teamCreateResult('space-team-1', 'existing');
     await h.provisioning.provisionForInbound({
       space: spaceRecord,
       target,
@@ -193,7 +215,7 @@ describe('FeishuProvisioning — happy-path ordering', () => {
       submission: submission('redelivered'),
     });
 
-    const requestIds = h.invokeCalls.map(
+    const requestIds = h.invokeCalls.filter((c) => c.command === 'team.create').map(
       (c) => (c.payload as Record<string, unknown>)['request_id'],
     );
     expect(requestIds).toEqual(['redelivered', 'redelivered']);
@@ -206,7 +228,7 @@ describe('FeishuProvisioning — happy-path ordering', () => {
 
     // The earlier attempt created the Team but died before binding, so Core
     // answers this replay with the Team it already published.
-    h.createResult = { status: 'existing', team_name: 'space-team-1', leader_name: 'leader-1' };
+    h.createResult = teamCreateResult('space-team-1', 'existing');
     const outcome = await h.provisioning.provisionForInbound({
       space: spaceRecord,
       target,
@@ -247,7 +269,7 @@ describe('FeishuProvisioning — concurrency: one run per target', () => {
       submission: submission('second'),
     });
 
-    resolveCreate({ status: 'created', team_name: 'shared-team', leader_name: 'leader-x' } as unknown as JsonValue);
+    resolveCreate(teamCreateResult('shared-team') as unknown as JsonValue);
 
     const [firstOutcome, secondOutcome] = await Promise.all([first, second]);
     expect(firstOutcome).toEqual({ status: 'submitted', turnId: 'turn-1' });
@@ -293,7 +315,7 @@ describe('FeishuProvisioning — interrupted run leaves at most an accepted orph
   it('an empty Team name from team.create is treated as no admission, not a crash', async () => {
     const h = await harness();
     const spaceRecord = await h.routing.bindSpace(space());
-    h.createResult = { status: 'created', team_name: '', leader_name: '' };
+    h.createResult = { ...teamCreateResult('space-team-1'), team_name: '' };
 
     const outcome = await h.provisioning.provisionForInbound({
       space: spaceRecord,
@@ -308,7 +330,7 @@ describe('FeishuProvisioning — interrupted run leaves at most an accepted orph
   it('a replayed-closed team.create answer is reported rather than retried', async () => {
     const h = await harness();
     const spaceRecord = await h.routing.bindSpace(space());
-    h.createResult = { status: 'closed', team_name: 'ghost-team', leader_name: 'x' };
+    h.createResult = teamCreateResult('ghost-team', 'closed');
 
     const outcome = await h.provisioning.provisionForInbound({
       space: spaceRecord,

--- a/packages/channel/feishu-channel/tests/feishu-session-bindings.test.ts
+++ b/packages/channel/feishu-channel/tests/feishu-session-bindings.test.ts
@@ -22,9 +22,11 @@ import { mkdtempSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import type { JsonValue } from '@excitedjs/dreamux-types';
+
+import { teamStatus } from './helpers/team-status.js';
 
 import { FeishuRouting } from '../src/routing/index.js';
 import { FeishuRoutingStore } from '../src/routing/store.js';
@@ -51,7 +53,7 @@ interface Harness {
   setStatus(teamName: string, status: 'running' | 'closed' | 'missing'): void;
 }
 
-async function harness(): Promise<Harness> {
+async function harness(readStatus?: (teamName: string) => Promise<JsonValue>): Promise<Harness> {
   const store = new FeishuRoutingStore({
     dispatcherId: 'disp-1',
     channelId: 'chan-1',
@@ -84,13 +86,14 @@ async function harness(): Promise<Harness> {
       throw new Error(`unexpected command ${command}`);
     }
     const teamName = (payload as Record<string, unknown>)['team_name'] as string;
+    if (readStatus !== undefined) return readStatus(teamName);
     const status = statuses.get(teamName) ?? 'missing';
     if (status === 'missing') {
-      const err = new Error(`no such team ${teamName}`) as Error & { code: string };
+      const err = new Error(`Team ${JSON.stringify(teamName)} does not exist`) as Error & { code: string };
       err.code = 'TEAM_NOT_FOUND';
       throw err;
     }
-    return { team: { status } } as unknown as JsonValue;
+    return teamStatus(teamName, status);
   };
 
   const notify = (
@@ -135,13 +138,39 @@ describe('FeishuBindingOperations — manual bind synchronous validation', () =>
     expect(h.notifications).toHaveLength(1);
   });
 
+  it('waits for complete canonical context before committing, including a lazy runtime', async () => {
+    let resolveStatus!: (answer: JsonValue) => void;
+    const h = await harness(() => new Promise((resolve) => { resolveStatus = resolve; }));
+    const bind = vi.spyOn(h.routing, 'bind');
+    const pending = h.ops.bindChannel({ target: { chatId: 'chat-a' }, teamName: 'team-a', display: null });
+    expect(bind).not.toHaveBeenCalled();
+    expect(h.notifications).toEqual([]);
+    resolveStatus(teamStatus('team-a'));
+    await pending;
+    expect(bind).toHaveBeenCalledOnce();
+    const card = JSON.stringify(h.notifications[0]!.card);
+    expect(card).toContain('team-a-leader');
+    expect(card).toContain('trae-gpt');
+    expect(card).toContain('/workspace/team-a');
+    expect(h.calls).toEqual(['team.status', 'notify']);
+  });
+
+  it('refuses a Team whose stored leader view is missing before binding or announcing', async () => {
+    const h = await harness(async () => ({ ...teamStatus('team-a'), leader: null }));
+    await expect(h.ops.bindChannel({ target: { chatId: 'chat-a' }, teamName: 'team-a', display: null }))
+      .rejects.toThrow('no complete TeamLeader runtime context');
+    expect(h.routing.bindingFor(chatTarget('chat-a', 'group'))).toBeUndefined();
+    expect(h.notifications).toEqual([]);
+    expect(h.cotCalls).toEqual([]);
+  });
+
   it('a bind to a nonexistent Team never becomes durable and never renders a card', async () => {
     const h = await harness();
     const target = { chatId: 'oc_ghost', threadId: undefined };
 
     await expect(
       h.ops.bindChannel({ target, teamName: 'ghost-team', display: null }),
-    ).rejects.toThrow(/no Team named/);
+    ).rejects.toThrow(/does not exist/);
 
     expect(h.routing.bindingFor(chatTarget('oc_ghost', 'group'))).toBeUndefined();
     expect(h.notifications).toHaveLength(0);
@@ -174,6 +203,7 @@ describe('FeishuBindingOperations — unbind, and closed-Team cleanup announceme
 
     const result = await h.ops.unbindChannel(target);
     expect(result.team_name).toBe('team-open');
+    expect(JSON.stringify(h.notifications[0]!.card)).toContain('the Team remains active.');
     expect(h.cotCalls).toEqual([{ op: 'released', teamName: 'team-open' }]);
     expect(h.notifications).toHaveLength(1);
   });
@@ -188,24 +218,28 @@ describe('FeishuBindingOperations — unbind, and closed-Team cleanup announceme
 
 });
 
-describe('FeishuBindingOperations — announceTeamClosed and announceProvisioned', () => {
-  it('announceTeamClosed emits one COT release and one card per removed route', async () => {
+describe('FeishuBindingOperations — announceRoutesRemoved and announceProvisioned', () => {
+  it('announceRoutesRemoved emits one COT release and one card per removed route', async () => {
     const h = await harness();
     const removed = [
       { target: chatTarget('oc_a', 'group'), display: 'A' },
       { target: chatTarget('oc_b', 'group'), display: null },
     ];
 
-    h.ops.announceTeamClosed({ teamName: 'closed-team', removed });
+    h.ops.announceRoutesRemoved({ teamName: 'closed-team', removed, reason: 'team_closed' });
 
     expect(h.cotCalls).toEqual([
       { op: 'released', teamName: 'closed-team' },
       { op: 'released', teamName: 'closed-team' },
     ]);
     expect(h.notifications).toHaveLength(2);
+    for (const { card } of h.notifications) {
+      expect(JSON.stringify(card)).toContain('all of its routes were removed automatically.');
+      expect(JSON.stringify(card)).not.toContain('remains active');
+    }
   });
 
-  it('announceProvisioned claims the COT route and sends a bound card naming the space', async () => {
+  it('announceProvisioned claims the COT route and sends a bound card with canonical runtime context', async () => {
     const h = await harness();
     const target = chatTarget('oc_new', 'group');
 
@@ -213,7 +247,9 @@ describe('FeishuBindingOperations — announceTeamClosed and announceProvisioned
       target,
       display: null,
       teamName: 'provisioned-team',
-      spaceName: 'space-a',
+      leaderName: 'leader-a',
+      agentRuntime: 'trae-gpt',
+      runtimeCwd: '/workspace/team-a',
     });
 
     expect(h.cotCalls).toEqual([{ op: 'claimed', teamName: 'provisioned-team' }]);

--- a/packages/channel/feishu-channel/tests/feishu-space-policy.test.ts
+++ b/packages/channel/feishu-channel/tests/feishu-space-policy.test.ts
@@ -19,6 +19,8 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
 import type { DreamuxLogger, JsonValue } from '@excitedjs/dreamux-types';
 
+import { teamCreateResult } from './helpers/team-status.js';
+
 import { FeishuProvisioning } from '../src/feishu-provisioning.js';
 import { FeishuRouting } from '../src/routing/index.js';
 import { FeishuRoutingStore } from '../src/routing/store.js';
@@ -162,7 +164,7 @@ describe('Provisioning snapshot immutability', () => {
       repo: null,
     });
 
-    resolveCreate({ status: 'created', team_name: 'old-snapshot-team', leader_name: 'l1' } as unknown as JsonValue);
+    resolveCreate(teamCreateResult('old-snapshot-team') as unknown as JsonValue);
     await run;
 
     const createPayload = invokeCalls[0] as Record<string, unknown>;
@@ -200,7 +202,7 @@ describe('Provisioning snapshot immutability', () => {
       },
       invoke: async (command, payload) => {
         invokeCalls.push(payload);
-        return { status: 'created', team_name: 'new-snapshot-team', leader_name: 'l2' } as unknown as JsonValue;
+        return teamCreateResult('new-snapshot-team') as unknown as JsonValue;
       },
       announce: () => undefined,
     });
@@ -246,10 +248,11 @@ describe('unbindSpace — stops future provisioning only', () => {
       submitter: {
         submit: async (): Promise<FeishuSubmitOutcome> => ({ status: 'submitted', turnId: 't3' }),
       },
-      invoke: async () =>
-        new Promise<JsonValue>((resolve) => {
+      invoke: async (command, payload) => {
+        return new Promise<JsonValue>((resolve) => {
           resolveCreate = resolve;
-        }),
+        });
+      },
       announce: () => undefined,
     });
 
@@ -265,7 +268,7 @@ describe('unbindSpace — stops future provisioning only', () => {
     expect(removed?.space_name).toBe('space-a');
     // No new provisioning will start (no policy left to provision under), but
     // the in-flight run is untouched and still completes.
-    resolveCreate({ status: 'created', team_name: 'surviving-team', leader_name: 'l3' } as unknown as JsonValue);
+    resolveCreate(teamCreateResult('surviving-team') as unknown as JsonValue);
     const outcome = await run;
     expect(outcome).toEqual({ status: 'submitted', turnId: 't3' });
     expect(routing.bindingFor(topicTarget('oc_c', 'thread-surviving'))?.team_name).toBe(

--- a/packages/channel/feishu-channel/tests/helpers/team-status.ts
+++ b/packages/channel/feishu-channel/tests/helpers/team-status.ts
@@ -1,0 +1,32 @@
+import type { TeamCreateResult } from '@excitedjs/dreamux-types';
+
+/** Canonical stored Team status with a leader whose runtime is still lazy. */
+export function teamStatus(teamName: string, status: 'running' | 'closed' = 'running') {
+  return {
+    team: {
+      team_name: teamName,
+      status,
+      leader_name: `${teamName}-leader`,
+      leader_agent_runtime: 'trae-gpt',
+    },
+    leader: {
+      agent_runtime: 'trae-gpt',
+      repo: { path: `/workspace/${teamName}` },
+      runtime_status: null,
+    },
+  };
+}
+
+/** Canonical `team.create` receipt with the facts needed by its first route card. */
+export function teamCreateResult(
+  teamName: string,
+  status: TeamCreateResult['status'] = 'created',
+): TeamCreateResult {
+  return {
+    status,
+    team_name: teamName,
+    leader_name: `${teamName}-leader`,
+    leader_agent_runtime: 'trae-gpt',
+    runtime_cwd: `/workspace/${teamName}`,
+  };
+}

--- a/packages/dreamux-types/src/team.ts
+++ b/packages/dreamux-types/src/team.ts
@@ -68,6 +68,8 @@ export interface TeamCreateResult {
   readonly status: 'created' | 'existing' | 'closed';
   readonly team_name: string;
   readonly leader_name: string;
+  readonly leader_agent_runtime: string;
+  readonly runtime_cwd: string;
 }
 
 /**

--- a/packages/dreamux-types/tests/team-teammate-contract.test.ts
+++ b/packages/dreamux-types/tests/team-teammate-contract.test.ts
@@ -139,6 +139,8 @@ describe('TeamCreateCommand carries restart-durable request identity and leader 
 
   it('TeamCreateResult status is exactly created | existing | closed', () => {
     assertType<Equal<TeamCreateResult['status'], 'created' | 'existing' | 'closed'>>();
+    assertType<Equal<TeamCreateResult['leader_agent_runtime'], string>>();
+    assertType<Equal<TeamCreateResult['runtime_cwd'], string>>();
   });
 });
 

--- a/packages/dreamux/src/service/team-collection/commands.ts
+++ b/packages/dreamux/src/service/team-collection/commands.ts
@@ -138,8 +138,16 @@ export function teamCommands(host: CoreCommandHost): readonly AnyCoreCommand[] {
         status: enumOf(['created', 'existing', 'closed']),
         team_name: STRING,
         leader_name: STRING,
+        leader_agent_runtime: STRING,
+        runtime_cwd: STRING,
       },
-      ['status', 'team_name', 'leader_name'],
+      [
+        'status',
+        'team_name',
+        'leader_name',
+        'leader_agent_runtime',
+        'runtime_cwd',
+      ],
     ),
     parse(payload) {
       const params = commandPayload(payload);

--- a/packages/dreamux/src/service/team-collection/index.ts
+++ b/packages/dreamux/src/service/team-collection/index.ts
@@ -9,9 +9,9 @@ import { requireLifecycleText } from '../agent-entity/types.js';
 import { KeyedAsyncQueue } from '../serial-queue.js';
 import { TeamStore } from './store.js';
 import type {
+  CreatedTeam,
   TeamCreateInput,
   TeamCreateAtNameInput,
-  TeamCreateResult,
   TeamHistoryQuery,
   TeamHistoryResult,
   TeamListRow,
@@ -149,7 +149,7 @@ export class TeamCollection {
           runtime_cwd: accepted.runtime_cwd,
         };
       }
-      const outcome: { created: TeamCreateResult | null } = { created: null };
+      const outcome: { created: CreatedTeam | null } = { created: null };
       const teamName = await allocateConcreteNameAsync({
         kind: 'team',
         base: namePrefix,
@@ -215,7 +215,7 @@ export class TeamCollection {
    * already occupies fails here rather than resolving to some other Team. Use
    * {@link createAtCandidate} when a name allocator should rotate instead.
    */
-  async create(input: TeamCreateAtNameInput): Promise<TeamCreateResult> {
+  async create(input: TeamCreateAtNameInput): Promise<CreatedTeam> {
     const created = await this.createAtCandidate(input);
     if (created === null) {
       throw new Error(
@@ -233,7 +233,7 @@ export class TeamCollection {
    */
   private async createAtCandidate(
     input: TeamCreateAtNameInput,
-  ): Promise<TeamCreateResult | null> {
+  ): Promise<CreatedTeam | null> {
     return this.runtimes.create(input, validateTeamId(input.name));
   }
 

--- a/packages/dreamux/src/service/team-collection/index.ts
+++ b/packages/dreamux/src/service/team-collection/index.ts
@@ -145,6 +145,8 @@ export class TeamCollection {
           status: accepted.status === 'closed' ? 'closed' : 'existing',
           team_name: accepted.team_id,
           leader_name: accepted.leader_name,
+          leader_agent_runtime: accepted.leader_agent_runtime,
+          runtime_cwd: accepted.runtime_cwd,
         };
       }
       const outcome: { created: TeamCreateResult | null } = { created: null };
@@ -185,6 +187,8 @@ export class TeamCollection {
         status: 'created',
         team_name: created.team.team_name,
         leader_name: created.team.leader_name,
+        leader_agent_runtime: created.team.leader_agent_runtime,
+        runtime_cwd: created.leader.repo.path,
       };
     });
   }

--- a/packages/dreamux/src/service/team-collection/index.ts
+++ b/packages/dreamux/src/service/team-collection/index.ts
@@ -185,10 +185,10 @@ export class TeamCollection {
       }
       return {
         status: 'created',
-        team_name: created.team.team_name,
-        leader_name: created.team.leader_name,
-        leader_agent_runtime: created.team.leader_agent_runtime,
-        runtime_cwd: created.leader.repo.path,
+        team_name: created.team_name,
+        leader_name: created.leader_name,
+        leader_agent_runtime: created.leader_agent_runtime,
+        runtime_cwd: created.runtime_cwd,
       };
     });
   }

--- a/packages/dreamux/src/service/team-collection/index.ts
+++ b/packages/dreamux/src/service/team-collection/index.ts
@@ -9,9 +9,9 @@ import { requireLifecycleText } from '../agent-entity/types.js';
 import { KeyedAsyncQueue } from '../serial-queue.js';
 import { TeamStore } from './store.js';
 import type {
-  CreatedTeam,
   TeamCreateInput,
   TeamCreateAtNameInput,
+  TeamCreateResult,
   TeamHistoryQuery,
   TeamHistoryResult,
   TeamListRow,
@@ -149,7 +149,7 @@ export class TeamCollection {
           runtime_cwd: accepted.runtime_cwd,
         };
       }
-      const outcome: { created: CreatedTeam | null } = { created: null };
+      const outcome: { created: TeamCreateResult | null } = { created: null };
       const teamName = await allocateConcreteNameAsync({
         kind: 'team',
         base: namePrefix,
@@ -215,7 +215,7 @@ export class TeamCollection {
    * already occupies fails here rather than resolving to some other Team. Use
    * {@link createAtCandidate} when a name allocator should rotate instead.
    */
-  async create(input: TeamCreateAtNameInput): Promise<CreatedTeam> {
+  async create(input: TeamCreateAtNameInput): Promise<TeamCreateResult> {
     const created = await this.createAtCandidate(input);
     if (created === null) {
       throw new Error(
@@ -233,7 +233,7 @@ export class TeamCollection {
    */
   private async createAtCandidate(
     input: TeamCreateAtNameInput,
-  ): Promise<CreatedTeam | null> {
+  ): Promise<TeamCreateResult | null> {
     return this.runtimes.create(input, validateTeamId(input.name));
   }
 

--- a/packages/dreamux/src/service/team-collection/mcp-delegate.ts
+++ b/packages/dreamux/src/service/team-collection/mcp-delegate.ts
@@ -530,8 +530,16 @@ function teamCreateSchema(): Record<string, unknown> {
       status: { type: 'string', enum: ['created', 'existing', 'closed'] },
       team_name: { type: 'string' },
       leader_name: { type: 'string' },
+      leader_agent_runtime: { type: 'string' },
+      runtime_cwd: { type: 'string' },
     },
-    ['status', 'team_name', 'leader_name'],
+    [
+      'status',
+      'team_name',
+      'leader_name',
+      'leader_agent_runtime',
+      'runtime_cwd',
+    ],
   );
 }
 

--- a/packages/dreamux/src/service/team-collection/runtime-registry.ts
+++ b/packages/dreamux/src/service/team-collection/runtime-registry.ts
@@ -17,9 +17,9 @@ import { TeamClosedError, teamErrorInfo } from './errors.js';
 import { readTeamRoster } from './roster-reader.js';
 import type { TeamStore } from './store.js';
 import type {
-  CreatedTeam,
   TeamCollectionOptions,
   TeamCreateAtNameInput,
+  TeamCreateResult,
   TeamRecord,
 } from './types.js';
 
@@ -57,7 +57,7 @@ export class TeamRuntimeRegistry {
   async create(
     input: TeamCreateAtNameInput,
     teamId: string,
-  ): Promise<CreatedTeam | null> {
+  ): Promise<TeamCreateResult | null> {
     requireLifecycleText(input.intent, 'Team create intent');
     // A cheap early-out before the expensive workspace preparation. The
     // authoritative answer is the exclusive record publication below, which

--- a/packages/dreamux/src/service/team-collection/runtime-registry.ts
+++ b/packages/dreamux/src/service/team-collection/runtime-registry.ts
@@ -17,9 +17,9 @@ import { TeamClosedError, teamErrorInfo } from './errors.js';
 import { readTeamRoster } from './roster-reader.js';
 import type { TeamStore } from './store.js';
 import type {
+  CreatedTeam,
   TeamCollectionOptions,
   TeamCreateAtNameInput,
-  TeamCreateResult,
   TeamRecord,
 } from './types.js';
 
@@ -57,7 +57,7 @@ export class TeamRuntimeRegistry {
   async create(
     input: TeamCreateAtNameInput,
     teamId: string,
-  ): Promise<TeamCreateResult | null> {
+  ): Promise<CreatedTeam | null> {
     requireLifecycleText(input.intent, 'Team create intent');
     // A cheap early-out before the expensive workspace preparation. The
     // authoritative answer is the exclusive record publication below, which

--- a/packages/dreamux/src/service/team-collection/runtime-registry.ts
+++ b/packages/dreamux/src/service/team-collection/runtime-registry.ts
@@ -74,14 +74,12 @@ export class TeamRuntimeRegistry {
     const created = await construction;
     if (created === null) return null;
     const { service, leaderResult } = created;
+    const team = service.view();
     return {
-      team: service.view(),
-      leader: leaderResult.teammate,
-      member_count: await service.memberCount(),
-      status: leaderResult.submission?.status ?? null,
-      ...(leaderResult.submission?.error !== undefined
-        ? { error: leaderResult.submission.error }
-        : {}),
+      team_name: team.team_name,
+      leader_name: team.leader_name,
+      leader_agent_runtime: team.leader_agent_runtime,
+      runtime_cwd: leaderResult.teammate.repo.path,
     };
   }
 

--- a/packages/dreamux/src/service/team-collection/types.ts
+++ b/packages/dreamux/src/service/team-collection/types.ts
@@ -325,7 +325,8 @@ export interface TeamHistoryResult {
   next_cursor: string | null;
 }
 
-export interface TeamCreateResult extends Omit<TeamSummary, 'leader'> {
+/** The fully materialized result returned only by the internal creation path. */
+export interface CreatedTeam extends Omit<TeamSummary, 'leader'> {
   /** A successful creation always publishes its TeamLeader identity. */
   leader: AgentEntityRuntimeStatus;
   /**

--- a/packages/dreamux/src/service/team-collection/types.ts
+++ b/packages/dreamux/src/service/team-collection/types.ts
@@ -325,8 +325,7 @@ export interface TeamHistoryResult {
   next_cursor: string | null;
 }
 
-/** The fully materialized result returned only by the internal creation path. */
-export interface CreatedTeam extends Omit<TeamSummary, 'leader'> {
+export interface TeamCreateResult extends Omit<TeamSummary, 'leader'> {
   /** A successful creation always publishes its TeamLeader identity. */
   leader: AgentEntityRuntimeStatus;
   /**

--- a/packages/dreamux/src/service/team-collection/types.ts
+++ b/packages/dreamux/src/service/team-collection/types.ts
@@ -325,7 +325,9 @@ export interface TeamHistoryResult {
   next_cursor: string | null;
 }
 
-export interface TeamCreateResult extends TeamSummary {
+export interface TeamCreateResult extends Omit<TeamSummary, 'leader'> {
+  /** A successful creation always publishes its TeamLeader identity. */
+  leader: AgentEntityRuntimeStatus;
   /**
    * The leader's first-turn result, or `null` when the team was created without
    * an explicit `prompt` (no leader process starts and no turn fires at creation).

--- a/packages/dreamux/src/service/team-collection/types.ts
+++ b/packages/dreamux/src/service/team-collection/types.ts
@@ -2,7 +2,6 @@ import {
   assertNotReservedAgentName,
   type AgentEntityIdentityStatus,
   type AgentEntityRuntimeStatus,
-  type AgentEntitySubmissionResult,
   type AgentEntityWorktreeIdentity,
 } from '../agent-entity/types.js';
 import type {
@@ -325,15 +324,12 @@ export interface TeamHistoryResult {
   next_cursor: string | null;
 }
 
-export interface TeamCreateResult extends Omit<TeamSummary, 'leader'> {
-  /** A successful creation always publishes its TeamLeader identity. */
-  leader: AgentEntityRuntimeStatus;
-  /**
-   * The leader's first-turn result, or `null` when the team was created without
-   * an explicit `prompt` (no leader process starts and no turn fires at creation).
-   */
-  status: AgentEntitySubmissionResult['status'] | null;
-  error?: string;
+/** Facts produced by the internal Team creation operation. */
+export interface TeamCreateResult {
+  team_name: string;
+  leader_name: string;
+  leader_agent_runtime: string;
+  runtime_cwd: string;
 }
 
 /** Read an optional Team status filter, in this domain's own vocabulary. */

--- a/packages/dreamux/tests/helpers/command-harness.ts
+++ b/packages/dreamux/tests/helpers/command-harness.ts
@@ -128,6 +128,8 @@ export function createFakeDispatcher(
         status: 'created',
         team_name: 'harness-team',
         leader_name: 'harness-leader',
+        leader_agent_runtime: 'fake-runtime',
+        runtime_cwd: '/tmp/harness-workspace',
       })),
     submitToTeamLeader:
       overrides.submitToTeamLeader ??

--- a/packages/dreamux/tests/team-collection-read-path.test.ts
+++ b/packages/dreamux/tests/team-collection-read-path.test.ts
@@ -221,7 +221,13 @@ describe('TeamCollection: shared create/open construction', () => {
     const [createResult, admitResult] = await Promise.all([creating, admitting]);
 
     expect(delivered).toBe(true);
-    expect(createResult.team.status).toBe('running');
+    expect(createResult).toEqual({
+      team_name: 'joined',
+      leader_name: expect.any(String),
+      leader_agent_runtime: 'fake',
+      runtime_cwd: expect.any(String),
+    });
+    expect((await harness.collection.summary('joined')).team.status).toBe('running');
     expect(admitResult.status).toBe('running');
     // Exactly one leader submission for both callers together.
     expect(gate.callCount()).toBe(1);

--- a/packages/dreamux/tests/team-create-idempotency.test.ts
+++ b/packages/dreamux/tests/team-create-idempotency.test.ts
@@ -103,6 +103,8 @@ describe('team.create idempotency', () => {
       status: 'existing',
       team_name: first.team_name,
       leader_name: first.leader_name,
+      leader_agent_runtime: first.leader_agent_runtime,
+      runtime_cwd: first.runtime_cwd,
     });
 
     // A fresh `TeamCollection` bound to the exact same `team/` root has no
@@ -120,6 +122,8 @@ describe('team.create idempotency', () => {
       status: 'existing',
       team_name: first.team_name,
       leader_name: first.leader_name,
+      leader_agent_runtime: first.leader_agent_runtime,
+      runtime_cwd: first.runtime_cwd,
     });
   });
 
@@ -177,6 +181,8 @@ describe('team.create idempotency', () => {
       status: 'closed',
       team_name: created.team_name,
       leader_name: created.leader_name,
+      leader_agent_runtime: created.leader_agent_runtime,
+      runtime_cwd: created.runtime_cwd,
     });
   });
 


### PR DESCRIPTION
## Summary

- cap non-JSON Feishu COT tool results at ten content lines while preserving JSON object/array output and the existing byte limit
- complete superseded COT cards successfully and keep genuine lifecycle interruptions unchanged
- restore TeamLeader runtime ID and cwd on route-bound cards, using the enriched team.create receipt for provisioning
- distinguish explicit unbind, final Team dissolution, and pre-final route-ended notifications with the selected English Card 2.0 designs

## Architecture

- manual bind performs one canonical team.status read; TEAM_NOT_FOUND propagates unchanged and closed is read from the successful response
- automatic provisioning consumes leader_agent_runtime and runtime_cwd directly from team.create and performs no redundant status read
- no persisted routing/config/state change, retry, polling, or compensation mechanism

## Verification

- PASS: affected builds for @excitedjs/feishu-channel and @excitedjs/dreamux
- PASS: @excitedjs/dreamux-types (106 tests)
- PASS: @excitedjs/feishu-channel (416 tests)
- PASS: 977 deterministic @excitedjs/dreamux tests
- LIVE ENVIRONMENT: 5 Codex live tests timed out or observed no mid-turn activity; no failures were on the changed contract paths
- PASS: rush change --verify --target-branch origin/next --no-fetch
- PASS: .agents/scripts/check.sh
- PASS: git diff --check and pre-commit gitleaks/internal-content gates

## Follow-up on this draft

- affected lint and test typechecking
- deterministic Dreamux rerun with live Codex skipped only for environment isolation
- independent implementation review and full repository gates

Refs #383