### PR TITLE
Teach the TeamLeader that a TeamMate is not a subagent

### DIFF
--- a/.agents/tasks/builtin-skills/README.md
+++ b/.agents/tasks/builtin-skills/README.md
@@ -16,3 +16,4 @@
 
 ## Tasks
 - [Adopt the lean managed-daemon self-upgrade SOP](/.agents/tasks/builtin-skills/adopt-lean-self-upgrade-sop/README.md) — `done`: Replace the unrunnable staged/independent-operator self-upgrade SOP with the lean four-step procedure, and realign every knowledge owner that documents the old contract
+- [Teach the TeamLeader that a TeamMate is not a subagent](/.agents/tasks/builtin-skills/teamwork-teammates-are-not-subagents/README.md) — `done`: Make the bundled teamwork skill tell a TeamLeader to hand members the question and its own framing as evidence, and to reopen the premise when review rounds keep adding mechanism, instead of using members as subagents of a frozen design

--- a/.agents/tasks/builtin-skills/teamwork-teammates-are-not-subagents/README.md
+++ b/.agents/tasks/builtin-skills/teamwork-teammates-are-not-subagents/README.md
@@ -1,0 +1,26 @@
+# Teach the TeamLeader that a TeamMate is not a subagent
+
+## Current state
+
+- Goal: Make the bundled teamwork skill tell a TeamLeader to hand members the question and its own framing as evidence, and to reopen the premise when review rounds keep adding mechanism, instead of using members as subagents of a frozen design
+- State: `done`
+- Requirement: [Current requirement](/.agents/tasks/builtin-skills/teamwork-teammates-are-not-subagents/requirement.md)
+- Final solution: [Judgment added to the teamwork skill](/.agents/tasks/builtin-skills/teamwork-teammates-are-not-subagents/technical-design/final.md)
+- Solution review Issue: N/A; the operator asked for the change directly and the boundary is one bundled skill.
+- Blockers: None.
+- Next action: Land the pull request after CI and review.
+- Related tasks:
+  - Prior ruling and the skill's current shape: [Refine the model-facing surfaces](/.agents/tasks/mcp/refine-model-facing-surfaces/README.md), ruling R8.
+  - The principle's repository-side form: [PR #392](https://github.com/excitedjs/dreamux/pull/392), whose task record lands with that PR.
+  - The failure that exposed the gap: [Suppress owner close/stop pushback](/.agents/tasks/completion-routing/suppress-owner-close-stop-pushback/README.md), PR #389 replaced by PR #391.
+
+## Development approval
+
+- Status: Granted by the operator on 2026-09-08 in the request itself: “你把 dreamux 内置的 teamwork 技能也优化一下，把这个原则写进那个技能。不要让team leader始终把teammate当做subagent 来用”.
+- Approved implementation boundary: `packages/dreamux/skills/team-leader/teamwork/SKILL.md`, one Rush change file, this task record.
+
+## Delivery
+
+- Pull request: [#393](https://github.com/excitedjs/dreamux/pull/393), opened on 2026-09-08 against `next`; CI and merge pending.
+- Verification: [Completed verification](/.agents/tasks/builtin-skills/teamwork-teammates-are-not-subagents/verification.md)
+- Knowledge closeout: the skill is its own owner; no domain or product page describes its content. Change file recorded.

--- a/.agents/tasks/builtin-skills/teamwork-teammates-are-not-subagents/requirement.md
+++ b/.agents/tasks/builtin-skills/teamwork-teammates-are-not-subagents/requirement.md
@@ -1,0 +1,58 @@
+# Requirement
+
+## Initial request
+
+- Operator, 2026-09-08: “你把 dreamux 内置的 teamwork 技能也优化一下，把这个原则写进那个技能。不要让team leader始终把teammate当做subagent 来用”.
+- The principle is the one PR #392 wrote into this repository's own review
+  prompts after PR #389: a member challenges the TeamLeader's framing rather
+  than confirming it.
+
+## Prior ruling this builds on
+
+- R8 of the model-facing-surfaces task, 2026-09-06: “我在大量的使用过程中，我发现teamleader 总是会把teammate 当做subagent去执行任务” and “重点就一句话，context not control”.
+  The current `teamwork` skill is the answer to that ruling, and it targeted
+  the brief: over-specific edit plans (“改什么，不改什么，怎么改”) that left a
+  member no room to report that the plan does not survive the code.
+- PR #389 had no edit plan. Its TeamLeader handed down a frozen premise, that
+  the producer owns the completion obligation, and asked reviewers to find
+  holes in it, so every reviewer became a subagent of that premise. The
+  2026-09-06 change did not cover that shape; this task does.
+
+## Current alignment
+
+- Status: Clarified; implemented directly with the operator on 2026-09-08.
+- Baseline: `origin/next` at `71316ab93fee0829475d2d41cdfffbed7cbfae2a`.
+- Desired behavior: the bundled `teamwork` skill tells a TeamLeader that a
+  member's own judgment is what distinguishes it from a subagent; that the
+  brief carries the question the work turns on before the leader's answer,
+  with the leader's design marked as a guess; that a member's identity includes
+  standing to contradict the leader's framing; and that when review rounds keep
+  adding mechanism to one area, the leader stops patching, writes the premise,
+  and puts it to members that have not seen the draft.
+- Scope: `packages/dreamux/skills/team-leader/teamwork/SKILL.md`, one Rush
+  change file, this task record.
+- Non-goals: no change to the skill's name, description, or load trigger; no
+  change to the `dev-workflow` skill; no new tool, prompt surface, or review
+  mechanism; no lifting of the repository-specific reviewer identity wording
+  from PR #392 into a skill that ships to every Team.
+
+## Acceptance criteria
+
+- The choice section says a member has a judgment of its own and that a member
+  briefed like a subagent returns a subagent's result.
+- The hand-down carries the question before the answer and marks the leader's
+  design as a guess.
+- `identity` includes standing to contradict the leader's framing.
+- One new situation section covers review rounds that keep adding mechanism.
+- Skill validator, Rush build, lint, test, `typecheck:tests`,
+  `.agents/scripts/check.sh`, and `git diff --check` pass.
+
+## Decisions and unknowns
+
+- Confirmed operator decisions: the initial request above, verbatim.
+- Labeled inference: the practice of giving fresh members the user's story and
+  the baseline rather than the draft comes from the PR #389 TeamLeader's own
+  retrospective, which the operator forwarded on 2026-09-08 (“架构 reviewer
+  只拿用户故事、基线源码和白皮书，先独立给解法；实现 reviewer 才拿现有 draft”).
+  It is adopted as the skill's advice, not recorded as an operator ruling.
+- Blocking unknowns: None.

--- a/.agents/tasks/builtin-skills/teamwork-teammates-are-not-subagents/technical-design/final.md
+++ b/.agents/tasks/builtin-skills/teamwork-teammates-are-not-subagents/technical-design/final.md
@@ -1,0 +1,35 @@
+# Final technical solution
+
+## Decision
+
+Add the judgment dimension to the existing sections of the bundled `teamwork`
+skill plus one new situation section. Every section stays one situation and a
+few moves.
+
+## Changes
+
+1. Choice section: the TeamMate bullet names its own judgment as the thing a
+   subagent lacks; a fifth question asks whether the work needs a judgment that
+   can contradict the leader's framing; one sentence says a member briefed like
+   a subagent returns a subagent's result.
+2. Hand-down: the guesses bullet includes the leader's design; a new bullet puts
+   the question the work turns on before the leader's answer.
+3. `identity`: standing to contradict the leader's framing.
+4. New section “When Every Round Finds Another Hole”: stop patching, write the
+   premise, put it to members that have not seen the draft; agreement among
+   members that share a brief proves a shared premise.
+5. “Keeping the Thread”: the reviewer gets the question, not the developer's
+   answer, nor the leader's.
+
+## Why stated here rather than linked
+
+The engineering whitepaper already states the convergence and stop-patching
+rules for this repository. `teamwork` ships in the package to every Team and
+cannot link into `.agents/`, so it states the leader-side version in its own
+words. Different owner, different audience.
+
+## Rejected
+
+- Lifting the PR #392 reviewer identity wording into `teamwork`: that is a
+  reviewer identity for this repository; `teamwork` is leader methodology.
+- A new tool, prompt surface, review seat, or review mechanism.

--- a/.agents/tasks/builtin-skills/teamwork-teammates-are-not-subagents/verification.md
+++ b/.agents/tasks/builtin-skills/teamwork-teammates-are-not-subagents/verification.md
@@ -1,0 +1,17 @@
+# Verification
+
+## Gates on the branch
+
+- Skill validator (skill-creator `quick_validate.py`) over
+  `packages/dreamux/skills/team-leader/teamwork` — passed.
+- Rush build, lint, `typecheck:tests`, and the full test run — passed. The
+  tests that read the skill file (`mcp-tool-descriptions`,
+  `bundled-skill-sources`, `team-leader-prompt`) stay green; the fragments the
+  first one rejects are absent from the skill body.
+- `.agents/scripts/check.sh` and `git diff --check` — passed.
+
+## Not verified
+
+Whether a TeamLeader that loads the new text reopens a premise instead of
+patching is observable only in later real Teams. No automated measure is
+claimed.

--- a/common/changes/@excitedjs/dreamux/dreamux-teamwork-teammates-are-not-subagents_2026-09-08-11-00.json
+++ b/common/changes/@excitedjs/dreamux/dreamux-teamwork-teammates-are-not-subagents_2026-09-08-11-00.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "The bundled `teamwork` skill now tells a TeamLeader what a member has that a subagent does not, a judgment of its own, and how to use it: the brief carries the question the work turns on before the leader's answer, the leader's design is marked as a guess, a member's identity includes standing to contradict the leader's framing, and when review rounds keep adding mechanism to one area the leader stops patching, writes the premise, and puts it to members that have not seen the draft. No skill name, description, or load trigger changes.",
+      "type": "patch",
+      "packageName": "@excitedjs/dreamux"
+    }
+  ],
+  "packageName": "@excitedjs/dreamux",
+  "email": "hvjfccdy6s@privaterelay.appleid.com"
+}

