### PR TITLE
feat: show COT tool details and concise notification labels

### DIFF
--- a/.agents/domains/channel.md
+++ b/.agents/domains/channel.md
@@ -830,15 +830,15 @@ an event changes only that catalog and its consumers.
 No event carries a turn identity: presentation correlation is the `source_id` a
 caller supplied, echoed back on its own input, and nothing exposes a
 runtime-native Turn object or transcript. Conversation events may contain
-redacted user/assistant display text and redacted tool arguments/results, whole:
-Core bounds nothing, and the Channel cuts a string only where it would exceed
-Feishu's per-event limit (「core那边只做脱敏，不做截断 … Channel这边先去解析JSON，
-然后在发送接口之前去做截断」, 2026-09-04). Redaction keeps a structured payload
-parseable — a quoted secret becomes the quoted string `<redacted>`, and a bare
-one stops at the quote or bracket that closes it — because the Channel parses
-`result_json` to decide how to show it. Other
-events contain no prompt or assistant text. No event contains native transcript
-paths, raw errors, or platform user identity.
+redacted user/assistant display text and redacted tool results, whole. Argument
+payloads and invocation strings are the operator-selected exception: Core
+serializes arguments and preserves invocation text without secret masking or path
+rewriting ("参数全给我放开，不要做脱敏了", 2026-09-09; see
+[the task record](../tasks/channel/refine-cot-tool-details-and-notifications/README.md)).
+Core bounds nothing; the Channel parses JSON and cuts a string only at its native
+send limit. Other event metadata does not expose a runtime transcript or its
+path. Raw arguments can contain the values submitted to a tool; they are not
+covered by the redacted-result/body guarantee.
 
 Delivery is live and best-effort: Core invokes listeners in publication order
 without awaiting them, and a listener's exception or rejection never escapes into
@@ -914,86 +914,79 @@ target fallbacks. Fencing is the whole of the TeamLeader's extra lifecycle
 policy; the Dispatcher, having no Team, is never fenced. Feishu ignores
 Team-member events explicitly and never routes them through a recipient's state.
 
-Once a recipient has an anchor, everything Core projects for it displays:
-assistant text, tool calls and results, and every input whatever its source name,
-including `task`, `task-notification`, `cron`, `system`, and a restart notice
-delivered inside a live session. The one exception is the body of the message
-this Channel itself submitted, which the operator can already see as their own
-Feishu message: the session holds a bounded set of the caller-owned ids it
-issued and recognizes an input by **comparing** `source_id` against them. Its
-mere presence proves nothing — cron fires, task push-backs, and restart notices
-carry one too. There is no source whitelist. A fact
-that arrives before the recipient has an anchor produces no card because there is
-nowhere to place one, not because its source or kind was filtered.
+Once a recipient has an anchor, Core-projected assistant text, tool calls and
+results, and inputs enter its display. Ordinary inputs retain their bodies.
+Automated inputs use compact Channel-owned labels: `TEAMMATE CALLBACK` with the
+producer name, `CRON TRIGGERED`, `WORKFLOW FINISHED` without a name, and
+`SYSTEM RESTARTED` for the current Dispatcher system notice. Completion kind and
+producer name come from structured provenance supplied by the completion owner,
+never from parsing its notification text. `TeammateInputEvent.notice` carries
+`TeammateInputNotice`: `{kind: 'teammate_completion', producer}`,
+`{kind: 'workflow_completion'}`, or null for other inputs. The producer is the
+host's Agent identity name and travels unchanged, like `teammate_name` in the
+actor scope; it is not part of the redacted notification body. Its owning
+identity store validates the name before creation.
+The model-facing body stays intact.
+The Channel suppresses only its own already-visible inbound body by comparing
+`source_id` with the bounded set it issued; a source ID's presence alone proves
+nothing. Before an anchor exists, there is no place to send a card.
 
-A tool row is composed from what the runtime said about the call, never from
-its argument schema. The row's `TOOL_CALL_START` carries the built-in `icon`
-the COT Message Brief documents for the call's `tool_action` (`read`; `write`
-for an edit; `search` for a search or a listing; `bash` for a run) and a
-`title` composed from the runtime's `summary`: the summary alone for a run,
-whose summary is already a sentence; a verb before it for a read, listing,
-search or edit; the display tool name before it for a call with no action. No
-row sends `TOOL_CALL_ARGS`: a call with neither an action nor a label — an MCP
-tool no runtime can label, today, this Channel's own tools (`reply`, `react`,
-`list_chat_bots`) and Core's teammate tools included — shows its display name
-behind the icon-library token
-`app-default_outlined` with its arguments hidden (operator ruling, 2026-09-04:
-「现在 mcp 工具效果比较差，mcp 工具隐藏掉参数吧，icon 选 app-default_outlined」); its
-output still expands. The Channel used to compose titles for Core's teammate
-tools (`spawn`, `send`, `close`, `workflow_run`) by matching the MCP name and
-re-parsing the arguments against Core's field names — a copy of Core's tool
-schema living in the Channel, with no record of the design. The operator had
-it removed, 2026-09-04: 「那你先给 dreamux 内置mcp 工具的覆盖都删掉吧。我想想这里怎么
-做。」 How Core's own tools get labelled is an open design point; until it is
-settled they are plain unlabelled rows. The Channel's own three tools lost
-their hand-made titles and icons the same day, on the ruling 「这些全部回退吧」
-that followed the operator noticing `react`'s built-in `default` icon renders
-nothing: no row is presented from the tool's identity any more, only from what
-the runtime said about the call. The `TOOL_CALL_RESULT` of a
-runtime-labelled row is the documented segment array: `Failed` first when it
-failed, the call's `items` as the pills of a `list` segment (each with the
-icon of the call's action, bounded by `TOOL_ITEMS_SOFT_MAX_BYTES` with one
-`+N` pill standing for the rest; a first item longer than the whole budget is
-truncated into one pill rather than folded into that count, per 「按照单条去截断
-即可」, 2026-09-04), the `invocation` as a `code` segment
-(`language: bash` for a run), then the output, shown by what it is rather
-than by how long it is: a value that parses as a JSON object or array is
-pretty-printed (`JSON.stringify(value, null, 2)`) in a `json` code segment,
-anything else is a plain `text` segment (「文本的输出，就按文本输出。能解析成JSON
-的再放进代码段」, 2026-09-04). The text segment travels with each space that
-begins a line, or sits in a run of two or more, turned into a no-break space
-(U+00A0, `preserveSpacing` in `feishu-cot-presentation.ts`): the client
-collapses a run of ordinary spaces and drops a leading one, so a Bash
-output's indentation and column alignment were lost (「这里头的空格都没了」,
-2026-09-04). A probe card the same day settled the client facts: a raw run
-collapses; U+00A0, U+2002 and the `&nbsp;` entity all keep it; a `<pre>`
-wrapper is shown as literal text with its spaces still collapsed; and an
-entity inside a row `title` is decoded too — tags are escaped, entities are
-decoded. The character was chosen over the entity for costing two bytes of
-the event budget rather than six, and a single inner space stays ordinary so
-a long line still wraps. A code segment keeps its own spaces. That rule replaced, within one day, both #347's
-inline exception for a one-line output under 120 bytes and the all-code rule
-that lasted one commit (「全都给他们包到代码块里面」), once MCP rows made the
-mix of boxed and unboxed outputs visible. A code segment spells its body in
-the documented `code` field. Every string a row sends is cut only where it
-would exceed Feishu's 4,096-byte per-event content limit, last, after the
-JSON was parsed and printed, with the English truncation marker (「截断长度以飞
-书平台上给出的最长长度为准，现在有点短」): the earlier 512-byte invocation and
-title soft caps and the 1,024-byte output soft cap are gone, and so is Core's
-own bounding. A read or edit that
-succeeded stops after its pills: the operator ruled the diff and the output
-redundant beside them (「有了胶囊的，可以忽略底下这个编辑的代码段。只看编辑了
-哪些文件就行了」) because the client cannot fold a code segment away; a failed
-one keeps them, since the output is where the failure's reason appears. A probe card sent to the operator on 2026-09-03 settled the
-three client facts this rests on: a titled row shows the `title` alone, with
-no tool name in front of it; an `ARGS` delta sent beside a title is shown
-nowhere, which is why the invocation has to travel in the result; and the
-client renders a code segment's body from `code` and from the older `content`
-alike, so the switch follows the docs, not a rendering failure. A third probe
-(2026-09-04) settled the icon facts: the icon-library token
-`app-default_outlined` renders a glyph on an untitled and on a titled row
-alike, while the built-in `default` renders no glyph at all — a row sent with
-`icon: default` looks exactly like one sent without `icon`.
+`/packages/channel/feishu-channel/src/feishu-cot-presentation.ts` owns the existing
+action names and title words: read/list_files/search/edit map to Read/List/Search/Edit
+and prefix a supplied summary with that word. The run action uses Bash as its
+untitled name and its summary without a prefix. The edit action also covers Write.
+Tools without an action use their raw runtime summary as title, or tool_name
+when untitled, without the former 80-byte name cap. Existing action icons remain.
+The Channel does not parse a tool's
+argument schema. It selects invocation code language from the existing
+tool_action: run uses bash, other actions use text. It formats JSON arguments
+locally, without a provider language-classification field. Arguments and invocation
+strings arrive without redaction by the operator's field-specific ruling.
+Generic/MCP tools follow the same display policy. A nonempty invocation always
+precedes arguments_json, even for non-Bash tools; only an empty invocation uses
+the JSON/text argument fallback. R3 explicitly confirmed this ordering. Codex
+web search supplies its native `{query, action}` through that argument fallback.
+
+The native event order remains START, END, then RESULT after execution. No row
+sends `TOOL_CALL_ARGS`: the client hides that delta beside a title, so arguments
+are rendered through the result's documented rich segments instead. END means
+argument input is complete and execution starts, not that execution finished.
+The COT Message Brief defines only toolCallId on END, and messageId,
+toolCallId, content, and role on RESULT; neither documents a per-tool execution
+status field. Failure text is therefore part of this Channel's result content.
+
+A call with items uses the native `list` result alone, whether the call succeeded
+or failed. Items retain action icons, the existing soft byte budget, per-item
+truncation, and the `+N` more pill. The existing pill budget counts text bytes;
+many short items can still exceed the final event budget and fall back to a
+status word. The operator declined the R2 accounting change in the task record.
+Other calls show their argument code segment without an ARGUMENTS heading,
+followed by a separate `{type: "text", text: "RESULT\n\n---"}`
+segment before the result area when output or a failure indication exists.
+The blank line keeps RESULT from becoming a Markdown setext heading. Ordinary
+failed rows put Failed after this label and before actual output, following any
+arguments. Failed without actual output still has the label and failure text.
+Non-list result assembly fits its two variable strings in
+result-then-argument order; it has no later whole-payload dropping stages.
+
+A JSON object or array is formatted with `JSON.stringify(value, null, 2)` and
+shown as `{type: "code", language: "json", code: ...}`. Other output remains a
+text segment, with the first ten content lines and an English truncation marker
+when more exist. A terminal LF/CRLF does not create another content line.
+`preserveSpacing` keeps indentation and repeated spaces using U+00A0; single
+inner spaces remain ordinary so wrapping still works. Code segments preserve
+their own spaces. The full result is classified before line/byte truncation.
+The Channel fits title and result text to Feishu's 4096-byte content limit and
+checks the complete event before sending; Core never truncates. Tool names are
+sent unchanged. START retains its original title-only fitting and final size
+check, without a shared title/name budget, under the operator's explicit ruling.
+
+The native client behavior was confirmed by rendering probes: titled rows show
+only the title, ARGS deltas beside a title disappear, list segments render pills,
+and code segments use the documented `code` field. `app-default_outlined` renders
+on titled and untitled rows; the built-in `default` renders no glyph. The current
+presentation supersedes the earlier hidden-MCP-arguments and failed-list-details
+rules; see [the task record](../tasks/channel/refine-cot-tool-details-and-notifications/README.md).
 
 A card's one terminal is a `turn.ended` activity. There is no per-submission
 lifecycle fact at this boundary at all: a provider folds any number of
@@ -1042,9 +1035,9 @@ reasoning in the
 
 Every admitted input publishes exactly one `teammate.input`, and the runtime's
 own stream carries everything after it; an entity whose conversation is out of
-scope publishes nothing. Input bodies and live activity are redacted in core —
-never bounded there: a surface cuts what it cannot send, where it sends it —
-and operator paths are renamed rather than blanked — the workspace
+scope publishes nothing. Core redacts input bodies and live activity except
+argument/invocation values, and never bounds them there: a surface cuts what it cannot send, where it sends it —
+and paths in the fields covered by redaction are renamed rather than blanked — the workspace
 reads `.` and this host's home reads `~`, from prefixes `Server.start()` resolves
 once and injects into each conversation projection as a value. Card I/O has a
 20-second operation deadline so settled draining state is eventually reaped.

--- a/.agents/domains/provider-runtime.md
+++ b/.agents/domains/provider-runtime.md
@@ -806,9 +806,16 @@ fails Codex's quoting round-trip check, keep their original spelling. The full
 display command is the invocation; raw arguments stay unchanged.
 A patch is its paths with the diffs codex prepared as invocation;
 a `webSearch` item, which carries no tool name and was dropped before, is a
-`web_search` row. Anything outside those tables — every MCP tool — reports
-`null` and displays as its name. Core sanitizes both facts exactly as it does
-arguments and results.
+`web_search` row. Codex projects that item's native `query` and `action` together
+as its arguments, preserving every search query and open/find parameter; this
+uses the existing argument seam and does not change native item pairing. Null
+or absent query/action fields are omitted; when neither is present, arguments
+remain null.
+Anything outside those tables — every MCP tool — reports
+`null` for descriptive facts and an empty item list, and displays as its name.
+Core redacts summaries/items/results but preserves argument/invocation values
+without redaction under the operator's current display policy; see
+[Channel projection](channel.md).
 
 A normal native turn ends at its provider-native terminal: Claude Code `result`
 or Codex `turn/completed`. A resident Claude session can answer several inputs

--- a/.agents/product/README.md
+++ b/.agents/product/README.md
@@ -223,30 +223,40 @@ the same change that touches it.
   the body the operator can already see in the chat.
   (Ruling: 「所有的 user 消息都隐藏即可」, 2026-09-03, in
   [split-streaming-display-from-pushback](/.agents/tasks/architecture/split-streaming-display-from-pushback/requirement.md).)
-- **A tool row says what the call was, not how the runtime spelled it.** A
-  tool row on the Feishu card is titled the way the runtime's own UI would
-  title it — a command's stated purpose, the file a read or edit touched, the
-  pattern a search ran, the task a sub-agent was given — carries the icon for
-  what it did, and expands to the call in the caller's own notation (the
-  shell command line, the task text) before its output. A read or edit that
-  succeeded expands to the files it touched as pills and nothing more; only
-  a failed one still shows its diff and output. A row no runtime could label
-  — today every MCP tool, the Channel's own reply/react/list_chat_bots
-  included — shows its tool name behind a generic app icon with its arguments
-  hidden; its output still expands. An output that parses as JSON is
-  pretty-printed in a json code segment; any other output is plain text
-  that keeps its indentation and column alignment (each space that begins
-  a line or sits in a run is sent as a no-break space, because the client
-  collapses ordinary runs; single spaces between words still wrap).
-  A non-JSON tool result keeps its first ten content lines and gains the English
-  truncation marker when an eleventh line exists; a terminal LF or CRLF does not
-  invent another content line. A JSON object or array bypasses that line rule.
-  Every card string is still finally bounded by Feishu's per-event limit, never
-  earlier in Core. Raw
-  JSON arguments appear nowhere on the card. Codex web searches are rows too.
-  The card's own words — row verbs (Read, Edit, Search, List), the Completed and
-  Failed status lines, and the truncation marker — are English. Dreamux's own teammate tools (spawn,
-  send, close, workflow) appear as plain unlabelled rows for now.
+- **Tool details use the runtime's facts.** Tool rows retain the fixed
+  Read/List/Search/Edit action words before a summary, with the matching action
+  name when no summary exists. The run action uses its summary directly or Bash
+  when untitled. Tools without an action use the summary directly or tool_name
+  when untitled, without the former 80-byte name cap. Rows keep the icon for their action.
+  A call with items expands to its list of pills
+  alone, including when it failed. Other calls show arguments as a code
+  segment without an ARGUMENTS heading. Nonempty invocation always wins: the
+  existing run action uses bash code, other actions use text code. Only when
+  invocation is empty does arguments_json
+  supply formatted JSON or text code. Argument/invocation values are shown
+  without secret masking or path rewriting, per the operator's explicit ruling;
+  generic/MCP tools follow the same rule. Before output or a failure indication,
+  a separate text segment shows RESULT and a horizontal divider. On a non-list
+  failed call, Failed follows this label and precedes actual output, after any
+  arguments; the failure area also appears when actual output is absent.
+  A JSON object or array is pretty-printed in
+  a json code segment; other output is text with its existing indentation and
+  column alignment preserved using no-break spaces. Text keeps its first ten
+  content lines and adds the English truncation marker when more exist; a
+  terminal newline is not another line. All segments share Feishu's per-event
+  byte limit, applied in the Channel. Other display fields retain their existing
+  Core redaction rules. Card-owned labels
+  remain English. Tool details still arrive through the existing native
+  START/END/RESULT event sequence.
+  (Task: [COT tool details and notifications](/.agents/tasks/channel/refine-cot-tool-details-and-notifications/README.md).)
+- **Automated input is summarized on the COT card.** A TeamMate completion is
+  `TEAMMATE CALLBACK` followed by its producer's name, a due cron fire is
+  `CRON TRIGGERED`, a Workflow callback is `WORKFLOW FINISHED` without a name,
+  and the current Dispatcher restart input is `SYSTEM RESTARTED`. These are
+  human display labels; the receiving agent still gets the full original body.
+  Actual task submissions and ordinary input remain visible, and the Channel
+  still suppresses its own already-visible inbound body by source ID.
+  (Task: [COT tool details and notifications](/.agents/tasks/channel/refine-cot-tool-details-and-notifications/README.md).)
 - **A compaction is one line.** When the runtime compacts its context, the
   card shows `COMPACTED SESSION` as an assistant message, and nothing of the
   summary the runtime wrote for itself. The uppercase label is specified in
@@ -256,8 +266,8 @@ the same change that touches it.
   feishu-cot-adapter 这里对齐最终上传到飞书的消息格式」, 2026-09-03, in
   [feishu-cot-conversation-cards](/.agents/tasks/channel/feishu-cot-conversation-cards/requirement.md).)
 - **A displayed input is announced when it is submitted, and always ends.** The
