### PR TITLE
Unwrap Codex shell launchers in tool display

### DIFF
--- a/.agents/domains/provider-runtime.md
+++ b/.agents/domains/provider-runtime.md
@@ -755,8 +755,13 @@ invocation; file tools are their path; searches their pattern or query;
 `Agent` its description with the prompt as invocation; `Skill` its name.
 Codex follows the TUI's own exec, patch and web-search cells: a uniformly
 parsed command is the files it read, the paths it listed, or `query in
-path`, otherwise the command's first line, always with the command as
-invocation; a patch is its paths with the diffs codex prepared as invocation;
+path`, otherwise the display command's first line.
+`/packages/agent-runtime/codex/src/tool-display.ts` decodes shell-word quoting
+and unwraps recognized Bash/Zsh/Sh and PowerShell launchers for display.
+Unrecognized or undecodable commands, including Windows drive-path text that
+fails Codex's quoting round-trip check, keep their original spelling. The full
+display command is the invocation; raw arguments stay unchanged.
+A patch is its paths with the diffs codex prepared as invocation;
 a `webSearch` item, which carries no tool name and was dropped before, is a
 `web_search` row. Anything outside those tables — every MCP tool — reports
 `null` and displays as its name. Core sanitizes both facts exactly as it does

--- a/.agents/tasks/channel/README.md
+++ b/.agents/tasks/channel/README.md
@@ -22,3 +22,4 @@
 - [Feishu conversation-of-thought cards](/.agents/tasks/channel/feishu-cot-conversation-cards/README.md) — `done`: Render dispatcher and TeamLeader conversations as conversation-anchored Feishu COT cards through a neutral, display-only core projection.
 - [Refine Feishu COT and binding cards](/.agents/tasks/channel/refine-feishu-cot-and-binding-cards/README.md) — `review`: Bound plain-text COT tool results by line count, restore Team runtime context on binding cards, distinguish route-removal notifications, and complete superseded COT cards successfully
 - [Feishu slash commands](/.agents/tasks/channel/add-feishu-slash-commands/README.md) — `done`: Handle /stop, /teams, and /dissolve deterministically in the Feishu channel through one extensible command table
+- [Align Codex command display parsing](/.agents/tasks/channel/align-codex-command-display/README.md) — `done`: Show the inner shell script in Codex tool rows instead of the shell launcher wrapper

--- a/.agents/tasks/channel/align-codex-command-display/README.md
+++ b/.agents/tasks/channel/align-codex-command-display/README.md
@@ -55,5 +55,6 @@
   N/A; no package boundary, term, entry point, CLI, config/state, protocol,
   lifecycle, or cross-process invariant changed. The provider's existing
   display owner remains responsible for its own command vocabulary.
-- Release note: Rush-generated Codex package patch change; no upgrade blocker
-  or rebuild action. Committed-branch verification runs before the authorized push.
+- Release notes: Rush-generated Codex `patch` and Feishu test-only `none`
+  changes; no upgrade blocker or rebuild action. Committed-branch verification
+  runs before the authorized push.

--- a/.agents/tasks/channel/align-codex-command-display/README.md
+++ b/.agents/tasks/channel/align-codex-command-display/README.md
@@ -10,7 +10,7 @@
 - Workflow: TeamLeader implementation after approval, followed by one independent read-only review.
 - Verification: [Checks and display evidence](/.agents/tasks/channel/align-codex-command-display/verification.md).
 - Blockers: No functional or architecture blocker; both review findings are approved and applied. All four repository gates also passed on the isolated delivery branch based on `next`, excluding the unrelated baseline commit.
-- Next action: Commit and push the isolated task patch, open the authorized PR to `next`, and wait for CI. Feishu client visual verification remains unperformed.
+- Next action: Await the required GitHub approving review and separate operator merge authorization. Current-head CI is tracked on the PR; Feishu client visual verification remains unperformed.
 - Related tasks: Builds on [Feishu conversation-of-thought cards](/.agents/tasks/channel/feishu-cot-conversation-cards/README.md); dedicated task creation confirmed by the operator on 2026-09-09.
 
 ## Development approval
@@ -36,7 +36,14 @@
   in response to the explicit commit, push, and PR question. This authorizes
   delivery to a PR targeting `next` and waiting for CI, not merge, deployment,
   or service restart.
-- Pull request / CI / merge: Not started.
+- Pull request: [#396](https://github.com/excitedjs/dreamux/pull/396),
+  `fix/codex-command-display` into `next`.
+- CI: All 9 checks passed for `1305d36d` in
+  [run 34288628691](https://github.com/excitedjs/dreamux/actions/runs/34288628691),
+  including Linux and macOS Rush gates. This delivery-record update will trigger
+  the ordinary CI checks again; the PR owns the current-head result.
+- Merge: Not performed or authorized; GitHub still requires an approving review.
+  No deployment or service restart was performed.
 - Knowledge closeout: Complete; owner updates and final local checks passed.
 
 ## Knowledge closeout

--- a/.agents/tasks/channel/align-codex-command-display/README.md
+++ b/.agents/tasks/channel/align-codex-command-display/README.md
@@ -1,0 +1,59 @@
+# Align Codex command display parsing
+
+## Current state
+
+- Goal: Show the inner shell script in Codex tool rows instead of the shell launcher wrapper
+- State: `done`
+- Requirement: [Current requirement](/.agents/tasks/channel/align-codex-command-display/requirement.md)
+- Final solution: [Final solution](/.agents/tasks/channel/align-codex-command-display/technical-design/final.md)
+- Solution review Issue: Not required for the minimal-change fast path.
+- Workflow: TeamLeader implementation after approval, followed by one independent read-only review.
+- Verification: [Checks and display evidence](/.agents/tasks/channel/align-codex-command-display/verification.md).
+- Blockers: No functional or architecture blocker; both review findings are approved and applied. All four repository gates also passed on the isolated delivery branch based on `next`, excluding the unrelated baseline commit.
+- Next action: Commit and push the isolated task patch, open the authorized PR to `next`, and wait for CI. Feishu client visual verification remains unperformed.
+- Related tasks: Builds on [Feishu conversation-of-thought cards](/.agents/tasks/channel/feishu-cot-conversation-cards/README.md); dedicated task creation confirmed by the operator on 2026-09-09.
+
+## Development approval
+
+- Status: Granted by the operator on 2026-09-09, directly answering the explicit development question: "批准，开始开发 (Recommended)".
+- Approved requirement: [Requirement](/.agents/tasks/channel/align-codex-command-display/requirement.md).
+- Approved solution: [Final solution](/.agents/tasks/channel/align-codex-command-display/technical-design/final.md).
+- Approved implementation boundary: Codex display-only shell decoding, directly affected regression tests, task/knowledge closeout, and package change notes; TeamLeader implementation and one independent read-only review. No commit, push, deployment, service restart, or merge authority.
+
+## Installation authorization
+
+- On 2026-09-09 the operator answered the installation-permission question:
+  "绕过 traex 的 githooks，安装 rush 的 hooks" (Bypass the Trae hooks and
+  install Rush's hooks).
+- Applied only to the dependency-installation child process: removed the injected
+  Git hook-path environment entries, then ran ordinary Rush update successfully.
+  Rush installed the repository pre-commit hook. No persistent Git configuration
+  change, `--bypass-policy`, or repository-hook suppression was used.
+
+## Delivery
+
+- Authorization: On 2026-09-09 the operator selected "提交并创建 PR (Recommended)"
+  in response to the explicit commit, push, and PR question. This authorizes
+  delivery to a PR targeting `next` and waiting for CI, not merge, deployment,
+  or service restart.
+- Pull request / CI / merge: Not started.
+- Knowledge closeout: Complete; owner updates and final local checks passed.
+
+## Knowledge closeout
+
+- [Provider runtime owner](/.agents/domains/provider-runtime.md): Updated the
+  Codex display-command description and linked the owning source. Both review
+  rulings and their implementation are recorded in [verification](verification.md).
+- [Product catalog](/.agents/product/README.md#observing-agents): N/A for a new
+  decision; this restores the existing **A tool row says what the call was,
+  not how the runtime spelled it** contract. No row or execution capability
+  is removed, and layout, labels, and redaction are unchanged.
+- Task record and parent index: Reconciled with the actual diff. The requirement
+  labels the initial raw-command behavior as an investigation baseline; the
+  approved solution still matches the implementation without a scope change.
+- Directory invariants, glossary, root routing, and maintenance references:
+  N/A; no package boundary, term, entry point, CLI, config/state, protocol,
+  lifecycle, or cross-process invariant changed. The provider's existing
+  display owner remains responsible for its own command vocabulary.
+- Release note: Rush-generated Codex package patch change; no upgrade blocker
+  or rebuild action. Committed-branch verification runs before the authorized push.

--- a/.agents/tasks/channel/align-codex-command-display/requirement.md
+++ b/.agents/tasks/channel/align-codex-command-display/requirement.md
@@ -1,0 +1,83 @@
+# Requirement
+
+## Initial request and user story
+
+An operator reading a Codex command on a Feishu COT card wants to see the
+command's script, not the runtime's shell launcher. The reported row starts
+with `/usr/bin/zsh -lc` rather than the useful command.
+
+Operator wording, 2026-09-09: "抄一下他的解析逻辑。" (Port Codex's parsing
+logic.) The operator subsequently selected a new dedicated task.
+
+## Current alignment
+
+- Status: The operator explicitly approved this requirement and the final
+  solution for development on 2026-09-09.
+- Verified upstream baseline: `openai/codex` commit
+  `49db349ffdd888f5e3c91abf9b7519d8631e6e9a` (2026-08-16), the source checkout
+  supplied for this investigation. This is a pinned source baseline, not a
+  claim about the latest release.
+- Codex serializes argv into `CommandExecution.command` with `shlex_join` in
+  `codex-rs/app-server-protocol/src/protocol/item_builders.rs:56`.
+- Its TUI decodes that string with `split_command_string` and unwraps a
+  recognized shell with `strip_bash_lc_and_escape` in
+  `codex-rs/tui/src/exec_command.rs:12-32`. The latter delegates to
+  `extract_shell_command`, which recognizes Bash-compatible and PowerShell
+  invocations. The existing test at `exec_command.rs:76-79` explicitly covers
+  `/usr/bin/zsh -lc`.
+- At the investigation baseline (`305e3fc8`), Dreamux used the raw command for
+  the run summary and invocation in
+  `/packages/agent-runtime/codex/src/tool-display.ts:49-63`. Core only redacted
+  these display values; Feishu composed its title and code segment from them.
+  The wrapper was not introduced by Feishu.
+- Display ownership follows commit `0c86deab` (#376): provider-specific labels
+  belong to the runtime provider, not the Channel.
+
+## Desired behavior and boundary
+
+- Recognized shell wrappers display their inner script. Ordinary run titles
+  use the script's first line; expanded invocation content uses its full text.
+- Preserve inner quotes, escapes, operators, Unicode, and line breaks. Parsing
+  is display-only: never execute, expand, or recursively interpret the script.
+- Retain existing `commandActions` classification and read/list/search labels
+  and items. Do not replace the full script with parsed action fragments.
+- Unrecognized wrappers and undecodable command strings keep their original
+  display text. Ordinary commands are not reformatted merely to match TUI
+  quoting preferences.
+- Raw tool arguments, execution, output, approval behavior, activity contracts,
+  redaction, and Feishu layout remain unchanged. Other runtimes are unaffected.
+- The affected product catalog entry is **A tool row says what the call was,
+  not how the runtime spelled it** under [Observing agents](../../../product/README.md#observing-agents).
+  This repairs the Codex label/invocation gap; it removes no tool row or
+  execution capability.
+
+## Acceptance criteria
+
+1. `/usr/bin/zsh -lc 'node --check script.mjs'` produces summary and invocation
+   `node --check script.mjs`, without the wrapper or its outer quotes.
+2. Bash, Zsh, and Sh wrappers follow the upstream three-argument `-lc`/`-c`
+   rule, including executable paths. PowerShell follows the upstream
+   `-Command`/`-c` extraction and supported preceding flags.
+3. Quoted shell scripts with embedded quotes, backslashes, operators, and
+   multiple lines survive decoding; summary selection happens after decoding.
+4. Unknown shells, unsupported flags, extra Bash positional arguments,
+   malformed quoting, and Windows command text rejected by the upstream
+   round-trip check are not partially stripped or rewritten.
+5. Read/list/search action labels and items remain unchanged, but their
+   invocation uses the same unwrapped script when it is displayed.
+6. Started and completed tool activity retain the original raw arguments and
+   carry matching decoded display facts. Existing output/error handling stays
+   unchanged.
+7. Build, lint, test, and test typechecking pass; an independent read-only
+   implementation review is resolved. Report visual verification separately
+   from automated projection checks, without claiming an unperformed live test.
+
+## Decisions and unknowns
+
+- Confirmed: port the upstream parsing logic; create a dedicated task.
+- Approved implementation detail: cover the complete upstream wrapper
+  extractor, including PowerShell, without importing its unrelated command
+  classification or TUI layout machinery.
+- Development approval: "批准，开始开发 (Recommended)" on 2026-09-09, in direct
+  response to the recorded requirement and final solution. No commit, push,
+  release, service restart, or merge is authorized by this approval.

--- a/.agents/tasks/channel/align-codex-command-display/technical-design/final.md
+++ b/.agents/tasks/channel/align-codex-command-display/technical-design/final.md
@@ -1,0 +1,84 @@
+# Final technical solution
+
+## Scope and workflow
+
+Implement the [requirement](/.agents/tasks/channel/align-codex-command-display/requirement.md)
+through the minimal-change fast path: one existing display owner, a small pure
+parsing change, no new dependency, public contract, state, process, security
+boundary, or Channel mechanism. The TeamLeader implements after approval; one
+separate read-only TeamMate reviews the whole change. No solution-review Issue
+is needed. Reclassify if implementation requires a wider boundary.
+
+## Upstream semantics
+
+Follow `openai/codex` revision
+`49db349ffdd888f5e3c91abf9b7519d8631e6e9a`:
+
+- `codex-rs/tui/src/exec_command.rs:19-32`: decode the serialized command using
+  POSIX shell-word quoting rules, with the same round-trip rule for Windows
+  drive-path text. Reject malformed quoting instead of guessing.
+- `codex-rs/shell-command/src/parse_command.rs:40-42`: try Bash-compatible
+  extraction, then PowerShell extraction.
+- `codex-rs/shell-command/src/bash.rs:103-115`: recognize exactly
+  `[shell, flag, script]`, where the detected shell is Bash, Zsh, or Sh and the
+  flag is exactly `-lc` or `-c`.
+- `codex-rs/shell-command/src/shell_detect.rs:39-59`: detect known executable
+  names through the host path/file-stem semantics, including executable
+  suffixes. Do not invent a broader shell registry.
+- `codex-rs/shell-command/src/powershell.rs:43-70`: recognize PowerShell and
+  pwsh; accept case-insensitive `-NoLogo` and `-NoProfile` before
+  `-Command`/`-c`, return the argument following that flag, and reject
+  unsupported flags before it.
+- `codex-rs/tui/src/exec_command.rs:12-17`: a recognized wrapper returns the
+  decoded script as-is, not another escaped or evaluated command.
+
+This ports wrapper extraction, not the entire TUI formatter: when no wrapper
+is recognized, retain Dreamux's existing original string rather than adopting
+Codex's argv reformatting. Do not strip inner wrappers or PowerShell script
+preambles. The extractor is a presentation operation, never an approval or
+execution-safety parser.
+
+## Implementation
+
+1. Add the small pure command-display decoder beside the existing Codex
+   `commandDisplay` logic in `/packages/agent-runtime/codex/src/tool-display.ts`.
+   Reproduce shell-word quoting and escaping needed to decode the upstream
+   serialized argv without evaluating variables, substitutions, or commands.
+   No subprocess, shell library dependency, exported API, or shared-core parser.
+2. Decode the raw `command` once inside `commandDisplay`. Reuse the resulting
+   script for both invocation and any first-line summary fallback. Keep
+   `commandActions`, action labels, and items unchanged: parsed actions can be
+   lossy and cannot reconstruct a whole pipeline or multiline script.
+3. Leave `/packages/agent-runtime/codex/src/turn-manager.ts` raw-argument
+   production unchanged. Leave Core projection, privacy handling, and Feishu
+   rendering unchanged. The existing neutral fields already carry the answer.
+4. Extend existing display and activity tests with upstream-shaped wrapped
+   commands; verify the final presentation through existing projection tests
+   or a focused test at that seam if the current fixture does not cover it.
+   Do not rewrite existing assertions to hide a behavior regression.
+
+## Verification
+
+- Cover Zsh/Bash/Sh and PowerShell extraction, absolute executable paths,
+  suffix handling, single/double quotes and adjacent quote fragments,
+  escaped quotes/backslashes, multiline and Unicode scripts, and the upstream
+  Python-with-nested-quotes snapshot example.
+- Cover ordinary commands, unsupported wrappers/flags, Bash extra arguments,
+  undecodable strings, and the upstream Windows non-round-trippable example.
+- Check both display fields, unchanged structured action labels/items, and
+  original arguments on started/completed activity.
+- Run the repository build, lint, test, and `typecheck:tests` through
+  `node common/scripts/install-run-rush.js`, plus `.agents/scripts/check.sh`
+  and the task-record validator. Resolve independent review findings.
+- Check the actual Feishu title and expanded code segment when a permitted
+  local-built display probe is available; otherwise explicitly report that
+  automated payload verification does not establish the live client result.
+  Do not restart or replace the running Dreamux service to obtain that test.
+
+## Knowledge and delivery
+
+Keep this task and its parent index current. At closeout, document only the
+narrow Codex display exception in the existing product/domain owners if needed
+for accuracy; do not create another architecture guide. Follow Rush change-file
+requirements for the changed package, without hand-editing generated changelogs.
+Commit, push, release, restart, and merge require their own operator authority.

--- a/.agents/tasks/channel/align-codex-command-display/verification.md
+++ b/.agents/tasks/channel/align-codex-command-display/verification.md
@@ -1,0 +1,121 @@
+# Verification
+
+## Scope and TeamLeader pre-review
+
+- Review baseline: `305e3fc8`; inspect the uncommitted workspace change, not
+  unrelated commits already in that baseline.
+- The only executable product change is the private display decoder in
+  `/packages/agent-runtime/codex/src/tool-display.ts`. No execution, activity
+  contract, Core projection, or Feishu rendering implementation changed.
+- Existing assertions were retained. New coverage checks shell extraction,
+  quoting, unsupported input, Windows round-trip spelling, structured action
+  labels, started/completed runtime facts, and Feishu title/code consumption.
+- The package LICENSE credits the rust-shlex parsing/quoting adaptation under
+  its MIT option; no dependency was added.
+- Initial compilation exposed TypeScript loop-inference errors on the three
+  quoting-strategy booleans. Explicit boolean annotations resolved them.
+- TeamLeader pre-review and final revalidation after both approved corrections
+  passed: build, lint, all tests, and test typechecking. The full test run
+  includes real Codex model gates.
+
+## Commands and results
+
+The four repository gates were rerun successfully after both approved review
+corrections on 2026-09-09. Build reused up-to-date outputs for unchanged packages;
+all test suites ran without skips.
+
+| Check | Result |
+| --- | --- |
+| `node common/scripts/install-run-rush.js update` | Passed after the authorized removal of injected hook-path environment entries from this child process; Rush installed the repository pre-commit hook. |
+| `node common/scripts/install-run-rush.js build` | Passed on the final source. |
+| `node common/scripts/install-run-rush.js lint` | Passed on the final source and tests. |
+| `node common/scripts/install-run-rush.js typecheck:tests` | Passed across all packages. |
+| `node common/scripts/install-run-rush.js test --only @excitedjs/agent-runtime-codex --only @excitedjs/feishu-channel` | Passed, including the added canonical Windows quoting cases. |
+| `node common/scripts/install-run-rush.js test` | Passed with the existing operator Codex proxy supplied through `HTTP_PROXY` and `HTTPS_PROXY`: 149 test files, 2,263 tests, no skips; includes all 9 `codex-live.test.ts` cases on Codex 0.153.4. |
+| `python3 .agents/skills/dev-workflow/scripts/init_task.py check --domain channel --slug align-codex-command-display` | Passed with this verification record included. |
+| `.agents/scripts/check.sh` | Passed: 193 files reachable. |
+| `git diff --check` | Passed. |
+
+The initial live-test process initialized Codex 0.153.4 but received no model
+response for even the plain `Reply with exactly the word ok.` case. Model cases
+failed by timeout or empty activity, including the issue #63 folding gate. The
+operator's interactive Codex alias supplies proxy variables; direct test child
+processes did not have them. The rerun supplies the same existing proxy without
+changing repository or persistent runtime configuration. No live-test skip,
+assertion change, or timeout increase was used.
+
+Rush generated the package patch note through `rush change --bulk`. Its own
+`ChangeFiles.validate` accepted the new uncommitted change file and Codex package
+coverage. `rush change --verify` discovers change files through a committed
+three-dot diff, so final branch verification remains a post-commit gate; no
+commit was created to make that check pass.
+
+## Delivery baseline
+
+The original workspace starts at `305e3fc8`, whose Workflow notification change
+is not part of `origin/next`. The original task commit `bac326a8` is preserved on
+its implementation branch. Only that patch was transferred onto `origin/next`
+(`2b3d6971`) as `fix/codex-command-display`, excluding the unrelated change from
+the PR. The only conflict was concurrent task-index additions; both entries are
+retained. The parser source and its direct tests are byte-identical to the
+reviewed implementation; runtime and Feishu tests applied without content
+conflicts. The checks above describe the original reviewed baseline.
+
+The isolated delivery branch passed build, lint, test, and `typecheck:tests`:
+150 test files and 2,300 tests, no skips, including all 9 real Codex cases.
+The test total includes coverage added by the newer trunk; the Codex display
+suite remains 62 cases. The task validator, KB check (206 reachable files),
+and diff whitespace checks also passed. No inherited commit is discarded or
+published as part of this task.
+
+## Display-chain evidence and visual limitation
+
+An in-memory probe imported the compiled Codex `toolDisplay`, Core
+`createConversationProjection`, and Feishu `toolCallStartEvents` /
+`toolCallResultEvents` implementations. Six cases passed: Zsh multiline, Bash
+Unicode and literal variables, PowerShell, unknown shell, malformed quoting,
+and noncanonical Windows drive-path text. The probe asserted the raw argument
+survived and the final title/code payload matched the decoded script or the
+unchanged input, as appropriate. It performed no command execution or network
+send.
+
+For `/usr/bin/zsh -lc "node --check script.mjs\necho done"`, the title was
+`node --check script.mjs` and the expanded code was the two-line inner script.
+
+No browser/client visual verification has been performed. This change has no
+local web UI or dev-server surface, and no browser tool is available in this
+session. No live Dreamux service was restarted, replaced, or used to send a
+probe card. Automated payload verification does not establish the rendered
+Feishu client result.
+
+## Independent review
+
+The single independent read-only review completed with no functional or
+architecture blocker and two improvement-level findings. The reviewer reported
+16,009 differential inputs with no mismatch against an independently transcribed
+Python oracle, including 3,253 unwrapped inputs and 1,292 Windows round-trip
+inputs. This is reviewer evidence, not execution of the original Rust; a shared
+transcription error remains possible. The review did not rerun repository gates
+or perform a Feishu client render.
+
+### TeamLeader adjudication
+
+| Finding | Verdict | Reason | Operator-ruling conflict / ratification |
+| --- | --- | --- | --- |
+| 1. NUL-input branch and fabricated fixture (`tool-display.ts:69`, `tool-display.test.ts:105` before cleanup) | Accepted; operator approved on 2026-09-09 | All traced producers already call `shlex_join`, which substitutes a literal marker on NUL; no reachable additional display failure needs this branch. | Operator ruling: "删除冗余分支 (Recommended)". Delete only this predicate and fixture; no other parsing rule changes. |
+| 2. Stale invocation description (`provider-runtime.md:664-665` before correction) | Accepted; operator approved on 2026-09-09 | The owner page must distinguish a recognized wrapper's decoded inner script from an unchanged ordinary command. | Operator ruling: "同步文档 (Recommended)". Documentation only; no new runtime behavior. |
+
+Finding 1 is applied after the operator's explicit approval: removed the NUL
+predicate and its fabricated test fixture only. The targeted Codex and Feishu
+package tests, task validator, KB check, and `git diff --check` pass after this
+cleanup; the final four-gate rerun also passed. Finding 2 is also applied after
+its separate approval: the provider-runtime owner now distinguishes the display
+command from unchanged raw arguments.
+
+The TeamLeader traced the reviewer's previously untraced guardian `Command`
+producer to upstream `core/src/guardian/approval_request.rs:199-208`: it also calls
+`shlex_join`. Therefore the review's side claim that this producer establishes
+noncanonical raw command input is not accepted. The Windows round-trip rule
+remains required by explicit acceptance criterion 4 and is not part of finding 1.
+The noted trailing-slash shell-path difference has no demonstrated executable
+producer and is not expanded into a new parser special case.

--- a/.agents/tasks/channel/align-codex-command-display/verification.md
+++ b/.agents/tasks/channel/align-codex-command-display/verification.md
@@ -48,8 +48,8 @@ Rush generated the Codex package patch note through `rush change --bulk`.
 Its `ChangeFiles.validate` accepted that file before commit. The first committed
 branch verification also required a description for the Feishu test-only change;
 `rush change` generated a `none` note for that package, retaining the existing
-Codex patch note. The committed-branch check runs before push with
-`--verify --target-branch origin/next --no-fetch`; no package version is edited.
+Codex patch note. The committed-branch check passed before push with
+`--verify --target-branch origin/next --no-fetch`; no package version was edited.
 
 ## Delivery baseline
 
@@ -68,6 +68,15 @@ The test total includes coverage added by the newer trunk; the Codex display
 suite remains 62 cases. The task validator, KB check (206 reachable files),
 and diff whitespace checks also passed. No inherited commit is discarded or
 published as part of this task.
+
+PR [#396](https://github.com/excitedjs/dreamux/pull/396) targets `next` from the
+isolated branch. All 9 checks in
+[CI run 34288628691](https://github.com/excitedjs/dreamux/actions/runs/34288628691)
+passed for head `1305d36d`, including Linux/macOS Rush and shellcheck, Rush change
+coverage, author metadata, KB, full-history gitleaks, and internal-content scan.
+The working tree was clean after push. GitHub reports `REVIEW_REQUIRED`; no
+merge, deployment, or service restart was performed. Later documentation-only
+head checks remain visible on the PR instead of being restated in a commit.
 
 ## Display-chain evidence and visual limitation
 

--- a/.agents/tasks/channel/align-codex-command-display/verification.md
+++ b/.agents/tasks/channel/align-codex-command-display/verification.md
@@ -44,11 +44,12 @@ processes did not have them. The rerun supplies the same existing proxy without
 changing repository or persistent runtime configuration. No live-test skip,
 assertion change, or timeout increase was used.
 
-Rush generated the package patch note through `rush change --bulk`. Its own
-`ChangeFiles.validate` accepted the new uncommitted change file and Codex package
-coverage. `rush change --verify` discovers change files through a committed
-three-dot diff, so final branch verification remains a post-commit gate; no
-commit was created to make that check pass.
+Rush generated the Codex package patch note through `rush change --bulk`.
+Its `ChangeFiles.validate` accepted that file before commit. The first committed
+branch verification also required a description for the Feishu test-only change;
+`rush change` generated a `none` note for that package, retaining the existing
+Codex patch note. The committed-branch check runs before push with
+`--verify --target-branch origin/next --no-fetch`; no package version is edited.
 
 ## Delivery baseline
 

--- a/common/changes/@excitedjs/agent-runtime-codex/dreamux-dreamux-ultra-03_2026-09-08-21-55.json
+++ b/common/changes/@excitedjs/agent-runtime-codex/dreamux-dreamux-ultra-03_2026-09-08-21-55.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Display the inner script of recognized Codex shell commands in tool summaries and invocations without changing execution arguments.",
+      "type": "patch",
+      "packageName": "@excitedjs/agent-runtime-codex"
+    }
+  ],
+  "packageName": "@excitedjs/agent-runtime-codex",
+  "email": "hvjfccdy6s@privaterelay.appleid.com"
+}

--- a/common/changes/@excitedjs/feishu-channel/fix-codex-command-display_2026-09-08-22-59.json
+++ b/common/changes/@excitedjs/feishu-channel/fix-codex-command-display_2026-09-08-22-59.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@excitedjs/feishu-channel",
+      "comment": "Cover decoded command display facts in Feishu tool row title and invocation tests without changing runtime behavior.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@excitedjs/feishu-channel"
+}

--- a/packages/agent-runtime/codex/LICENSE
+++ b/packages/agent-runtime/codex/LICENSE
@@ -1,6 +1,8 @@
 MIT License
 
 Copyright (c) 2026 excitedjs
+Copyright (c) 2015 Nicholas Allegra (comex), for shell-word parsing and quoting
+adapted from rust-shlex 1.3.0.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/packages/agent-runtime/codex/src/tool-display.ts
+++ b/packages/agent-runtime/codex/src/tool-display.ts
@@ -12,6 +12,8 @@
  * for summary and invocation and shows as its name.
  */
 
+import { parse as parsePath } from 'node:path';
+
 import type { RuntimeToolAction } from '@excitedjs/dreamux-types';
 
 import type { ThreadItem } from './types.js';
@@ -47,7 +49,7 @@ interface CommandAction {
 }
 
 function commandDisplay(item: ThreadItem): ToolDisplay {
-  const command = stringField(item, 'command');
+  const command = shellScriptForDisplay(stringField(item, 'command'));
   const actions = commandActions(item['commandActions']);
   const first = actions[0];
   const uniform = first !== undefined && actions.every((entry) => entry.action === first.action);
@@ -61,6 +63,100 @@ function commandDisplay(item: ThreadItem): ToolDisplay {
     invocation: command,
     items: first.action === 'read' ? unique(actions.map((entry) => entry.file)) : [],
   };
+}
+
+function shellScriptForDisplay(command: string | null): string | null {
+  if (command === null) return command;
+  const words = splitShellWords(command);
+  if (words === null || words.length === 0) return command;
+  // Codex only decodes Windows drive-path text when its shlex spelling round-trips exactly.
+  if (command.includes(':\\') && words.map(quoteShellWord).join(' ') !== command) return command;
+  let shell = words[0]!;
+  while (!['bash', 'zsh', 'sh', 'pwsh', 'powershell'].includes(shell)) {
+    const stem = parsePath(shell).name;
+    if (stem === shell) return command;
+    shell = stem;
+  }
+  if (['bash', 'zsh', 'sh'].includes(shell)) {
+    return words.length === 3 && (words[1] === '-lc' || words[1] === '-c') ? words[2]! : command;
+  }
+  for (let i = 1; i + 1 < words.length; i++) {
+    const flag = words[i]!.toLowerCase();
+    if (flag === '-command' || flag === '-c') return words[i + 1]!;
+    if (flag !== '-nologo' && flag !== '-noprofile') return command;
+  }
+  return command;
+}
+
+// Shell-word parsing and quoting follow rust-shlex 1.3.0; attribution is in LICENSE.
+function splitShellWords(command: string): string[] | null {
+  const words: string[] = [];
+  let word = '';
+  let quote = '';
+  let started = false;
+  for (let i = 0; i < command.length; i++) {
+    const char = command[i]!;
+    if (quote === "'") {
+      if (char === "'") quote = '';
+      else word += char;
+    } else if (char === '\\') {
+      const next = command[++i];
+      if (next === undefined) return null;
+      if (next !== '\n') {
+        if (quote === '"' && !['$', '`', '"', '\\'].includes(next)) word += '\\';
+        word += next;
+      }
+      started = true;
+    } else if (quote === '"') {
+      if (char === '"') quote = '';
+      else word += char;
+    } else if (char === "'" || char === '"') {
+      quote = char;
+      started = true;
+    } else if (char === ' ' || char === '\t' || char === '\n') {
+      if (started) words.push(word);
+      word = '';
+      started = false;
+    } else if (char === '#' && !started) {
+      while (i < command.length && command[i] !== '\n') i++;
+    } else {
+      word += char;
+      started = true;
+    }
+  }
+  if (quote !== '') return null;
+  if (started) words.push(word);
+  return words;
+}
+
+function quoteShellWord(word: string): string {
+  if (word === '') return "''";
+  let result = '';
+  for (let start = 0; start < word.length;) {
+    let unquoted = true;
+    let single = true;
+    let double = true;
+    let end = start;
+    if (word[start] === '^') {
+      unquoted = false;
+      double = false;
+      end++;
+    }
+    for (; end < word.length; end++) {
+      const char = word[end]!;
+      const nextUnquoted: boolean = unquoted && /^[a-zA-Z0-9_+./:@\]-]$/.test(char);
+      const nextSingle: boolean = single && char !== "'" && char !== '^' && char !== '\\';
+      const nextDouble: boolean = double && !['`', '$', '!', '^'].includes(char);
+      if (!nextUnquoted && !nextSingle && !nextDouble) break;
+      unquoted = nextUnquoted;
+      single = nextSingle;
+      double = nextDouble;
+    }
+    const chunk = word.slice(start, end);
+    result += unquoted ? chunk : single ? `'${chunk}'` : `"${chunk.replace(/[$`"\\]/g, '\\$&')}"`;
+    start = end;
+  }
+  return result;
 }
 
 function commandActions(value: unknown): CommandAction[] {

--- a/packages/agent-runtime/codex/tests/codex-runtime.test.ts
+++ b/packages/agent-runtime/codex/tests/codex-runtime.test.ts
@@ -687,6 +687,46 @@ describe('CodexRuntime native turn end', () => {
     await runtime.stop();
   });
 
+  it('decodes command display on start and completion without changing raw arguments', async () => {
+    const activity: RuntimeActivity[] = [];
+    const client = new FakeCodexWsClient({ autoComplete: false });
+    const { deps } = makeDeps({ client, activitySink: (fact) => { activity.push(fact); } });
+    const runtime = new CodexRuntime(identity(null), deps);
+    await runtime.start();
+    const submission = requireSubmitted(await runtime.submit({ text: 'check the script' }));
+    const command = "/usr/bin/zsh -lc 'node --check script.mjs\necho done'";
+    for (const phase of ['started', 'completed'] as const) {
+      client.emitItem('fresh-thread-1', 'turn-1', phase, {
+        type: 'commandExecution',
+        id: 'exec-1',
+        command,
+        commandActions: [{ type: 'unknown', command: 'node --check script.mjs' }],
+        status: phase === 'started' ? 'inProgress' : 'completed',
+        aggregatedOutput: phase === 'completed' ? 'done' : null,
+      });
+    }
+    expect(activity.filter((fact) => fact.kind === 'tool.call')).toEqual(
+      ['started', 'completed'].map((status) => ({
+        kind: 'tool.call',
+        occurredAt: expect.any(Number),
+        id: `turn-1:exec-1:${status}`,
+        callId: 'exec-1',
+        toolName: 'exec_command',
+        action: 'run',
+        summary: 'node --check script.mjs',
+        invocation: 'node --check script.mjs\necho done',
+        items: [],
+        status,
+        arguments: command,
+        result: status === 'completed' ? 'done' : null,
+        error: null,
+      })),
+    );
+    client.emitCompleted('fresh-thread-1', 'turn-1', 'checked');
+    await submission.settled;
+    await runtime.stop();
+  });
+
   it('ends a native turn no submission ever bound, after its items displayed', async () => {
     const activity: RuntimeActivity[] = [];
     const client = new FakeCodexWsClient({ autoComplete: false });

--- a/packages/agent-runtime/codex/tests/tool-display.test.ts
+++ b/packages/agent-runtime/codex/tests/tool-display.test.ts
@@ -20,6 +20,133 @@ describe('toolDisplay', () => {
     })).toEqual({ action: 'run', summary: 'npm test', invocation: 'npm test\necho done', items: [] });
   });
 
+  it.each([
+    ['/usr/bin/zsh', '-lc'],
+    ['zsh', '-c'],
+    ['/bin/bash', '-lc'],
+    ['bash', '-c'],
+    ['/bin/sh', '-c'],
+    ['sh', '-lc'],
+    ['bash.exe', '-lc'],
+    ['/bin/zsh.backup.exe', '-c'],
+  ])('unwraps %s %s without changing the inner script', (shell, flag) => {
+    expect(toolDisplay({
+      type: 'commandExecution',
+      id: 'item-1',
+      command: `${shell} ${flag} 'node --check script.mjs'`,
+    })).toEqual({ action: 'run', summary: 'node --check script.mjs', invocation: 'node --check script.mjs', items: [] });
+  });
+
+  it.each([
+    [String.raw`/bin/zsh -lc "python3 -c 'print(\"Hello, world!\")'"`, `python3 -c 'print("Hello, world!")'`],
+    [String.raw`bash -c 'printf '\''%s'\'' "value"'`, `printf '%s' "value"`],
+    [String.raw`bash -c 'printf '"'%s'"' value'`, `printf '%s' value`],
+    ['bash -c "echo \\$HOME \\`date\\` \\\\path \\q"', 'echo $HOME `date` \\path \\q'],
+    [String.raw`bash -c 'echo "$HOME" $(pwd) && printf "%s" "雪" | wc -c'`, 'echo "$HOME" $(pwd) && printf "%s" "雪" | wc -c'],
+    ['bash -c "node --check script.mjs\necho done"', 'node --check script.mjs\necho done'],
+    ['bash -c "echo one\\\ntwo"', 'echo onetwo'],
+    ['bash -c echo\\\nhello', 'echohello'],
+    ["bash -c 'echo one\\\ntwo'", 'echo one\\\ntwo'],
+    ["bash -c 'bash -c echo'", 'bash -c echo'],
+    ["bash -c ''", ''],
+    ["bash -c '  echo hello'", '  echo hello'],
+    ["bash -c 'echo one\r\necho two'", 'echo one\r\necho two'],
+    ["# launcher\n bash\t-c 'echo hello' # trailing comment", 'echo hello'],
+    ["bash -c echo#literal", 'echo#literal'],
+  ])('decodes shell quoting in %s', (command, script) => {
+    expect(toolDisplay({ type: 'commandExecution', id: 'item-1', command })).toEqual({
+      action: 'run',
+      summary: script.trimStart().split('\n', 1)[0]?.trimEnd() || null,
+      invocation: script,
+      items: [],
+    });
+  });
+
+  it.each([
+    'pwsh -Command',
+    'powershell.exe -c',
+    '/usr/local/bin/pwsh -NoLogo -NoProfile -Command',
+    'pwsh -nOpRoFiLe -COMMAND',
+  ])('unwraps %s using the upstream PowerShell flag rules', (prefix) => {
+    expect(toolDisplay({
+      type: 'commandExecution',
+      id: 'item-1',
+      command: `${prefix} 'Write-Host "$HOME"'`,
+    })).toEqual({ action: 'run', summary: 'Write-Host "$HOME"', invocation: 'Write-Host "$HOME"', items: [] });
+  });
+
+  it('uses the argument following PowerShell -Command without interpreting its script or trailing arguments', () => {
+    const script = 'try { [Console]::OutputEncoding=[System.Text.Encoding]::UTF8 } catch {}\nWrite-Host hi';
+    expect(toolDisplay({
+      type: 'commandExecution',
+      id: 'item-1',
+      command: `pwsh -Command '${script}' extra`,
+    })).toMatchObject({ summary: script.split('\n')[0], invocation: script });
+  });
+
+  it.each([
+    'npm test\necho done',
+    '  node  --check "script.mjs"',
+    '/usr/bin/fish -c "echo hi"',
+    'BASH -c "echo hi"',
+    'env bash -c "echo hi"',
+    'bash --login -c "echo hi"',
+    'bash -l -c "echo hi"',
+    'bash -lc "echo hi" argument',
+    'bash -lc',
+    'bash -lc "echo hi',
+    "bash -lc 'echo hi",
+    'bash -c echo\\',
+    'pwsh -File script.ps1',
+    'pwsh -ExecutionPolicy Bypass -Command "Write-Host hi"',
+    'pwsh -NoProfile -Command',
+    String.raw`C:\Program Files\Git\bin\bash.exe -lc "echo hi"`,
+    String.raw`bash -c 'echo C:\work'`,
+  ])('preserves an ordinary or unrecognized command: %s', (command) => {
+    expect(toolDisplay({ type: 'commandExecution', id: 'item-1', command })).toEqual({
+      action: 'run',
+      summary: command.trimStart().split('\n', 1)[0]?.trimEnd() || null,
+      invocation: command,
+      items: [],
+    });
+  });
+
+  it.each([
+    [String.raw`bash -c "echo C:\\work"`, String.raw`echo C:\work`],
+    [String.raw`bash -c "echo C:\\work "'$HOME'`, String.raw`echo C:\work $HOME`],
+    [String.raw`bash -c "echo C:\\work "'^caret'`, String.raw`echo C:\work ^caret`],
+    [String.raw`bash -c "echo C:\\work '雪'"`, String.raw`echo C:\work '雪'`],
+    [String.raw`bash -c "echo C:\\work "'!'`, String.raw`echo C:\work !`],
+  ])('accepts canonical Windows drive-path quoting: %s', (command, script) => {
+    expect(toolDisplay({ type: 'commandExecution', id: 'item-1', command }))
+      .toEqual({ action: 'run', summary: script, invocation: script, items: [] });
+  });
+
+  it.each([
+    { type: 'read', name: 'a.rs', path: '/repo/a.rs', action: 'read', summary: 'a.rs', items: ['/repo/a.rs'] },
+    { type: 'listFiles', path: 'src', action: 'list_files', summary: 'src', items: [] },
+    { type: 'search', query: 'TODO', path: 'src', action: 'search', summary: 'TODO in src', items: [] },
+  ])('keeps the $type label and items while unwrapping its invocation', ({ action, summary, items, ...entry }) => {
+    expect(toolDisplay({
+      type: 'commandExecution',
+      id: 'item-1',
+      command: "zsh -lc 'cat a.rs | grep TODO'",
+      commandActions: [entry],
+    })).toEqual({ action, summary, invocation: 'cat a.rs | grep TODO', items });
+  });
+
+  it('uses the whole decoded script rather than lossy mixed action fragments', () => {
+    expect(toolDisplay({
+      type: 'commandExecution',
+      id: 'item-1',
+      command: "zsh -lc 'cat a.rs | grep TODO\necho done'",
+      commandActions: [
+        { type: 'read', name: 'a.rs', path: '/repo/a.rs', command: 'cat a.rs' },
+        { type: 'search', query: 'TODO', command: 'grep TODO' },
+      ],
+    })).toEqual({ action: 'run', summary: 'cat a.rs | grep TODO', invocation: 'cat a.rs | grep TODO\necho done', items: [] });
+  });
+
   it('labels an all-read command by the files it read, deduplicated, the way the TUI groups an Explored cell, and lists their paths', () => {
     expect(toolDisplay({
       type: 'commandExecution',

--- a/packages/channel/feishu-channel/tests/feishu-cot-tool-rows.test.ts
+++ b/packages/channel/feishu-channel/tests/feishu-cot-tool-rows.test.ts
@@ -61,6 +61,24 @@ describe('runtime-labelled tool rows', () => {
     });
   });
 
+  it('uses decoded display facts rather than raw wrapped arguments for the title and invocation', () => {
+    const call = toolCall({
+      tool_name: 'exec_command',
+      summary: 'node --check script.mjs',
+      invocation: 'node --check script.mjs\necho done',
+      arguments_json: JSON.stringify("/usr/bin/zsh -lc 'node --check script.mjs\necho done'"),
+    });
+    const [start] = toolCallStartEvents(call);
+    expect(start!.content).toMatchObject({ icon: 'bash', title: 'node --check script.mjs' });
+    const [result] = toolCallResultEvents({ ...call, status: 'completed', result_json: 'done' });
+    expect(result!.content).toMatchObject({
+      content: [
+        { type: 'code', language: 'bash', code: 'node --check script.mjs\necho done' },
+        { type: 'text', text: 'done' },
+      ],
+    });
+  });
+
   it('leads a read row with a verb and the read icon', () => {
     const [start] = toolCallStartEvents(toolCall({
       tool_name: 'Read',


### PR DESCRIPTION
## Summary
- Show the inner script of recognized Bash/Zsh/Sh and PowerShell commands in Codex tool summaries and expanded invocations, following the pinned Codex TUI parsing rules. Preserve unknown or undecodable input and the Windows quoting round-trip rule.
- Keep parsing in the Codex display owner: raw arguments, execution, approval, action labels, redaction, and Feishu rendering remain unchanged. No new dependency or public API.
- Add display/runtime/Feishu regression coverage, rust-shlex attribution, Rush change notes, and the completed task and provider knowledge updates. The original workspace's unrelated Workflow commit is excluded.

Task: `.agents/tasks/channel/align-codex-command-display/README.md`
Upstream baseline: `openai/codex@49db349ffdd888f5e3c91abf9b7519d8631e6e9a`.

## Test plan
- [x] `node common/scripts/install-run-rush.js build`
- [x] `node common/scripts/install-run-rush.js lint`
- [x] `node common/scripts/install-run-rush.js test` — 150 files, 2,300 tests, no skips; includes 9 real Codex tests. The existing operator proxy was supplied through HTTP_PROXY/HTTPS_PROXY for live model access.
- [x] `node common/scripts/install-run-rush.js typecheck:tests`
- [x] `node common/scripts/install-run-rush.js change --verify --target-branch origin/next --no-fetch`
- [x] Task validator, `.agents/scripts/check.sh`, and `git diff --check`
- [x] Independent read-only review: no functional or architecture blocker; both accepted cleanup findings resolved with operator approval.
- [x] In-memory provider-to-Feishu payload probe for quoting, multiline scripts, unknown shells, malformed input, and Windows text.
- [ ] Feishu client visual verification was not performed; payload tests do not establish the rendered client result. No live service was restarted or deployed.

## Review scope
Only the command display fix and its tests/docs/change notes are included. Local gates were rerun on the isolated branch based on `next` after transferring the reviewed patch; the only transfer conflict was concurrent task-index additions, both retained.