--- a/packages/dreamux/skills/team-leader/teamwork/SKILL.md
+++ b/packages/dreamux/skills/team-leader/teamwork/SKILL.md
@@ -20,7 +20,8 @@ Three ways to get a piece of work done:
   long it lives, what it returns — and that description is the one to read.
 - **A TeamMate.** A member of this Team that continues independently: its own
   runtime and context, its own history, a conversation you can continue across
-  turns, and visible to the user.
+  turns, visible to the user — and a judgment of its own, the one thing a
+  subagent does not have.
 
 Choose by asking about the work, not about the size of the request:
 
@@ -30,9 +31,13 @@ Choose by asking about the work, not about the size of the request:
 - May the user want to inspect it or continue it?
 - Does it need a standing role — someone who writes, someone who reviews — held
   across several turns?
+- Does it need a judgment that is not yours — a reading of the problem that can
+  contradict your framing, not only complete it?
 
 Any yes points past a subagent to a TeamMate. A member is a seat, not a single
-errand: spawn one for a role you will keep sending work to.
+errand: spawn one for a role you will keep sending work to. A member briefed
+like a subagent — your answer, its confirmation — costs what a member costs and
+returns what a subagent returns.
 
 The members of this Team need not all run the same engine. `get_capabilities`
 lists the runtimes this Team can spawn; read it before you choose, and staff the