-  input appears with the text that was submitted, before any runtime has
-  accepted it, so a submission that fails is visible together with what failed.
+  input appears before any runtime accepts it, using its body or the automated
+  input label described above, so a submission that fails remains visible.
   Anything no runtime accepted — a stopped, skipped, ambiguous, or failed
   admission — ends its own display as a failure, carrying the reason, instead of
   leaving a surface open forever. That includes a completion push-back whose

--- a/.agents/skills/dev-workflow/SKILL.md
+++ b/.agents/skills/dev-workflow/SKILL.md
@@ -17,6 +17,26 @@ the current implementation and not as permission to edit code. Verify code facts
 challenge hidden assumptions, and keep the confirmed task record current so work
 can survive context compression or transfer to another TeamLeader.
 
+## Mandatory clarification of unsettled requirements
+
+At every stage, if code or knowledge-base facts expose ambiguity, an inaccurate
+description, or a possible scope wider than the operator has stated, use
+`ask_human_question` to confirm and clarify **one issue at a time**. This duty also
+applies to behavior the operator has not mentioned. Evidence reveals a question;
+it does not authorize the TeamLeader to choose or extend the requirement.
+
+Keep unresolved interpretations out of accepted requirements and out of the basis
+for design, implementation, and review. Pause dependent work until the answer
+arrives; continue independent, already authorized work. Do not reopen a decision
+the operator has already settled or turn routine implementation choices within
+that scope into new approval requests. Follow the concrete procedure in
+[requirement-clarification.md](references/requirement-clarification.md).
+
+The TeamLeader must remain alert to this failure throughout the task: imprecise
+requirements compounded by the TeamLeader's overinterpretation propagate into
+developer briefs, implementation, and review. More reviewers and passing tests
+cannot repair an unconfirmed premise.
+
 ## Hard development gate
 
 Do not modify product code, tests, configuration, scripts, migrations, generated
@@ -126,6 +146,11 @@ development authorization, authoritative `.agents/**` and GitHub updates, commit
 pushes, PR actions, and the final merge outcome. Technical consultation may
 delegate only each seat's disjoint proposal or solution-review task file. TeamMate
 agreement and vote count never replace TeamLeader judgment or an operator decision.
+
+When drafting a developer handoff or follow-up, read
+[TeamMate task briefs: good and bad cases](references/teammate-briefs.md) for
+examples of concise task prompts, where to keep context, and how an over-prescribed
+handoff can displace the actual requirement.
 
 Every technical-solution consultant and implementation-review TeamMate carries the
 common challenger identity from

--- a/.agents/skills/dev-workflow/references/requirement-clarification.md
+++ b/.agents/skills/dev-workflow/references/requirement-clarification.md
@@ -17,6 +17,43 @@ Do not route work solely from the label supplied by the operator:
   and the concrete structural problem and completion boundary are explicit.
 - Treat a refactor that changes observable behavior as a requirement change.
 
+## Ask about each unsettled interpretation
+
+When code or knowledge-base facts reveal that the operator's description is
+ambiguous, inaccurate, or could cover more behavior than stated, the TeamLeader
+must use `ask_human_question` to clarify each issue separately. An omission is not
+approval to change the omitted behavior. Apply this rule whenever the discovery
+occurs, including during implementation and review.
+
+`ask_human_question` is the operator's name for the interactive clarification
+tool. The current Feishu channel exposes it as `ask_user_question`; use that tool
+in the originating topic with its `chat_id` and `message_id`.
+
+1. State the operator's actual wording and the specific code or knowledge-base
+   fact that creates the uncertainty. Label the TeamLeader's interpretation as an
+   interpretation, not as an operator decision.
+2. Explain the concrete behavior or scope difference, then ask one focused
+   question through `ask_human_question`. Do not bundle independent decisions.
+3. Wait for the answer before proceeding with work that depends on it. Record the
+   answer verbatim or narrower, then move to the next unresolved issue. Independent
+   work within the already authorized scope may continue.
+4. Update the requirement and affected task artifacts before handing the settled
+   scope to a developer or reviewer. Until confirmed, the interpretation stays an
+   open question and cannot be cited as an accepted requirement.
+
+Do not silently choose the broadest reading, treat an existing design document as
+permission, or use reviewer agreement and passing tests to validate an inferred
+requirement. Later approval does not retroactively authorize an earlier expansion.
+Already settled decisions and routine implementation choices within the approved
+behavior do not require repeated clarification.
+
+Operator ruling (2026-09-10): "如果用户没提到，但是你在知识库和代码事实中发现用户的描述模糊，不准确，或者可能有更大覆盖范围，有歧义等，务必用 ask_human_question 工具逐个确认与澄清。"
+
+The TeamLeader must keep this risk in view throughout the workflow: an imprecise
+requirement document combined with the TeamLeader's overinterpretation amplifies
+downstream errors. Clarification belongs before that interpretation becomes a
+developer brief or review criterion.
+
 ## Clarify the task, not the implementation
 
 Use concrete discoveries to help the operator expose hidden constraints. Prefer a

--- a/.agents/skills/dev-workflow/references/teammate-briefs.md
+++ b/.agents/skills/dev-workflow/references/teammate-briefs.md
@@ -1,0 +1,90 @@
+# TeamMate task briefs: good and bad cases
+
+Read when composing a developer's `spawn` or a follow-up `send`. These examples
+apply the bundled `teamwork` skill's "Context, Not Control" guidance to this
+repository. They supplement the [developer identity](developer-identity.md) and
+[implementation handoff](implementation.md), without changing approval or
+ownership rules.
+
+## Where information belongs
+
+| Place | Content |
+| --- | --- |
+| `identity` | The standing role, write boundaries, and freedom to challenge the brief. |
+| Task documents | The current requirement, approved constraints and solution, relevant evidence, and verification expectations. |
+| `prompt` | This assignment's outcome, document pointers, important facts not recorded there, and the expected report. |
+
+Keep necessary context available without copying the whole task into every
+message. Explain a real constraint once in its owning document; label an
+unconfirmed assumption so the recipient can question it. Concision is useful
+because it leaves room for judgment, not because prompts have a word limit.
+
+## Good case: an approved implementation
+
+The operator accepted this concise COT handoff after requesting a fresh Claude
+developer: "你这次下发的不是很好吗？" (2026-09-10).
+The following is an English rendering of the task prompt; the role
+and repository-write boundaries were supplied separately in `identity`.
+
+```text
+ultracode: Complete the original COT display requirements and correct the
+ordering of Failed, including verification.
+
+Requirements:
+.agents/tasks/channel/refine-cot-tool-details-and-notifications/implementation-brief.md
+
+The source is at the clean next baseline. Choose the implementation yourself;
+report the changes, verification results, and remaining issues when finished.
+```
+
+The task document contains the display rules and required checks. The prompt
+states the requested outcome and verified starting state, then leaves the
+developer to investigate and implement. `ultracode` is included because the
+operator explicitly requested it; this example does not make it a default for
+other tasks. A reused example must not assert a clean baseline without checking.
+The operator accepted the handoff; that is not evidence that the implementation
+or its tests have completed.
+
+## Bad case: prescribing the recipient's execution
+
+This condensed counterexample captures the rejected handoff pattern:
+
+```text
+Use ultracode. By that I mean the workflow tool I selected. Load these extra
+orchestration guides, call that tool, use my stages and runtime choices, and
+report its run ID. Restore the old title map, remove the language fields, and
+carry forward my previous repair list. Follow this sequence exactly.
+```
+
+The TeamLeader replaced the user's method with a similarly named mechanism,
+turned implementation guesses into orders, and carried discarded code into a
+fresh task. The clean baseline already had the fixed titles and did not have
+the added language contract: those repair instructions were stale. More detail
+would reinforce the wrong premise.
+
+Instead, name the desired behavior against the actual starting source. Keep
+historical decisions where they explain a current constraint; do not hand over
+an abandoned patch plan as the new requirement. Forward an operator-selected
+method without silently substituting a different system with the same name.
+
+## Good and bad follow-ups
+
+Good: provide the observable mismatch and its owning requirement, then let the
+same developer investigate it.
+
+```text
+The failed tool row still shows Failed before the arguments. The accepted
+display order puts failure text in the RESULT area after arguments. Please
+correct that behavior and verify the complete resulting change.
+```
+
+Bad: repeat the role, paste the whole requirement again, specify each line to
+move, and add new prohibitions after every reply. When an unexpected result
+exposes a different reading of the problem, ask for the developer's reasoning
+before overriding it. When the operator requests a fresh developer, give that
+developer the current task rather than the previous conversation's accumulated
+execution instructions.
+
+The TeamLeader's work is accurate requirements and ownership boundaries, followed
+by inspection of the complete result. A capable recipient should not have to
+work around the TeamLeader's unverified implementation plan to do the task.

--- a/.agents/tasks/channel/README.md
+++ b/.agents/tasks/channel/README.md
@@ -24,3 +24,4 @@
 - [Feishu slash commands](/.agents/tasks/channel/add-feishu-slash-commands/README.md) — `done`: Handle /stop, /teams, and /dissolve deterministically in the Feishu channel through one extensible command table
 - [Align Codex command display parsing](/.agents/tasks/channel/align-codex-command-display/README.md) — `done`: Show the inner shell script in Codex tool rows instead of the shell launcher wrapper
 - [Display turn usage summaries](/.agents/tasks/channel/display-turn-usage-summary/README.md) — `done`: Implement native context and cumulative token usage as the final assistant activity; draft-only delivery pending live Codex verification.
+- [Refine COT tool details and notification display](/.agents/tasks/channel/refine-cot-tool-details-and-notifications/README.md) — `review`: Show tool arguments and labeled results, preserve list-only rows, and summarize automated inputs on Feishu COT cards.

