### PR TITLE
fix: route question answers from their actual card

### DIFF
--- a/.agents/domains/channel.md
+++ b/.agents/domains/channel.md
@@ -165,20 +165,22 @@ field descriptions, so a model reads the two as one tool: 1-4 `questions`, each
 with a `header` chip, a `question`, and 2-4 `options` of `label` +
 `description`. Four fields differ, and two of them are the chat. A `chat_id` is
 required, because a chat tool needs a destination and AskUserQuestion has no
-such concept; a `message_id` is optional, and when the model names the message
-its question came out of, the card is addressed the way a reply is — into that
-message's topic, under the anchor the target router already holds for it. With
-no message named, the card is addressed at the chat, which in a topic group
-opens a topic of its own: right for a question belonging to no particular
-message, wrong for one that does. A message id from another chat is ignored
-rather than obeyed, the same rule `reply` follows, so a stale id cannot
-redirect a question into a conversation it was not meant for.
+such concept; a `message_id` is optional. When supplied, that exact id addresses
+an interactive-card reply, just as it does for `reply`, without an observed-message
+lookup or anchor substitution. Without it the card is created in the named chat;
+in a topic group it opens a topic of its own.
 
-After a successful question-card send, the session records the returned message
-ids against the question's target in the existing observed-message ledger. The
-answer envelope and presentation anchor carry the answered card's message id.
-A subsequent question using that id therefore inherits the same topic; it
-does not substitute the earlier human message or the round's deduplication id.
+Question rounds store their sent card id, not a precomputed routing target. On
+submission or cancellation, the card callback identifies the answered card. Feishu
+message lookup supplies its actual chat and optional thread id for existing
+chat-mode and binding routing. Expiry resolves the sent card id through the same
+path. The answer envelope and presentation anchor carry that card id, never the
+earlier human message or the round's deduplication id. A failed lookup is logged
+as a delivery failure; it is not a reason to route to a guessed parent chat.
+
+This adds one message query per settlement. The existing Feishu message reader
+exposes chat/topic metadata alongside content; Core and runtime providers acquire
+no Feishu-specific fields or routing responsibilities.
 
 The other two fields are gone. There is no `multiSelect`: the operator ruled
 multi-select out of this channel, so every question takes exactly one answer.

--- a/.agents/domains/channel.md
+++ b/.agents/domains/channel.md
@@ -174,6 +174,12 @@ message, wrong for one that does. A message id from another chat is ignored
 rather than obeyed, the same rule `reply` follows, so a stale id cannot
 redirect a question into a conversation it was not meant for.
 
+After a successful question-card send, the session records the returned message
+ids against the question's target in the existing observed-message ledger. The
+answer envelope and presentation anchor carry the answered card's message id.
+A subsequent question using that id therefore inherits the same topic; it
+does not substitute the earlier human message or the round's deduplication id.
+
 The other two fields are gone. There is no `multiSelect`: the operator ruled
 multi-select out of this channel, so every question takes exactly one answer.
 And there is no `preview`: it was first drawn as a column beside the options,

--- a/.agents/product/README.md
+++ b/.agents/product/README.md
@@ -43,10 +43,14 @@ the same change that touches it.
   tool returns as soon as the card is sent, never the answer. Anyone in the chat
   may answer, an explicit operator ruling rather than a gap, and the answer
   arrives as an ordinary inbound message carrying who clicked and the answered
-  card's message id. Follow-up questions addressed to that card stay in its
-  existing topic. Dismissing the card tells the agent to stop asking and talk
-  it through instead; a card nobody answers closes itself before Feishu stops
-  accepting clicks and tells the agent to stand still rather than wait forever.
+  card's message id. A supplied reply message id is used directly, including
+  one the session has not observed; without one, the card is a new chat message.
+  Answers and expiry notices follow the card's actual conversation, obtained
+  from message details. A failed lookup does not redirect them to the parent
+  chat. Follow-up questions addressed to the card stay in its existing topic.
+  Dismissing the card tells the agent to stop asking and talk it through instead;
+  a card nobody answers closes itself before Feishu stops accepting clicks and
+  tells the agent to stand still rather than wait forever.
   (Domain: [channel](/.agents/domains/channel.md).)
 - **A message that starts with a known slash command is executed, not
   delivered.** In the built-in Feishu channel a human message whose leading

--- a/.agents/product/README.md
+++ b/.agents/product/README.md
@@ -42,10 +42,11 @@ the same change that touches it.
   questions, each with an "Other" text box — and the agent stops and waits: the
   tool returns as soon as the card is sent, never the answer. Anyone in the chat
   may answer, an explicit operator ruling rather than a gap, and the answer
-  arrives as an ordinary inbound message carrying who clicked. Dismissing the
-  card tells the agent to stop asking and talk it through instead; a card nobody
-  answers closes itself before Feishu stops accepting clicks and tells the agent
-  to stand still rather than wait forever.
+  arrives as an ordinary inbound message carrying who clicked and the answered
+  card's message id. Follow-up questions addressed to that card stay in its
+  existing topic. Dismissing the card tells the agent to stop asking and talk
+  it through instead; a card nobody answers closes itself before Feishu stops
+  accepting clicks and tells the agent to stand still rather than wait forever.
   (Domain: [channel](/.agents/domains/channel.md).)
 - **A message that starts with a known slash command is executed, not
   delivered.** In the built-in Feishu channel a human message whose leading

--- a/.agents/tasks/channel/README.md
+++ b/.agents/tasks/channel/README.md
@@ -25,4 +25,4 @@
 - [Align Codex command display parsing](/.agents/tasks/channel/align-codex-command-display/README.md) — `done`: Show the inner shell script in Codex tool rows instead of the shell launcher wrapper
 - [Display turn usage summaries](/.agents/tasks/channel/display-turn-usage-summary/README.md) — `done`: Implement native context and cumulative token usage as the final assistant activity; draft-only delivery pending live Codex verification.
 - [Refine COT tool details and notification display](/.agents/tasks/channel/refine-cot-tool-details-and-notifications/README.md) — `done`: After #401, show actual output without an extra status line; show Complete or Failed below a divider only when output is absent, without a RESULT heading.
-- [Keep question-card replies in their topic](/.agents/tasks/channel/fix-question-card-topic-routing/README.md) — `done`: Preserve the answered card message identity and route follow-up questions to its existing topic
+- [Keep question-card replies in their topic](/.agents/tasks/channel/fix-question-card-topic-routing/README.md) — `review`: Send explicit card replies and route settlements from the actual card's conversation.

--- a/.agents/tasks/channel/README.md
+++ b/.agents/tasks/channel/README.md
@@ -25,3 +25,4 @@
 - [Align Codex command display parsing](/.agents/tasks/channel/align-codex-command-display/README.md) — `done`: Show the inner shell script in Codex tool rows instead of the shell launcher wrapper
 - [Display turn usage summaries](/.agents/tasks/channel/display-turn-usage-summary/README.md) — `done`: Implement native context and cumulative token usage as the final assistant activity; draft-only delivery pending live Codex verification.
 - [Refine COT tool details and notification display](/.agents/tasks/channel/refine-cot-tool-details-and-notifications/README.md) — `done`: After #401, show actual output without an extra status line; show Complete or Failed below a divider only when output is absent, without a RESULT heading.
+- [Keep question-card replies in their topic](/.agents/tasks/channel/fix-question-card-topic-routing/README.md) — `done`: Preserve the answered card message identity and route follow-up questions to its existing topic

--- a/.agents/tasks/channel/fix-question-card-topic-routing/README.md
+++ b/.agents/tasks/channel/fix-question-card-topic-routing/README.md
@@ -1,0 +1,27 @@
+# Keep question-card replies in their topic
+
+- Goal: Keep follow-up questions in the answered card's topic.
+- State: `done`
+- Requirement: [Current requirement](/.agents/tasks/channel/fix-question-card-topic-routing/requirement.md)
+- Final solution: [Minimal repair](/.agents/tasks/channel/fix-question-card-topic-routing/technical-design/final.md)
+- Verification: [Evidence](/.agents/tasks/channel/fix-question-card-topic-routing/verification.md)
+- Solution review Issue: Not needed for the minimal-change fast path.
+- Blockers: None.
+- Next action: Open the reviewed repair PR to next and wait for CI.
+- Related tasks: Found during [COT display work](../refine-cot-tool-details-and-notifications/README.md); this is an independent, pre-existing routing defect.
+
+## Development approval
+
+The operator requested the repair on 2026-09-10 after the diagnosis was reported:
+“修一下这个回复卡片问题”. The accompanying constraint was:
+“我的回复消息应该带上的是回复的卡片的message_id，不应该带别的。”
+
+Approved boundary: question-card topic routing with the answered card identity
+preserved. The TeamLeader owns this mechanically direct local repair and its
+verification; no public or persisted contract changes.
+
+## Delivery
+
+- Baseline: `22cf0a7a53ea636daad9c939ff2185e3379bc42e` from freshly fetched next.
+- Pull request / CI / merge: Pending.
+- Knowledge closeout: Complete; channel domain and product behavior match the reviewed implementation.

--- a/.agents/tasks/channel/fix-question-card-topic-routing/README.md
+++ b/.agents/tasks/channel/fix-question-card-topic-routing/README.md
@@ -1,16 +1,24 @@
 # Keep question-card replies in their topic
 
 - Goal: Keep follow-up questions in the answered card's topic.
-- State: `done`
+- State: `review`
 - Requirement: [Current requirement](/.agents/tasks/channel/fix-question-card-topic-routing/requirement.md)