@@ -60,7 +65,13 @@ Carry into the brief:
 - **The user's own constraints, verbatim.** Their words, not your paraphrase. A
   paraphrased constraint is a constraint you have already started deciding.
 - **Your guesses, marked as guesses.** Say which parts you inferred, so a member
-  that finds the inference wrong knows it is allowed to say so.
+  that finds the inference wrong knows it is allowed to say so. Your design is
+  a guess too: the owner you chose and the mechanism you prefer.
+- **The question the work turns on, before your answer to it.** Which fact is
+  being decided and who could own it, then your current answer as one
+  candidate. A design handed down as settled makes every later member a
+  subagent of it: reviewers find ever more precise holes inside your premise,
+  and none of them is asked whether the premise holds.
 - **What "done" means, and what you need to read back.** The evidence that would
   show it, and the shape of the report you will carry outward: what changed, the
   evidence for it, and the questions left open.
@@ -85,7 +96,9 @@ report a conflict with the code, or a blocker, is the correct result of the
 turn, not a failure to deliver.
 
 `identity` holds what stands for every turn of the member's life: its role, its
-boundaries, and the posture of stopping to report rather than pushing through.
+boundaries, the posture of stopping to report rather than pushing through, and
+its standing to contradict your framing — what you hand down is evidence, not a
+verdict.
 `prompt` holds this turn's task. `send` carries the next turn's task the same
 way; the standing role is already in place and does not need restating.
 