--- a/.agents/tasks/channel/refine-cot-tool-details-and-notifications/README.md
+++ b/.agents/tasks/channel/refine-cot-tool-details-and-notifications/README.md
@@ -1,0 +1,108 @@
+# Refine COT tool details and notification display
+
+## Current state
+
+- Goal: Show tool arguments and labeled results, preserve list-only rows, and
+  summarize automated inputs on Feishu COT cards.
+- State: `review`
+- Requirement: [Current requirement](/.agents/tasks/channel/refine-cot-tool-details-and-notifications/requirement.md).
+- Final solution: [Technical solution](/.agents/tasks/channel/refine-cot-tool-details-and-notifications/technical-design/final.md).
+- Solution review Issue: None; the operator explicitly directed development
+  after the interactive requirement and presentation-design alignment.
+- Baseline: Freshly fetched `origin/next`,
+  `00b858efa2f9cfdb7fdbf829aac9cfe0856b6915`, before implementation.
+- Current review base: freshly fetched `origin/next` at
+  `7ed1d886964e520025cbc1e8151c8ff2eefd9a58`, unchanged at final pre-review.
+  The earlier implementation had been rebased after the operator clarified
+  "不是 dev，说错了，是 next"; it was subsequently discarded as recorded below.
+- Branch: `feat/cot-tool-details-and-notifications`.
+- Restart baseline: Freshly fetched next at
+  `7ed1d886964e520025cbc1e8151c8ff2eefd9a58`. On 2026-09-10 all non-.agents files
+  and local branch HEAD were restored to this commit; the old developer was
+  closed. At that reset only .agents records remained changed; the fresh Claude
+  implementation passed final local pre-review. The remote draft PR and published Alpha
+  still contain the discarded implementation.
+- Blockers: External final review remains pending. The test-fixture scan failure
+  was resolved under operator approval by changing only the synthetic commands;
+  staged gitleaks now passes with its rules unchanged. The operator rejected the
+  added shared START title/name budget; its withdrawal is verified while the
+  approved 80-byte cap removal remains.
+  Earlier implementation and gate results are historical.
+  R2 remains unchanged, R3 keeps invocation-first selection, and R6 keeps the
+  existing formatting entry under the operator's explicit rulings.
+- Next action: Update the existing draft PR, run CI, and request the
+  operator-selected external final review. Its
+  [implementation brief](/.agents/tasks/channel/refine-cot-tool-details-and-notifications/implementation-brief.md)
+  states the original presentation requirement plus failure ordering against next.
+  External final review remains required. The replacement Codex writer was closed and its
+  partial source edits were discarded before this reassignment.
+- Related tasks: Builds on
+  [Feishu COT cards](/.agents/tasks/channel/feishu-cot-conversation-cards/README.md)
+  and [COT refinement](/.agents/tasks/channel/refine-feishu-cot-and-binding-cards/README.md).
+
+## Development approval
+
+- Status: Granted by the operator on 2026-09-09, following source investigation,
+  private rendering probes, and iterative agreement on the presentation.
+- Approval: "开始开发吧，推进到 PR 创建出来，然后给我发一个 Alpha 包。"
+- Baseline constraint: "开始开发之前，你先从 next 分支拉出最新开发分支。"
+- Scope: The linked requirement and its neutral runtime/Core/Channel plumbing,
+  tests, release declarations, and repository knowledge. The operator's later
+  refinements, "workflow 先不展示 name 了" and "参数全给我放开，不要做脱敏了",
+  are included. The latter supersedes the brief withdrawal of argument display
+  and approves raw argument/invocation presentation. It does not authorize a
+  global redaction removal or ratify unrelated review findings.
+- Workflow interpretation: The explicit instruction to start development
+  authorizes this task record and routine implementation decisions without a
+  further intake or development-permission round. Single-writer implementation
+  and independent implementation review remain required. The later ruling
+  "如果是代码简化的话，直接做就行了" permits behavior-preserving simplification
+  directly; specific earlier no-change rulings still bind this task.
+- Review handoff (2026-09-09): "你去找devbox去review". The operator selected the
+  final reviewer. Prepare a draft PR as its concrete review surface while this
+  task remains in review; do not claim review completion or release readiness
+  merely because that draft exists. This review-handoff interpretation overrides
+  the usual post-closeout PR timing, not the validation or final-review gate.
+- Delivery boundary: Create the PR and publish an Alpha; merging, installing it
+  into the running service, and restarting the service are not requested.
+- Alpha feedback approval (2026-09-09): "ARGUMENTS 这个标题给删了，只保留 RESULT".
+  Remove only the argument heading; preserve the argument payload and RESULT.
+- Provider burden feedback (2026-09-10): "那你这就是在给provider适配增加负担。"
+  The TeamLeader withdraws the unnecessary invocation-language contract while
+  preserving argument display and the separate completion-provenance feature.
+- Failure-order approval (2026-09-10): "确实，这个顺序问题要修一下。"
+  Arguments precede the RESULT area, which contains Failed before actual output.
+- Fixed-title correction (2026-09-10): "那几个固定的Read Search 之类的单词你给我恢复了吗？"
+  The earlier blanket removal is superseded. After the reset, baseline action
+  names and title words already exist and are preserved, not restored by the
+  new implementation.
+- Restart instruction (2026-09-10): "你把非.agents 目录的变更全部回退到和next
+  分支一致，然后跟我复述需求，然后拉一个新的developer 重新做吧。"
+  The new implementation is authorized after restoration and requirement playback;
+  do not reuse the previous developer or replay its patch.
+- Requirement-playback correction (2026-09-10): "我是说我最初定下来的需求。现在代码都
+  让你回退了，哪还有恢复这一说了？" Describe the requested feature against next;
+  repairs of the discarded implementation are not new development work items.
+- Developer and method selection (2026-09-10): "原始需求再加上failed 顺序出错，派给claude，
+  让他用ultracode 一次性搞定。" Claude owns the complete implementation through
+  its own ultracode, including verification. It supersedes the interim Codex
+  assignment. The operator clarified "不要告诉他dreamux 的ultracode，这俩不是一个东西";
+  the TeamLeader's added skill-path and orchestration-tool requirements are
+  withdrawn. Hand down the requirement and the ultracode instruction only.
+- Fresh-context instruction (2026-09-10): "拉一个新的吧，那个claude 都被你污染了。"
+  and "不要那么啰嗦。他比你还能干。" The first Claude seat was closed without
+  implementation changes. A fresh Claude receives only the concise display
+  brief, the ultracode instruction, and necessary ownership boundaries; it
+  chooses the implementation itself.
+
+## Delivery
+
+- PR: [Draft #401](https://github.com/excitedjs/dreamux/pull/401), targeting `next`.
+- Alpha: `0.25.0-alpha.g4a45d478cc7c`, published and verified on npm after the
+  operator explicitly requested publication. It includes the rebase and heading
+  removal. It belongs to the discarded implementation and does not validate the
+  new attempt.
+- Verification: [Local checks and review](/.agents/tasks/channel/refine-cot-tool-details-and-notifications/verification.md).
+- Knowledge closeout: Product, Channel, provider, task, and requested workflow-skill
+  records are aligned with the final local implementation; external review may
+  require further updates.

--- a/.agents/tasks/channel/refine-cot-tool-details-and-notifications/implementation-brief.md
+++ b/.agents/tasks/channel/refine-cot-tool-details-and-notifications/implementation-brief.md
@@ -1,0 +1,44 @@
+# COT display requirements
+
+Make Feishu tool details readable and system notifications concise.
+
+## Expected display
+
+1. Keep the existing fixed action titles and icons. Other tools use summary as
+   their title when present, otherwise tool_name. The operator subsequently
+   approved removing its 80-byte cap; keep the original title fitting and native
+   event-size check. The operator rejected the added shared title/name budget.
+2. Calls with list items show only the list. Other calls show arguments first
+   as a code segment, without an ARGUMENTS heading. Prefer invocation; use
+   arguments_json only when invocation is empty. Keep the current bash/text
+   choice for invocation; JSON argument objects/arrays use formatted json code.
+3. Arguments and invocation are displayed without redaction or path rewriting.
+   Other fields retain their existing redaction rules.
+4. Before the result area, insert an independent text segment containing
+   `RESULT\n\n---`. JSON result objects/arrays use formatted json code; other
+   results remain text. Keep the existing whitespace filling, line truncation,
+   and event byte limit.
+5. On non-list failures, the order is: argument code, RESULT/divider, Failed,
+   actual output. Failure without output still has RESULT and Failed. Preserve
+   existing successful empty-content and list-overflow behavior.
+6. Automated notifications display one short line:
+   - `TEAMMATE CALLBACK · {name}`
+   - `CRON TRIGGERED`
+   - `WORKFLOW FINISHED` (no workflow name)
+   - `SYSTEM RESTARTED` for the existing restart notice.
+   The model still receives the complete original notification body.
+
+## Boundaries
+
+The starting code is next at `7ed1d886964e520025cbc1e8151c8ff2eefd9a58`.
+Keep native tool event timing, argument/result pairing, source-id suppression,
+and state/config formats. The existing tool action is sufficient for code
+language selection; no new provider language-classification field is needed.
+Include native Codex search query/action data in the displayed arguments.
+
+## Completion
+
+Implement and verify the complete behavior. Run the repository's Rush build,
+lint, test, typecheck:tests, and built CLI smoke gates. Include appropriate
+Rush change declarations and report verification results and real limitations.
+The TeamLeader owns .agents, Git, PR, publication, and final external review.

--- a/.agents/tasks/channel/refine-cot-tool-details-and-notifications/requirement.md
+++ b/.agents/tasks/channel/refine-cot-tool-details-and-notifications/requirement.md
@@ -1,0 +1,182 @@
+# Requirement
+
+## Starting point
+
+This is a new implementation of the requested tool details and concise system
+notifications on next, not a repair of the discarded feature patch. Next already
+has the fixed Read/List/Search/Edit/Bash action names and title words. Keep that
+existing behavior. Next has no added provider/shared invocation-language contract
+to remove. The operator corrected the TeamLeader's framing explicitly:
+"我是说我最初定下来的需求。现在代码都让你回退了，哪还有恢复这一说了？"
+Historical corrections below explain the desired presentation; they are not a
+checklist of old code to rebuild and then repair.
+
+## Operator decisions
+
+The operator selected the following behavior after comparing private COT
+rendering probes. Quotes preserve the decisions; the rules below state their
+implementation boundary.
+
+- "有 summary 的时候用 summary 作为title" and
+  "没有 summary 的时候 传递 tool_name". The later Alpha correction preserves
+  the existing fixed action words: "你怎么把我那几个固定标题给我删了？就是 Read
+  edit、write、search、这几个。", followed by "那几个固定的Read Search 之类的单词
+  你给我恢复了吗？". The TeamLeader's earlier removal of all action prefixes
+  was too broad. The next baseline already has the required action naming/title
+  rule, which remains in place; generic tools
+  without an action still use the literal summary or tool_name.
+- "原始需求里有提过要动这个 80 截断逻辑吗？为什么替我做决定？" (2026-09-10).
+  The TeamLeader had expanded tool_name into an uncapped-name requirement
+  without authorization. That interpretation and the resulting removal request
+  were withdrawn. The subsequent explicit ruling supersedes preservation:
+  "算了去掉就去掉吧，我还没见过超过 80 字符的 toolname". Remove the 80-byte
+  tool-name cap under this new authorization, not as an inferred original demand.
+  On the separate START title/name budget question, the operator then selected
+  "保持原事件处理 (Recommended)": remove only the approved 80-byte cap and
+  withdraw the added shared-budget rule. Keep the original title fitting and
+  final event-size check.
+- "args 作为第一个代码段传递": shell invocations use Bash code and JSON
+  arguments use JSON code. After initially saying "这么麻烦就先不展示参数了",
+  the operator immediately superseded that withdrawal with "你把参数给我展示出来吧，
+  先不做脱敏了", then clarified "参数全给我放开，不要做脱敏了".
+  All argument detail is displayed without redaction, including existing shell
+  invocations and newly visible generic/MCP JSON. The proposed redaction repair
+  is not requested.
+- "那确实应该优先显示invocation ，而不是arguments_json。
+  只有invocation为空，才显示arguments_json" (2026-09-09, R3). This priority
+  applies to every tool; it is not limited to Bash.
+- "result 如果是 json 就放进代码段，不是的话就继续作为 text 节点插入。
+  保留现在的空白字符填充逻辑。"
+- "他们有 list，那就只渲染 list。" This takes precedence over the earlier
+  mistaken suggestion to expand arguments/results for file-list rows.
+- "就是在现在的 result 块前面插入一个新 text 块" with the fixed RESULT label
+  and a horizontal divider. A blank line separates the label and `---`, so the
+  label does not become a Markdown setext heading.
+- "ARGUMENTS 这个标题给删了，只保留 RESULT" (2026-09-09, Alpha feedback).
+  Remove the argument heading only; keep the argument code segment and the
+  independent RESULT label/divider. This supersedes the earlier argument label.
+- "确实，这个顺序问题要修一下。" (2026-09-10), after the operator observed
+  Failed before the arguments. Put the failure text in the RESULT area: argument
+  code first, then RESULT/divider, then Failed and any actual output. A failed
+  call without actual output still has a RESULT area containing Failed.
+- "那你这就是在给provider适配增加负担。" (2026-09-10), after examining the
+  previous attempt's inferred invocationLanguage field. That discarded
+  implementation is not part of the new baseline. Use the existing Channel
+  action-based code-language choice; fine-grained script-language detection is
+  not a requested capability. Argument content remains visible.
+- Automated push-backs should be one line: `TEAMMATE CALLBACK` and the producer's
+  name, a cron-trigger label, and `WORKFLOW FINISHED`.
+- "workflow 先不展示 name 了" (2026-09-09): no Workflow name extraction or display.
+- The operator deferred further discussion of provider argument/result caching:
+  "先不管这个了". Do not redesign that lifecycle in this task.
+
+## Accepted behavior
+
+1. Preserve the existing action-based names and title words. Baseline names are
+   Read, List, Search, Edit, and Bash for read, list_files, search, edit, and run.
+   With a summary, the first four prefix that summary with their action word;
+   run keeps the summary as-is. Without a summary, omit the title and show the
+   action name. The existing edit action also covers Write; no new Write action
+   or provider classification is requested. For tools without an action, use
+   the nonblank summary itself as title, or tool_name when untitled. Remove the
+   existing 80-byte name cap under the later explicit operator ruling.
+   Keep existing action icons. Generic titles do not add a tool-name prefix,
+   and untitled generic rows use tool_name. Keep the native event-size limit.
+2. When items produce a list, display that list alone; the rule is based on the
+   supplied items, not an allowlist of tool names. Do not add arguments, RESULT,
+   a divider, or output to list-only content, including failed calls with items.
+   Keep the existing list budgeting and overflow fallback: after the known
+   many-short-items issue was presented as R2, the operator ruled "不用动。下一个".
+   This narrow baseline limitation is accepted for this task.
+3. Otherwise display an argument code segment without an ARGUMENTS label when
+   arguments exist. Always select a nonempty invocation before arguments_json,
+   regardless of tool or notation. Use the existing Channel rule: invocation
+   code is bash when tool_action is run, otherwise text. Only when invocation
+   is empty, use arguments_json:
+   pretty-print JSON objects/arrays as JSON code, otherwise use text code.
+   Do not add a provider language-detection field for this display choice.
+   All argument payloads and displayed invocation strings
+   bypass Core redaction, including secret masking and path rewriting; JSON
+   serialization and Channel byte fitting still apply. This exception does not
+   change the existing redaction of summaries, items, results, or input/assistant
+   bodies. Do not introduce a configuration flag or a new redaction mechanism.
+   Include Codex webSearch's existing query/action parameters in its argument
+   projection so calls without invocation can show them. The operator approved
+   this R4 mapping with "好的。"; native pairing is unchanged.
+4. Before each existing nonempty output segment or failure indication, insert the separate segment
+   `{ "type": "text", "text": "RESULT\n\n---" }`. Preserve the output's current
+   JSON-object/array versus text classification, ten-content-line text limit,
+   whitespace filling, redaction, and final per-event byte limit. Do not prepend
+   the label inside the output/code string. On ordinary non-list failed rows,
+   place the existing Failed text after the RESULT label and before actual
+   output; it never precedes arguments. Emit RESULT and Failed even when that
+   failed call has no actual output. Keep successful empty-content and the
+   previously retained list-overflow fallbacks unchanged.
+5. Display automated inputs as one-line labels:
+   - TeamMate completion: `TEAMMATE CALLBACK · {producer_name}`.
+   - Due cron fire: `CRON TRIGGERED` (the aligned English wording for a fire).
+   - Workflow terminal callback: `WORKFLOW FINISHED`, without a name or run ID.
+   - The current Core system input (Dispatcher restart): `SYSTEM RESTARTED`.
+   Keep actual task submissions and other ordinary input bodies visible. Keep
+   source-id recognition of the Channel's own inbound body intact.
+6. Simplification affects the human COT display only. The receiving agent still
+   receives the existing full notification and task body. Do not parse prose or
+   XML to infer notification kind/name; retain the submitting owner's facts.
+
+## Baseline and current evidence
+
+Implementation starts at freshly fetched next commit
+`00b858efa2f9cfdb7fdbf829aac9cfe0856b6915`. Earlier investigation used a different
+checkout; facts must be checked against this baseline.
+
+The original implementation is superseded. On 2026-09-10 the operator directed
+restoring every non-.agents file to next, restating the requirements, and assigning
+a new developer. The freshly fetched restart baseline is
+`7ed1d886964e520025cbc1e8151c8ff2eefd9a58`; all implementation files and the branch
+HEAD were reset to it, with only .agents records retained. The new developer
+implements these requirements from that source, not by replaying the discarded
+feature patch. Previous Alpha, review, and test evidence is historical.
+
+- Both start and completion tool activities cross Core projection with
+  arguments, invocation, items, and result fields. The current Channel renders
+  invocation but not the full `arguments_json`.
+- Claude pairs native tool_use/tool_result in its provider. Codex projects each
+  native item independently. Channel only tracks call ID/card generation.
+- `TOOL_CALL_END` marks parameter completion and precedes execution results.
+  `list` is supported in `TOOL_CALL_RESULT.content`; native titled rows hide
+  `TOOL_CALL_ARGS`. These choices and event order remain in force.
+- Completion producers distinguish TeamMate and Workflow before the recipient
+  currently reduces both to a text-only task-notification input. TeamMate facts
+  carry the producer name. Cron and restart already have distinct sources.
+- Latest next has no Workflow record name. The operator explicitly excluded
+  displaying it, so no name/state/compiler change is necessary.
+
+Source owners:
+
+- `/packages/agent-runtime/claude-code/src/runtime-activity.ts`
+- `/packages/agent-runtime/codex/src/turn-manager.ts`
+- `/packages/dreamux/src/channel/conversation-projection.ts`
+- `/packages/dreamux/src/service/teammate-service/index.ts`
+- `/packages/dreamux/src/service/completion-router/index.ts`
+- `/packages/channel/feishu-channel/src/feishu-cot-events.ts`
+- `/packages/channel/feishu-channel/src/feishu-cot-presentation.ts`
+
+## Scope and validation
+
+Implement within runtime display facts, neutral conversation projection, and
+Feishu presentation. Keep native event timing, argument/result pairing, card
+lifetime, routing, completion delivery, and persisted state formats intact.
+The operator explicitly changed the argument/invocation redaction contract;
+leave the other projection fields under their existing policy. No Workflow-name
+capability, new retry/cache, separate notification bus, or redaction rewrite.
+
+Verify exact tool event/segment order, restored action titles and generic summary/name selection, generic JSON
+arguments, Bash versus other invocations, unredacted argument/invocation values
+using synthetic secrets and paths, preserved redaction on other fields,
+list-only success/failure, RESULT as an independent segment, byte boundaries
+with Unicode, unchanged text/JSON output rules, notification provenance/redaction,
+and source-id suppression. Run the
+repository build, lint, test, and typecheck:tests gates plus built CLI smoke,
+knowledge checks, release declarations, and independent review. Create a PR to
+next, dispatch the existing feature-branch Alpha release, and verify its exact
+published package version before reporting delivery.

--- a/.agents/tasks/channel/refine-cot-tool-details-and-notifications/technical-design/final.md
+++ b/.agents/tasks/channel/refine-cot-tool-details-and-notifications/technical-design/final.md
@@ -1,0 +1,106 @@
+# Technical solution
+
+## Display ownership
+
+The operator restored parameter display and explicitly ruled: "参数全给我放开，
+不要做脱敏了". This supersedes the brief parameter-display withdrawal and the
+proposed redaction repair. Keep runtime-specific interpretation in provider
+`tool-display.ts` modules. The clean next baseline already supplies invocation
+and tool_action; those facts suffice for Channel's code-language choice.
+Providers keep their existing invocation extraction and shell unwrapping; they
+do not need a new code-language classification for this display feature.
+No new language field crosses RuntimeActivity or TeammateActivity. For the
+approved native argument projection, the Codex
+provider maps the native webSearch query/action fields into its existing argument
+fact. Keep this protocol-specific extraction inside the provider; do not recover
+queries from the display summary or add a cache.
+
+At the existing Core conversation projection boundary, serialize structured
+arguments without running the redactor and preserve the invocation string
+unchanged. This applies equally to shell commands, scripts, and generic/MCP
+arguments. Do not add a Channel-specific bypass flag or a configuration option.
+Summaries, items, results, and input/assistant bodies remain under their existing
+redaction rules. Completion producer names are host identity metadata, carried
+unchanged like the actor scope's teammate_name. This is an explicitly selected
+exception for argument details, not a global removal of redaction.
+
+Retain Channel's baseline action-based tool names and title composition:
+read/list_files/search/edit use Read/List/Search/Edit before a summary, while
+run uses its summary without a prefix and Bash as its untitled name. The existing
+edit action covers Write too. Tools without an action use the supplied summary
+literally as title, or the supplied tool name when untitled. Remove the 80-byte
+name cap under the subsequent explicit operator ruling. Keep the original title
+fitting and final native event-size check; the operator rejected the added shared
+title/name budget. Keep action icons. Do not add a provider field or infer another
+action to restore these words.
+A nonempty item list is the entire result presentation, regardless of status.
+Other rows always select nonempty invocation before arguments_json, regardless
+of notation, as explicitly ruled for R3. Channel uses its existing tool_action
+fact: run invocation uses bash code; other invocation uses text code. This
+is existing baseline behavior, not a language-detection feature. Only an absent
+invocation selects the JSON/text
+argument fallback. Keep this existing priority; do not apply the rejected
+non-Bash JSON-priority proposal. Rows display that code segment without an
+ARGUMENTS heading, per the operator's Alpha feedback, and then the
+independent fixed `RESULT\n\n---` text segment immediately before the existing
+output segment. Preserve the result's JSON/text, whitespace, and line-limit
+rules. Put Failed inside the RESULT area: arguments, RESULT/divider, Failed,
+then any actual output. A failure without actual output still emits the RESULT
+label and Failed; success without output emits neither. Keep the success
+empty-content and list-overflow fallbacks. The RESULT label shares the existing 4096-byte event budget
+with the payloads. For approved R7, retain the existing result-then-argument
+string fitting and final event-size check, and remove the three now-unreachable
+whole-payload/status fallback branches. With lists handled separately, the two
+variable strings can fit within the budget alongside their fixed labels. Do not
+add a replacement fallback mechanism. The Channel
+formats JSON and fits the complete encoded event; it does not redact arguments.
+Keep the existing shared argument-formatting entry and its callers: the operator
+rejected the R6 relocation proposal with "不改。其他地方还要用". Do not move that
+work into the non-list RESULT branch as part of this task.
+
+## Automated input provenance
+
+Preserve the existing completion producer's kind and TeamMate source name through
+ordinary submission into the neutral input projection. TeammateInputNotice carries
+teammate_completion with producer or workflow_completion without a name;
+TeammateInputEvent.notice is null for other inputs. This shape belongs beside the
+input contract and carries only the facts this display consumes. Reuse the current admitted-input
+path; do not create a new event family, parse notification bodies, expose all
+model-envelope attributes, or change model-facing notification text.
+
+Feishu maps that metadata and the existing cron/system source names to the
+operator-selected English labels. Unknown/ordinary input continues through the
+existing text display. Core retains the input-body redactor; notice.producer is
+validated host identity metadata and travels unchanged like teammate_name.
+The receiving agent's body and completion delivery behavior
+remain unchanged. Workflow only needs its already-existing kind; no name or run
+record changes are required.
+
+## Implementation and review boundary
+
+One developer owns implementation files/tests and release declarations. The
+TeamLeader owns this record and repository knowledge. The developer may choose
+local names and small helper shapes within the stated ownership constraints;
+source evidence takes precedence over assumptions from the earlier checkout.
+
+The operator discarded the first implementation on 2026-09-10. A new developer
+starts from next at `7ed1d886964e520025cbc1e8151c8ff2eefd9a58`, with the old writer
+closed and all non-.agents files restored to the baseline. Design from these
+requirements and the baseline owners; do not replay the previous implementation.
+Existing domain-page edits are retained design records pending reconciliation,
+not evidence that the restored source already implements them. In particular,
+argument display needs no new shared type or provider language contract. Any
+neutral metadata required for the separate notification-label feature must carry
+only missing producer facts; explain each shared-field change by that capability.
+
+Keep the existing native START/END/RESULT order, the Core-owned field policies, Channel
+call-generation tracking, provider caching behavior, ten-line text result rule,
+and current state schemas. Verify both providers and the layer above each edited seam. Independent review
+must challenge whether completion facts are sufficient and minimal,
+whether only argument details bypass redaction, and whether list-only or byte
+fitting paths produce unwanted details or orphan labels.
+
+The verification and delivery plan is the requirement's final section. This
+record captures the agreed presentation plus the necessary implementation
+plumbing under the operator's explicit development instruction; it does not
+claim that the operator selected individual type or helper names.

--- a/.agents/tasks/channel/refine-cot-tool-details-and-notifications/verification.md
+++ b/.agents/tasks/channel/refine-cot-tool-details-and-notifications/verification.md
@@ -1,0 +1,301 @@
+# Verification
+
+## Current attempt: restarted from next on 2026-09-10
+
+The operator stopped the prior attempt and requested restoring all non-.agents
+files to next before a new developer starts. The old writer was closed, origin/next
+was fetched, and local HEAD is now `7ed1d886964e520025cbc1e8151c8ff2eefd9a58`.
+`git diff --exit-code origin/next -- . ':(exclude).agents'` and the index check
+both passed; status showed only retained .agents changes. No previous product
+patch remains in this baseline. The remote PR and published Alpha have not been
+rewritten by this local reset.
+
+The following previous-attempt reviews, gate runs, and publications are historical
+evidence only. Fresh implementation, full verification, and external review are
+required for the new attempt. The current requirement preserves baseline fixed
+action titles, puts Failed in RESULT after arguments, and excludes any new
+provider language-classification contract.
+
+The operator subsequently corrected the requirement playback: existing next
+behavior is retained, not "restored" by the new developer. The new task is tool
+argument/result presentation and concise notification labels. The TeamLeader
+sent this framing correction to the new developer; no additional reset or
+reintroduction of the discarded implementation was requested.
+
+## Name-cap correction during the new pre-review
+
+The TeamLeader incorrectly treated the existing 80-byte name truncation as a
+requirement defect. The operator objected: "原始需求里有提过要动这个 80 截断逻辑吗？
+为什么替我做决定？" The original requirement said tool_name, not an uncapped
+name. The TeamLeader withdrew the removal request and corrected the brief,
+requirement, design, and product/Channel records. The old speculative
+oversized-name finding did not authorize removing it.
+
+The operator then explicitly decided: "算了去掉就去掉吧，我还没见过超过 80 字符的
+toolname". This later ruling authorizes removal of the cap. The TeamLeader
+forwarded it to the same developer and updated the current requirement; the
+original overreach remains recorded above rather than retroactively justified.
+
+## Claude implementation pre-review
+
+The TeamLeader inspected the complete package diff and the changed assertions
+against the recorded user decisions. Fixed action titles remain as in next;
+generic summaries no longer gain a tool-name prefix. Non-list content is argument
+code, RESULT/divider, failure text when present, then output. No-output failure
+and argument-only success are covered, along with invocation priority, raw
+arguments, result/body redaction, list-only failure, notification labels, and
+the retained list-overflow limitation. Native timing and provider pairing are
+unchanged.
+
+The follow-up removed the name cap as authorized, but also introduced a shared
+START title/name byte budget: title is fitted first and name takes the remainder.
+The latter is an additional behavior decision, not an accepted consequence of
+the cap-removal ruling. The operator selected "保持原事件处理 (Recommended)" on
+the separate question: withdraw the shared-budget addition and keep the original
+title fitting and final event-size check. The final follow-up implements this
+ruling; the TeamLeader verified the START name/title assignments against next.
+
+The developer reports all five gates passing on this follow-up tree and supplied
+`common/temp/gate-logs/rush-*.log`; the TeamLeader inspected the build, lint,
+test, test-typecheck, and smoke completion summaries. The change-verification
+log uses the default origin/main comparison, so it does not validate this PR
+against next; rerun with an explicit origin/next target after committing. The
+previous trailing blank line is removed, and the final `git diff --check` passes.
+Skill validation and the repository KB check pass independently.
+
+Final local checks after the budget-rule withdrawal:
+
+| Gate | Result |
+| --- | --- |
+| Rush build | Passed, 2 operations executed and 6 cached |
+| Rush lint | Passed, 7 operations |
+| Rush test | Passed, 2418 tests across 7 packages; expected stderr warnings in 3 packages |
+| Rush typecheck:tests | Passed, 6 operations |
+| Rush smoke-built-cli | Passed, 1 operation |
+| git diff --check | Passed |
+| dev-workflow skill validation | Passed |
+| .agents/scripts/check.sh | Passed, 223 reachable KB files |
+
+The removed test covered only the rejected shared START budget. The approved
+long-name test and existing event-size assertions remain. No live Feishu probe or
+service installation was performed for this replacement implementation. A fresh
+fetch confirms that next remains at the restart baseline. Independent final
+review remains assigned to the operator-selected external reviewer; local gates
+do not substitute for that review.
+
+The first commit attempt was rejected by the mandatory pre-commit gitleaks scan:
+`curl-auth-header` matched synthetic command fixtures in
+`feishu-cot-tool-rows.test.ts` and `cot-projection-privacy.test.ts` (four matches).
+No commit was created and no guardrail was bypassed. AGENTS.md requires asking
+on guardrail false positives; replacing these authentication-header fixtures
+with plain diagnostic commands while retaining the assertions was proposed.
+The operator approved modifying the test samples. Because the question card
+routed outside the original topic, its verified answer was forwarded by a
+coordinating Team. That Team closed without making edits and explicitly returned
+fixture ownership. This TeamLeader replaced the fictitious authentication-header
+commands with `echo "token: dummy"`, preserving raw-argument and other-field
+redaction assertions. The internal-content gate also rejected the fictitious
+home-directory path in that sample; the same approved fixture-only correction
+uses `/tmp/cot-output.txt` instead, preserving the path-propagation assertion.
+The original developer remains idle; this TeamLeader owns
+verification, documentation, staging, commit, and publication. Scan rules remain
+unchanged.
+
+After that fixture-only edit, full Rush test, lint, and typecheck:tests pass
+again, and staged gitleaks reports no leaks. The original raw-argument and result/summary/item
+redaction assertions remain; production source is unchanged by this follow-up.
+
+While that question was pending, a separate existing ask-user routing defect was
+confirmed in source and installed code: sending a question card does not observe
+its returned message ID in the target router. The answer exposes that card ID;
+a later question addressed to it misses the router lookup and falls back to the
+group, dropping the reply anchor. Send logs confirm an anchored first card and
+an unanchored second card. The fix is outside the current COT implementation;
+use an observed ordinary message from the original topic for subsequent questions.
+
+The developer's three reported questions are adjudicated as follows:
+
+- Producer name: accept unchanged identity metadata. Completion source comes
+  from the host producerName in turn-recording.ts; identity-store.ts validates
+  names at creation, and actorScope already carries identity.name unchanged as
+  teammate_name. The original design's payload redactor on this new identity
+  field was a TeamLeader implementation assumption, now corrected. Existing
+  notification-body redaction remains unchanged.
+- Result fitting: accept the removal of unreachable whole-payload fallbacks
+  under the already-approved simplification ruling; the final event-size check
+  and known list fallback remain.
+- Failed list rows: accept list-only as explicitly required for calls with
+  items regardless of status. The changed test is a documented product decision,
+  not a hidden weakening of error-display coverage.
+
+## Previous attempt: review and implementation state
+
+The initial shared xhigh review completed with seven finders, nine candidates,
+nine verifiers, seven grouped findings, and no coverage failures. TeamLeader
+adjudication and the operator rulings are recorded below. Every initial finding
+now has a disposition. The original writer completed R4 and R7 together; the
+TeamLeader inspected their complete diff and checked the final combined gate
+logs. Final review of the complete resulting change is assigned to the
+operator-selected external reviewer and remains pending.
+
+Implementation started from freshly fetched next commit
+`00b858efa2f9cfdb7fdbf829aac9cfe0856b6915`, before any implementation write. The
+branch has not been rebased; later next commits do not change that starting fact.
+
+## Round 1 adjudication and operator rulings
+
+| ID | Finding | Disposition and source evidence | Operator ruling and boundary |
+| --- | --- | --- | --- |
+| R1 | Escaped quoted secrets survive argument redaction | Superseded by explicit raw-argument policy; implemented and tested. The TeamLeader reproduced the old regex failure with a synthetic script, then verified arguments_json is serialized without redaction and invocation is copied unchanged. | After briefly withdrawing argument display, the operator restored it: "你把参数给我展示出来吧，先不做脱敏了", then "参数全给我放开，不要做脱敏了". This applies to arguments/invocations only, not a global redaction removal. |
+| R2 | Many short list items exceed the event limit after pill framing | Defer under explicit no-change ruling. 150 three-character paths reproduce the status-only fallback. The same text-only pill accounting exists in the pinned baseline. | "不用动。下一个". Keep the existing list budget and fallback; do not fix this known limitation in the task. |
+| R3 | Non-Bash invocation takes priority over full JSON arguments | Reject as intended behavior. Agent prompt is the invocation and wins over the full input; the existing code already implements the desired ordering. | "那确实应该优先显示invocation ，而不是arguments_json。只有invocation为空，才显示arguments_json". Keep invocation first for every tool. The proposed non-Bash JSON-priority change is withdrawn. |
+| R4 | Codex webSearch does not project query/action as arguments | Accept, ratified, implemented. `argumentsFor` maps the existing native query/action into arguments; other item kinds retain the previous field selection. The runtime regression covers started/completed, both queries, unchanged summary, and absent invocation. | The operator replied "好的。" to this exact mapping proposal. No pairing/cache redesign or inference from title text. |
+| R5 | An oversized full tool name can throw during START | Reject as a blocking finding. A synthetic name beyond 4096 bytes demonstrates the exception mechanism, but no supported producer was shown to supply it. | No arbitrary name cap or speculative defensive change. This remains a reachability evidence gap. |
+| R6 | START and list-only paths format arguments they do not display | Reject under explicit no-change ruling. Keep the shared formatting entry and its callers. | "不改。其他地方还要用". This is the operator's stated reason, not a newly verified inventory of consumers. |
+| R7 | Three whole-payload/status fallback stages are unreachable after string fitting | Accept, ratified, implemented. The assembler now keeps only result-then-argument string fitting; the final native event-size check remains. Unicode/size/label coverage is retained and extended. | "如果是代码简化的话，直接做就行了". Behavior-preserving simplification may proceed directly; this does not override the specific R2/R3/R6 rulings or authorize product changes. |
+
+All ratified corrections were recorded before dispatch to the original single
+writer. No proposed redaction rewrite, list-budget fix, JSON-priority change, or
+formatting relocation was implemented. The short-lived parameter-display
+withdrawal was superseded before any commit or release; the final requirement
+and solution describe restored, unredacted arguments.
+
+## TeamLeader pre-review of the final combined revision
+
+The TeamLeader traced runtime activity through Core projection into the Channel,
+including the layer above each edited seam. `invocation` always wins over
+arguments_json, the argument exception is field-specific, and the RESULT header
+is its own text segment. Native provider pairing, card generation tracking, and
+START/END/RESULT order remain unchanged. The completion producer crosses the
+existing admitted-input path; model rendering still reads only source, attrs,
+text, and reminder, so the full notification body is preserved.
+
+R4 forwards query/action as structured provider facts instead of parsing a
+summary. R7 removes only the three unreachable fallback stages: after fitting,
+the two variable strings and fixed labels fit within the result budget. The
+final event-size check and operator-retained list fallback remain present.
+
+The final combined repository gates (writer run 5, logs inspected by the
+TeamLeader) passed:
+
+| Command | Result |
+| --- | --- |
+| `node common/scripts/install-run-rush.js update` | Passed during setup; dependency state unchanged afterwards |
+| `node common/scripts/install-run-rush.js build` | Passed, 2 executed operations; unchanged operations cached |
+| `node common/scripts/install-run-rush.js lint` | Passed, 7 operations |
+| `node common/scripts/install-run-rush.js test` | Passed, 4 ordinary operations plus 3 with expected stderr warnings |
+| `node common/scripts/install-run-rush.js typecheck:tests` | Passed, 6 operations |
+| `node common/scripts/install-run-rush.js smoke-built-cli` | Passed, 1 operation; other packages define no smoke command |
+
+The first implementation test run encountered one scheduler timing failure;
+its focused rerun and subsequent complete runs passed, including the final
+combined revision. Changed package test configs include both source and tests
+and exclude only dependencies/build output. Runtime, Channel, and Core tests
+cover invocation notation, generic JSON, raw argument/path values, preserved
+redaction on other fields, list-only failures, Unicode byte fitting, source-id
+suppression, and completion provenance. Focused final Channel tests passed 98
+cases; Codex runtime/display tests passed 119 cases. No real secrets were used
+in regression inputs or external probes.
+
+## Final review handoff
+
+After final TeamLeader pre-review passed, a second shared xhigh workflow started.
+The operator then requested the named external reviewer: "你去找devbox去review".
+The TeamLeader stopped the redundant workflow and is providing a draft PR at a
+pinned commit as the requested review surface. The stopped run is not a clean
+review and no conclusion is inferred from it. The first completed xhigh review
+and its ratified corrections remain recorded above.
+
+External final review remains pending until the selected reviewer's result is adjudicated.
+The draft PR is an explicit review artifact, not a ready-to-merge declaration.
+Its scope is the complete diff against the pinned baseline, with the current
+requirement, final solution, and the R1-R7 dispositions above. The subsequent
+operator-requested Alpha feedback reopens implementation; no repeated reviewer
+status checks are needed while awaiting its reply.
+
+## Alpha publication and feedback
+
+PR #401 head `b70d22429b2da7ca73532c90520104a2794299b7` passed all nine
+GitHub CI checks. After the operator explicitly requested publication,
+[release run 34366550601](https://github.com/excitedjs/dreamux/actions/runs/34366550601)
+succeeded and exact npm metadata confirmed
+`@excitedjs/dreamux@0.25.0-alpha.gb70d22429b2d`. The install command and tarball
+link were delivered. This does not claim external final review completion.
+
+The approved Alpha adjustment removes the ARGUMENTS heading while retaining
+the code payload and RESULT label/divider. TeamLeader inspected the complete
+follow-up diff and the writer's run 6 logs: Rush build, lint, test,
+typecheck:tests, and built CLI smoke all passed. The three test operations
+with warnings emit expected stderr from failure-path tests; no test failed.
+Focused Channel coverage passed 110 cases. The changed assertions remove only
+the deleted heading expectations and retain argument payload, RESULT ordering,
+failure display, and event byte-limit assertions.
+
+An arguments-only row now uses the existing single-segment form with a code
+segment, as the native content contract allows. No final-build live probe of
+this form is claimed. Tool title behavior, Failed placement, and the provider
+pairing lifecycle are unchanged by this follow-up.
+
+## Rebase onto refreshed next
+
+The operator corrected the target with "不是 dev，说错了，是 next". After a fresh
+fetch, both task commits replayed without conflicts onto
+`7ed1d886964e520025cbc1e8151c8ff2eefd9a58`. Stable patch IDs for the package and
+release-declaration diff before and after the rebase match. The first commit's
+range-diff differs only in surrounding product-document context introduced by
+next; the argument-heading removal replays identically. Task metadata records
+the new review base separately from the original development baseline.
+
+Fresh validation on the rebased source passed Rush build, lint,
+typecheck:tests, test (including real Codex integration), and built CLI smoke.
+The test warning operations contain the existing expected stderr. No package
+source adjustment or test assertion change was needed for the rebase.
+
+The rebased head `4a45d478cc7c2a6015a3a6bcf37d9289de3a55fe` also passed all nine
+GitHub CI checks. At the operator's request,
+[release run 34372428582](https://github.com/excitedjs/dreamux/actions/runs/34372428582)
+published `@excitedjs/dreamux@0.25.0-alpha.g4a45d478cc7c`; exact npm metadata
+confirmed availability and the operator received the install command and tarball.
+The operator subsequently requested Devbox re-review focused on complexity and
+entropy reduction; the request pins this same head. No review result has been
+received or inferred.
+
+## Invocation-language correction
+
+After the operator identified the provider burden, the TeamLeader withdrew the
+added language-classification contract. The implementation returns code-language
+selection to the existing Channel action rule and removes the new provider
+inference, shared event fields, and Core forwarding. Argument content,
+invocation-first selection, and completion provenance remain in scope. The
+language-specific classification introduced by this task is superseded, including
+the earlier tests expecting PowerShell/JavaScript run actions to display as text.
+Those actions return to the prior bash code-label behavior; this does not alter
+their execution or invocation text. The writer's run 7 passed build, lint,
+typecheck:tests, test, and built CLI smoke. Its language-only restoration leaves
+the Claude provider package equal to next; existing shell unwrapping remains.
+These results precede the following failure-order correction.
+
+## Failure-order correction
+
+The operator approved fixing Failed before arguments: "确实，这个顺序问题要修一下。"
+Non-list rows put arguments first, then the RESULT label/divider, then Failed
+and any actual output. Failed without output still belongs in that RESULT
+area. Successful empty-content and previously retained list-overflow fallbacks
+are unchanged. Fresh combined implementation and validation are pending.
+
+The TeamLeader reopened the official COT Message Brief on 2026-09-10 and checked
+the END and RESULT sections: END marks complete argument input and execution
+starting; neither documented payload has a per-tool execution-status field.
+No native status field or new lifecycle event is introduced for this correction.
+
+## Remaining delivery and limitations
+
+- Initial task/knowledge links, anti-leak hooks, and committed Rush change
+  verification passed. Validate the Alpha feedback again before updating the PR.
+- CI for the next revision remains pending. No build has been
+  installed into the running service; no final-build live Feishu probe is claimed.
+- The baseline result redactor has the same escaped-string limitation observed
+  in R1. That path is unchanged; the argument ruling does not authorize its
+  rewrite. R2's known list overflow remains per the explicit operator ruling.
+- Config/state schemas, maintenance skill contracts, and completion delivery
+  routing are unchanged. No manual rebuild or restart is part of this task.

--- a/common/changes/@excitedjs/agent-runtime-codex/refine-cot-tool-details-and-notifications_2026-09-10-01-55.json
+++ b/common/changes/@excitedjs/agent-runtime-codex/refine-cot-tool-details-and-notifications_2026-09-10-01-55.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Project a web search's query and action as the call's arguments, so a search row can show what was asked; codex states them outside the argument members every other item uses.",
+      "type": "minor",
+      "packageName": "@excitedjs/agent-runtime-codex"
+    }
+  ],
+  "packageName": "@excitedjs/agent-runtime-codex",
+  "email": "hvjfccdy6s@privaterelay.appleid.com"
+}