-- Final solution: [Minimal repair](/.agents/tasks/channel/fix-question-card-topic-routing/technical-design/final.md)
+- Final solution: [Actual-card routing](/.agents/tasks/channel/fix-question-card-topic-routing/technical-design/final.md)
 - Verification: [Evidence](/.agents/tasks/channel/fix-question-card-topic-routing/verification.md)
-- Solution review Issue: Not needed for the minimal-change fast path.
+- Solution review Issue: The operator approved the replacement in conversation; review proceeds on PR #402.
 - Blockers: None.
-- Next action: Open the reviewed repair PR to next and wait for CI.
+- Next action: Publish the verified revision and obtain DevBox review on PR #402.
 - Related tasks: Found during [COT display work](../refine-cot-tool-details-and-notifications/README.md); this is an independent, pre-existing routing defect.
 
 ## Development approval
+
+On 2026-09-10 the operator approved replacing the minimal repair with direct
+reply addressing and message-query-based settlement routing:
+“可以，改一下提个 pr 上去我看看”. The current requirement and final solution record
+that proposal. This approval includes removal of the precomputed round target,
+the shared expiry resolution path, and one message lookup per settlement.
+
+### Earlier minimal repair approval
 
 The operator requested the repair on 2026-09-10 after the diagnosis was reported:
 “修一下这个回复卡片问题”. The accompanying constraint was:
@@ -23,5 +31,16 @@ verification; no public or persisted contract changes.
 ## Delivery
 
 - Baseline: `22cf0a7a53ea636daad9c939ff2185e3379bc42e` from freshly fetched next.
-- Pull request / CI / merge: Pending.
-- Knowledge closeout: Complete; channel domain and product behavior match the reviewed implementation.
+- Pull request: https://github.com/excitedjs/dreamux/pull/402 (open).
+- Earlier repair: `1e011989dff1487ca45120bb4cfab206bc7b6438`, CI passed and Alpha published.
+- Current revision: Actual-card routing implemented on next `6bb8a713`; local gates passed.
+- Review: DevBox review of this revision is pending. Do not reuse the earlier patch approval.
+- Knowledge closeout: Channel and product documentation updated for actual-card routing.
+
+## Review workflow ruling
+
+The operator explicitly replaced the planned independent workflow review:
+“不要跑 dynamic-workflow 了。你直接找 devbox 去 review” (2026-09-10).
+No workflow review was started. TeamLeader pre-review and repository checks run
+before publication; DevBox reviews the updated PR directly. The previous approval
+of the minimal patch is not a review of this revision.

--- a/.agents/tasks/channel/fix-question-card-topic-routing/requirement.md
+++ b/.agents/tasks/channel/fix-question-card-topic-routing/requirement.md
@@ -1,12 +1,57 @@
 # Requirement
 
-## Confirmed outcome
+## Current approved outcome (2026-09-10)
 
-The operator requested a fix for follow-up question cards opening a new topic.
-The answer must carry the message id of the card being answered:
-“我的回复消息应该带上的是回复的卡片的message_id，不应该带别的。”
+The original constraint was: “我的回复消息应该带上的是回复的卡片的message_id，不应该带别的。”
+After reviewing the minimal repair, the operator approved the proposed replacement:
+“可以，改一下提个 pr 上去我看看”. The accepted proposal separates sending a card
+from routing its answer:
+
+- Send exactly as `reply` does: an explicit `message_id` addresses a reply to
+  that message; without it, create a message in `chat_id`.
+- Route submitted and cancelled answers from the actual card's message details,
+  using the callback's card message id. Preserve that id in the answer envelope
+  and presentation anchor.
+- Expiry uses the sent card id through the same message-query and delivery path.
+- Remove the question round's precomputed `target`. Resolve the card's actual
+  chat/topic through Feishu message lookup and the existing binding router.
+- A failed lookup is a delivery failure, never evidence that the answer belongs
+  to the parent chat or Dispatcher. One lookup per settlement is accepted.
+- Keep this change within Feishu transport/channel. No Core, runtime provider,
+  shared Dreamux contract, persistence, new routing cache, or COT display change.
+
+This supersedes the earlier restriction on API lookup and on preserving unknown
+message and cross-chat send behavior: sending now follows the explicit message id
+just as `reply` does. It does not change unrelated notification sending.
 
 ## Current source evidence