@@ -126,6 +139,21 @@ has been working in the shared workspace while you were elsewhere.
 
 An unexplained override teaches nothing and repeats itself on the next task.
 
+## When Every Round Finds Another Hole
+
+A second review round that still adds state, special cases, or call sites to
+the same area is not a design getting robust; it is a design failing slowly.
+Each finding is real, each patch is correct, and the sum is a mechanism nobody
+asked for.
+
+- **Stop sending patches.** The model is wrong, not the details. Write the
+  one-sentence premise the rounds have been refining — which owner, which fact
+  — and make that sentence the next question.
+- **Put it to members that have not seen the current design.** Give them the
+  user's story and the baseline code, not the draft; a member that starts from
+  the draft inherits its owner. Agreement among members that share your brief
+  proves they share your premise, not that it holds.
+
 ## Keeping the Thread
 
 A conversation with one member accumulates context that a new one does not have,
@@ -138,6 +166,6 @@ and every member you keep open is another writer in the shared workspace.
   conclusions.
 - Independence is worth paying for when you want a real check. Two members that
   share a brief also share its blind spots; give the reviewer the question, not
-  the developer's answer.
+  the developer's answer, nor yours.
 - Close a member when its role is finished, so the members still open are the
   ones actually working and the writer of any given path stays unambiguous.


### PR DESCRIPTION
## Summary

The bundled `teamwork` skill now tells a TeamLeader what a member has that a subagent does not, a judgment of its own, and how to use it.

The skill's 2026-09-06 version answered "context, not control" by taking the edit plan out of the brief. PR #389 showed the shape that did not cover: no edit plan, but a frozen premise handed down as settled, with reviewers asked to find holes inside it. Each found a more precise hole; none was asked whether the premise held. This carries the principle PR #392 wrote into this repository's review prompts to every Team through the skill itself.

## Changes to `teamwork`

- Choice section: a member's own judgment is the thing a subagent lacks; a fifth question asks whether the work needs a judgment that can contradict the leader's framing; a member briefed like a subagent returns a subagent's result.
- Hand-down: the leader's design is a guess too; a new bullet puts the question the work turns on before the leader's answer.
- `identity` carries standing to contradict the leader's framing.
- New section "When Every Round Finds Another Hole": stop patching, write the one-sentence premise, put it to members that have not seen the draft; agreement among members that share a brief proves a shared premise.
- "Keeping the Thread": the reviewer gets the question, not the developer's answer, nor the leader's.

Name, description, and load trigger are unchanged. One patch change file for `@excitedjs/dreamux`.

## Verification

- Skill validator, Rush build, lint, test, `typecheck:tests`, `.agents/scripts/check.sh`, `git diff --check`.

## Records

- `.agents/tasks/builtin-skills/teamwork-teammates-are-not-subagents/`

Refs #389 and #392.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TUY56nDnNaV3NX5nT2vFkg