--- a/common/changes/@excitedjs/dreamux-types/refine-cot-tool-details-and-notifications_2026-09-10-01-55.json
+++ b/common/changes/@excitedjs/dreamux-types/refine-cot-tool-details-and-notifications_2026-09-10-01-55.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "teammate.input now carries an optional notice naming the producer of an automated push-back, and the tool.call contract states that invocation and arguments_json are published verbatim while every other member keeps Core redaction.",
+      "type": "minor",
+      "packageName": "@excitedjs/dreamux-types"
+    }
+  ],
+  "packageName": "@excitedjs/dreamux-types",
+  "email": "hvjfccdy6s@privaterelay.appleid.com"
+}

--- a/common/changes/@excitedjs/dreamux/refine-cot-tool-details-and-notifications_2026-09-10-01-55.json
+++ b/common/changes/@excitedjs/dreamux/refine-cot-tool-details-and-notifications_2026-09-10-01-55.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Publish tool call arguments and invocations to conversation displays exactly as the runtime wrote them, without secret masking or workspace/home path renaming; summaries, items, results, and message bodies keep their existing redaction. Completion push-backs now also state which TeamMate or Workflow reported, so a display can label them without parsing the notification body.",
+      "type": "minor",
+      "packageName": "@excitedjs/dreamux"
+    }
+  ],
+  "packageName": "@excitedjs/dreamux",
+  "email": "hvjfccdy6s@privaterelay.appleid.com"
+}

--- a/common/changes/@excitedjs/feishu-channel/refine-cot-tool-details-and-notifications_2026-09-10-01-55.json
+++ b/common/changes/@excitedjs/feishu-channel/refine-cot-tool-details-and-notifications_2026-09-10-01-55.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "COT tool rows now show what the call was: an argument code segment, then a RESULT label and divider, then the output, with a failure line inside the result area instead of ahead of the arguments. A call that named the items it was about still shows those pills alone, now including a failed one. A row the runtime labelled but named no action for uses that label as its title, and an unlabelled one shows its whole tool name. Automated push-backs display one line — TEAMMATE CALLBACK, CRON TRIGGERED, WORKFLOW FINISHED, SYSTEM RESTARTED — while the agent still receives the full notification.",
+      "type": "minor",
+      "packageName": "@excitedjs/feishu-channel"
+    }
+  ],
+  "packageName": "@excitedjs/feishu-channel",
+  "email": "hvjfccdy6s@privaterelay.appleid.com"
+}