+
+Feishu callback context exposes `open_message_id` and `open_chat_id`, but no
+`thread_id`. The existing `im.v1.message.get` reader discards the response's chat
+and topic fields. Expose those Feishu facts and reuse existing inbound routing.
+The current question registry stores a target inferred before sending; its
+settlement carries that target even if the actual card was sent elsewhere.
+
+Official contracts:
+
+- [Card callback](https://open.larkoffice.com/document/feishu-cards/card-callback-communication)
+- [Message details](https://open.larkoffice.com/document/server-docs/im-v1/message/get)
+
+## Acceptance
+
+1. Explicit message ids reach the card reply transport unchanged, including an
+   id absent from the observation ledger. No id still creates a new message.
+2. Submitted and cancelled answers resolve the actual card's chat/topic, and
+   carry that card id in both their envelope and anchor.
+3. Consecutive rounds remain in the actual topic without relying on prior card
+   observation. Expiry uses the sent card id and the same resolution path.
+4. Lookup failures do not deliver to an inferred parent chat or Dispatcher.
+5. Existing ordinary-message routing, card lifecycle, and content-reading
+   behavior remain intact. No precomputed target survives in a question round.
+
+## Earlier minimal repair (superseded)
+
+### Earlier source evidence
 
 `askUserQuestion` resolves the original message's target and sends a card, but
 never records the resulting card id in `FeishuTargetRouter`. Settlement already
@@ -15,7 +60,7 @@ question addressed to that card misses the router's observed-message ledger and
 falls back to the group; transport receives no reply anchor and creates a new
 message/topic. The defect predates the COT display change.
 
-## Scope and invariants
+### Earlier scope and invariants
 
 - Keep successive question/answer rounds in an already observed topic.
 - Preserve the answered card id in the answer envelope and presentation anchor.
@@ -23,7 +68,7 @@ message/topic. The defect predates the COT display change.
 - Leave no-message, unknown-message and cross-chat behavior unchanged.
 - No new fields, persistence, API lookup, routing fallback, or COT display change.
 
-## Acceptance
+### Earlier acceptance
 
 1. A question addressed to an observed message is sent in its topic.
 2. Clicking and submitting it delivers the actual card id as `message_id` and
@@ -33,4 +78,4 @@ message/topic. The defect predates the COT display change.
    and its answer carries the second card's id.
 4. Existing routing, question registry and settlement tests continue to pass.
 
-No unsettled product decisions remain within this boundary.
+These restrictions describe the earlier repair, not the current brief.

--- a/.agents/tasks/channel/fix-question-card-topic-routing/requirement.md
+++ b/.agents/tasks/channel/fix-question-card-topic-routing/requirement.md
@@ -1,0 +1,36 @@
+# Requirement
+
+## Confirmed outcome
+
+The operator requested a fix for follow-up question cards opening a new topic.
+The answer must carry the message id of the card being answered:
+“我的回复消息应该带上的是回复的卡片的message_id，不应该带别的。”
+
+## Current source evidence
+
+`askUserQuestion` resolves the original message's target and sends a card, but
+never records the resulting card id in `FeishuTargetRouter`. Settlement already
+uses the card id in both the answer envelope and presentation anchor. A later
+question addressed to that card misses the router's observed-message ledger and
+falls back to the group; transport receives no reply anchor and creates a new
+message/topic. The defect predates the COT display change.
+
+## Scope and invariants
+
+- Keep successive question/answer rounds in an already observed topic.
+- Preserve the answered card id in the answer envelope and presentation anchor.
+- Reuse the existing message-to-target ledger and its lifetime and bounds.
+- Leave no-message, unknown-message and cross-chat behavior unchanged.
+- No new fields, persistence, API lookup, routing fallback, or COT display change.
+
+## Acceptance
+
+1. A question addressed to an observed message is sent in its topic.
+2. Clicking and submitting it delivers the actual card id as `message_id` and
+   the presentation anchor; neither the earlier message nor the synthetic round
+   id replaces it.
+3. A second question using that answer's `message_id` stays in the same topic,
+   and its answer carries the second card's id.
+4. Existing routing, question registry and settlement tests continue to pass.
+
+No unsettled product decisions remain within this boundary.

--- a/.agents/tasks/channel/fix-question-card-topic-routing/technical-design/final.md
+++ b/.agents/tasks/channel/fix-question-card-topic-routing/technical-design/final.md
@@ -1,18 +1,31 @@
-# Minimal repair
+# Route question answers from the actual card
 
-After `askUserQuestion` successfully sends the card, record every returned message
-id against its already resolved `target` with `FeishuTargetRouter.observe`, then
-activate the round as before. This is the same existing ledger used for sent
-replies and notifications. Failed sends never reach the registration step.
+Approved on 2026-09-10 after the minimal observation-ledger repair in PR #402.
 
-Keep `deliverAskUserSettlement` unchanged: its envelope and presentation anchor
-already identify the answered card correctly. No other layer needs a new fact.
+Sending a question uses the caller's chat id and optional reply message id
+directly, matching `reply`. It no longer passes through `outboundTarget` and
+`notificationTarget` to select a different anchor or silently create a new topic
+on an observation miss.
 
-Add one integration regression in the existing settlement suite using the real
-session operations, registry and target router with a fake transport. Execute two
-question/pick/submit rounds, feed the first answer's message id into the next
-question, and assert transport destinations plus both answer identities. Run it
-against the baseline first to establish the missing second reply anchor.
+The registry owns questions, answers, expiry and the sent card id, not a
+precomputed routing target. A submitted or cancelled settlement uses the card id
+reported by its callback. Expiry uses the card id recorded on successful send.
+Both reach the same settlement delivery path.
 
-Validation: Rush build, lint, test, typecheck:tests and built-CLI smoke; knowledge
-links, diff whitespace and change declarations; one independent read-only review.
+That path queries the existing Feishu message reader for the actual card, obtains
+its chat and optional thread id, and resolves them through existing Feishu
+chat-mode and binding routing. Preserve normal topic-group versus ordinary-chat
+semantics. The answer envelope and presentation anchor use the actual card id.
+A lookup failure follows the existing delivery-failure handling and does not
+fall back to guessed parent-chat or Dispatcher delivery.
+
+Expose the message response's chat/topic metadata in the existing Feishu reader.
+The HTTP operation already exists; no new cache, persistence, Core or provider
+surface is needed. This costs one message lookup per settlement, as approved.
+Unrelated notifications and ordinary-message delivery remain unchanged.
+
+Validation covers direct reply addressing without an observation, no-id creation,
+submitted/cancelled answers, consecutive rounds, expiry, and lookup failure without
+misdelivery. Existing content reads must still work. Run Rush build, lint, test,
+typecheck:tests and built-CLI smoke, change verification and KB checks; independently
+review the complete resulting PR diff before publication.

--- a/.agents/tasks/channel/fix-question-card-topic-routing/technical-design/final.md
+++ b/.agents/tasks/channel/fix-question-card-topic-routing/technical-design/final.md
@@ -1,0 +1,18 @@
+# Minimal repair
+
+After `askUserQuestion` successfully sends the card, record every returned message
+id against its already resolved `target` with `FeishuTargetRouter.observe`, then
+activate the round as before. This is the same existing ledger used for sent
+replies and notifications. Failed sends never reach the registration step.
+
+Keep `deliverAskUserSettlement` unchanged: its envelope and presentation anchor
+already identify the answered card correctly. No other layer needs a new fact.
+
+Add one integration regression in the existing settlement suite using the real
+session operations, registry and target router with a fake transport. Execute two
+question/pick/submit rounds, feed the first answer's message id into the next
+question, and assert transport destinations plus both answer identities. Run it
+against the baseline first to establish the missing second reply anchor.
+
+Validation: Rush build, lint, test, typecheck:tests and built-CLI smoke; knowledge
+links, diff whitespace and change declarations; one independent read-only review.

--- a/.agents/tasks/channel/fix-question-card-topic-routing/verification.md
+++ b/.agents/tasks/channel/fix-question-card-topic-routing/verification.md
@@ -1,24 +1,51 @@
 # Verification
 
-- Baseline regression: Rush test for `@excitedjs/feishu-channel` fails on the
-  second card's missing `replyToMessageId`; the first answer already carries the
-  correct card id. Private local log: `/tmp/question-card-before.log`.
-- Product change: one registration loop after successful question-card send.
-- Final local gates: Rush build, lint, test, typecheck:tests and built-CLI smoke
-  passed. The Feishu package passed 26 test files / 467 tests. Full-suite warnings
-  are existing runtime/live-test stderr output; no failing test remains.
-- Logs: `/tmp/question-card-{build,lint,test,types,smoke}.log`.
-- Knowledge links: 227 reachable files; task record and diff whitespace checks pass.
-- Independent review: One read-only Claude reviewer traced session send, target
-  routing, transport, settlement and lifecycle fences. No functional or architecture
-  blocker. The TeamLeader checked the returned reasoning against the current diff.
+## Actual-card routing revision
 
-## Review adjudication
+- Integration base: `6bb8a713` (next, including PR #403).
+- Product diff is limited to Feishu transport/channel. The registry no longer
+  stores a target; settlement reads the actual card's conversation. Sending uses
+  the explicit reply id without consulting the observation ledger.
+- The observed-message ledger tests were moved to their owning router suite,
+  not removed. Ordinary inbound projection delegates to the same chat-mode rule.
+- Developer checks passed: Rush build, lint, test and typecheck:tests; channel
+  tests passed 27 files / 473 cases before rebasing. Developer-reported mutation
+  checks made the regression tests fail when topic projection or explicit reply
+  addressing was removed, or when read failure delivered to a guessed chat.
+- Final rebased gates: Rush build, lint, test, typecheck:tests and
+  smoke-built-cli all passed (exit 0). Logs are in
+  `/tmp/question-card-final-gates/`. Test warnings are the existing intentional
+  failure-path and live-runtime stderr output; no tests failed.
+- Final package tests: feishu-channel 27 files / 475 passed (including the two
+  additional tests from #403); feishu-transport 12 files / 195 passed.
+- Knowledge links: 227 files reachable; whitespace check passed.
+- `rush change --verify -b origin/next` passed after the implementation commit,
+  finding both the feishu-channel and feishu-transport change files.
+- Mandatory commit hooks passed, including staged ESLint, gitleaks and the
+  internal-content gate; no hook was bypassed.
+- Message-read failure and empty lookup results produce no delivery. Expiry card
+  repaint remains independent of answer delivery.
+- Chat-mode resolution retains the existing inbound behavior, including ordinary
+  group projection when mode cannot be resolved. The no-misdelivery guarantee on
+  query failure covers the new message-details lookup. A thread-bearing card may
+  also require the existing cached chat-mode lookup on a cold cache.
+- Message details do not report `chat_type`. Readback without a thread uses the
+  existing group default; unbound direct-chat answers still reach the Dispatcher.
+  This internal target-kind limitation is visible to the PR reviewer.
+- No live Feishu probe or service installation was performed.
+- Independent review: Pending DevBox on the updated PR, as explicitly requested.
+  The planned dynamic workflow was not started.
 
-| Finding | Disposition | Reason | Operator conflict |
-| --- | --- | --- | --- |
-| Two documentation paragraph wraps | Accept; reflowed | Formatting only | None |
+## Earlier minimal patch (superseded)
 
-The review added no product requirement or implementation mechanism. The repair
-uses the existing ledger and leaves the answer envelope unchanged.
-- Live Feishu probe: Not run; no running service was changed.
+The earlier `1e011989` revision registered sent cards in the observation ledger.
+Its two-round regression, local gates, CI and independent Claude review passed,
+with two documentation wraps corrected. It was published as an Alpha. Those
+results describe the earlier patch, not the replacement implementation above.
+
+## Follow-up maintenance candidate
+
+`feishu-session-ops.ts` remains below the 700-line gate at 675 lines. Its
+question-card send/settlement/expiry responsibilities are a candidate for a future
+owner-level extraction if that area grows. No extraction or comment trimming was
+included in this routing fix.

--- a/.agents/tasks/channel/fix-question-card-topic-routing/verification.md
+++ b/.agents/tasks/channel/fix-question-card-topic-routing/verification.md
@@ -1,0 +1,24 @@
+# Verification
+
+- Baseline regression: Rush test for `@excitedjs/feishu-channel` fails on the
+  second card's missing `replyToMessageId`; the first answer already carries the
+  correct card id. Private local log: `/tmp/question-card-before.log`.
+- Product change: one registration loop after successful question-card send.
+- Final local gates: Rush build, lint, test, typecheck:tests and built-CLI smoke
+  passed. The Feishu package passed 26 test files / 467 tests. Full-suite warnings
+  are existing runtime/live-test stderr output; no failing test remains.
+- Logs: `/tmp/question-card-{build,lint,test,types,smoke}.log`.
+- Knowledge links: 227 reachable files; task record and diff whitespace checks pass.
+- Independent review: One read-only Claude reviewer traced session send, target
+  routing, transport, settlement and lifecycle fences. No functional or architecture
+  blocker. The TeamLeader checked the returned reasoning against the current diff.
+
+## Review adjudication
+
+| Finding | Disposition | Reason | Operator conflict |
+| --- | --- | --- | --- |
+| Two documentation paragraph wraps | Accept; reflowed | Formatting only | None |
+
+The review added no product requirement or implementation mechanism. The repair
+uses the existing ledger and leaves the answer envelope unchanged.
+- Live Feishu probe: Not run; no running service was changed.

--- a/common/changes/@excitedjs/feishu-channel/fix-feishu-question-card-routing_2026-09-10-01-34.json
+++ b/common/changes/@excitedjs/feishu-channel/fix-feishu-question-card-routing_2026-09-10-01-34.json
@@ -1,7 +1,7 @@
 {
   "changes": [
     {
-      "comment": "Keep follow-up question cards in their original topic by recording sent card message ids for reply routing.",
+      "comment": "Question cards are addressed exactly as `reply` is: an explicit message id sends the card as a reply to that message, and without one the card is created in the chat. A submitted, dismissed, or expired answer is routed from the card it belongs to, whose chat and topic are read back from Feishu, instead of from a target computed before the card was sent; a follow-up question therefore stays in the topic its answer came from. An answer whose card cannot be located is a failed delivery rather than a message sent to a guessed chat.",
       "type": "patch",
       "packageName": "@excitedjs/feishu-channel"
     }

--- a/common/changes/@excitedjs/feishu-channel/fix-feishu-question-card-routing_2026-09-10-01-34.json
+++ b/common/changes/@excitedjs/feishu-channel/fix-feishu-question-card-routing_2026-09-10-01-34.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Keep follow-up question cards in their original topic by recording sent card message ids for reply routing.",
+      "type": "patch",
+      "packageName": "@excitedjs/feishu-channel"
+    }
+  ],
+  "packageName": "@excitedjs/feishu-channel",
+  "email": "hvjfccdy6s@privaterelay.appleid.com"
+}

--- a/common/changes/@excitedjs/feishu-transport/fix-feishu-question-card-routing_2026-09-10-11-40.json
+++ b/common/changes/@excitedjs/feishu-transport/fix-feishu-question-card-routing_2026-09-10-11-40.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Message reads report the chat and topic a message is in, alongside its content.",
+      "type": "minor",
+      "packageName": "@excitedjs/feishu-transport"
+    }
+  ],
+  "packageName": "@excitedjs/feishu-transport",
+  "email": "hvjfccdy6s@privaterelay.appleid.com"
+}

--- a/packages/channel/feishu-channel/src/feishu-ask-user.ts
+++ b/packages/channel/feishu-channel/src/feishu-ask-user.ts
@@ -35,7 +35,6 @@ import {
   type AskUserQuestionSpec,
 } from './feishu-ask-user-card.js';
 import { DREAMUX_ACTION_KEY, type FeishuCardActionResponse } from './feishu-pairing-card.js';
-import type { FeishuTarget } from './routing/target.js';
 
 const REQUEST_ID_BYTES = 8;
 
@@ -68,11 +67,6 @@ const realTimers: AskUserTimers = {
   },
 };
 
-export interface AskUserOpenInput {
-  readonly questions: readonly AskUserQuestionSpec[];
-  readonly target: FeishuTarget;
-}
-
 export interface AskUserOpened {
   readonly requestId: string;
   readonly card: unknown;
@@ -91,7 +85,6 @@ export interface AskUserOpened {
  */
 export interface AskUserSettlement {
   readonly requestId: string;
-  readonly target: FeishuTarget;
   readonly outcome: 'submitted' | 'cancelled' | 'expired';
   readonly text: string;
   /**
@@ -101,8 +94,10 @@ export interface AskUserSettlement {
    */
   readonly sourceId: string;
   /**
-   * The question card's own message id — a real `om_` id, and the anchor the
-   * answer belongs under. Absent only if the send never reported one.
+   * The question card's own message id — a real `om_` id. It is the anchor the
+   * answer belongs under and the only address the session has for it: where
+   * the answer is delivered is read from this card, not from where the round
+   * was opened. Absent only if the send never reported one.
    */
   readonly cardMessageId?: string;
   /** Who clicked. Absent when the round closed on its timer. */
@@ -111,13 +106,11 @@ export interface AskUserSettlement {
 
 /**
  * A round that closed on its own. Unlike a click, nothing is there to repaint
- * the card from a callback response, so the message id is carried out and the
- * session patches the card in place.
+ * the card from a callback response, so the session patches the card in place
+ * — at `settlement.cardMessageId`, the same id the answer is routed from.
  */
 export interface AskUserExpiry {
   readonly settlement: AskUserSettlement;
-  /** Absent only if the card's id never came back from the send. */
-  readonly messageId?: string;
   readonly card: unknown;
 }
 
@@ -139,7 +132,7 @@ export interface AskUserRegistry {
    * that threw leave a question behind with no card, and its TTL would later
    * report an unanswered question to a model whose user was never asked one.
    */
-  open(input: AskUserOpenInput): AskUserOpened;
+  open(questions: readonly AskUserQuestionSpec[]): AskUserOpened;
   apply(event: FeishuCardActionEvent): AskUserApplyResult;
   /** Drop every open round; their cards report the round as gone on next click. */
   abandonAll(): void;
@@ -148,7 +141,6 @@ export interface AskUserRegistry {
 interface OpenRound {
   readonly requestId: string;
   readonly questions: readonly AskUserQuestionSpec[];
-  readonly target: FeishuTarget;
   readonly answers: Map<number, AskUserAnswer>;
   messageId?: string;
   timer?: unknown;
@@ -252,7 +244,6 @@ export function createAskUserRegistry(
     const cardMessageId = by?.cardMessageId ?? round.messageId;
     return {
       requestId: round.requestId,
-      target: round.target,
       outcome,
       text,
       sourceId: `ask_user_question:${round.requestId}`,
@@ -298,12 +289,11 @@ export function createAskUserRegistry(
   }
 
   return {
-    open(input): AskUserOpened {
+    open(questions): AskUserOpened {
       const requestId = newRequestId();
       const round: OpenRound = {
         requestId,
-        questions: input.questions,
-        target: input.target,
+        questions,
         answers: new Map(),
       };
       return {
@@ -317,12 +307,8 @@ export function createAskUserRegistry(
             // the round is gone; `closeRound` on a stale round would report a
             // second settlement for one question.
             if (rounds.get(requestId) !== round) return;
-            const settlement = closeRound(round, 'expired');
             options.onExpire?.({
-              settlement,
-              ...(round.messageId !== undefined
-                ? { messageId: round.messageId }
-                : {}),
+              settlement: closeRound(round, 'expired'),
               card: buildAskUserClosedCard('expired'),
             });
           }, ttlMs);

--- a/packages/channel/feishu-channel/src/feishu-session-ops.ts
+++ b/packages/channel/feishu-channel/src/feishu-session-ops.ts
@@ -39,7 +39,10 @@ import {
 import { AsyncMutex } from './lib/mutex.js';
 import type { FeishuChannelSessionOptions } from './feishu-channel.js';
 import type { PeerBot } from './chat-bots-store.js';
-import type { FeishuTargetRouter } from './feishu-target-router.js';
+import type {
+  FeishuInboundRoute,
+  FeishuTargetRouter,
+} from './feishu-target-router.js';
 import { CHANNEL_REMINDER, type FeishuInboundDelivery } from './feishu-submit.js';
 import type {
   AskUserExpiry,
@@ -370,23 +373,52 @@ export async function approvePairingByToken(
 }
 
 /**
+ * Where the question card actually is, asked of Feishu rather than assumed.
+ *
+ * The round was opened before its card existed, so nothing it holds says where
+ * the card landed: a question sent as a reply lives in the replied-to message's
+ * topic, which only Feishu can report. A card this fails to locate is a failed
+ * delivery — the chat the question was asked from is a guess, and a guess puts
+ * one conversation's answer in front of another.
+ */
+async function askUserCardRoute(
+  h: SessionHandle,
+  cardMessageId: string,
+): Promise<FeishuInboundRoute> {
+  const read = await h.bot.readMessage?.({ messageId: cardMessageId });
+  const card = read?.items.find((item) => item.messageId === cardMessageId);
+  if (card === undefined || card.chatId === '') {
+    throw new Error(`Feishu reported no chat for card ${cardMessageId}`);
+  }
+  return h.targetRouter.project({
+    chatId: card.chatId,
+    ...(card.threadId !== undefined ? { threadId: card.threadId } : {}),
+  });
+}
+
+/**
  * Hand a settled ask-user round to Core as an ordinary inbound submission.
  *
  * The answer travels the path a typed reply travels, so nothing downstream has
  * to learn that a card produced it. A delivery that fails is logged and
  * dropped, exactly as the inbound path treats a message Core would not take:
  * re-delivering risks a second turn for one answer, and the user can say it
- * again.
+ * again. A card that cannot be located fails the same way, for the same reason.
  */
 async function deliverAskUserSettlement(
   h: SessionHandle,
   settlement: AskUserSettlement,
 ): Promise<void> {
-  const { target } = settlement;
+  const { cardMessageId } = settlement;
   try {
+    if (cardMessageId === undefined) {
+      throw new Error('the question card reported no message id');
+    }
+    const route = await askUserCardRoute(h, cardMessageId);
+    const { target } = route;
     const outcome = await h.delivery.deliver({
       target,
-      containerChatId: target.kind === 'topic' ? target.chatId : null,
+      containerChatId: route.containerChatId,
       submission: {
         attrs: {
           // Same provenance the inbound envelope carries, in the same place:
@@ -396,9 +428,7 @@ async function deliverAskUserSettlement(
           ...(target.threadId !== undefined
             ? { thread_id: target.threadId }
             : {}),
-          ...(settlement.cardMessageId !== undefined
-            ? { message_id: settlement.cardMessageId }
-            : {}),
+          message_id: cardMessageId,
           // Anyone in the chat may answer the card; this is deliberate, so
           // there is no check on who clicked. Carrying the clicker keeps the
           // fact the model would otherwise lose.
@@ -414,9 +444,8 @@ async function deliverAskUserSettlement(
           chatId: target.chatId,
           // The question card, never `sourceId`: this id is handed to Feishu as
           // a COT presentation's origin, and a synthetic one would be sent to
-          // the API as if it were real. Empty when the card id is unknown,
-          // which the COT layer already treats as "no anchor".
-          messageId: settlement.cardMessageId ?? '',
+          // the API as if it were real.
+          messageId: cardMessageId,
           target,
         },
       },
@@ -435,7 +464,7 @@ async function deliverAskUserSettlement(
     log(h).error(
       {
         dispatcher_id: h.opts.dispatcherId,
-        chat_id: target.chatId,
+        message_id: cardMessageId,
         ask_user_request_id: settlement.requestId,
         err: errInfo(err),
       },
@@ -451,11 +480,12 @@ async function deliverAskUserSettlement(
  * card-action route, and the answer reaches Core as an inbound submission, so
  * the tool that called this is long finished by the time the user decides.
  *
- * `messageId` is the message the question came out of, and the target follows
- * it the way an ordinary reply does — into that message's topic, under the
- * anchor the router holds for it. Without one the target names the chat, and
- * in a topic group the card opens a topic of its own, which is right for a
- * question that belongs to no particular message and wrong for one that does.
+ * `messageId` addresses the card the way `reply` addresses a message: the card
+ * is sent as a reply to it, which is what puts it in that message's topic.
+ * Without one the card is a new message in the chat, and in a topic group that
+ * opens a topic of its own — right for a question that belongs to no particular
+ * message, wrong for one that does. Where the answer goes is not decided here;
+ * it is read back from the card that was actually sent.
  *
  * The round is put in play only once the card is really sent, so a send that
  * throws leaves no question behind and fails where the model can see it.
@@ -468,14 +498,15 @@ export async function askUserQuestion(
     messageId?: string;
   },
 ): Promise<{ request_id: string }> {
-  const target = h.targetRouter.outboundTarget(input.chatId, input.messageId);
-  const opened = h.askUser.open({ questions: input.questions, target });
+  const opened = h.askUser.open(input.questions);
   const sent = await sendCard(h, {
-    target: h.targetRouter.notificationTarget(target),
+    target: {
+      conversationId: input.chatId,
+      ...(input.messageId !== undefined ? { replyTo: input.messageId } : {}),
+    },
     card: opened.card,
     mode: 'inbound',
   });
-  for (const messageId of sent.messageIds) h.targetRouter.observe(messageId, target);
   opened.activate(sent.messageIds[0]);
   return { request_id: opened.requestId };
 }
@@ -493,7 +524,7 @@ export async function expireAskUserQuestion(
   expiry: AskUserExpiry,
 ): Promise<void> {
   await deliverAskUserSettlement(h, expiry.settlement);
-  const { messageId } = expiry;
+  const messageId = expiry.settlement.cardMessageId;
   if (messageId === undefined) return;
   try {
     await h.bot.editCard(messageId, expiry.card);

--- a/packages/channel/feishu-channel/src/feishu-session-ops.ts
+++ b/packages/channel/feishu-channel/src/feishu-session-ops.ts
@@ -475,6 +475,7 @@ export async function askUserQuestion(
     card: opened.card,
     mode: 'inbound',
   });
+  for (const messageId of sent.messageIds) h.targetRouter.observe(messageId, target);
   opened.activate(sent.messageIds[0]);
   return { request_id: opened.requestId };
 }

--- a/packages/channel/feishu-channel/src/feishu-target-router.ts
+++ b/packages/channel/feishu-channel/src/feishu-target-router.ts
@@ -68,27 +68,52 @@ export class FeishuTargetRouter {
     signal?: AbortSignal,
   ): Promise<FeishuInboundRoute> {
     assertRoutingActive(signal);
-    let route: FeishuInboundRoute = {
-      target: chatTarget(event.chatId, event.chatType),
-      containerChatId: null,
-    };
-    if (
-      event.chatType === 'group' &&
-      event.threadId !== undefined &&
-      event.threadId !== ''
-    ) {
-      const mode = await this.chatMode(event.chatId, signal);
-      assertRoutingActive(signal);
-      if (mode === 'topic') {
-        route = {
-          target: topicTarget(event.chatId, event.threadId),
-          containerChatId: event.chatId,
-        };
-      }
-    }
+    const route = await this.project(
+      {
+        chatId: event.chatId,
+        chatType: event.chatType,
+        ...(event.threadId !== undefined ? { threadId: event.threadId } : {}),
+      },
+      signal,
+    );
     assertRoutingActive(signal);
     this.observe(event.messageId, route.target);
     return route;
+  }
+
+  /**
+   * Which target a message sits in, from the place Feishu reports for it.
+   *
+   * A thread id is only half the answer: outside a topic-mode group it names a
+   * reply chain rather than a topic, so the chat's mode decides — and that
+   * lookup is spent only on a message that claims a thread at all. `chatType`
+   * is absent for a message read back from the API, which reports none; an
+   * ordinary group is what this router already assumes for a chat it cannot
+   * name, and the two kinds differ only in whether a binding could exist.
+   */
+  async project(
+    place: { chatId: string; threadId?: string; chatType?: string },
+    signal?: AbortSignal,
+  ): Promise<FeishuInboundRoute> {
+    const chatType = place.chatType ?? 'group';
+    if (
+      chatType === 'group' &&
+      place.threadId !== undefined &&
+      place.threadId !== ''
+    ) {
+      const mode = await this.chatMode(place.chatId, signal);
+      assertRoutingActive(signal);
+      if (mode === 'topic') {
+        return {
+          target: topicTarget(place.chatId, place.threadId),
+          containerChatId: place.chatId,
+        };
+      }
+    }
+    return {
+      target: chatTarget(place.chatId, chatType),
+      containerChatId: null,
+    };
   }
 
   /** Record a message this session sent or received against its target. */

--- a/packages/channel/feishu-channel/tests/feishu-ask-user.test.ts
+++ b/packages/channel/feishu-channel/tests/feishu-ask-user.test.ts
@@ -37,13 +37,11 @@ import {
   type AskUserQuestionSpec,
 } from '../src/feishu-ask-user-card.js';
 import { DREAMUX_ACTION_KEY } from '../src/feishu-pairing-card.js';
-import { FeishuTargetRouter } from '../src/feishu-target-router.js';
 import {
   ASK_USER_NEXT_INSTRUCTION,
   askUserQuestionDef,
 } from '../src/tools/ask-user-question.js';
 import type { FeishuToolContext, FeishuToolSession } from '../src/tools/types.js';
-import { chatTarget, topicTarget } from '../src/routing/target.js';
 
 const QUESTIONS: readonly AskUserQuestionSpec[] = [
   {
@@ -63,8 +61,6 @@ const QUESTIONS: readonly AskUserQuestionSpec[] = [
     ],
   },
 ];
-
-const target = chatTarget('oc_test', 'group');
 
 function event(
   action: string,
@@ -115,7 +111,7 @@ function openRound(
   registry: AskUserRegistry,
   messageId: string | undefined = undefined,
 ): string {
-  const opened = registry.open({ questions: QUESTIONS, target });
+  const opened = registry.open(QUESTIONS);
   opened.activate(messageId);
   return opened.requestId;
 }
@@ -267,7 +263,7 @@ describe('ask-user registry', () => {
       onExpire: (expiry) => expired.push(expiry),
     });
     // The send threw, so `activate` was never reached.
-    const opened = registry.open({ questions: QUESTIONS, target });
+    const opened = registry.open(QUESTIONS);
 
     const applied = registry.apply(
       event(DREAMUX_ASK_SUBMIT_ACTION, {
@@ -283,7 +279,7 @@ describe('ask-user registry', () => {
 
   it('refuses a submit with nothing chosen instead of spending the round', () => {
     const registry = createAskUserRegistry({ timers: manualTimers() });
-    const opened = registry.open({ questions: QUESTIONS, target });
+    const opened = registry.open(QUESTIONS);
     opened.activate(undefined);
     const { requestId } = opened;
 
@@ -370,7 +366,7 @@ describe('ask-user registry', () => {
 
     expect(expired).toHaveLength(1);
     expect(expired[0]?.settlement.outcome).toBe('expired');
-    expect(expired[0]?.messageId).toBe('om_card');
+    expect(expired[0]?.settlement.cardMessageId).toBe('om_card');
     expect(expired[0]?.settlement.text).toContain('take no further action');
     // The card id is carried out because nothing else can repaint a card that
     // expired without a click to answer.
@@ -467,8 +463,8 @@ describe('ask_user_question tool', () => {
   });
 
   it('leaves the message id out when the model named none', () => {
-    // Not an empty string: the target router reads "no message to thread
-    // under" from the field's absence, and would look up '' as an id.
+    // Not an empty string: absence is what tells the send there is no message
+    // to reply under, and '' would be handed to Feishu as a message id.
     expect(askUserQuestionDef.parse(validArgs)).not.toHaveProperty('messageId');
   });
 
@@ -515,54 +511,5 @@ describe('ask_user_question tool', () => {
         questions: Array.from({ length: 5 }, () => validArgs.questions[0]),
       }),
     ).toThrow(/1-4 questions/);
-  });
-});
-
-/**
- * Where `message_id` sends the card. The rule is the one `reply` already
- * follows — the card belongs wherever the message it answers lives — so this
- * covers the router, not a second routing path for questions.
- */
-describe('addressing the question card', () => {
-  const silent = {
-    error: () => undefined,
-    warn: () => undefined,
-    info: () => undefined,
-    debug: () => undefined,
-    trace: () => undefined,
-  };
-
-  function router(): FeishuTargetRouter {
-    return new FeishuTargetRouter({ chatModes: {}, log: silent });
-  }
-
-  it('follows the named message into its topic', () => {
-    const r = router();
-    r.observe('om_asked', topicTarget('oc_room', 'omt_thread'));
-
-    expect(r.outboundTarget('oc_room', 'om_asked')).toEqual(
-      topicTarget('oc_room', 'omt_thread'),
-    );
-  });
-
-  it('addresses the chat itself when no message is named', () => {
-    const r = router();
-    r.observe('om_asked', topicTarget('oc_room', 'omt_thread'));
-
-    // A question that belongs to no message opens a topic of its own.
-    expect(r.outboundTarget('oc_room', undefined)).toEqual(
-      chatTarget('oc_room', 'group'),
-    );
-  });
-
-  it('ignores a message from another chat rather than redirecting the card', () => {
-    const r = router();
-    r.observe('om_elsewhere', topicTarget('oc_other', 'omt_thread'));
-
-    // Deliberate: a stale or copied id must not send a question meant for one
-    // conversation into another. The named chat wins.
-    expect(r.outboundTarget('oc_room', 'om_elsewhere')).toEqual(
-      chatTarget('oc_room', 'group'),
-    );
   });
 });

--- a/packages/channel/feishu-channel/tests/feishu-inbound-enrichment.test.ts
+++ b/packages/channel/feishu-channel/tests/feishu-inbound-enrichment.test.ts
@@ -75,6 +75,7 @@ function item(
     mentions: [],
     deleted: false,
     malformed: false,
+    chatId: 'oc_room',
     ...overrides,
   };
 }

--- a/packages/channel/feishu-channel/tests/feishu-settlement-envelope.test.ts
+++ b/packages/channel/feishu-channel/tests/feishu-settlement-envelope.test.ts
@@ -1,23 +1,30 @@
 /**
- * An ask-card answer is a channel message, and its envelope has to read like
- * one.
+ * An ask-card answer is a channel message, and it arrives where the card is.
  *
- * The settlement envelope is built by hand in `feishu-session-ops.ts` rather
- * than by the inbound formatter, so nothing but this test keeps the two in
- * step. What matters is the `source` attribute and its position: the model
- * reads `<channel source="feishu" …>` and ties the answer to the
- * `channel-feishu` MCP server whose tools it must use to reply, exactly as it
- * does for an ordinary inbound message.
+ * Two things are settled here and nowhere else. The envelope is built by hand
+ * in `feishu-session-ops.ts` rather than by the inbound formatter, so nothing
+ * but this test keeps the two in step: what matters is the `source` attribute
+ * and its position, because the model reads `<channel source="feishu" …>` and
+ * ties the answer to the `channel-feishu` MCP server whose tools it must use to
+ * reply, exactly as it does for an ordinary inbound message.
+ *
+ * And where the answer goes is read back from the card itself. The round is
+ * opened before its card exists, so it cannot know where Feishu put one — a
+ * question sent as a reply lands in the replied-to message's topic — which is
+ * why every settlement asks Feishu where its card is, and why a card that
+ * cannot be found is delivered nowhere at all.
  */
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 
 import { createAskUserRegistry } from '../src/feishu-ask-user.js';
 import {
+  DREAMUX_ASK_CANCEL_ACTION,
   DREAMUX_ASK_OPTION_KEY,
   DREAMUX_ASK_PICK_ACTION,
   DREAMUX_ASK_QUESTION_KEY,
   DREAMUX_ASK_REQUEST_KEY,
   DREAMUX_ASK_SUBMIT_ACTION,
+  type AskUserQuestionSpec,
 } from '../src/feishu-ask-user-card.js';
 import { DREAMUX_ACTION_KEY } from '../src/feishu-pairing-card.js';
 import { FeishuTargetRouter } from '../src/feishu-target-router.js';
@@ -29,13 +36,10 @@ import {
   type SessionHandle,
 } from '../src/feishu-session-ops.js';
 import { CHANNEL_REMINDER } from '../src/feishu-submit.js';
-import type {
-  FeishuInboundDelivery,
-  FeishuSubmission,
-} from '../src/feishu-submit.js';
+import type { FeishuInboundDelivery } from '../src/feishu-submit.js';
 import { AsyncMutex } from '../src/lib/mutex.js';
-import { topicTarget } from '../src/routing/target.js';
-import { createFakeFeishuBot } from './helpers/fake-feishu-bot.js';
+import { chatTarget, topicTarget } from '../src/routing/target.js';
+import { createFakeFeishuBot, type FakeFeishuBot } from './helpers/fake-feishu-bot.js';
 
 const silent = {
   error: () => undefined,
@@ -45,16 +49,29 @@ const silent = {
   trace: () => undefined,
 };
 
+const QUESTIONS: readonly AskUserQuestionSpec[] = [
+  {
+    header: 'Choice',
+    question: 'Which option?',
+    options: [
+      { label: 'First', description: 'Use the first option' },
+      { label: 'Second', description: 'Use the second option' },
+    ],
+  },
+];
+
+type Delivered = Parameters<FeishuInboundDelivery['deliver']>[0];
+
 function capturingDelivery(): {
   delivery: FeishuInboundDelivery;
-  submissions: FeishuSubmission[];
+  delivered: Delivered[];
 } {
-  const submissions: FeishuSubmission[] = [];
+  const delivered: Delivered[] = [];
   return {
-    submissions,
+    delivered,
     delivery: {
       async deliver(input) {
-        submissions.push(input.submission);
+        delivered.push(input);
         return { status: 'submitted', turnId: 'turn-1' };
       },
       // This suite is about the submission envelope; a command never builds one.
@@ -67,7 +84,7 @@ function capturingDelivery(): {
 
 function handle(
   delivery: FeishuInboundDelivery,
-  bot = createFakeFeishuBot(),
+  bot: FakeFeishuBot = createFakeFeishuBot(),
 ): SessionHandle {
   return sessionHandle({
     opts: {
@@ -89,100 +106,238 @@ function handle(
   });
 }
 
+/** What Feishu will report about a card the session sent. */
+function cardSitsIn(
+  bot: FakeFeishuBot,
+  messageId: string,
+  place: { chatId: string; threadId?: string },
+): void {
+  bot.setMessageRead(messageId, 'default', {
+    items: [{
+      messageId,
+      messageType: 'interactive',
+      content: '{}',
+      mentions: [],
+      deleted: false,
+      malformed: false,
+      chatId: place.chatId,
+      ...(place.threadId !== undefined ? { threadId: place.threadId } : {}),
+    }],
+  });
+}
+
+/** Ask a question and answer the card it sent, as a user's two clicks would. */
+async function clickThrough(
+  h: SessionHandle,
+  cardMessageId: string,
+  requestId: string,
+  last: string = DREAMUX_ASK_SUBMIT_ACTION,
+): Promise<void> {
+  for (const action of [DREAMUX_ASK_PICK_ACTION, last]) {
+    await handleCardAction(h, {
+      actionValue: {
+        [DREAMUX_ACTION_KEY]: action,
+        [DREAMUX_ASK_REQUEST_KEY]: requestId,
+        [DREAMUX_ASK_QUESTION_KEY]: 0,
+        [DREAMUX_ASK_OPTION_KEY]: 0,
+      },
+      openMessageId: cardMessageId,
+      operatorOpenId: 'ou_clicker',
+      raw: {},
+    });
+  }
+}
+
+/** A click hands the answer to Core detached, so its arrival is awaited here. */
+async function answers(delivered: Delivered[], count: number): Promise<void> {
+  await vi.waitFor(() => expect(delivered).toHaveLength(count));
+}
+
+describe('sending the question card', () => {
+  it('replies to the message the model named, seen before or not', async () => {
+    const bot = createFakeFeishuBot();
+    const h = handle(capturingDelivery().delivery, bot);
+
+    await askUserQuestion(h, {
+      chatId: 'oc_room',
+      // Nothing in this session has ever seen this message. An explicit id is
+      // obeyed anyway, exactly as `reply` obeys one.
+      messageId: 'om_never_observed',
+      questions: QUESTIONS,
+    });
+
+    expect(bot.sentCards[0]?.target).toEqual({
+      chatId: 'oc_room',
+      replyToMessageId: 'om_never_observed',
+    });
+  });
+
+  it('creates a new message when the model named none', async () => {
+    const bot = createFakeFeishuBot();
+    const h = handle(capturingDelivery().delivery, bot);
+
+    await askUserQuestion(h, { chatId: 'oc_room', questions: QUESTIONS });
+
+    // A question that belongs to no message opens a topic of its own in a
+    // topic group, which is what a question about nothing in particular wants.
+    expect(bot.sentCards[0]?.target).toEqual({ chatId: 'oc_room' });
+  });
+});
+
 describe('the ask-card settlement envelope', () => {
-  it('uses each answered card id to keep the next question in the same topic', async () => {
-    const { delivery, submissions } = capturingDelivery();
+  it('carries source="feishu" and the card the answer came from', async () => {
+    const { delivery, delivered } = capturingDelivery();
     const bot = createFakeFeishuBot();
     const h = handle(delivery, bot);
-    const target = topicTarget('oc_room', 'omt_thread');
-    h.targetRouter.observe('om_initial', target);
-    let messageId = 'om_initial';
+    bot.setChatMode('oc_room', 'topic');
 
-    try {
-      for (let round = 0; round < 2; round++) {
-        const opened = await askUserQuestion(h, {
-          chatId: target.chatId,
-          messageId,
-          questions: [{
-            header: 'Choice',
-            question: 'Which option?',
-            options: [
-              { label: 'First', description: 'Use the first option' },
-              { label: 'Second', description: 'Use the second option' },
-            ],
-          }],
-        });
-        const card = bot.sentCards[round];
-        expect(card?.target).toEqual({
-          chatId: target.chatId,
-          replyToMessageId: messageId,
-        });
-        const cardId = card?.messageIds[0];
-        if (cardId === undefined) throw new Error('expected a sent card');
+    const opened = await askUserQuestion(h, {
+      chatId: 'oc_room',
+      messageId: 'om_root',
+      questions: QUESTIONS,
+    });
+    const cardId = bot.sentCards[0]?.messageIds[0] ?? '';
+    // The card was sent as a reply, so Feishu put it in the root's topic —
+    // a place the round that asked the question never knew.
+    cardSitsIn(bot, cardId, { chatId: 'oc_room', threadId: 'omt_thread' });
 
-        for (const action of [DREAMUX_ASK_PICK_ACTION, DREAMUX_ASK_SUBMIT_ACTION]) {
-          await handleCardAction(h, {
-            actionValue: {
-              [DREAMUX_ACTION_KEY]: action,
-              [DREAMUX_ASK_REQUEST_KEY]: opened.request_id,
-              [DREAMUX_ASK_QUESTION_KEY]: 0,
-              [DREAMUX_ASK_OPTION_KEY]: 0,
-            },
-            openMessageId: cardId,
-            operatorOpenId: 'ou_clicker',
-            raw: {},
-          });
-        }
+    await clickThrough(h, cardId, opened.request_id);
+    await answers(delivered, 1);
 
-        const answer = submissions[round];
-        expect(answer?.attrs).toMatchObject({
-          source: 'feishu',
-          chat_id: target.chatId,
-          thread_id: target.threadId,
-          message_id: cardId,
-          ask_user_request_id: opened.request_id,
-        });
-        expect(answer?.anchor).toEqual({
-          chatId: target.chatId,
-          messageId: cardId,
-          target,
-        });
-        messageId = String(answer?.attrs.message_id);
-      }
-      expect(submissions).toHaveLength(2);
-    } finally {
-      h.askUser.abandonAll();
+    expect(delivered[0]?.target).toEqual(topicTarget('oc_room', 'omt_thread'));
+    // The parent chat a Collaboration Space is keyed by; only a topic has one.
+    expect(delivered[0]?.containerChatId).toBe('oc_room');
+    expect(delivered[0]?.submission.attrs).toMatchObject({
+      source: 'feishu',
+      chat_id: 'oc_room',
+      thread_id: 'omt_thread',
+      message_id: cardId,
+      sender_id: 'ou_clicker',
+      ask_user_request_id: opened.request_id,
+    });
+    expect(delivered[0]?.submission.anchor).toEqual({
+      chatId: 'oc_room',
+      messageId: cardId,
+      target: topicTarget('oc_room', 'omt_thread'),
+    });
+    // The same standing note an inbound message carries: an answer leaves the
+    // model in the same chat, under the same consequence.
+    expect(delivered[0]?.submission.reminder).toBe(CHANNEL_REMINDER);
+  });
+
+  it('routes a dismissal from its card too', async () => {
+    const { delivery, delivered } = capturingDelivery();
+    const bot = createFakeFeishuBot();
+    const h = handle(delivery, bot);
+    bot.setChatMode('oc_room', 'topic');
+
+    const opened = await askUserQuestion(h, {
+      chatId: 'oc_room',
+      messageId: 'om_root',
+      questions: QUESTIONS,
+    });
+    const cardId = bot.sentCards[0]?.messageIds[0] ?? '';
+    cardSitsIn(bot, cardId, { chatId: 'oc_room', threadId: 'omt_thread' });
+
+    await clickThrough(h, cardId, opened.request_id, DREAMUX_ASK_CANCEL_ACTION);
+    await answers(delivered, 1);
+
+    expect(delivered[0]?.target).toEqual(topicTarget('oc_room', 'omt_thread'));
+    expect(delivered[0]?.submission.attrs).toMatchObject({ message_id: cardId });
+    expect(delivered[0]?.submission.anchor).toEqual({
+      chatId: 'oc_room',
+      messageId: cardId,
+      target: topicTarget('oc_room', 'omt_thread'),
+    });
+    expect(delivered[0]?.submission.text).toContain('dismissed');
+  });
+
+  it('keeps a follow-up question in the topic its answer came from', async () => {
+    const { delivery, delivered } = capturingDelivery();
+    const bot = createFakeFeishuBot();
+    const h = handle(delivery, bot);
+    bot.setChatMode('oc_room', 'topic');
+    let messageId = 'om_root';
+
+    for (let round = 0; round < 2; round++) {
+      const opened = await askUserQuestion(h, {
+        chatId: 'oc_room',
+        messageId,
+        questions: QUESTIONS,
+      });
+      expect(bot.sentCards[round]?.target).toEqual({
+        chatId: 'oc_room',
+        replyToMessageId: messageId,
+      });
+      const cardId = bot.sentCards[round]?.messageIds[0] ?? '';
+      cardSitsIn(bot, cardId, { chatId: 'oc_room', threadId: 'omt_thread' });
+
+      await clickThrough(h, cardId, opened.request_id);
+      await answers(delivered, round + 1);
+
+      expect(delivered[round]?.target).toEqual(
+        topicTarget('oc_room', 'omt_thread'),
+      );
+      expect(delivered[round]?.submission.attrs['message_id']).toBe(cardId);
+      // What the model hands the next question: the card it just answered.
+      messageId = String(delivered[round]?.submission.attrs['message_id']);
     }
   });
 
-  it('carries source="feishu" among its attributes, next to the ids', async () => {
-    const { delivery, submissions } = capturingDelivery();
+  it('delivers an ordinary group card to the group, and repaints it', async () => {
+    const { delivery, delivered } = capturingDelivery();
+    const bot = createFakeFeishuBot();
+    const h = handle(delivery, bot);
+    cardSitsIn(bot, 'om_card', { chatId: 'oc_room' });
 
     // Expiry is the settlement path that delivers synchronously; a click
-    // detaches delivery and builds the very same submission.
-    await expireAskUserQuestion(handle(delivery), {
+    // detaches delivery and builds the very same submission, from the id its
+    // callback reports instead of the id the send recorded.
+    await expireAskUserQuestion(h, {
       settlement: {
         requestId: 'req-1',
-        target: topicTarget('oc_room', 'omt_thread'),
         outcome: 'expired',
         text: 'The question expired with no answer.',
         sourceId: 'ask:req-1',
         cardMessageId: 'om_card',
-        operatorOpenId: 'ou_clicker',
       },
       card: {},
     });
 
-    expect(submissions).toHaveLength(1);
-    expect(submissions[0]?.attrs).toMatchObject({
-      source: 'feishu',
+    expect(delivered[0]?.target).toEqual(chatTarget('oc_room', 'group'));
+    expect(delivered[0]?.containerChatId).toBeNull();
+    expect(delivered[0]?.submission.attrs).toMatchObject({
       chat_id: 'oc_room',
-      thread_id: 'omt_thread',
       message_id: 'om_card',
-      ask_user_request_id: 'req-1',
     });
-    // The same standing note an inbound message carries: an answer leaves the
-    // model in the same chat, under the same consequence.
-    expect(submissions[0]?.reminder).toBe(CHANNEL_REMINDER);
+    expect(delivered[0]?.submission.attrs['thread_id']).toBeUndefined();
+    expect(bot.editedCards).toEqual([{ messageId: 'om_card', card: {} }]);
+  });
+
+  it.each([
+    ['the lookup fails', new Error('feishu refused the read')],
+    ['it reports nothing about the card', { items: [] }],
+  ])('delivers nowhere at all when %s', async (_case, read) => {
+    const { delivery, delivered } = capturingDelivery();
+    const bot = createFakeFeishuBot();
+    const h = handle(delivery, bot);
+    bot.setMessageRead('om_card', 'default', read);
+
+    await expireAskUserQuestion(h, {
+      settlement: {
+        requestId: 'req-1',
+        outcome: 'expired',
+        text: 'The question expired with no answer.',
+        sourceId: 'ask:req-1',
+        cardMessageId: 'om_card',
+      },
+      card: {},
+    });
+
+    // Not the chat the question was asked from, and not the Dispatcher Agent:
+    // a guessed parent chat shows one conversation's answer to another. The
+    // repaint is independent and still happens.
+    expect(delivered).toHaveLength(0);
+    expect(bot.editedCards).toEqual([{ messageId: 'om_card', card: {} }]);
   });
 });

--- a/packages/channel/feishu-channel/tests/feishu-settlement-envelope.test.ts
+++ b/packages/channel/feishu-channel/tests/feishu-settlement-envelope.test.ts
@@ -12,9 +12,19 @@
 import { describe, expect, it } from 'vitest';
 
 import { createAskUserRegistry } from '../src/feishu-ask-user.js';
+import {
+  DREAMUX_ASK_OPTION_KEY,
+  DREAMUX_ASK_PICK_ACTION,
+  DREAMUX_ASK_QUESTION_KEY,
+  DREAMUX_ASK_REQUEST_KEY,
+  DREAMUX_ASK_SUBMIT_ACTION,
+} from '../src/feishu-ask-user-card.js';
+import { DREAMUX_ACTION_KEY } from '../src/feishu-pairing-card.js';
 import { FeishuTargetRouter } from '../src/feishu-target-router.js';
 import {
+  askUserQuestion,
   expireAskUserQuestion,
+  handleCardAction,
   sessionHandle,
   type SessionHandle,
 } from '../src/feishu-session-ops.js';
@@ -55,8 +65,10 @@ function capturingDelivery(): {
   };
 }
 
-function handle(delivery: FeishuInboundDelivery): SessionHandle {
-  const bot = createFakeFeishuBot();
+function handle(
+  delivery: FeishuInboundDelivery,
+  bot = createFakeFeishuBot(),
+): SessionHandle {
   return sessionHandle({
     opts: {
       dispatcherId: 'dispatcher-1',
@@ -78,6 +90,71 @@ function handle(delivery: FeishuInboundDelivery): SessionHandle {
 }
 
 describe('the ask-card settlement envelope', () => {
+  it('uses each answered card id to keep the next question in the same topic', async () => {
+    const { delivery, submissions } = capturingDelivery();
+    const bot = createFakeFeishuBot();
+    const h = handle(delivery, bot);
+    const target = topicTarget('oc_room', 'omt_thread');
+    h.targetRouter.observe('om_initial', target);
+    let messageId = 'om_initial';
+
+    try {
+      for (let round = 0; round < 2; round++) {
+        const opened = await askUserQuestion(h, {
+          chatId: target.chatId,
+          messageId,
+          questions: [{
+            header: 'Choice',
+            question: 'Which option?',
+            options: [
+              { label: 'First', description: 'Use the first option' },
+              { label: 'Second', description: 'Use the second option' },
+            ],
+          }],
+        });
+        const card = bot.sentCards[round];
+        expect(card?.target).toEqual({
+          chatId: target.chatId,
+          replyToMessageId: messageId,
+        });
+        const cardId = card?.messageIds[0];
+        if (cardId === undefined) throw new Error('expected a sent card');
+
+        for (const action of [DREAMUX_ASK_PICK_ACTION, DREAMUX_ASK_SUBMIT_ACTION]) {
+          await handleCardAction(h, {
+            actionValue: {
+              [DREAMUX_ACTION_KEY]: action,
+              [DREAMUX_ASK_REQUEST_KEY]: opened.request_id,
+              [DREAMUX_ASK_QUESTION_KEY]: 0,
+              [DREAMUX_ASK_OPTION_KEY]: 0,
+            },
+            openMessageId: cardId,
+            operatorOpenId: 'ou_clicker',
+            raw: {},
+          });
+        }
+
+        const answer = submissions[round];
+        expect(answer?.attrs).toMatchObject({
+          source: 'feishu',
+          chat_id: target.chatId,
+          thread_id: target.threadId,
+          message_id: cardId,
+          ask_user_request_id: opened.request_id,
+        });
+        expect(answer?.anchor).toEqual({
+          chatId: target.chatId,
+          messageId: cardId,
+          target,
+        });
+        messageId = String(answer?.attrs.message_id);
+      }
+      expect(submissions).toHaveLength(2);
+    } finally {
+      h.askUser.abandonAll();
+    }
+  });
+
   it('carries source="feishu" among its attributes, next to the ids', async () => {
     const { delivery, submissions } = capturingDelivery();
 

--- a/packages/channel/feishu-channel/tests/feishu-target-router.test.ts
+++ b/packages/channel/feishu-channel/tests/feishu-target-router.test.ts
@@ -1,0 +1,56 @@
+/**
+ * The observed-message ledger: which target this session files a message under.
+ *
+ * A reply is addressed by message id and Feishu threads it; the ledger's job is
+ * the other half — naming the place the reply landed in, so a later reply to
+ * *it* is filed there too. That place is read from the message replied to, and
+ * only when it is in the chat the caller named: a stale or copied id must not
+ * quietly move a conversation somewhere else.
+ */
+import { describe, expect, it } from 'vitest';
+
+import { FeishuTargetRouter } from '../src/feishu-target-router.js';
+import { chatTarget, topicTarget } from '../src/routing/target.js';
+
+const silent = {
+  error: () => undefined,
+  warn: () => undefined,
+  info: () => undefined,
+  debug: () => undefined,
+  trace: () => undefined,
+};
+
+function router(): FeishuTargetRouter {
+  return new FeishuTargetRouter({ chatModes: {}, log: silent });
+}
+
+describe('the target an outbound message is filed under', () => {
+  it('follows the named message into its topic', () => {
+    const r = router();
+    r.observe('om_asked', topicTarget('oc_room', 'omt_thread'));
+
+    expect(r.outboundTarget('oc_room', 'om_asked')).toEqual(
+      topicTarget('oc_room', 'omt_thread'),
+    );
+  });
+
+  it('names the chat itself when no message is named', () => {
+    const r = router();
+    r.observe('om_asked', topicTarget('oc_room', 'omt_thread'));
+
+    expect(r.outboundTarget('oc_room', undefined)).toEqual(
+      chatTarget('oc_room', 'group'),
+    );
+  });
+
+  it('ignores a message from another chat rather than following it there', () => {
+    const r = router();
+    r.observe('om_elsewhere', topicTarget('oc_other', 'omt_thread'));
+
+    // Deliberate: a stale or copied id must not file a message meant for one
+    // conversation under another. The named chat wins.
+    expect(r.outboundTarget('oc_room', 'om_elsewhere')).toEqual(
+      chatTarget('oc_room', 'group'),
+    );
+  });
+});

--- a/packages/channel/feishu-transport/src/transport/message-read.ts
+++ b/packages/channel/feishu-transport/src/transport/message-read.ts
@@ -7,7 +7,7 @@ export interface FeishuMessageReadRequest {
   cardContent?: FeishuMessageReadMode
 }
 
-/** Content-only projection of one `im.v1.message.get` item. */
+/** Projection of one `im.v1.message.get` item: its content, and where it is. */
 export interface FeishuMessageReadItem {
   messageId: string
   messageType: string
@@ -15,6 +15,10 @@ export interface FeishuMessageReadItem {
   mentions: Mention[]
   deleted: boolean
   malformed: boolean
+  /** The chat the message is in. Empty when the response omitted it. */
+  chatId: string
+  /** The topic it is in, present only for a message inside one. */
+  threadId?: string
 }
 
 export interface FeishuMessageReadResponse {
@@ -31,6 +35,8 @@ export interface RawMessageReadItem {
   message_id?: string
   msg_type?: string
   deleted?: boolean
+  chat_id?: string
+  thread_id?: string
   body?: { content?: string }
   mentions?: Array<{
     key?: string
@@ -46,12 +52,15 @@ export function normalizeMessageReadItem(
   const messageId = raw.message_id ?? ''
   const messageType = raw.msg_type ?? ''
   const content = raw.body?.content ?? ''
+  const threadId = raw.thread_id ?? ''
   return {
     messageId,
     messageType,
     content,
     mentions: (raw.mentions ?? []).map(normalizeMessageReadMention),
     deleted: raw.deleted === true,
+    chatId: raw.chat_id ?? '',
+    ...(threadId !== '' ? { threadId } : {}),
     malformed:
       messageId === '' ||
       messageType === '' ||

--- a/packages/channel/feishu-transport/tests/transport.test.ts
+++ b/packages/channel/feishu-transport/tests/transport.test.ts
@@ -132,6 +132,8 @@ function stubClient() {
       items: [{
         message_id: 'om_read',
         msg_type: 'interactive',
+        chat_id: 'oc_read',
+        thread_id: 'omt_topic',
         body: { content: JSON.stringify({ title: 'visible' }) },
         upper_message_id: 'om_parent',
         sender: {
@@ -716,6 +718,10 @@ describe('createFeishuTransport — message reads', () => {
         }],
         deleted: false,
         malformed: false,
+        // Where the message is, which is how a card answer finds its way back
+        // into the conversation the card is actually in.
+        chatId: 'oc_read',
+        threadId: 'omt_topic',
       }],
     })
   })
@@ -759,6 +765,7 @@ describe('createFeishuTransport — message reads', () => {
         content: '',
         mentions: [],
         deleted: true,
+        chatId: '',
         malformed: true,
       }],
     })


### PR DESCRIPTION
Question cards now reply directly to the supplied message ID, including messages
absent from the session's observation ledger. Answers and expiry notices resolve
the actual card's chat/topic through Feishu message details and retain that card's
ID in the inbound envelope and presentation anchor. A failed message lookup is a
delivery failure instead of a guessed parent-chat route.

The question registry no longer stores a precomputed target or a duplicate expiry
message ID. Feishu message reads expose chat/topic metadata, and ordinary inbound
messages and card settlements share the existing chat-mode projection. Core,
runtime providers, persisted state and unrelated notification sending are unchanged.

Validation: Rush build, lint, test, typecheck:tests, built-CLI smoke, knowledge links,
change declarations and commit hooks. Regression coverage includes unobserved reply
IDs, no-ID creation, submitted/cancelled answers, consecutive rounds, expiry and
message-lookup failures. Existing router ledger tests were retained in their owning
suite. Rebased onto next `6bb8a713` before final verification.

Each settlement adds one message-details lookup. Thread-bearing cards also use the
existing cached chat-mode lookup; its ordinary-inbound fallback behavior is
unchanged. Message details omit chat type, so readback uses the existing group
default when no topic is resolved; unbound direct-chat answers still reach the
Dispatcher. Live Feishu validation is recorded below.

DevBox review requested by the operator; the earlier approval covered the
superseded minimal patch.

Task: [requirements and implementation record](https://github.com/excitedjs/dreamux/blob/fix/feishu-question-card-routing/.agents/tasks/channel/fix-question-card-topic-routing/README.md).

CI: [all 9 checks passed](https://github.com/excitedjs/dreamux/actions/runs/34435750357)
on `94ee3505778a1b37756cb0edb5b308b06c5f110e`, including Linux and macOS gates.

Alpha published from `94ee3505778a1b37756cb0edb5b308b06c5f110e`:
`@excitedjs/dreamux@0.25.0-alpha.g94ee3505778a`
([release run](https://github.com/excitedjs/dreamux/actions/runs/34436982446),
[tarball](https://registry.npmjs.org/@excitedjs/dreamux/-/dreamux-0.25.0-alpha.g94ee3505778a.tgz)).
Registry metadata and downloaded tarball SHA-512 integrity were verified.

```sh
npm install -g @excitedjs/dreamux@0.25.0-alpha.g94ee3505778a
```

Live Feishu validation passed on `0.25.0-alpha.g94ee3505778a`: after the operator
upgraded, the first question was answered, and the second question was sent using
exactly the first settlement envelope's `message_id`. Both answer envelopes
retained the original topic, and the operator confirmed that the second card
rendered in that same topic. The two-card test is complete.