--- a/packages/agent-runtime/codex/src/turn-manager.ts
+++ b/packages/agent-runtime/codex/src/turn-manager.ts
@@ -481,10 +481,35 @@ function itemActivity(
     toolName,
     ...toolDisplay(item),
     status: phase === 'started' ? 'started' : failed ? 'failed' : 'completed',
-    arguments: toJsonValue(item['arguments'] ?? item['input'] ?? item['command'] ?? item['changes'] ?? null),
+    arguments: argumentsFor(item),
     result: phase === 'completed' ? resultFor(item) : null,
     error,
   };
+}
+
+/**
+ * The call's own input, under whichever member of the item carries it.
+ *
+ * A web search states its input in `query` and `action` — the queries, the URL
+ * opened, the pattern looked for — rather than in a tool-call argument member,
+ * so those are its arguments. A search that only had a query carries
+ * `action: null`, which says the search had no action rather than that it had
+ * a null one, so an absent member is left out instead of shown as `null`.
+ * Every other item keeps the members codex already names for its input.
+ */
+function argumentsFor(item: ThreadItem): JsonValue | null {
+  if (item.type === 'webSearch') {
+    const query = item['query'] ?? null;
+    const action = item['action'] ?? null;
+    if (query === null && action === null) return null;
+    return toJsonValue({
+      ...(query === null ? {} : { query }),
+      ...(action === null ? {} : { action }),
+    });
+  }
+  return toJsonValue(
+    item['arguments'] ?? item['input'] ?? item['command'] ?? item['changes'] ?? null,
+  );
 }
 
 function resultFor(item: ThreadItem): JsonValue | null {

--- a/packages/agent-runtime/codex/tests/codex-runtime.test.ts
+++ b/packages/agent-runtime/codex/tests/codex-runtime.test.ts
@@ -855,6 +855,82 @@ describe('CodexRuntime native turn end', () => {
     await runtime.stop();
   });
 
+  it('projects what a web search asked for, which it states outside an argument member', async () => {
+    const activity: RuntimeActivity[] = [];
+    const client = new FakeCodexWsClient({ autoComplete: false });
+    const { deps } = makeDeps({ client, activitySink: (fact) => { activity.push(fact); } });
+    const runtime = new CodexRuntime(identity(null), deps);
+    await runtime.start();
+    const submission = requireSubmitted(await runtime.submit({ text: 'look it up' }));
+    const action = { type: 'search', queries: ['rust async traits', 'pin projection'] };
+    for (const phase of ['started', 'completed'] as const) {
+      client.emitItem('fresh-thread-1', 'turn-1', phase, {
+        type: 'webSearch',
+        id: 'search-1',
+        query: 'rust async traits',
+        action,
+      });
+    }
+    // A web search carries no `arguments`/`input`/`command`/`changes` member,
+    // so without this mapping the row could show nothing about what was asked.
+    // The label the TUI picks is unchanged, and the item has no invocation.
+    expect(activity.filter((fact) => fact.kind === 'tool.call')).toEqual(
+      ['started', 'completed'].map((status) => ({
+        kind: 'tool.call',
+        occurredAt: expect.any(Number),
+        id: `turn-1:search-1:${status}`,
+        callId: 'search-1',
+        toolName: 'web_search',
+        action: 'search',
+        summary: 'rust async traits …',
+        invocation: null,
+        items: [],
+        status,
+        arguments: { query: 'rust async traits', action },
+        result: null,
+        error: null,
+      })),
+    );
+    client.emitCompleted('fresh-thread-1', 'turn-1', 'found it');
+    await submission.settled;
+    await runtime.stop();
+  });
+
+  it('leaves out the action a plain web search reports as null', async () => {
+    const activity: RuntimeActivity[] = [];
+    const client = new FakeCodexWsClient({ autoComplete: false });
+    const { deps } = makeDeps({ client, activitySink: (fact) => { activity.push(fact); } });
+    const runtime = new CodexRuntime(identity(null), deps);
+    await runtime.start();
+    const submission = requireSubmitted(await runtime.submit({ text: 'look it up' }));
+    // A query-only search states its action as null, not as an absent member;
+    // showing `"action": null` in the row's arguments would be noise.
+    client.emitItem('fresh-thread-1', 'turn-1', 'completed', {
+      type: 'webSearch',
+      id: 'search-1',
+      query: 'rust async traits',
+      action: null,
+    });
+    expect(activity.filter((fact) => fact.kind === 'tool.call')).toEqual([{
+      kind: 'tool.call',
+      occurredAt: expect.any(Number),
+      id: 'turn-1:search-1:completed',
+      callId: 'search-1',
+      toolName: 'web_search',
+      action: 'search',
+      summary: 'rust async traits',
+      invocation: null,
+      items: [],
+      status: 'completed',
+      arguments: { query: 'rust async traits' },
+      result: null,
+      error: null,
+    }]);
+    client.emitCompleted('fresh-thread-1', 'turn-1', 'found it');
+    await submission.settled;
+    await runtime.stop();
+  });
+
   it('ends a native turn no submission ever bound, after its items displayed', async () => {
     const activity: RuntimeActivity[] = [];
     const client = new FakeCodexWsClient({ autoComplete: false });

--- a/packages/channel/feishu-channel/src/feishu-cot-activity.ts
+++ b/packages/channel/feishu-channel/src/feishu-cot-activity.ts
@@ -122,11 +122,11 @@ export function acceptAssistantMessage(
 }
 
 /**
- * One body Core admitted as input, on this recipient's card.
+ * One input Core admitted, on this recipient's card.
  *
  * The caller has already decided this is not the body the operator can see in
- * their own Feishu message; everything else — cron fires, task push-backs,
- * restart notices, another Channel's message — displays normally.
+ * their own Feishu message, and which text stands for it: a person's or an
+ * Agent's own words, or the one-line label an automated push-back gets.
  */
 export function acceptInputMessage(
   sink: CotActivitySink,

--- a/packages/channel/feishu-channel/src/feishu-cot-adapter.ts
+++ b/packages/channel/feishu-channel/src/feishu-cot-adapter.ts
@@ -49,6 +49,7 @@ import {
   acceptToolCallActivity,
   type CotActivitySink,
 } from './feishu-cot-activity.js';
+import { inputDisplayContent } from './feishu-cot-presentation.js';
 import { FeishuCotIo, type FeishuCotIoHandle } from './feishu-cot-io.js';
 import { FeishuInboundCorrelations } from './feishu-inbound-anchor.js';
 import {
@@ -210,7 +211,8 @@ export class FeishuCotAdapter {
    * the operator can already see as their own Feishu message. Recognition is a
    * comparison against the ids this session issued: a `source_id` is present on
    * cron fires, task push-backs, and restart notices too, so its mere presence
-   * proves nothing.
+   * proves nothing. What is shown for an automated push-back is the label the
+   * presentation layer picks, not the notification the model reads.
    */
   onInput(event: TeammateInputEvent): void {
     const found = this.stateFor(event);
@@ -218,7 +220,7 @@ export class FeishuCotAdapter {
     if (this.inboundCorrelations.consume(event.source_id)) return;
     acceptInputMessage(this.activity, found.key, found.state, {
       displayId: `input:${randomUUID()}`,
-      content: event.content,
+      content: inputDisplayContent(event),
     });
   }
 

--- a/packages/channel/feishu-channel/src/feishu-cot-events.ts
+++ b/packages/channel/feishu-channel/src/feishu-cot-events.ts
@@ -12,12 +12,13 @@ import {
   escapedBytes,
   nonEmpty,
   preserveSpacing,
+  prettyJson,
   toolPresentation,
   truncateEscaped,
   TRUNCATION_MARKER,
   type CotToolCallActivity,
 } from './feishu-cot-presentation.js';
-import type { CotItemList } from './feishu-cot-presentation.js';
+import type { CotCodeSegment } from './feishu-cot-presentation.js';
 
 export const FEISHU_COT_EVENT_CONTENT_MAX_BYTES = 4_096;
 export const FEISHU_COT_APPEND_MAX_BYTES = 64 * 1_024;
@@ -135,7 +136,8 @@ export function toolCallStartEvents(event: CotToolCallActivity): FeishuCotEventI
       },
     }),
     // No row sends `TOOL_CALL_ARGS`: beside a title the client shows the
-    // delta nowhere, and a row nothing could title hides its arguments.
+    // delta nowhere, and a row nothing could title hides it too. What the
+    // call was reaches the card as a segment of its result instead.
     checkedEvent({
       eventType: 'TOOL_CALL_END',
       content: { toolCallId },
@@ -148,28 +150,19 @@ export function toolCallResultEvents(event: CotToolCallActivity): FeishuCotEvent
   const messageId = opaqueDisplayId('result', event.event_id);
   const toolCallId = opaqueDisplayId('call', event.call_id);
   const presentation = toolPresentation(event);
-  const statusText = event.status === 'failed' ? 'Failed' : 'Completed';
-  let content: unknown;
-  if (presentation.items !== null && event.status !== 'failed') {
-    // A read or edit that succeeded shows its items and nothing else: the
-    // diff and the output are redundant beside the pills, and the client
-    // cannot fold a code segment away. A failed one keeps them, because the
-    // output is the only place the failure's reason appears.
-    content = assembleToolResultContent({
-      failed: false,
-      argumentsText: null,
-      items: presentation.items,
-      result: null,
-    });
-  } else {
-    content = assembleToolResultContent({
-      failed: event.status === 'failed',
-      argumentsText: presentation.invocation,
-      argumentsLanguage: presentation.invocationLanguage,
-      items: presentation.items,
-      result: toolResultOutput(event.result_json),
-    });
-  }
+  const failed = event.status === 'failed';
+  const statusText = failed ? 'Failed' : 'Completed';
+  // A call that named the things it was about is presented by those pills
+  // alone, whatever its status: they already say what it touched, and the
+  // client cannot fold a code segment away beside them, so a diff and an
+  // output below them would bury the row that was supposed to be a glance.
+  const content: unknown = presentation.items !== null
+    ? { type: 'list', ...presentation.items }
+    : toolResultContent(
+      failed,
+      presentation.arguments,
+      toolResultOutput(event.result_json),
+    );
   const projected = {
     eventType: 'TOOL_CALL_RESULT',
     content: {
@@ -243,21 +236,6 @@ function opaqueDisplayId(kind: string, source: string): string {
 
 
 /**
- * The pieces of one `TOOL_CALL_RESULT`: what the call was, in the caller's
- * notation, and what came back. Segments follow the COT Message Brief —
- * `{type:'text', text}` and `{type:'code', language, code}`, alone or as an
- * array — and `language` is documented as semantic only, never highlighted.
- */
-export interface ToolResultParts {
-  readonly failed: boolean;
-  readonly argumentsText: string | null;
-  readonly argumentsLanguage?: 'text' | 'bash';
-  /** The call's items, shown as the pills of a `list` segment before anything else. */
-  readonly items?: CotItemList | null;
-  readonly result: ToolResultOutput | null;
-}
-
-/**
  * What came back, as the card shows it: a structured value pretty-printed as
  * a `json` code segment, anything else as plain text — text output stays
  * text, and only what parses as JSON goes into a code segment. The whole text
@@ -274,14 +252,8 @@ export interface ToolResultOutput {
 export function toolResultOutput(resultJson: string | null): ToolResultOutput | null {
   const text = nonEmpty(resultJson);
   if (text === null) return null;
-  try {
-    const value: unknown = JSON.parse(text);
-    if (typeof value === 'object' && value !== null) {
-      return { kind: 'json', text: JSON.stringify(value, null, 2) };
-    }
-  } catch {
-    // Not JSON: the runtime's own text, shown as text.
-  }
+  const structured = prettyJson(text);
+  if (structured !== null) return { kind: 'json', text: structured };
   let boundary = -1;
   for (let line = 0; line < 10; line += 1) {
     boundary = text.indexOf('\n', boundary + 1);
@@ -295,64 +267,83 @@ export function toolResultOutput(resultJson: string | null): ToolResultOutput | 
   };
 }
 
-export function assembleToolResultContent(parts: ToolResultParts): unknown {
-  let argumentsText = parts.argumentsText;
-  let result = parts.result;
+/**
+ * The label that separates what was asked from what came back.
+ *
+ * Its own segment, before the output rather than glued onto it, so it survives
+ * whatever the output turns out to be — a `json` code block included. The blank
+ * line keeps the word a paragraph: directly above `---` it would be Markdown's
+ * setext heading instead.
+ */
+const RESULT_HEADER = 'RESULT\n\n---';
+
+/**
+ * One row's content, fitted to what a Feishu event may carry.
+ *
+ * The two variable strings are cut in the order a reader can spare them:
+ * output first, then the arguments, each shrunk by what the whole content
+ * overshot. Both shrink to their truncation marker at worst, and the fixed
+ * labels beside them are a few dozen bytes, so this always converges well
+ * inside the budget; `toolCallResultEvents` still measures the finished event.
+ */
+function toolResultContent(
+  failed: boolean,
+  argumentCode: CotCodeSegment | null,
+  output: ToolResultOutput | null,
+): unknown {
   const maxBytes = FEISHU_COT_EVENT_CONTENT_MAX_BYTES -
     EVENT_CONTENT_RESERVE_BYTES;
-  let content = toolResultSegments(parts, argumentsText, result);
+  let code = argumentCode;
+  let result = output;
+  let content = toolResultSegments(failed, code, result);
 
   if (jsonBytes(content) > maxBytes && result !== null) {
     result = {
       kind: result.kind,
       text: shrinkForContentBudget(result.text, jsonBytes(content) - maxBytes),
     };
-    content = toolResultSegments(parts, argumentsText, result);
+    content = toolResultSegments(failed, code, result);
   }
-  if (jsonBytes(content) > maxBytes && argumentsText !== null) {
-    argumentsText = shrinkForContentBudget(
-      argumentsText,
-      jsonBytes(content) - maxBytes,
-    );
-    content = toolResultSegments(parts, argumentsText, result);
-  }
-  if (jsonBytes(content) > maxBytes) {
-    result = null;
-    content = toolResultSegments(parts, argumentsText, result);
-  }
-  if (jsonBytes(content) > maxBytes) {
-    argumentsText = null;
-    content = toolResultSegments(parts, argumentsText, result);
-  }
-  if (jsonBytes(content) > maxBytes) {
-    return { type: 'text', text: parts.failed ? 'Failed' : 'Completed' };
+  if (jsonBytes(content) > maxBytes && code !== null) {
+    code = {
+      language: code.language,
+      code: shrinkForContentBudget(code.code, jsonBytes(content) - maxBytes),
+    };
+    content = toolResultSegments(failed, code, result);
   }
   return content;
 }
 
+/**
+ * What an expanded row shows, in the order it happened: what was asked, then
+ * the RESULT label, then what came back — a failure line included, because a
+ * failure is what that call returned and belongs on the same side of the label
+ * as the output explaining it. A call that succeeded with nothing to show says
+ * so in one word and needs no label.
+ */
 function toolResultSegments(
-  parts: ToolResultParts,
-  argumentsText: string | null,
+  failed: boolean,
+  argumentCode: CotCodeSegment | null,
   result: ToolResultOutput | null,
 ): unknown {
   const segments: Array<Record<string, unknown>> = [];
-  if (parts.failed) segments.push({ type: 'text', text: 'Failed' });
-  if (parts.items) segments.push({ type: 'list', ...parts.items });
-  if (argumentsText !== null) {
+  if (argumentCode !== null) {
     segments.push({
       type: 'code',
-      language: parts.argumentsLanguage ?? 'text',
-      code: argumentsText,
+      language: argumentCode.language,
+      code: argumentCode.code,
     });
   }
+  if (failed || result !== null) {
+    segments.push({ type: 'text', text: RESULT_HEADER });
+  }
+  if (failed) segments.push({ type: 'text', text: 'Failed' });
   if (result !== null) {
     segments.push(result.kind === 'json'
       ? { type: 'code', language: 'json', code: result.text }
       : { type: 'text', text: result.text });
   }
-  if (segments.length === 0) {
-    return { type: 'text', text: parts.failed ? 'Failed' : 'Completed' };
-  }
+  if (segments.length === 0) return { type: 'text', text: 'Completed' };
   return segments.length === 1 ? segments[0] : segments;
 }
 

--- a/packages/channel/feishu-channel/src/feishu-cot-presentation.ts
+++ b/packages/channel/feishu-channel/src/feishu-cot-presentation.ts
@@ -1,12 +1,13 @@
 /**
- * What a COT card shows for a tool call. Core redacts; this module owns display
- * text, deriving it from one tool call; `feishu-cot-events.ts`, its only
- * caller, builds the events and fits them to Feishu's per-event limit — the
+ * What a COT card shows for one Core fact — a tool call, or an input. Core
+ * redacts; this module owns display text, deriving it from that one fact;
+ * its callers build the events and fit them to Feishu's per-event limit — the
  * one bound a card string has, and the one truncation must follow.
  */
 import type {
   RuntimeToolAction,
   TeammateActivity,
+  TeammateInputEvent,
 } from '@excitedjs/dreamux-types';
 
 /** The one activity member this presentation layer renders. */
@@ -15,18 +16,29 @@ export type CotToolCallActivity = Extract<TeammateActivity, { kind: 'tool.call' 
 /** What the pills of a result's item list may spend before the rest is folded into a `more` pill. */
 export const TOOL_ITEMS_SOFT_MAX_BYTES = 512;
 export const TRUNCATION_MARKER = '… (truncated)';
-const TOOL_NAME_MAX_BYTES = 80;
 
-function displayToolName(toolName: string): string {
-  const leaf = toolName
-    .split(/(?:__|[.:/\\])/)
-    .filter((part) => part !== '')
-    .at(-1)
-    ?.trim();
-  return truncateUtf8(
-    leaf === undefined || leaf === '' ? 'tool' : leaf,
-    TOOL_NAME_MAX_BYTES,
-  );
+/**
+ * The provenance names Core's own automated producers use, and the one line a
+ * card shows instead of each notification's body.
+ *
+ * Provenance is open by contract — a consumer that presents inputs differently
+ * by source owns that mapping, which is this. A cron fire and a restart notice
+ * name themselves; a completion push-back names every producer the same way,
+ * so the producer comes from the event's own `notice` fact and never from
+ * reading the body back apart.
+ */
+const SCHEDULED_SOURCE = 'cron';
+const SYSTEM_SOURCE = 'system';
+
+export function inputDisplayContent(event: TeammateInputEvent): string {
+  if (event.notice !== null) {
+    return event.notice.kind === 'teammate_completion'
+      ? `TEAMMATE CALLBACK · ${event.notice.producer}`
+      : 'WORKFLOW FINISHED';
+  }
+  if (event.source === SCHEDULED_SOURCE) return 'CRON TRIGGERED';
+  if (event.source === SYSTEM_SOURCE) return 'SYSTEM RESTARTED';
+  return event.content;
 }
 
 
@@ -42,11 +54,18 @@ export interface CotItemList {
   readonly more?: CotListItem;
 }
 
+/** One `code` segment of a tool row, as the COT Message Brief shapes it. */
+export interface CotCodeSegment {
+  /** Documented as semantic only: the client labels the block, never highlights it. */
+  readonly language: 'text' | 'bash' | 'json';
+  readonly code: string;
+}
+
 /**
  * What the runtime said about the call, ready for the card: the row's title
  * composed from the runtime's summary, the icon of the action it named, the
- * invocation the expanded row shows in the caller's notation instead of as
- * JSON, and the items the call was about as the pills of a `list` segment.
+ * call's arguments as one code segment, and the items the call was about as
+ * the pills of a `list` segment.
  * Nothing here comes from the tool's identity: a Channel-owned tool and a
  * foreign MCP tool are presented by the same rule, so the Channel's hand-made
  * titles for its own `reply`, `react` and `list_chat_bots` all come back out.
@@ -55,8 +74,7 @@ interface ToolPresentation {
   readonly toolCallName: string;
   readonly icon?: CotToolIcon;
   readonly title?: string;
-  readonly invocation: string | null;
-  readonly invocationLanguage: 'text' | 'bash';
+  readonly arguments: CotCodeSegment | null;
   readonly items: CotItemList | null;
 }
 
@@ -65,8 +83,7 @@ interface ToolPresentation {
  * enum (`search`, `bash`, `read`, `write`, `doc`, `calendar`, `task`,
  * `meeting`, `default`) or a token from the card icon library. This Channel
  * uses the built-ins a runtime's tool actions map onto, and the library's
- * `app-default_outlined` for a call nothing could label; an MCP tool row also
- * hides its arguments.
+ * `app-default_outlined` for a call nothing could label.
  */
 export type CotToolIcon = 'search' | 'bash' | 'read' | 'write' | 'app-default_outlined';
 
@@ -102,11 +119,11 @@ const ACTION_VERBS: Readonly<Record<RuntimeToolAction, string>> = {
 
 export function toolPresentation(event: CotToolCallActivity): ToolPresentation {
   const actionName = event.tool_action === null
-    ? displayToolName(event.tool_name)
+    ? event.tool_name
     : ACTION_TOOL_NAMES[event.tool_action];
-  const title = runtimeToolTitle(event, actionName);
+  const title = runtimeToolTitle(event);
   // A call with neither an action nor a label — an MCP tool, today — shows
-  // its name behind the generic app icon; its arguments are not shown.
+  // its name behind the generic app icon.
   const icon: CotToolIcon | undefined = event.tool_action === null
     ? (title === null ? 'app-default_outlined' : undefined)
     : ACTION_ICONS[event.tool_action];
@@ -114,10 +131,54 @@ export function toolPresentation(event: CotToolCallActivity): ToolPresentation {
     toolCallName: actionName,
     ...(icon === undefined ? {} : { icon }),
     ...(title === null ? {} : { title }),
-    invocation: nonEmpty(event.invocation),
-    invocationLanguage: event.tool_action === 'run' ? 'bash' : 'text',
+    arguments: argumentCode(event),
     items: itemList(event),
   };
+}
+
+/**
+ * What the call was, as one code segment.
+ *
+ * `invocation` is the one member of the input that has a notation of its own —
+ * the command line, the diff, the prompt handed to a sub-agent — so it wins
+ * over the full structured input for every tool: it is what the runtime's own
+ * UI would show, and the JSON around it adds nothing a reader wants. Only a
+ * call that has none falls back to `arguments_json`, pretty-printed when it is
+ * an object or an array and shown as it came otherwise. The notation follows
+ * the action the runtime named: a `run` invocation is a shell command line,
+ * and nothing else claims to be.
+ */
+function argumentCode(event: CotToolCallActivity): CotCodeSegment | null {
+  const invocation = nonEmpty(event.invocation);
+  if (invocation !== null) {
+    return {
+      language: event.tool_action === 'run' ? 'bash' : 'text',
+      code: invocation,
+    };
+  }
+  const args = nonEmpty(event.arguments_json);
+  if (args === null) return null;
+  const structured = prettyJson(args);
+  return structured === null
+    ? { language: 'text', code: args }
+    : { language: 'json', code: structured };
+}
+
+/**
+ * The pretty-printed form of a payload that is a JSON object or array, or
+ * `null` for anything else — a bare scalar and unparsable text alike. What a
+ * value *is* decides how it is shown, on the way in and on the way back.
+ */
+export function prettyJson(text: string): string | null {
+  try {
+    const value: unknown = JSON.parse(text);
+    if (typeof value === 'object' && value !== null) {
+      return JSON.stringify(value, null, 2);
+    }
+  } catch {
+    // Not JSON: the runtime's own text, shown as text.
+  }
+  return null;
 }
 
 /**
@@ -148,12 +209,19 @@ function itemList(event: CotToolCallActivity): CotItemList | null {
   return { items };
 }
 
-function runtimeToolTitle(event: CotToolCallActivity, actionName: string): string | null {
+/**
+ * The row's title: the runtime's own one-line label for the call. A runtime
+ * that named an action labelled the object of the call — a path, a pattern —
+ * so the row leads with that action's verb; a runtime that named none wrote a
+ * whole label already, and repeating the tool's name in front of it says the
+ * same thing twice beside a row that already shows the name.
+ */
+function runtimeToolTitle(event: CotToolCallActivity): string | null {
   if (event.summary === null) return null;
   const summary = event.summary.trim();
   if (summary === '') return null;
   return event.tool_action === null
-    ? `${actionName}: ${summary}`
+    ? summary
     : `${ACTION_VERBS[event.tool_action]}${summary}`;
 }
 
@@ -197,19 +265,4 @@ export function truncateEscaped(value: string, maxBytes: number): string {
 
 export function escapedBytes(value: string): number {
   return Buffer.byteLength(JSON.stringify(value).slice(1, -1), 'utf8');
-}
-
-function truncateUtf8(value: string, maxBytes: number): string {
-  if (Buffer.byteLength(value, 'utf8') <= maxBytes) return value;
-  const markerBytes = Buffer.byteLength(TRUNCATION_MARKER, 'utf8');
-  const prefixBudget = Math.max(0, maxBytes - markerBytes);
-  const prefix: string[] = [];
-  let bytes = 0;
-  for (const character of value) {
-    const characterBytes = Buffer.byteLength(character, 'utf8');
-    if (bytes + characterBytes > prefixBudget) break;
-    prefix.push(character);
-    bytes += characterBytes;
-  }
-  return `${prefix.join('')}${TRUNCATION_MARKER}`;
 }

--- a/packages/channel/feishu-channel/tests/feishu-cot-delivery.test.ts
+++ b/packages/channel/feishu-channel/tests/feishu-cot-delivery.test.ts
@@ -148,6 +148,7 @@ function inputEvent(
     source,
     source_id: sourceId,
     content,
+    notice: null,
     redacted: false,
   };
 }

--- a/packages/channel/feishu-channel/tests/feishu-cot-tool-rows.test.ts
+++ b/packages/channel/feishu-channel/tests/feishu-cot-tool-rows.test.ts
@@ -5,10 +5,12 @@
  * `title`; `TOOL_CALL_RESULT` segments `{type:'text', text}`,
  * `{type:'code', language, code}` and `{type:'list', items, more?}`).
  *
- * What came back is shown by what it is, not by how long it is: a value that
- * parses as JSON is pretty-printed in a `json` code segment, anything else is
- * plain text (operator ruling, 2026-09-04). Plain text keeps ten content
- * lines; every result remains bounded by Feishu's per-event content limit.
+ * An expanded row reads in the order it happened: what was asked as one code
+ * segment, the RESULT label, then what came back. What came back is shown by
+ * what it is, not by how long it is: a value that parses as JSON is
+ * pretty-printed in a `json` code segment, anything else is plain text
+ * (operator ruling, 2026-09-04). Plain text keeps ten content lines; every
+ * result remains bounded by Feishu's per-event content limit.
  */
 
 import { describe, expect, it } from 'vitest';
@@ -45,6 +47,18 @@ function eventTypes(events: ReadonlyArray<{ eventType: string }>): string[] {
   return events.map((event) => event.eventType);
 }
 
+/**
+ * The label that stands between the call and what came back, as its own
+ * segment. The blank line keeps `RESULT` a paragraph: directly above `---` it
+ * would be Markdown's setext heading instead.
+ */
+const RESULT = { type: 'text', text: 'RESULT\n\n---' };
+
+/** The segments of one `TOOL_CALL_RESULT`, whether it sent one or many. */
+function segmentsOf(event: { content: unknown }): unknown {
+  return (event.content as { content: unknown }).content;
+}
+
 describe('runtime-labelled tool rows', () => {
   it('titles a run row with the runtime summary, icons it, and sends no raw arguments', () => {
     const events = toolCallStartEvents(toolCall({
@@ -74,6 +88,7 @@ describe('runtime-labelled tool rows', () => {
     expect(result!.content).toMatchObject({
       content: [
         { type: 'code', language: 'bash', code: 'node --check script.mjs\necho done' },
+        RESULT,
         { type: 'text', text: 'done' },
       ],
     });
@@ -97,32 +112,48 @@ describe('runtime-labelled tool rows', () => {
     expect(start!.content).toMatchObject({ toolCallName: 'List', icon: 'search', title: 'List src' });
   });
 
-  it('names the tool before the summary when the runtime has no action for it', () => {
+  it('titles a row the runtime labelled but named no action for with that label alone', () => {
     const [start] = toolCallStartEvents(toolCall({
       tool_name: 'Skill',
       tool_action: null,
       summary: 'team-workflow',
     }));
+    // No `Skill: ` prefix: the label is already a whole label, and the row
+    // shows the tool's name beside it anyway.
     expect(start!.content).toEqual({
       toolCallId: expect.any(String),
       toolCallName: 'Skill',
-      title: 'Skill: team-workflow',
+      title: 'team-workflow',
     });
   });
 
-  it('hides the arguments of a call nothing could label and gives it the generic app icon', () => {
+  it('names a call nothing could label by its whole name, behind the generic app icon', () => {
     const events = toolCallStartEvents(toolCall({
       tool_name: 'mcp__other__thing',
       tool_action: null,
       arguments_json: '{"x":1}',
     }));
+    // The name as the runtime spelled it: the leaf alone loses which server a
+    // foreign tool came from, and two servers may offer the same leaf.
     expect(eventTypes(events)).toEqual(['TOOL_CALL_START', 'TOOL_CALL_END']);
     expect(events[0]!.content).toEqual({
       toolCallId: expect.any(String),
-      toolCallName: 'thing',
+      toolCallName: 'mcp__other__thing',
       icon: 'app-default_outlined',
     });
   });
+
+  it('spells out a long name rather than cutting it at a length of its own', () => {
+    const toolName = `mcp__${'server-with-a-long-name'.repeat(3)}__do_the_thing`;
+    expect(toolName.length).toBeGreaterThan(80);
+    const [start] = toolCallStartEvents(toolCall({ tool_name: toolName, tool_action: null }));
+    expect(start!.content).toEqual({
+      toolCallId: expect.any(String),
+      toolCallName: toolName,
+      icon: 'app-default_outlined',
+    });
+  });
+
 
   it("presents the Channel's own tools by the same rule as any other MCP tool", () => {
     for (const toolName of ['mcp__chan-cot__reply', 'channel-chan-cot.react', 'feishu.list_chat_bots']) {
@@ -133,7 +164,7 @@ describe('runtime-labelled tool rows', () => {
       }));
       expect(start!.content).toEqual({
         toolCallId: expect.any(String),
-        toolCallName: toolName.split(/__|\./).at(-1),
+        toolCallName: toolName,
         icon: 'app-default_outlined',
       });
     }
@@ -141,13 +172,21 @@ describe('runtime-labelled tool rows', () => {
       tool_name: 'mcp__chan-cot__reply',
       tool_action: null,
       status: 'completed',
+      arguments_json: '{"chat_id":"oc_1","text":"hi"}',
       result_json: '{"message_ids":["om_1"]}',
     }));
-    // No fixed Completed line: the output expands like any other tool's — a
-    // structured value, so pretty-printed as JSON.
-    expect(result!.content).toMatchObject({
-      content: { type: 'code', language: 'json', code: '{\n  "message_ids": [\n    "om_1"\n  ]\n}' },
-    });
+    // No fixed Completed line: a tool with no notation of its own shows its
+    // whole structured input as JSON, and the output expands like any other
+    // tool's — also a structured value, so also pretty-printed.
+    expect(segmentsOf(result!)).toEqual([
+      {
+        type: 'code',
+        language: 'json',
+        code: '{\n  "chat_id": "oc_1",\n  "text": "hi"\n}',
+      },
+      RESULT,
+      { type: 'code', language: 'json', code: '{\n  "message_ids": [\n    "om_1"\n  ]\n}' },
+    ]);
   });
 
   it('expands a result into the invocation as a code segment and a text output as text', () => {
@@ -161,6 +200,7 @@ describe('runtime-labelled tool rows', () => {
       role: 'tool',
       content: [
         { type: 'code', language: 'bash', code: 'git status --short' },
+        RESULT,
         // The leading space is a no-break space: the client drops an ordinary one.
         { type: 'text', text: '\u00a0M src/a.ts\n?? src/b.ts' },
       ],
@@ -180,8 +220,9 @@ describe('runtime-labelled tool rows', () => {
     }));
     // Each space that begins a line or sits in a run of two or more becomes
     // U+00A0; the single spaces stay, so a long line still wraps at them.
-    expect(result!.content).toMatchObject({
-      content: {
+    expect(segmentsOf(result!)).toEqual([
+      RESULT,
+      {
         type: 'text',
         text: [
           'DIST_TAGS={',
@@ -191,7 +232,7 @@ describe('runtime-labelled tool rows', () => {
           'a single space between words stays a space',
         ].join('\n'),
       },
-    });
+    ]);
   });
 
   it('measures the cut after the spaces were converted', () => {
@@ -199,7 +240,7 @@ describe('runtime-labelled tool rows', () => {
       status: 'completed',
       result_json: '  x\n'.repeat(3_000),
     }));
-    const shown = (result!.content as { content: { type: string; text: string } }).content;
+    const shown = (segmentsOf(result!) as Array<{ type: string; text: string }>)[1]!;
     expect(shown.text.startsWith('\u00a0\u00a0x\n')).toBe(true);
     expect(shown.text.endsWith('… (truncated)')).toBe(true);
     // Two bytes per converted space, counted inside the event limit.
@@ -219,18 +260,20 @@ describe('runtime-labelled tool rows', () => {
       const [event] = toolCallResultEvents(toolCall({
         status: 'completed', result_json: ten + separator + eleventh,
       }));
-      expect(event!.content).toMatchObject({
-        content: { type: 'text', text: ten + separator + '… (truncated)' },
-      });
+      expect(segmentsOf(event!)).toEqual([
+        RESULT,
+        { type: 'text', text: ten + separator + '… (truncated)' },
+      ]);
     }
   });
 
   it.each([Array.from({ length: 12 }, (_, i) => i), { values: Array.from({ length: 12 }, (_, i) => i) }])(
     'keeps all lines of a JSON object or array', (value) => {
       const [event] = toolCallResultEvents(toolCall({ status: 'completed', result_json: JSON.stringify(value) }));
-      expect(event!.content).toMatchObject({
-        content: { type: 'code', language: 'json', code: JSON.stringify(value, null, 2) },
-      });
+      expect(segmentsOf(event!)).toEqual([
+        RESULT,
+        { type: 'code', language: 'json', code: JSON.stringify(value, null, 2) },
+      ]);
     },
   );
 
@@ -245,7 +288,7 @@ describe('runtime-labelled tool rows', () => {
     JSON.stringify({ values: Array.from({ length: 12 }, () => '界'.repeat(1_000)) }),
   ])('still applies the event byte limit after classification and line cutting', (output) => {
     const [event] = toolCallResultEvents(toolCall({ status: 'completed', result_json: output }));
-    const shown = (event!.content as { content: { text?: string; code?: string } }).content;
+    const shown = (segmentsOf(event!) as Array<{ text?: string; code?: string }>)[1]!;
     expect(shown.text ?? shown.code).toContain('… (truncated)');
     expect(Buffer.byteLength(JSON.stringify(event!.content), 'utf8')).toBeLessThanOrEqual(4_096);
   });
@@ -257,8 +300,9 @@ describe('runtime-labelled tool rows', () => {
       status: 'completed',
       result_json: '{"teammate":{"name":"tm-1","status":"running"},"status":"submitted"}',
     }));
-    expect(result!.content).toMatchObject({
-      content: {
+    expect(segmentsOf(result!)).toEqual([
+      RESULT,
+      {
         type: 'code',
         language: 'json',
         code: [
@@ -271,13 +315,13 @@ describe('runtime-labelled tool rows', () => {
           '}',
         ].join('\n'),
       },
-    });
+    ]);
   });
 
   it('shows an output that is not a JSON object or array as text, a bare scalar included', () => {
     for (const output of ['42', 'true', 'ok', '{"unterminated": 1']) {
       const [result] = toolCallResultEvents(toolCall({ status: 'completed', result_json: output }));
-      expect(result!.content).toMatchObject({ content: { type: 'text', text: output } });
+      expect(segmentsOf(result!)).toEqual([RESULT, { type: 'text', text: output }]);
     }
   });
 
@@ -286,7 +330,7 @@ describe('runtime-labelled tool rows', () => {
       status: 'completed',
       result_json: 'x'.repeat(10_000),
     }));
-    const shown = (result!.content as { content: { type: string; text: string } }).content;
+    const shown = (segmentsOf(result!) as Array<{ type: string; text: string }>)[1]!;
     expect(shown.type).toBe('text');
     expect(shown.text.endsWith('… (truncated)')).toBe(true);
     // Past the old 1,024-byte soft cap, inside the 4,096-byte event limit.
@@ -333,7 +377,7 @@ describe('runtime-labelled tool rows', () => {
     });
   });
 
-  it('keeps the diff and the output on a failed edit, after the failure line and the pills', () => {
+  it('shows a failed edit as its pills alone, like the one that succeeded', () => {
     const [result] = toolCallResultEvents(toolCall({
       tool_name: 'Edit',
       tool_action: 'edit',
@@ -343,13 +387,12 @@ describe('runtime-labelled tool rows', () => {
       items: ['src/a.ts'],
       result_json: 'file not found',
     }));
-    expect(result!.content).toMatchObject({
-      content: [
-        { type: 'text', text: 'Failed' },
-        { type: 'list', items: [{ text: 'src/a.ts', icon: 'write' }] },
-        { type: 'code', language: 'text', code: 'src/a.ts\n@@ -1 +1 @@\n-x\n+y' },
-        { type: 'text', text: 'file not found' },
-      ],
+    // A call that named what it was about is presented by that list, whatever
+    // its status: the pills already say what it touched, and the client cannot
+    // fold the diff away beside them.
+    expect(segmentsOf(result!)).toEqual({
+      type: 'list',
+      items: [{ text: 'src/a.ts', icon: 'write' }],
     });
   });
 
@@ -382,19 +425,149 @@ describe('runtime-labelled tool rows', () => {
     expect(list.more).toEqual({ text: `+${paths.length - list.items!.length}` });
   });
 
-  it('shows a failed result with its failure line first', () => {
+  it('puts a failure inside the result area, after the command that failed', () => {
     const [result] = toolCallResultEvents(toolCall({
       status: 'failed',
       summary: 'Run the tests',
       invocation: 'npm test',
       result_json: 'command failed',
     }));
-    expect(result!.content).toMatchObject({
-      content: [
-        { type: 'text', text: 'Failed' },
-        { type: 'code', language: 'bash', code: 'npm test' },
-        { type: 'text', text: 'command failed' },
-      ],
+    // Failed is what the call returned, so it belongs on the result side of
+    // the label, never in front of the command a reader is judging.
+    expect(segmentsOf(result!)).toEqual([
+      { type: 'code', language: 'bash', code: 'npm test' },
+      RESULT,
+      { type: 'text', text: 'Failed' },
+      { type: 'text', text: 'command failed' },
+    ]);
+  });
+
+  it('still opens a result area for a failure that returned no output', () => {
+    const [result] = toolCallResultEvents(toolCall({
+      status: 'failed',
+      summary: 'Run the tests',
+      invocation: 'npm test',
+    }));
+    expect(segmentsOf(result!)).toEqual([
+      { type: 'code', language: 'bash', code: 'npm test' },
+      RESULT,
+      { type: 'text', text: 'Failed' },
+    ]);
+  });
+
+  it('says Completed alone when a call succeeded with nothing to show', () => {
+    const [result] = toolCallResultEvents(toolCall({ status: 'completed' }));
+    expect(segmentsOf(result!)).toEqual({ type: 'text', text: 'Completed' });
+  });
+
+  it('shows the arguments alone when a call succeeded and returned nothing', () => {
+    const [result] = toolCallResultEvents(toolCall({
+      status: 'completed',
+      invocation: 'git add -A',
+    }));
+    expect(segmentsOf(result!)).toEqual({
+      type: 'code',
+      language: 'bash',
+      code: 'git add -A',
     });
+  });
+
+  it('prefers the invocation to the full arguments for every tool, not only Bash', () => {
+    const [result] = toolCallResultEvents(toolCall({
+      tool_name: 'Agent',
+      tool_action: null,
+      status: 'completed',
+      summary: 'Review the diff',
+      invocation: 'Review the diff and report only real defects.',
+      arguments_json: JSON.stringify({
+        description: 'Review the diff',
+        prompt: 'Review the diff and report only real defects.',
+        subagent_type: 'general-purpose',
+      }),
+      result_json: 'no defects found',
+    }));
+    // The prompt is what the call was; the JSON around it repeats the title
+    // and adds routing nobody reads. `text`, because only a `run` action
+    // claims to be a shell command line.
+    expect(segmentsOf(result!)).toEqual([
+      { type: 'code', language: 'text', code: 'Review the diff and report only real defects.' },
+      RESULT,
+      { type: 'text', text: 'no defects found' },
+    ]);
+  });
+
+  it('falls back to the structured input only when there is no invocation', () => {
+    const [result] = toolCallResultEvents(toolCall({
+      tool_name: 'mcp__probe__lookup',
+      tool_action: null,
+      status: 'completed',
+      arguments_json: '{"id":7,"deep":{"on":true}}',
+      result_json: 'ok',
+    }));
+    expect(segmentsOf(result!)).toEqual([
+      {
+        type: 'code',
+        language: 'json',
+        code: '{\n  "id": 7,\n  "deep": {\n    "on": true\n  }\n}',
+      },
+      RESULT,
+      { type: 'text', text: 'ok' },
+    ]);
+  });
+
+  it.each(['42', 'a bare string the runtime passed', '{"unterminated": 1'])(
+    'shows structured input that is not an object or an array as text code: %j',
+    (args) => {
+      const [result] = toolCallResultEvents(toolCall({
+        tool_name: 'mcp__probe__lookup',
+        tool_action: null,
+        status: 'completed',
+        arguments_json: args,
+      }));
+      expect(segmentsOf(result!)).toEqual({ type: 'code', language: 'text', code: args });
+    },
+  );
+
+  it('shows argument values exactly as the runtime wrote them', () => {
+    // Core hands this layer the real command on purpose: a masked one is a
+    // command nobody can judge. Nothing here rewrites paths or masks values.
+    const command = 'echo "token: dummy" > /tmp/cot-output.txt';
+    const [result] = toolCallResultEvents(toolCall({
+      status: 'completed',
+      invocation: command,
+      result_json: 'ok',
+    }));
+    expect(segmentsOf(result!)).toEqual([
+      { type: 'code', language: 'bash', code: command },
+      RESULT,
+      { type: 'text', text: 'ok' },
+    ]);
+  });
+
+  it('fits a long argument and a long output into one event, cutting both', () => {
+    const [result] = toolCallResultEvents(toolCall({
+      status: 'failed',
+      invocation: `echo ${'界'.repeat(3_000)}`,
+      result_json: '界'.repeat(3_000),
+    }));
+    const shown = segmentsOf(result!) as Array<{ type: string; text?: string; code?: string }>;
+    expect(shown.map((segment) => segment.type)).toEqual(['code', 'text', 'text', 'text']);
+    expect(shown[0]!.code!.endsWith('… (truncated)')).toBe(true);
+    expect(shown[1]).toEqual(RESULT);
+    expect(shown[2]).toEqual({ type: 'text', text: 'Failed' });
+    expect(shown[3]!.text!.endsWith('… (truncated)')).toBe(true);
+    expect(Buffer.byteLength(JSON.stringify(result!.content), 'utf8')).toBeLessThanOrEqual(4_096);
+  });
+
+  it('falls back to the status alone when even the pills do not fit', () => {
+    // The known list-budget limitation: many short items pass the pill budget
+    // and still overflow the event, and the row then says only how it ended.
+    const [result] = toolCallResultEvents(toolCall({
+      tool_action: 'edit',
+      status: 'failed',
+      items: Array.from({ length: 150 }, (_, i) => `f${i}`),
+    }));
+    expect(segmentsOf(result!)).toEqual({ type: 'text', text: 'Failed' });
+    expect(Buffer.byteLength(JSON.stringify(result!.content), 'utf8')).toBeLessThanOrEqual(4_096);
   });
 });

--- a/packages/channel/feishu-channel/tests/feishu-cot.test.ts
+++ b/packages/channel/feishu-channel/tests/feishu-cot.test.ts
@@ -128,6 +128,7 @@ function input(
   content: string,
   source = 'feishu',
   sourceId: string | null = null,
+  notice: TeammateInputEvent['notice'] = null,
 ): TeammateInputEvent {
   return {
     schema_version: 1,
@@ -137,6 +138,7 @@ function input(
     source,
     source_id: sourceId,
     content,
+    notice,
     redacted: false,
   };
 }
@@ -821,8 +823,8 @@ describe('FeishuCotSessionSeam — default-show, without a source whitelist', ()
     lease?.release();
   }
 
-  it.each(['task', 'task-notification', 'cron', 'system', 'a-future-source'])(
-    'shows a %s input once the recipient has an anchor',
+  it.each(['task', 'task-notification', 'a-future-source'])(
+    'shows a %s input body once the recipient has an anchor',
     async (source) => {
       const { seam, cot } = seamHarness();
       submitThroughSeam(
@@ -846,6 +848,62 @@ describe('FeishuCotSessionSeam — default-show, without a source whitelist', ()
       await seam.close();
     },
   );
+
+  /**
+   * An automated push-back is news about work, not a message anyone wrote, and
+   * its body is a paragraph of instructions addressed to the model. The card
+   * shows the one line that says which producer reported, and the model still
+   * receives the whole body — the two are different consumers of one input.
+   */
+  it.each([
+    {
+      what: 'a cron fire',
+      event: (): TeammateInputEvent =>
+        input(LEADER, 'Your scheduled job "nightly" is due …', 'cron'),
+      shown: 'CRON TRIGGERED',
+    },
+    {
+      what: 'a restart notice',
+      event: (): TeammateInputEvent =>
+        input(LEADER, 'The Dreamux dispatcher restarted; your session …', 'system'),
+      shown: 'SYSTEM RESTARTED',
+    },
+    {
+      what: 'a TeamMate completion',
+      event: (): TeammateInputEvent =>
+        input(
+          LEADER,
+          'TeamMate tm-scout has finished its task. This is an automated notification …',
+          'task-notification',
+          null,
+          { kind: 'teammate_completion', producer: 'tm-scout' },
+        ),
+      shown: 'TEAMMATE CALLBACK · tm-scout',
+    },
+    {
+      what: 'a Workflow completion',
+      event: (): TeammateInputEvent =>
+        input(
+          LEADER,
+          'Workflow wf_abc123 has completed. This is an automated notification …',
+          'task-notification',
+          null,
+          { kind: 'workflow_completion' },
+        ),
+      shown: 'WORKFLOW FINISHED',
+    },
+  ])('reduces $what to one line on the card', async ({ event, shown }) => {
+    const { seam, cot } = seamHarness();
+    submitThroughSeam(seam, LEADER, 'turn-channel', anchorAt('oc_team', 'om_1'));
+    await settle();
+
+    seam.handle(event());
+    seam.handle(message(LEADER, 'on it'));
+    await settle();
+
+    expectOpeningTexts(cot.cards[0]!, [shown, 'on it']);
+    await seam.close();
+  });
 
   it('forwards the turn end, which is the only terminal a card has', async () => {
     const { seam, cot } = seamHarness();

--- a/packages/dreamux-types/src/index.ts
+++ b/packages/dreamux-types/src/index.ts
@@ -118,6 +118,7 @@ export type {
   TeammateActivityEvent,
   TeammateActorScope,
   TeammateInputEvent,
+  TeammateInputNotice,
   TeammateRole,
   TeammateStateEvent,
   TeammateStatus,

--- a/packages/dreamux-types/src/teammate.ts
+++ b/packages/dreamux-types/src/teammate.ts
@@ -65,6 +65,19 @@ export interface TeammateActorScope {
 }
 
 /**
+ * Which producer's work an automated push-back reports.
+ *
+ * Carried only where the body alone cannot say it. A cron fire and a restart
+ * notice already name themselves through `source`, and an ordinary task or
+ * Channel message is the sender's own words; a completion push-back is the one
+ * input whose provenance name is the same for every producer, so the producer
+ * is stated here rather than recovered by parsing the notification prose.
+ */
+export type TeammateInputNotice =
+  | { readonly kind: 'teammate_completion'; readonly producer: string }
+  | { readonly kind: 'workflow_completion' };
+
+/**
  * Core admitted one input for this TeamMate.
  *
  * Published at the moment of submission, before any runtime has accepted it, so
@@ -91,13 +104,21 @@ export type TeammateInputEvent = TeammateActorScope & {
   readonly source_id: string | null;
   /** The source's own body, never the assembled provenance envelope. */
   readonly content: string;
+  /**
+   * What kind of automated push-back this is, when it is one. `null` for every
+   * input a person or an Agent wrote, whose body is what a reader wants. Its
+   * producer name is an Agent name the host assigned, not payload text, so it
+   * carries neither a secret nor a path and `redacted` never speaks for it.
+   */
+  readonly notice: TeammateInputNotice | null;
   readonly redacted: boolean;
 };
 
 /**
  * One thing the runtime did, in the runtime's own vocabulary, already
- * redacted by Core. Core bounds nothing here: how much of a payload a
- * surface can show is that surface's own limit, applied where it sends.
+ * redacted by Core — except for the two argument members named below. Core
+ * bounds nothing here: how much of a payload a surface can show is that
+ * surface's own limit, applied where it sends.
  *
  * The member names match `RuntimeActivity`'s on purpose: this is the same
  * fact with its payloads made safe to display, not a second vocabulary a
@@ -117,11 +138,19 @@ export type TeammateActivity =
       readonly tool_name: string;
       readonly tool_action: RuntimeToolAction | null;
       readonly summary: string | null;
+      /**
+       * What the call was, verbatim: the two argument members carry the
+       * runtime's own text with neither secret masking nor path renaming, so
+       * the command a reader is asked to judge is the command that ran. Every
+       * other member here, `redacted` included, keeps the ordinary policy.
+       */
       readonly invocation: string | null;
       readonly items: readonly string[];
       readonly status: 'started' | 'completed' | 'failed';
+      /** The call's full structured input as JSON text, verbatim like `invocation`. */
       readonly arguments_json: string | null;
       readonly result_json: string | null;
+      /** Whether any redacted member was rewritten; the argument members never count. */
       readonly redacted: boolean;
     }
   | {

--- a/packages/dreamux-types/tests/team-teammate-contract.test.ts
+++ b/packages/dreamux-types/tests/team-teammate-contract.test.ts
@@ -26,6 +26,7 @@ import type {
   TeammateActivityEvent,
   TeammateActorScope,
   TeammateInputEvent,
+  TeammateInputNotice,
   TeammateStateEvent,
 } from '../src/teammate.js';
 
@@ -252,6 +253,7 @@ describe('TeammateStateEvent, teammate.input, and teammate.activity', () => {
         | 'source'
         | 'source_id'
         | 'content'
+        | 'notice'
         | 'redacted'
       >
     >();
@@ -266,6 +268,7 @@ describe('TeammateStateEvent, teammate.input, and teammate.activity', () => {
       source: 'feishu',
       source_id: 'message-fixture',
       content: 'hello',
+      notice: null,
       redacted: false,
     };
 
@@ -274,6 +277,34 @@ describe('TeammateStateEvent, teammate.input, and teammate.activity', () => {
     // issued. Presence proves nothing: cron fires, task push-backs, and restart
     // notices carry a source id too.
     expect(Object.keys(input)).not.toContain('turn_id');
+  });
+
+  it('names the producer only for the push-backs whose provenance name cannot', () => {
+    const callback: TeammateInputEvent = {
+      schema_version: 1,
+      occurred_at: 1,
+      teammate_name: 'agent-1',
+      role: 'teammate',
+      team_name: 'team-a',
+      kind: 'teammate.input',
+      source: 'task-notification',
+      source_id: null,
+      content: 'TeamMate tm-1 has finished its task. …',
+      notice: { kind: 'teammate_completion', producer: 'tm-1' },
+      redacted: false,
+    };
+
+    // The body still carries the whole notification the model reads; the
+    // notice is the same fact stated as data, for a display that shows one line.
+    expect(callback.notice).toEqual({ kind: 'teammate_completion', producer: 'tm-1' });
+    expect(callback.content).toContain('has finished its task');
+    // A Workflow push-back names no producer: the operator's display shows none.
+    assertType<
+      Equal<
+        keyof Extract<TeammateInputNotice, { kind: 'workflow_completion' }>,
+        'kind'
+      >
+    >();
   });
 
   it('teammate.activity nests the whole runtime vocabulary under one kind, addressed by the actor alone', () => {

--- a/packages/dreamux/src/channel/conversation-projection.ts
+++ b/packages/dreamux/src/channel/conversation-projection.ts
@@ -5,6 +5,7 @@ import type {
   TeammateActivity,
   TeammateActivityEvent,
   TeammateInputEvent,
+  TeammateInputNotice,
   TeammateRole,
 } from '@excitedjs/dreamux-types';
 
@@ -72,6 +73,8 @@ export interface ConversationInput {
   readonly sourceId: string | null;
   /** The source's own body, never the assembled provenance envelope. */
   readonly text: string;
+  /** Which producer's work this reports, for the automated push-backs that carry one. */
+  readonly notice: TeammateInputNotice | null;
   readonly occurredAt: number;
 }
 
@@ -136,6 +139,11 @@ export function createConversationProjection(input: {
           source: admitted.source,
           source_id: admitted.sourceId,
           content: content.value,
+          // The producer is an Agent name this host assigned, from an alphabet
+          // (`TEAMMATE_NAME_PATTERN`) with no separator, colon, or space in it:
+          // no redaction rule can match one, and the two that could match its
+          // *shape* would only mangle a legal name.
+          notice: admitted.notice,
           redacted: content.redacted,
         };
         input.coreEvents.publish(identity.dispatcher_id, event);
@@ -207,12 +215,11 @@ function projectedActivity(
       const summary = activity.summary === null
         ? null
         : redactText(activity.summary, cwd, homePathPrefixes);
-      const invocation = activity.invocation === null
-        ? null
-        : redactText(activity.invocation, cwd, homePathPrefixes);
       const items = activity.items.map((item) => redactText(item, cwd, homePathPrefixes));
-      const args = redactJson(activity.arguments, cwd, homePathPrefixes);
-      const result = redactJson(activity.error ?? activity.result, cwd, homePathPrefixes);
+      const resultText = jsonText(activity.error ?? activity.result);
+      const result = resultText === null
+        ? null
+        : redactText(resultText, cwd, homePathPrefixes);
       return {
         kind: 'tool.call',
         event_id: activity.id,
@@ -220,14 +227,17 @@ function projectedActivity(
         tool_name: activity.toolName,
         tool_action: activity.action,
         summary: summary?.value ?? null,
-        invocation: invocation?.value ?? null,
+        // What the call was is shown as the runtime wrote it. A masked command
+        // is a command nobody can judge — the operator asked to read the real
+        // one — so these two members skip the redactor while every payload
+        // around them keeps it.
+        invocation: activity.invocation,
         items: items.map((item) => item.value),
         status: activity.status,
-        arguments_json: args?.value ?? null,
+        arguments_json: jsonText(activity.arguments),
         result_json: result?.value ?? null,
-        redacted: (summary?.redacted ?? false) || (invocation?.redacted ?? false) ||
-          items.some((item) => item.redacted) ||
-          (args?.redacted ?? false) || (result?.redacted ?? false),
+        redacted: (summary?.redacted ?? false) ||
+          items.some((item) => item.redacted) || (result?.redacted ?? false),
       };
     }
     case 'turn.ended': {
@@ -245,18 +255,17 @@ function projectedActivity(
 }
 
 /**
- * A structured value travels as its compact JSON text, redacted like any other
- * string; a value that already is a string travels as itself. A consumer that
- * wants the structure back parses the text — it is whole, never cut, and a
- * redacted secret inside it is still a JSON string, so it still parses.
+ * A structured value travels as its compact JSON text; a value that already is
+ * a string travels as itself. What this guarantees is the serialization: the
+ * text is whole, never cut. Parsability is not part of it — the result text
+ * still passes the redactor after this point, and a replacement that lands
+ * inside a JSON string can leave text no parser accepts — so a consumer that
+ * wants the structure back treats a parse failure as "this is text", which is
+ * what a display does with any payload it cannot read as JSON.
  */
-function redactJson(
-  value: JsonValue | string | null,
-  cwd: string,
-  homePathPrefixes: readonly string[],
-): RedactedText | null {
+function jsonText(value: JsonValue | string | null): string | null {
   if (value === null) return null;
-  return redactText(typeof value === 'string' ? value : JSON.stringify(value), cwd, homePathPrefixes);
+  return typeof value === 'string' ? value : JSON.stringify(value);
 }
 
 /**

--- a/packages/dreamux/src/service/teammate-service/index.ts
+++ b/packages/dreamux/src/service/teammate-service/index.ts
@@ -2,6 +2,7 @@ import type {
   AgentRuntimeInterruptOutcome,
   AgentRuntimeStartOutcome,
   AgentRuntimeStatus,
+  TeammateInputNotice,
   TeammateRole,
 } from '@excitedjs/dreamux-types';
 
@@ -319,6 +320,7 @@ export class TeammateService {
       source: input.source,
       sourceId: input.sourceId ?? null,
       text: input.text,
+      notice: input.notice ?? null,
       occurredAt: Date.now(),
     });
   }
@@ -368,8 +370,13 @@ export class TeammateService {
         completion,
         dispatcherCompletionSpillDir(this.current().dispatcher_id),
       );
+      // The body says whose work finished in prose the model reads; the notice
+      // says the same in facts, so a display can show one line without parsing
+      // that prose back apart.
       return Object.freeze({
-        submit: () => this.submitCompletionInput(body),
+        submit: () => this.submitCompletionInput(body, completion.kind === 'teammate'
+          ? { kind: 'teammate_completion', producer: completion.source }
+          : { kind: 'workflow_completion' }),
       });
     } finally {
       leave();
@@ -526,6 +533,7 @@ export class TeammateService {
    */
   private async submitCompletionInput(
     body: string,
+    notice: TeammateInputNotice,
   ): Promise<CompletionDeliveryResult> {
     let leave: (() => void) | null = null;
     try {
@@ -536,7 +544,7 @@ export class TeammateService {
     try {
       return asCompletionDeliveryResult(
         await this.submitAdmitted(
-          { source: COMPLETION_SOURCE, text: body },
+          { source: COMPLETION_SOURCE, text: body, notice },
           { wake: false },
         ),
       );

--- a/packages/dreamux/src/service/teammate-service/submission.ts
+++ b/packages/dreamux/src/service/teammate-service/submission.ts
@@ -22,16 +22,19 @@
  * converting its Markdown fences would corrupt exactly the text the source
  * meant the model to read.
  */
+import type { TeammateInputNotice } from '@excitedjs/dreamux-types';
+
 import type { TurnCompletionDelivery } from './turn-recording.js';
 
 /**
  * One admitted submission, as `TeammateService` accepts it.
  *
- * The first four fields are the complete model-facing input. The last three are
- * Core-only facts that are never rendered: `sourceId` is the key of the bounded
- * duplicate ledger, `intent` is the durable recovery subject of the turn Core
- * actually admits, and `deliverCompletion` is the optional callback for a
- * Core-side initiator awaiting this turn's completion.
+ * The first four fields are the complete model-facing input. The rest are
+ * Core-only facts that are never rendered: `notice` says which producer an
+ * automated push-back reports, `sourceId` is the key of the bounded duplicate
+ * ledger, `intent` is the durable recovery subject of the turn Core actually
+ * admits, and `deliverCompletion` is the optional callback for a Core-side
+ * initiator awaiting this turn's completion.
  */
 export interface TeammateSubmitInput {
   /** Open, owner-selected provenance name. Rendered as the envelope root. */
@@ -42,6 +45,12 @@ export interface TeammateSubmitInput {
   readonly text: string;
   /** One optional trailing note, rendered once after the source block. */
   readonly reminder?: string;
+  /**
+   * Which producer's work an automated push-back reports. Never rendered: the
+   * body already says it in the words the model reads, and this is the same
+   * fact for the display that shows a line instead of that body.
+   */
+  readonly notice?: TeammateInputNotice;
   /** Stable per-source id for Core's duplicate ledger. Never rendered. */
   readonly sourceId?: string;
   /** Recovery subject for a newly admitted turn. Never rendered. */

--- a/packages/dreamux/tests/admission-ledger.test.ts
+++ b/packages/dreamux/tests/admission-ledger.test.ts
@@ -589,6 +589,54 @@ describe('TeammateService.prepareCompletion: completion delivery defaults to the
     expect(deliveredText.startsWith('<task-notification')).toBe(true);
     expect(deliveredText).not.toMatch(/^<channel/);
   });
+
+  it.each([
+    {
+      what: 'a TeamMate',
+      fact: {
+        kind: 'teammate' as const,
+        source: 'reporter-agent',
+        status: 'completed' as const,
+        result: 'the work is done',
+      },
+      notice: { kind: 'teammate_completion', producer: 'reporter-agent' },
+      says: 'TeamMate reporter-agent has finished its task.',
+    },
+    {
+      what: 'a Workflow',
+      fact: {
+        kind: 'workflow' as const,
+        source: 'workflow' as const,
+        runId: 'wf-1',
+        status: 'completed' as const,
+        result: 'the run is done',
+      },
+      notice: { kind: 'workflow_completion' },
+      says: 'Workflow wf-1 has completed.',
+    },
+  ])('tells the display which producer reported when $what finished', async (
+    { fact, notice, says },
+  ) => {
+    const { projection, inputs } = recordingProjection();
+    const h = await harness({ conversationProjection: projection });
+    await h.service.submitInput({ source: 'channel', text: 'get started' });
+
+    await (await h.service.prepareCompletion(fact)).submit();
+
+    // Every provenance name here is the same `task-notification`, so the
+    // producer is stated as a fact rather than read back out of the prose.
+    expect(inputs[1]?.notice).toEqual(notice);
+    // The model still gets the whole notification body it always got.
+    expect(inputs[1]?.text).toContain(says);
+    expect(h.submittedInputs[1]?.text).toContain(says);
+  });
+
+  it('leaves an ordinary submission without a producer notice', async () => {
+    const { projection, inputs } = recordingProjection();
+    const h = await harness({ conversationProjection: projection });
+    await h.service.submitInput({ source: 'channel', text: 'do the thing' });
+    expect(inputs[0]?.notice).toBeNull();
+  });
 });
 
 /**

--- a/packages/dreamux/tests/completion-delivery.test.ts
+++ b/packages/dreamux/tests/completion-delivery.test.ts
@@ -471,6 +471,7 @@ describe('the real conversation projection presents a dispatcher completion deli
         source: COMPLETION_SOURCE,
         sourceId: null,
         text: 'TeamMate worker has finished its task.',
+        notice: { kind: 'teammate_completion', producer: 'worker' },
         occurredAt: Date.now(),
       },
     );
@@ -519,6 +520,7 @@ describe('the real conversation projection presents a dispatcher completion deli
         source: COMPLETION_SOURCE,
         sourceId: null,
         text: 'TeamMate worker has finished its task.',
+        notice: { kind: 'teammate_completion', producer: 'worker' },
         occurredAt: Date.now(),
       },
     );

--- a/packages/dreamux/tests/core-event-catalog.test.ts
+++ b/packages/dreamux/tests/core-event-catalog.test.ts
@@ -95,6 +95,7 @@ function catalogFixtures(): Record<ChannelCoreEvent['kind'], ChannelCoreEvent> {
       source: 'feishu',
       source_id: null,
       content: 'hi',
+      notice: null,
       redacted: false,
     },
     'teammate.activity': {
@@ -353,7 +354,7 @@ describe('DispatcherCoreEventBus: live, best-effort delivery', () => {
     const agent: ProjectedAgent = { identity, role: 'teammate' };
     expect(() =>
       projection.projectInput(agent, {
-        source: 'feishu', sourceId: null, text: 'go', occurredAt: Date.now(),
+        source: 'feishu', sourceId: null, text: 'go', notice: null, occurredAt: Date.now(),
       }),
     ).not.toThrow();
     expect(() =>
@@ -729,6 +730,7 @@ describe('display fact correlation', () => {
       source: 'feishu:chat-1',
       sourceId: 'message-fixture',
       text: 'investigate',
+      notice: null,
       occurredAt: Date.now(),
     });
     projection.projectActivity(agent, {
@@ -765,7 +767,7 @@ describe('display fact correlation', () => {
     const identity = makeIdentity({ team_id: 'alpha', name: 'scout' });
     const agent: ProjectedAgent = { identity, role: 'teammate' };
     projection.projectInput(agent, {
-      source: 'feishu:chat-1', sourceId: null, text: 'do it', occurredAt: Date.now(),
+      source: 'feishu:chat-1', sourceId: null, text: 'do it', notice: null, occurredAt: Date.now(),
     });
     projection.projectActivity(agent, {
       kind: 'turn.ended', occurredAt: Date.now(), status: 'completed', reason: null,
@@ -789,7 +791,7 @@ describe('display fact correlation', () => {
     const identity = makeIdentity({ team_id: null, name: 'scout' });
     const agent: ProjectedAgent = { identity, role: 'teammate' };
     projection.projectInput(agent, {
-      source: 'dispatcher:cli', sourceId: null, text: 'go', occurredAt: Date.now(),
+      source: 'dispatcher:cli', sourceId: null, text: 'go', notice: null, occurredAt: Date.now(),
     });
 
     expect(publisher.published).toHaveLength(0);
@@ -805,7 +807,7 @@ describe('display fact correlation', () => {
     const identity = makeIdentity({ team_id: 'alpha', name: 'scout' });
     const agent: ProjectedAgent = { identity, role: 'teammate' };
     projection.projectInput(agent, {
-      source: 'feishu', sourceId: null, text: 'go', occurredAt: Date.now(),
+      source: 'feishu', sourceId: null, text: 'go', notice: null, occurredAt: Date.now(),
     });
 
     expect(publisher.published).toHaveLength(0);

--- a/packages/dreamux/tests/cot-projection-privacy.test.ts
+++ b/packages/dreamux/tests/cot-projection-privacy.test.ts
@@ -35,6 +35,7 @@ import {
 } from './helpers/event-harness.js';
 
 const CWD = '/workspace/repo';
+const HOME = '/home/operator';
 
 function harness(overrides: { hasSources?: boolean } = {}) {
   const publisher = createCapturingPublisher(overrides.hasSources ?? true);
@@ -42,7 +43,7 @@ function harness(overrides: { hasSources?: boolean } = {}) {
   const projection = createConversationProjection({
     coreEvents: publisher,
     log: logger,
-    homePathPrefixes: [],
+    homePathPrefixes: [HOME],
   });
   const identity = makeIdentity({ team_id: 'alpha', name: 'scout', cwd: CWD });
   const agent: ProjectedAgent = { identity, role: 'teammate' };
@@ -76,6 +77,7 @@ function projectPrompt(
     source: 'feishu',
     sourceId: null,
     text,
+    notice: null,
     occurredAt: Date.now(),
   });
 }
@@ -372,7 +374,7 @@ describe('conversation projection: content visible after redaction is unchanged,
     expect(tool.kind === 'tool.call' && tool.redacted).toBe(false);
   });
 
-  it('renames workspace paths inside the tool summary and invocation, like every other payload', () => {
+  it('renames workspace paths in the summary and items while the call itself stays verbatim', () => {
     const { publisher, projection, agent } = harness();
     projection.projectActivity(agent, {
       kind: 'tool.call',
@@ -392,11 +394,16 @@ describe('conversation projection: content visible after redaction is unchanged,
 
     const tool = activityOf(publisher);
     expect(tool.kind === 'tool.call' && tool.summary).toBe('src/a.ts');
-    expect(tool.kind === 'tool.call' && tool.invocation).toBe('cat src/a.ts');
     expect(tool.kind === 'tool.call' && tool.items).toEqual(['src/a.ts']);
+    // The command a reader is asked to judge is the command that ran: the two
+    // argument members skip the redactor, paths included (operator ruling,
+    // 2026-09-09: "参数全给我放开，不要做脱敏了").
+    expect(tool.kind === 'tool.call' && tool.invocation).toBe(`cat ${CWD}/src/a.ts`);
+    expect(tool.kind === 'tool.call' && tool.arguments_json)
+      .toBe(JSON.stringify({ command: `cat ${CWD}/src/a.ts` }));
   });
 
-  it('passes a long summary through whole and folds a redacted invocation into redacted', () => {
+  it('passes a long summary through whole and leaves a secret-shaped invocation alone', () => {
     const { publisher, projection, agent } = harness();
     projection.projectActivity(agent, {
       kind: 'tool.call',
@@ -409,14 +416,46 @@ describe('conversation projection: content visible after redaction is unchanged,
       invocation: 'post https://example.test with Bearer abcDEF123.ghiJKL456-_9',
       items: [],
       status: 'started',
-      arguments: null,
+      arguments: { token: 'abc123secret', home: `${HOME}/keys` },
       result: null,
       error: null,
     });
 
     const tool = activityOf(publisher);
     expect(tool.kind === 'tool.call' && tool.summary?.length).toBe(100_000);
-    expect(tool.kind === 'tool.call' && tool.invocation).toBe('post https://example.test with Bearer <redacted>');
+    expect(tool.kind === 'tool.call' && tool.invocation)
+      .toBe('post https://example.test with Bearer abcDEF123.ghiJKL456-_9');
+    expect(tool.kind === 'tool.call' && tool.arguments_json)
+      .toBe(JSON.stringify({ token: 'abc123secret', home: `${HOME}/keys` }));
+    // Nothing the redactor still owns fired, so the row is not marked redacted:
+    // the argument members never count toward it.
+    expect(tool.kind === 'tool.call' && tool.redacted).toBe(false);
+  });
+
+  it('keeps the redactor on every member beside the two argument ones', () => {
+    const { publisher, projection, agent } = harness();
+    projection.projectActivity(agent, {
+      kind: 'tool.call',
+      occurredAt: Date.now(),
+      id: 'evt-1',
+      callId: 'call-1',
+      toolName: 'Bash',
+      action: 'run',
+      summary: 'echo with token: dummy',
+      invocation: 'echo "token: dummy"',
+      items: [`${CWD}/src/a.ts`],
+      status: 'failed',
+      arguments: { command: 'echo "token: dummy"' },
+      result: null,
+      error: 'failed with token: dummy',
+    });
+
+    const tool = activityOf(publisher);
+    expect(tool.kind === 'tool.call' && tool.summary).toBe('echo with token: <redacted>');
+    expect(tool.kind === 'tool.call' && tool.result_json).toBe('failed with token: <redacted>');
+    expect(tool.kind === 'tool.call' && tool.items).toEqual(['src/a.ts']);
+    expect(tool.kind === 'tool.call' && tool.invocation)
+      .toBe('echo "token: dummy"');
     expect(tool.kind === 'tool.call' && tool.redacted).toBe(true);
   });
 

--- a/packages/dreamux/tests/input-source-lifecycle.test.ts
+++ b/packages/dreamux/tests/input-source-lifecycle.test.ts
@@ -351,6 +351,7 @@ function allCatalogEvents(): ChannelCoreEvent[] {
       source: 'channel',
       source_id: null,
       content: 'hi',
+      notice: null,
       redacted: false,
     },
     {

--- a/packages/dreamux/tests/package-boundary-guards.test.ts
+++ b/packages/dreamux/tests/package-boundary-guards.test.ts
@@ -430,6 +430,7 @@ describe('each package\'s index.ts re-export set is an intentional, pinned surfa
         'TeammateStateEvent',
         'TeammateStatus',
         'TeammateInputEvent',
+        'TeammateInputNotice',
       ].sort(),
     );
   });


### PR DESCRIPTION
Tool rows now show invocation or structured arguments before a labeled result area. Failed appears inside that result area instead of before the command. Automated completion and schedule inputs use concise labels on the Feishu card while the model still receives their complete bodies.

- Preserve fixed action titles and icons. Other rows use the runtime summary or complete tool name; remove the separate 80-byte name cap while retaining the existing START title fitting and event-size check.
- Prefer invocation, then formatted JSON/text arguments, with no ARGUMENTS heading. Argument and invocation values bypass masking and path rewriting under the approved display policy; other payload fields keep their existing redaction rules.
- Emit a separate RESULT/divider segment before failure text and output. Rows with items remain list-only, including failed calls; existing whitespace, line limits, and list-overflow behavior remain.
- Carry completion kind and producer through the existing input projection for TEAMMATE CALLBACK, WORKFLOW FINISHED, CRON TRIGGERED, and SYSTEM RESTARTED labels. No provider language-classification contract is added.
- Forward Codex web-search query/action as arguments. Add the requested workflow clarification rule and concise TeamMate briefing examples.

Validation: Rush build, lint, test (2418 passed), typecheck:tests, and smoke-built-cli pass. Skill validation, KB checks, git diff --check, mandatory pre-commit scans, and Rush change verification against origin/next pass. Fresh Feishu client probing has not been performed for this implementation. [GitHub CI](https://github.com/excitedjs/dreamux/actions/runs/34393066051) passed all 9 checks, including Linux and macOS build/test jobs. Final external review is pending.

[Requirement and operator decisions](.agents/tasks/channel/refine-cot-tool-details-and-notifications/requirement.md) · [Verification](.agents/tasks/channel/refine-cot-tool-details-and-notifications/verification.md)

Alpha: `@excitedjs/dreamux@0.25.0-alpha.g3180b18cd009`, published from this implementation by [release run 34393391714](https://github.com/excitedjs/dreamux/actions/runs/34393391714).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
