### PR TITLE
Report a finished Workflow run as tagged facts, not an inlined result

### DIFF
--- a/.agents/domains/model-facing-writing.md
+++ b/.agents/domains/model-facing-writing.md
@@ -259,6 +259,41 @@ text once `structuredContent` is present). Receipt attachment belongs to the
 MCP delegates, not public tool metadata, Command data, or a Channel provider
 contract.
 
+## Completion Notifications
+
+A completion reaches its recipient as ordinary turn text, so every notification
+opens by saying the host sent it: `This is an automated notification from
+Dreamux, not a message from the user.` Two producers follow that sentence with
+different shapes, because they report different kinds of thing
+(`/packages/dreamux/src/service/teammate-service/completion-renderer.ts`).
+
+A **TeamMate** answers in its own words, so the answer is the notification: a
+one-line status sentence, then the result inline, or the path to it when the
+result is over the inline budget.
+
+A **Workflow** run returns a script's value rather than prose written for a
+reader, and its caller usually decides whether to read it at all. So the
+notification states facts and names files:
+
+```
+<workflow-notification>
+<task-id>run-9f2a</task-id>
+<output-file><run-dir>/output.json</output-file>
+<status>completed — 4 agents: 4 succeeded, 0 failed</status>
+<summary>Dynamic workflow "<the description its script declared>" completed</summary>
+<diagnostics>Per-agent results: <run-dir>/journal.jsonl — …</diagnostics>
+</workflow-notification>
+```
+
+The result is deliberately absent: no tag carries it, so no run can flood its
+caller's context with a value the caller may not want, and `<output-file>` is
+therefore written for every terminal. A non-null run error is appended to
+`<status>`, so a failed run needs no tag of its own. Agents are counted as
+succeeded and failed against a total, and only those two: Dreamux has no way to
+skip one Agent of a run, and an Agent a terminal settled as stopped is in the
+total but in neither count, which the run's own terminal status already
+explains.
+
 ## Tests
 
 Tests should protect contracts, not prose preferences. Prefer:

--- a/.agents/domains/state-config-and-files.md
+++ b/.agents/domains/state-config-and-files.md
@@ -112,9 +112,11 @@ state/<dispatcher-id>/
     workflow/<run-id>/
       record.json
       journal.jsonl
+      output.json
   workflow/<run-id>/
     record.json
     journal.jsonl
+    output.json
 ```
 
 `teammate/` and `team/` hold only entity directories, because listing a
@@ -271,6 +273,19 @@ transition writes `completed`, `failed`, or `stopped`; startup first adopts an
 already-committed terminal journal fact when present and otherwise converts a
 leftover `running` record to `stopped`. Journals are server-written JSONL and
 are not replayed by the current runtime.
+
+The record carries the `name` and `description` the submitted script declared,
+read before the record exists so a run can report itself in its own words. Both
+are nullable for a record written before runs carried them; a run created by
+the current build always has both.
+
+Every terminal also writes `output.json` beside those two: the run's status,
+result, error, and Agent names, as one document. A run converged to a terminal
+by the startup recovery above writes it too, so the file exists for every
+finished run and not only for one whose caller was notified. The completion
+notification names this path instead of carrying the result, so it is state
+with the same lifetime as the run, not a cache — a sweep between the notification and the
+caller's read would otherwise hand the caller a dangling path.
 
 Source:
 

--- a/.agents/product/README.md
+++ b/.agents/product/README.md
@@ -327,6 +327,12 @@ the same change that touches it.
   caller not to poll for completion and allow a natural turn end while waiting
   for the push; operator-requested progress inspection remains available.
   (Task: [strengthen-dispatch-and-compaction-text](/.agents/tasks/mcp/strengthen-dispatch-and-compaction-text/README.md).)
+- **A Workflow push states facts; a TeamMate push carries its answer.** A
+  TeamMate's completion is its own words, so the push contains the result. A
+  finished Workflow run's push instead names its status, its Agent counts, and
+  the paths to its output and journal — the result stays in the run's
+  `output.json` and never enters the caller's context unasked. (Domain:
+  [model-facing-writing](/.agents/domains/model-facing-writing.md).)
 
 ## Local state and upgrades
 

--- a/.agents/product/dynamic-workflow-usage.md
+++ b/.agents/product/dynamic-workflow-usage.md
@@ -1,6 +1,6 @@
 # Dynamic Workflow Usage Guide (Beta)
 
-> Applies to Dreamux 0.22.x-beta. The capability is beta: its interface is
+> Applies to Dreamux 0.24.x-beta. The capability is beta: its interface is
 > stable, while behavior may still receive small refinements.
 
 Dynamic Workflow is Dreamux's deterministic multi-agent orchestration
@@ -197,15 +197,18 @@ export const meta = {
 };
 ```
 
-`name` and `description` are required strings. `whenToUse` is an optional
+`name` and `description` are required strings, and both are recorded with the
+run: `description` is the phrase the terminal notification quotes back, so write
+it as the sentence you want to read when the run finishes. `whenToUse` is an optional
 string. Each `phases` entry is `{ title, detail?, model? }`. `detail` and
 `model` are descriptive compatibility metadata; `model` does not select an
 agent model or runtime. Unknown recursively plain literal keys on `meta` and
 phase objects are accepted and currently ignored.
 
-Metadata is validated before the orchestration body can start agents. It is not
-persisted on the run, projected by `workflow_status` or `workflow_list`, or used
-for permission confirmation.
+Metadata is validated at submission, before a run exists. `name` and
+`description` are persisted on the run and projected by `workflow_status` and
+`workflow_list`; the remaining keys are validated only. No part of `meta` is
+used for permission confirmation.
 
 Metadata must be a recursively plain literal object: no variables, calls,
 interpolation, computed properties, methods, shorthand properties, or spread.
@@ -356,9 +359,11 @@ clamped.
 `args` is also optional. Supply direct JSON values; do not encode an object or
 array as JSON text.
 
-For an admitted request, `workflow_run` returns `run_id` immediately. Script
-compilation, entry, or metadata failures happen asynchronously and produce a
-durable failed run plus its terminal completion.
+For an admitted request, `workflow_run` returns `run_id` immediately. A script
+that declares no valid `meta` is rejected by the call itself, before a run
+exists — a run is created with the words its own script declares. Compilation
+and entry failures happen asynchronously and produce a durable failed run plus
+its terminal completion.
 
 ### 4.2 Status
 
@@ -366,8 +371,8 @@ durable failed run plus its terminal completion.
 workflow_status({ run_id: 'run-abc123' })
 ```
 
-Returns the current phase, agent progress, concrete TeamMate names, and terminal
-result when available.
+Returns the words the script declared about itself, the current phase, agent
+progress, concrete TeamMate names, and terminal result when available.
 
 ### 4.3 List
 
@@ -387,6 +392,29 @@ Requests the stopped outcome and resolves only after the run is durably
 terminal: in-flight agent turns settle, the terminal fact is persisted and
 delivered, and the returned status is already final
 (`/packages/dreamux/src/service/workflow-service/run-terminal.ts`).
+
+### 4.5 Terminal Notification
+
+When a run reaches a terminal, its caller is pushed one notification. It states
+what happened and names the files; it never carries the result:
+
+```
+This is an automated notification from Dreamux, not a message from the user.
+
+<workflow-notification>
+<task-id>run-abc123</task-id>
+<output-file>~/.dreamux/state/<dispatcher-id>/workflow/run-abc123/output.json</output-file>
+<status>completed — 4 agents: 4 succeeded, 0 failed</status>
+<summary>Dynamic workflow "What this workflow does" completed</summary>
+<diagnostics>Per-agent results: .../journal.jsonl — one {"kind":"result",...} line per settled Agent.</diagnostics>
+</workflow-notification>
+```
+
+`<summary>` quotes the `description` the script declared. `<status>` is the
+terminal status, the Agent counts, and — when the run has one — its error. Read
+`<output-file>` to get the run's result: it holds `run_id`, `status`, `result`,
+`error`, and the Agent names, and it is written for every terminal, including a
+stopped run whose caller is not notified at all.
 
 ---
 

--- a/common/changes/@excitedjs/dreamux/feat-workflow-notification-tags_2026-09-08-15-20.json
+++ b/common/changes/@excitedjs/dreamux/feat-workflow-notification-tags_2026-09-08-15-20.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Report a finished Dynamic Workflow run as tagged facts instead of an inlined result. The completion push now carries `<task-id>`, `<output-file>`, `<status>` with the run's Agent counts and error, `<summary>` quoting the script's own `description`, and `<diagnostics>`; the result itself is written to a new server-owned `output.json` beside the run's `record.json` and `journal.jsonl`, and the push names that path. A run's `record.json` additionally stores the `name` and `description` its script declared, and `workflow_status` / `workflow_list` project both; a record written without them still loads, reading both as null. A script that declares no valid `meta` is now rejected by `workflow_run` itself instead of producing a durable failed run. TeamMate completion pushes are unchanged.",
+      "type": "minor",
+      "packageName": "@excitedjs/dreamux"
+    }
+  ],
+  "packageName": "@excitedjs/dreamux",
+  "email": "hvjfccdy6s@privaterelay.appleid.com"
+}

--- a/packages/dreamux/skills/dispatcher/dreamux-maintenance/references/service-lifecycle.md
+++ b/packages/dreamux/skills/dispatcher/dreamux-maintenance/references/service-lifecycle.md
@@ -78,9 +78,15 @@ runtime app-server readiness, and same-version restart cautions.
   `~/.dreamux/state/<dispatcher-id>/workflow/<run-id>/`; TeamLeader-scoped
   Workflow state lives under
   `~/.dreamux/state/<dispatcher-id>/team/<team-id>/workflow/<run-id>/`. Each
-  run's `record.json` and append-only `journal.jsonl` are fully server-owned. Do
-  not edit, truncate, copy over, synthesize, or delete either file as a repair
-  action.
+  run's `record.json`, append-only `journal.jsonl`, and terminal `output.json`
+  are fully server-owned. Do not edit, truncate, copy over, synthesize, or
+  delete any of the three as a repair action.
+- `record.json` carries the `name` and `description` the submitted script
+  declared; both are null on a record written by a build that did not record
+  them. `output.json` is written at every terminal and holds that run's status,
+  result, error, and Agent names. The run's completion notification names the
+  `output.json` path rather than carrying the result, so treat the file as the
+  supported way to read a finished run's result.
 - Use `workflow_status` and `workflow_list` in the original caller scope for
   public run inspection. Treat `record.json` and `journal.jsonl` as narrow
   diagnostics only when the supported surfaces are insufficient; sanitize
@@ -89,10 +95,12 @@ runtime app-server readiness, and same-version restart cautions.
   Do not change durable state to override that bound. A run can start at most
   1000 agents across its complete lifecycle; `parallel()` accepts at most 4096
   functions and `pipeline()` accepts at most 4096 items per call.
-- A returned `{ run_id }` is a durable acceptance receipt, not proof that script
-  compilation, metadata validation, runtime execution, completion delivery,
-  or visible Channel delivery succeeded. Inspect the run's terminal state and
-  then the delivery boundary separately.
+- A script that declares no valid `meta` is rejected by `workflow_run` itself,
+  before a run id exists; there is no durable record to inspect for that case.
+  A returned `{ run_id }` is a durable acceptance receipt, not proof that script
+  compilation, runtime execution, completion delivery, or visible Channel
+  delivery succeeded. Inspect the run's terminal state and then the delivery
+  boundary separately.
 - A run stopped by `workflow_stop`, Team dissolve, or host stop converges its
   record and journal to `stopped` and pushes no terminal completion to the
   Agent that started it; a run whose completed or failed terminal was selected

--- a/packages/dreamux/src/platform/paths.ts
+++ b/packages/dreamux/src/platform/paths.ts
@@ -404,6 +404,17 @@ export function workflowRunJournalPath(input: WorkflowRunPathInput): string {
 }
 
 /**
+ * `<run-dir>/output.json` — the terminal result the caller is pointed at.
+ *
+ * The completion notification names this path instead of inlining the result,
+ * so it has to survive as long as the run does: state beside the record and the
+ * journal, not a cache a sweep may remove between the notification and the read.
+ */
+export function workflowRunOutputPath(input: WorkflowRunPathInput): string {
+  return join(workflowRunDir(input), 'output.json');
+}
+
+/**
  * `<entity-dir>/identity.json` — durable identity and runtime association.
  *
  * The entity directory arrives already resolved from the owner that

--- a/packages/dreamux/src/service/completion-router/index.ts
+++ b/packages/dreamux/src/service/completion-router/index.ts
@@ -4,18 +4,38 @@ import { errorInfo } from '../../platform/error-info.js';
 
 interface CompletionFactBase {
   status: 'completed' | 'failed' | 'stopped';
-  result: string | null;
 }
 
 export interface TeammateCompletionFact extends CompletionFactBase {
   kind: 'teammate';
   source: string;
+  result: string | null;
 }
 
+/** How many of a run's Agents reached each outcome, counted at its terminal. */
+export interface WorkflowAgentTally {
+  total: number;
+  succeeded: number;
+  failed: number;
+}
+
+/**
+ * A finished Workflow run, as its caller is told about it.
+ *
+ * The result itself is not carried: it is written where the run's other durable
+ * facts live, and the caller is given the path. What travels here is only what
+ * the notification states without a read — the run's own words, how its Agents
+ * came out, and where to look next.
+ */
 export interface WorkflowCompletionFact extends CompletionFactBase {
   kind: 'workflow';
   source: 'workflow';
   runId: string;
+  description: string | null;
+  error: string | null;
+  agents: WorkflowAgentTally;
+  outputPath: string;
+  journalPath: string;
 }
 
 export type PreparedCompletionFact =

--- a/packages/dreamux/src/service/teammate-collection/mcp-tool-descriptors.ts
+++ b/packages/dreamux/src/service/teammate-collection/mcp-tool-descriptors.ts
@@ -475,6 +475,10 @@ function workflowRunSchema(): Record<string, unknown> {
       team_id: { type: ['string', 'null'] },
       caller_kind: { type: 'string', enum: ['dispatcher', 'team_leader'] },
       script_hash: { type: 'string' },
+      // The words the script declared about itself. Null only on a record
+      // written before a run carried them.
+      name: { type: ['string', 'null'] },
+      description: { type: ['string', 'null'] },
       status: {
         type: 'string',
         enum: ['running', 'completed', 'failed', 'stopped'],
@@ -497,6 +501,8 @@ function workflowRunSchema(): Record<string, unknown> {
       'team_id',
       'caller_kind',
       'script_hash',
+      'name',
+      'description',
       'status',
       'max_concurrency',
       'phase',

--- a/packages/dreamux/src/service/teammate-service/completion-renderer.ts
+++ b/packages/dreamux/src/service/teammate-service/completion-renderer.ts
@@ -1,6 +1,10 @@
 import { resolveCompletionBody } from '@excitedjs/dreamux-utils';
 
-import type { PreparedCompletionFact } from '../completion-router/index.js';
+import type {
+  PreparedCompletionFact,
+  TeammateCompletionFact,
+  WorkflowCompletionFact,
+} from '../completion-router/index.js';
 
 /**
  * The submission seam carries text only, so a pushed completion reaches the
@@ -10,51 +14,86 @@ import type { PreparedCompletionFact } from '../completion-router/index.js';
 const NOTIFICATION_SENTENCE =
   'This is an automated notification from Dreamux, not a message from the user.';
 
-/** Render any routed completion through the shared inline/spill pipeline. */
+/** Render any routed completion through the shape its producer reports in. */
 export async function buildCompletionTurnText(
   completion: PreparedCompletionFact,
   spillDir: string,
 ): Promise<string> {
-  const head = `${completionStatusLine(completion)} ${NOTIFICATION_SENTENCE}`;
+  return completion.kind === 'workflow'
+    ? workflowNotification(completion)
+    : teammateNotification(completion, spillDir);
+}
+
+/**
+ * One TeamMate's settled turn: prose plus the result it produced.
+ *
+ * A TeamMate answers in its own words, so the answer is the body — inlined when
+ * it fits the turn budget and spilled to a file when it does not.
+ */
+async function teammateNotification(
+  completion: TeammateCompletionFact,
+  spillDir: string,
+): Promise<string> {
+  const head = `${teammateStatusLine(completion)} ${NOTIFICATION_SENTENCE}`;
   const body = await resolveCompletionBody(completion, spillDir);
   return body.kind === 'inline'
     ? `${head} Output below:\n\n${body.text}`
     : `${head} The output is too long, so the full result was saved to a file:\n\n${body.path}`;
 }
 
-function completionStatusLine(completion: PreparedCompletionFact): string {
-  switch (completion.kind) {
-    case 'teammate':
-      return teammateStatusLine(completion.source, completion.status);
-    case 'workflow':
-      return workflowStatusLine(completion.runId, completion.status);
-  }
+/**
+ * One finished Workflow run: tagged facts and the paths to everything else.
+ *
+ * A run produces a script's return value, not an answer written for a reader,
+ * and the caller usually needs to know how it went before deciding whether to
+ * read it at all. So the notification states the outcome and names the files,
+ * and the result stays on disk until the caller asks for it.
+ */
+function workflowNotification(completion: WorkflowCompletionFact): string {
+  return [
+    NOTIFICATION_SENTENCE,
+    '',
+    '<workflow-notification>',
+    `<task-id>${completion.runId}</task-id>`,
+    `<output-file>${completion.outputPath}</output-file>`,
+    `<status>${workflowStatus(completion)}</status>`,
+    `<summary>${workflowSummary(completion)}</summary>`,
+    `<diagnostics>${workflowDiagnostics(completion)}</diagnostics>`,
+    '</workflow-notification>',
+  ].join('\n');
 }
 
-function teammateStatusLine(
-  source: string,
-  status: PreparedCompletionFact['status'],
-): string {
-  switch (status) {
-    case 'completed':
-      return `TeamMate ${source} has finished its task.`;
-    case 'failed':
-      return `TeamMate ${source}'s task failed.`;
-    case 'stopped':
-      return `TeamMate ${source}'s task was stopped.`;
-  }
+function workflowStatus(completion: WorkflowCompletionFact): string {
+  const { total, succeeded, failed } = completion.agents;
+  const agents = `${total} ${total === 1 ? 'agent' : 'agents'}`;
+  const counts = `${agents}: ${succeeded} succeeded, ${failed} failed`;
+  const reason = completion.error === null ? '' : ` — ${completion.error}`;
+  return `${completion.status} — ${counts}${reason}`;
 }
 
-function workflowStatusLine(
-  runId: string,
-  status: PreparedCompletionFact['status'],
-): string {
-  switch (status) {
+function workflowSummary(completion: WorkflowCompletionFact): string {
+  // A run created before records carried the script's own words has no
+  // description, and its id is then the only thing a summary can truthfully say.
+  const subject = completion.description === null
+    ? completion.runId
+    : JSON.stringify(completion.description);
+  return `Dynamic workflow ${subject} ${completion.status}`;
+}
+
+function workflowDiagnostics(completion: WorkflowCompletionFact): string {
+  return (
+    `Per-agent results: ${completion.journalPath} — one {"kind":"result",...} ` +
+    'line per settled Agent. Read it before diagnosing an unexpected result.'
+  );
+}
+
+function teammateStatusLine(completion: TeammateCompletionFact): string {
+  switch (completion.status) {
     case 'completed':
-      return `Workflow ${runId} has completed.`;
+      return `TeamMate ${completion.source} has finished its task.`;
     case 'failed':
-      return `Workflow ${runId} failed.`;
+      return `TeamMate ${completion.source}'s task failed.`;
     case 'stopped':
-      return `Workflow ${runId} was stopped.`;
+      return `TeamMate ${completion.source}'s task was stopped.`;
   }
 }

--- a/packages/dreamux/src/service/workflow-service/index.ts
+++ b/packages/dreamux/src/service/workflow-service/index.ts
@@ -26,6 +26,8 @@ import { validateWorkflowArgs } from './json-args.js';
 import { WorkflowJournal } from './journal.js';
 import { parseWorkflowMaxConcurrency } from './limits.js';
 import { WorkflowRun } from './run.js';
+import { publishWorkflowRunOutput } from './run-support.js';
+import { readWorkflowMeta } from './script-compiler.js';
 import {
   ForkedWorkflowRunner,
   type WorkflowRunnerFactory,
@@ -119,6 +121,10 @@ export class WorkflowService implements WorkflowOps {
     if (script.trim() === '') {
       throw new Error('workflow script must be non-empty');
     }
+    // Read here, not in the runner child: the record is created before the
+    // child exists, and a run reports itself in the words its own script
+    // declared. A script that declares none is rejected at submission.
+    const meta = readWorkflowMeta(script);
 
     const runId = validateWorkflowRunId(
       this.opts.generateRunId?.() ?? `run-${randomUUID()}`,
@@ -132,6 +138,8 @@ export class WorkflowService implements WorkflowOps {
       team_id: this.scope.teamId,
       caller_kind: this.opts.callerKind,
       script_hash: createHash('sha256').update(script).digest('hex'),
+      name: meta.name,
+      description: meta.description,
       status: 'running',
       max_concurrency: maxConcurrency,
       phase: null,
@@ -317,6 +325,7 @@ export class WorkflowService implements WorkflowOps {
         record.updated_at = committedTerminal.ended_at;
       }
       await this.store.write(record);
+      await publishWorkflowRunOutput(record);
       this.opts.log.warn(
         { run_id: record.run_id, status: record.status },
         committedTerminal === null

--- a/packages/dreamux/src/service/workflow-service/journal.ts
+++ b/packages/dreamux/src/service/workflow-service/journal.ts
@@ -50,7 +50,7 @@ export class WorkflowJournal {
   private tail: Promise<void> = Promise.resolve();
   private facts: WorkflowJournalFacts | null = null;
 
-  constructor(private readonly path: string) {}
+  constructor(readonly path: string) {}
 
   create(event: Extract<WorkflowJournalEvent, { kind: 'run' }>): Promise<void> {
     return this.enqueue(async () => {

--- a/packages/dreamux/src/service/workflow-service/run-support.ts
+++ b/packages/dreamux/src/service/workflow-service/run-support.ts
@@ -1,4 +1,50 @@
+import { writeFileAtomic } from '../../platform/atomic-write.js';
+import { workflowRunOutputPath } from '../../platform/paths.js';
+import type { WorkflowAgentTally } from '../completion-router/index.js';
 import type { WorkflowAgentOptions } from './protocol.js';
+import type { WorkflowAgentRecord, WorkflowRunRecord } from './types.js';
+
+/**
+ * Write the terminal result where the caller is told to find it.
+ *
+ * The completion notification names this file instead of carrying the result,
+ * so every terminal record has one: a run stopped with nobody to notify and a
+ * run recovered as terminal after a restart included. It is rewritten
+ * identically when the terminal task is retried.
+ */
+export async function publishWorkflowRunOutput(
+  record: WorkflowRunRecord,
+): Promise<string> {
+  const path = workflowRunOutputPath({
+    dispatcherId: record.dispatcher_id,
+    teamId: record.team_id,
+    runId: record.run_id,
+  });
+  const output = {
+    run_id: record.run_id,
+    status: record.status,
+    result: record.result,
+    error: record.error,
+    agents: record.agents
+      .filter((agent) => agent.name !== null)
+      .map((agent) => ({ index: agent.index, name: agent.name })),
+  };
+  await writeFileAtomic(path, `${JSON.stringify(output, null, 2)}\n`, {
+    mode: 0o600,
+  });
+  return path;
+}
+
+/** Count how a run's Agents came out, for the one line that reports it. */
+export function tallyWorkflowAgents(
+  agents: readonly WorkflowAgentRecord[],
+): WorkflowAgentTally {
+  return {
+    total: agents.length,
+    succeeded: agents.filter((agent) => agent.status === 'completed').length,
+    failed: agents.filter((agent) => agent.status === 'failed').length,
+  };
+}
 
 export class WorkflowSemaphore {
   private active = 0;

--- a/packages/dreamux/src/service/workflow-service/run.ts
+++ b/packages/dreamux/src/service/workflow-service/run.ts
@@ -37,6 +37,8 @@ import type {
 import {
   nonEmpty,
   normalizeAgentOptions,
+  publishWorkflowRunOutput,
+  tallyWorkflowAgents,
   WorkflowPersistenceError,
   WorkflowSemaphore,
 } from './run-support.js';
@@ -631,26 +633,19 @@ export class WorkflowRun {
       this.unlockedHandles.add(handle);
     }
 
+    const outputPath = await publishWorkflowRunOutput(candidate);
     const deliverTerminal = this.deliverTerminal;
     if (deliverTerminal !== null) {
       await deliverTerminal({
         kind: 'workflow',
         source: 'workflow',
-        runId: this.record.run_id,
+        runId: candidate.run_id,
         status: candidate.status as WorkflowTerminalStatus,
-        result: JSON.stringify(
-          {
-            run_id: candidate.run_id,
-            status: candidate.status,
-            result: candidate.result,
-            error: candidate.error,
-            agents: candidate.agents
-              .filter((agent) => agent.name !== null)
-              .map((agent) => ({ index: agent.index, name: agent.name })),
-          },
-          null,
-          2,
-        ),
+        description: candidate.description,
+        error: candidate.error,
+        agents: tallyWorkflowAgents(candidate.agents),
+        outputPath,
+        journalPath: this.deps.journal.path,
       });
       this.deliverTerminal = null;
     }

--- a/packages/dreamux/src/service/workflow-service/script-compiler.ts
+++ b/packages/dreamux/src/service/workflow-service/script-compiler.ts
@@ -14,6 +14,29 @@ interface WorkflowMetaExport {
   initializer: Expression;
 }
 
+/** The identity a workflow script declares about itself. */
+export interface WorkflowMeta {
+  name: string;
+  description: string;
+}
+
+/**
+ * Read the declared identity without compiling.
+ *
+ * The scope that creates a run needs the script's own words before the runner
+ * child exists, so the durable record carries them from the moment the run is
+ * created. Validation lives in one place, so what this accepts and what the
+ * compiler accepts cannot drift.
+ */
+export function readWorkflowMeta(source: string): WorkflowMeta {
+  const program = parseWorkflowScript(source);
+  const metaExport = workflowMetaExport(program.body[0]);
+  if (metaExport === null) {
+    throw new Error('workflow script must start with export const meta');
+  }
+  return validateWorkflowMeta(readPlainLiteralObject(metaExport.initializer));
+}
+
 /**
  * Compile the single public Workflow dialect into one private async closure.
  * The metadata source range is replaced with syntax + whitespace that preserves
@@ -200,18 +223,21 @@ function plainPropertyName(property: Property): string {
   throw new Error('workflow meta object keys must be non-computed literals');
 }
 
-function validateWorkflowMeta(meta: Record<string, unknown>): void {
-  if (typeof meta.name !== 'string' || typeof meta.description !== 'string') {
+function validateWorkflowMeta(meta: Record<string, unknown>): WorkflowMeta {
+  const { name, description } = meta;
+  if (typeof name !== 'string' || typeof description !== 'string') {
     throw new Error('workflow meta must include string name and description');
   }
   if (meta.whenToUse !== undefined && typeof meta.whenToUse !== 'string') {
     throw new Error('workflow meta whenToUse must be a string');
   }
-  if (meta.phases === undefined) return;
-  if (!Array.isArray(meta.phases)) {
-    throw new Error('workflow meta phases must be an array of objects');
+  if (meta.phases !== undefined) {
+    if (!Array.isArray(meta.phases)) {
+      throw new Error('workflow meta phases must be an array of objects');
+    }
+    for (const phase of meta.phases) validateWorkflowPhase(phase);
   }
-  for (const phase of meta.phases) validateWorkflowPhase(phase);
+  return { name, description };
 }
 
 function validateWorkflowPhase(phase: unknown): void {

--- a/packages/dreamux/src/service/workflow-service/store.ts
+++ b/packages/dreamux/src/service/workflow-service/store.ts
@@ -122,6 +122,8 @@ function parseRecord(
     team_id: teamId,
     caller_kind: callerKind as WorkflowCallerKind,
     script_hash: stringField(raw, 'script_hash', path),
+    name: optionalNullableStringField(raw, 'name', path),
+    description: optionalNullableStringField(raw, 'description', path),
     status: status as WorkflowRunStatus,
     max_concurrency: numberField(raw, 'max_concurrency', path),
     phase: nullableStringField(raw, 'phase', path),
@@ -158,6 +160,13 @@ function parseAgent(raw: unknown, path: string, position: number): WorkflowAgent
   };
 }
 
+/**
+ * Read a field a record written by an older build may not carry at all.
+ *
+ * `nullableStringField` rejects `undefined`, which is the right answer for a
+ * field every record has always had; a field added later is absent, not
+ * malformed, so it reads as null instead of failing the whole record.
+ */
 function optionalNullableStringField(
   record: Record<string, unknown>,
   field: string,

--- a/packages/dreamux/src/service/workflow-service/types.ts
+++ b/packages/dreamux/src/service/workflow-service/types.ts
@@ -38,6 +38,15 @@ export interface WorkflowRunRecord {
   team_id: string | null;
   caller_kind: WorkflowCallerKind;
   script_hash: string;
+  /**
+   * The `meta.name` / `meta.description` the submitted script declared.
+   *
+   * Null only on a record written before the run carried its own words; a run
+   * created by this build always has both, because the submitting scope reads
+   * them before the record exists.
+   */
+  name: string | null;
+  description: string | null;
   status: WorkflowRunStatus;
   max_concurrency: number;
   phase: string | null;
@@ -128,6 +137,8 @@ export function workflowRunResult(record: WorkflowRunRecord): WorkflowRunRecord 
     team_id: record.team_id,
     caller_kind: record.caller_kind,
     script_hash: record.script_hash,
+    name: record.name,
+    description: record.description,
     status: record.status,
     max_concurrency: record.max_concurrency,
     phase: record.phase,

--- a/packages/dreamux/tests/admission-ledger.test.ts
+++ b/packages/dreamux/tests/admission-ledger.test.ts
@@ -609,10 +609,14 @@ describe('TeammateService.prepareCompletion: completion delivery defaults to the
         source: 'workflow' as const,
         runId: 'wf-1',
         status: 'completed' as const,
-        result: 'the run is done',
+        description: 'the run',
+        error: null,
+        agents: { total: 1, succeeded: 1, failed: 0 },
+        outputPath: '/runs/wf-1/output.json',
+        journalPath: '/runs/wf-1/journal.jsonl',
       },
       notice: { kind: 'workflow_completion' },
-      says: 'Workflow wf-1 has completed.',
+      says: '<task-id>wf-1</task-id>',
     },
   ])('tells the display which producer reported when $what finished', async (
     { fact, notice, says },
@@ -626,7 +630,7 @@ describe('TeammateService.prepareCompletion: completion delivery defaults to the
     // Every provenance name here is the same `task-notification`, so the
     // producer is stated as a fact rather than read back out of the prose.
     expect(inputs[1]?.notice).toEqual(notice);
-    // The model still gets the whole notification body it always got.
+    // The model still gets the whole notification body its producer renders.
     expect(inputs[1]?.text).toContain(says);
     expect(h.submittedInputs[1]?.text).toContain(says);
   });

--- a/packages/dreamux/tests/completion-renderer.test.ts
+++ b/packages/dreamux/tests/completion-renderer.test.ts
@@ -4,7 +4,10 @@ import { join } from 'node:path';
 
 import { afterEach, describe, expect, it } from 'vitest';
 
-import type { PreparedCompletionFact } from '../src/service/completion-router/index.js';
+import type {
+  PreparedCompletionFact,
+  WorkflowCompletionFact,
+} from '../src/service/completion-router/index.js';
 import { buildCompletionTurnText } from '../src/service/teammate-service/completion-renderer.js';
 
 const roots: string[] = [];
@@ -54,33 +57,72 @@ describe('buildCompletionTurnText', () => {
     },
   );
 
-  it.each([
-    ['completed', 'Workflow report-1 has completed.'],
-    ['failed', 'Workflow report-1 failed.'],
-    ['stopped', 'Workflow report-1 was stopped.'],
-  ] as const)('renders workflow %s wording', async (status, line) => {
+  it('states a finished run as tagged facts and never inlines its result', async () => {
     const text = await buildCompletionTurnText(
-      workflowCompletion(status, 'result'),
+      workflowCompletion('completed'),
       temporarySpillDir(),
     );
 
-    expect(text).toBe(`${line} ${NOTIFICATION} Output below:\n\nresult`);
+    expect(text).toBe(
+      [
+        NOTIFICATION,
+        '',
+        '<workflow-notification>',
+        '<task-id>report-1</task-id>',
+        '<output-file>/runs/report-1/output.json</output-file>',
+        '<status>completed — 3 agents: 3 succeeded, 0 failed</status>',
+        '<summary>Dynamic workflow "survey the tree" completed</summary>',
+        '<diagnostics>Per-agent results: /runs/report-1/journal.jsonl — one ' +
+          '{"kind":"result",...} line per settled Agent. Read it before ' +
+          'diagnosing an unexpected result.</diagnostics>',
+        '</workflow-notification>',
+      ].join('\n'),
+    );
+    // The result is the one thing the notification does not carry: no tag holds
+    // it, and no length of result can put it into the caller's context.
+    expect(text).not.toContain('<result>');
   });
 
-  it('uses the same spill directory for workflow completions', async () => {
-    const spillDir = temporarySpillDir();
+  it.each(['failed', 'stopped'] as const)(
+    'appends the %s reason to the status line',
+    async (status) => {
+      const text = await buildCompletionTurnText(
+        {
+          ...workflowCompletion(status),
+          error: 'boom',
+          agents: { total: 3, succeeded: 1, failed: 2 },
+        },
+        temporarySpillDir(),
+      );
+
+      expect(text).toContain(
+        `<status>${status} — 3 agents: 1 succeeded, 2 failed — boom</status>`,
+      );
+      expect(text).toContain(
+        `<summary>Dynamic workflow "survey the tree" ${status}</summary>`,
+      );
+    },
+  );
+
+  it('counts a single Agent in the singular', async () => {
     const text = await buildCompletionTurnText(
-      workflowCompletion('completed', 'x'.repeat(32_001)),
-      spillDir,
+      {
+        ...workflowCompletion('completed'),
+        agents: { total: 1, succeeded: 1, failed: 0 },
+      },
+      temporarySpillDir(),
     );
 
-    const prefix =
-      `Workflow report-1 has completed. ${NOTIFICATION} The output is too ` +
-      'long, so the full result was saved to a file:\n\n';
-    expect(text.startsWith(prefix)).toBe(true);
-    expect(text.slice(prefix.length)).toMatch(
-      new RegExp(`^${escapeRegex(spillDir)}/completion-[0-9a-f-]+\\.output$`, 'u'),
+    expect(text).toContain('<status>completed — 1 agent: 1 succeeded, 0 failed</status>');
+  });
+
+  it('names the run when the record predates the script\'s own words', async () => {
+    const text = await buildCompletionTurnText(
+      { ...workflowCompletion('completed'), description: null },
+      temporarySpillDir(),
     );
+
+    expect(text).toContain('<summary>Dynamic workflow report-1 completed</summary>');
   });
 });
 
@@ -98,19 +140,18 @@ function teammateCompletion(
 
 function workflowCompletion(
   status: PreparedCompletionFact['status'],
-  result: string,
-): PreparedCompletionFact {
+): WorkflowCompletionFact {
   return {
     kind: 'workflow',
     source: 'workflow',
     runId: 'report-1',
     status,
-    result,
+    description: 'survey the tree',
+    error: null,
+    agents: { total: 3, succeeded: 3, failed: 0 },
+    outputPath: '/runs/report-1/output.json',
+    journalPath: '/runs/report-1/journal.jsonl',
   };
-}
-
-function escapeRegex(value: string): string {
-  return value.replace(/[.*+?^${}()|[\]\\]/gu, '\\$&');
 }
 
 function temporarySpillDir(): string {

--- a/packages/dreamux/tests/completion-token-routing.test.ts
+++ b/packages/dreamux/tests/completion-token-routing.test.ts
@@ -21,6 +21,7 @@ import {
   type CompletionInitiator,
   type PreparedCompletionDelivery,
   type PreparedCompletionFact,
+  type TeammateCompletionFact,
 } from '../src/service/completion-router/index.js';
 import {
   completedCompletion,
@@ -28,15 +29,21 @@ import {
   foldSubmissions,
 } from './helpers/runtime-submission.js';
 
-/** Records every user-visible send attempt the router actually makes. */
+/**
+ * Records every user-visible send attempt the router actually makes.
+ *
+ * Token folding is a property of a provider-settled turn, so every case here
+ * routes TeamMate completions; a Workflow terminal carries no token and would
+ * exercise a different entry point.
+ */
 class RecordingInitiator implements CompletionInitiator {
-  readonly prepared: PreparedCompletionFact[] = [];
-  readonly submitted: PreparedCompletionFact[] = [];
+  readonly prepared: TeammateCompletionFact[] = [];
+  readonly submitted: TeammateCompletionFact[] = [];
   readonly recipientKey: object;
 
   constructor(
     key?: object,
-    private readonly gate?: (fact: PreparedCompletionFact) => Promise<void>,
+    private readonly gate?: (fact: TeammateCompletionFact) => Promise<void>,
   ) {
     this.recipientKey = key ?? {};
   }
@@ -44,6 +51,9 @@ class RecordingInitiator implements CompletionInitiator {
   async prepareCompletion(
     fact: PreparedCompletionFact,
   ): Promise<PreparedCompletionDelivery> {
+    if (fact.kind !== 'teammate') {
+      throw new Error('completion token routing is a TeamMate-only path');
+    }
     this.prepared.push(fact);
     await this.gate?.(fact);
     return Object.freeze({

--- a/packages/dreamux/tests/workflow-service.test.ts
+++ b/packages/dreamux/tests/workflow-service.test.ts
@@ -14,12 +14,17 @@ import type { CompletionDeliveryPolicy } from '../src/service/completion-router/
 import {
   workflowRunDir,
   workflowRunJournalPath,
+  workflowRunOutputPath,
   workflowRunRecordPath,
 } from '../src/platform/paths.js';
 import { WORKFLOW_AGENT_SYSTEM_PROMPT } from '../src/service/workflow-service/agent-policy.js';
 import { WorkflowService } from '../src/service/workflow-service/index.js';
 import { WorkflowRun } from '../src/service/workflow-service/run.js';
-import type { WorkflowRunRecord } from '../src/service/workflow-service/types.js';
+import {
+  workflowRunResult,
+  type WorkflowRunRecord,
+} from '../src/service/workflow-service/types.js';
+import { teammateToolDescriptors } from '../src/service/teammate-collection/mcp-tool-descriptors.js';
 import type { LockedTeammate } from '../src/service/teammate-service/types.js';
 import {
   beginWorkflowRoot,
@@ -36,6 +41,16 @@ import {
   waitUntil,
   type WorkflowRootState,
 } from './helpers/workflow-harness.js';
+
+/**
+ * The smallest script the submission path accepts.
+ *
+ * A run is created with the words its own script declares, so `WorkflowService`
+ * reads `meta` before the record exists; a script without one never reaches the
+ * runner these tests fake.
+ */
+const SCRIPT =
+  "export const meta = { name: 'noop', description: 'noop run' };";
 
 let root: WorkflowRootState;
 
@@ -55,6 +70,10 @@ function recordPath(runId: string): string {
 
 function journalPath(runId: string): string {
   return workflowRunJournalPath({ ...SCOPE, runId });
+}
+
+function outputPath(runId: string): string {
+  return workflowRunOutputPath({ ...SCOPE, runId });
 }
 
 async function writeJson(path: string, value: unknown): Promise<void> {
@@ -81,6 +100,8 @@ function baseRecord(overrides: Partial<WorkflowRunRecord> = {}): WorkflowRunReco
     team_id: SCOPE.teamId,
     caller_kind: 'dispatcher',
     script_hash: 'hash',
+    name: null,
+    description: null,
     status: 'running',
     max_concurrency: 4,
     phase: null,
@@ -156,6 +177,17 @@ describe('WorkflowService.start() reads committed durable facts only', () => {
     // Durably written, not only held in memory.
     const onDisk = JSON.parse(await readFile(recordPath('run-a'), 'utf8')) as WorkflowRunRecord;
     expect(onDisk.status).toBe('stopped');
+
+    // A recovered run notifies nobody, so nothing else would ever write its
+    // output file — and the maintenance skill sends an operator to that file
+    // for any finished run's result. Every terminal has one, this one included.
+    expect(JSON.parse(await readFile(outputPath('run-a'), 'utf8'))).toEqual({
+      run_id: 'run-a',
+      status: 'stopped',
+      result: null,
+      error: onDisk.error,
+      agents: [{ index: 0, name: 'agent-1' }],
+    });
 
     const journalLines = (await readFile(journalPath('run-a'), 'utf8'))
       .trim()
@@ -276,7 +308,7 @@ describe('journal + terminal settlement: exactly one terminal outcome', () => {
     });
 
     await service.start();
-    const accepted = await service.run({ script: 'noop' });
+    const accepted = await service.run({ script: SCRIPT });
     expect(accepted.run_id).toBe('run-a');
 
     const stopped = await service.stop({ run_id: 'run-a' });
@@ -300,6 +332,118 @@ describe('journal + terminal settlement: exactly one terminal outcome', () => {
     expect(terminalRows).toHaveLength(1);
     expect(terminalRows[0]?.status).toBe('stopped');
     expect(delivery.delivered).toEqual([]);
+  });
+});
+
+describe('the report a terminal run leaves behind', () => {
+  function serviceWith(
+    runnerFactory: ReturnType<typeof fakeWorkflowRunnerFactory>,
+    delivery: ReturnType<typeof fakeCompletionDelivery>,
+  ): WorkflowService {
+    return new WorkflowService({
+      ...SCOPE,
+      callerKind: 'dispatcher',
+      teammates: fakeTeammateFactory(() => {
+        throw new Error('no agents in this script');
+      }),
+      completionDelivery: delivery.policy,
+      completionInitiator: () => fakeCompletionInitiator(),
+      log: silentLog(),
+      createRunner: runnerFactory.factory,
+      generateRunId: fixedRunIds('run-a'),
+    });
+  }
+
+  it('records the words its script declared, and refuses a script declaring none', async () => {
+    const service = serviceWith(
+      fakeWorkflowRunnerFactory(),
+      fakeCompletionDelivery(),
+    );
+    await service.start();
+    await service.run({ script: SCRIPT });
+
+    const record = JSON.parse(
+      await readFile(recordPath('run-a'), 'utf8'),
+    ) as WorkflowRunRecord;
+    expect(record.name).toBe('noop');
+    expect(record.description).toBe('noop run');
+
+    // A run reports itself in its script's own words, so a script that declares
+    // none is refused at submission, where the caller still hears why.
+    await expect(service.run({ script: 'return 1;' })).rejects.toThrow(
+      /must start with export const meta/u,
+    );
+  });
+
+  it('publishes the result beside the record and points the caller at it', async () => {
+    const runnerFactory = fakeWorkflowRunnerFactory();
+    const delivery = fakeCompletionDelivery();
+    const service = serviceWith(runnerFactory, delivery);
+    await service.start();
+    await service.run({ script: SCRIPT });
+
+    runnerFactory.runners[0]!.emit({
+      type: 'run_result',
+      status: 'completed',
+      result: { ok: true },
+    });
+    await waitUntil(() => delivery.delivered.length >= 1);
+
+    expect(delivery.delivered[0]).toMatchObject({
+      kind: 'workflow',
+      status: 'completed',
+      description: 'noop run',
+      error: null,
+      agents: { total: 0, succeeded: 0, failed: 0 },
+      outputPath: outputPath('run-a'),
+      journalPath: journalPath('run-a'),
+    });
+    // The result itself never rides along: the caller is told where it is.
+    expect(delivery.delivered[0]).not.toHaveProperty('result');
+    expect(JSON.parse(await readFile(outputPath('run-a'), 'utf8'))).toEqual({
+      run_id: 'run-a',
+      status: 'completed',
+      result: { ok: true },
+      error: null,
+      agents: [],
+    });
+  });
+
+  it('reads a record written before runs carried their own words', async () => {
+    const legacy: Record<string, unknown> = {
+      ...baseRecord({ run_id: 'run-old', status: 'completed' }),
+    };
+    delete legacy['name'];
+    delete legacy['description'];
+    await writeJson(recordPath('run-old'), legacy);
+
+    const service = serviceWith(
+      fakeWorkflowRunnerFactory(),
+      fakeCompletionDelivery(),
+    );
+    await service.start();
+
+    await expect(service.status({ run_id: 'run-old' })).resolves.toMatchObject({
+      name: null,
+      description: null,
+      status: 'completed',
+    });
+  });
+
+  it('publishes output.json for a terminal nobody is notified about', async () => {
+    const delivery = fakeCompletionDelivery();
+    const service = serviceWith(fakeWorkflowRunnerFactory(), delivery);
+    await service.start();
+    await service.run({ script: SCRIPT });
+
+    await service.stop({ run_id: 'run-a' });
+
+    expect(delivery.delivered).toEqual([]);
+    expect(JSON.parse(await readFile(outputPath('run-a'), 'utf8'))).toMatchObject({
+      run_id: 'run-a',
+      status: 'stopped',
+      result: null,
+    });
   });
 });
 
@@ -334,7 +478,7 @@ describe('owner-side exact-instance eviction', () => {
     });
     await service.start();
 
-    const acceptedA = await service.run({ script: 'noop' });
+    const acceptedA = await service.run({ script: SCRIPT });
     expect(acceptedA.run_id).toBe('run-x');
     const runnerA = runnerFactory.runners[0]!;
     runnerA.emit({ type: 'run_result', status: 'completed', result: null });
@@ -345,7 +489,7 @@ describe('owner-side exact-instance eviction', () => {
 
     await rm(workflowRunDir({ ...SCOPE, runId: 'run-x' }), { recursive: true, force: true });
 
-    const acceptedB = await service.run({ script: 'noop' });
+    const acceptedB = await service.run({ script: SCRIPT });
     expect(acceptedB.run_id).toBe('run-x');
     // B has not reached run_result — it is still live, status 'running'.
     // Delete B's own durable record so the only place a correct answer can
@@ -403,7 +547,7 @@ describe('Workflow terminal delivery across stop races', () => {
       generateRunId: fixedRunIds('run-a'),
     });
     await service.start();
-    await service.run({ script: 'noop' });
+    await service.run({ script: SCRIPT });
 
     const runner = runnerFactory.runners[0]!;
     runner.emit({ type: 'agent_start', index: 0, prompt: 'do it', options: {} });
@@ -444,14 +588,18 @@ describe('Workflow terminal delivery across stop races', () => {
       generateRunId: fixedRunIds('run-a'),
     });
     await service.start();
-    await service.run({ script: 'noop' });
+    await service.run({ script: SCRIPT });
 
     const runner = runnerFactory.runners[0]!;
     runner.emit({ type: 'run_result', status: 'failed', error: 'boom' });
     await waitUntil(() => delivery.delivered.length >= 1);
 
-    expect(delivery.delivered[0]).toMatchObject({ kind: 'workflow', status: 'failed' });
-    expect(String(delivery.delivered[0]?.result)).toContain('boom');
+    expect(delivery.delivered[0]).toMatchObject({
+      kind: 'workflow',
+      status: 'failed',
+      error: 'boom',
+      description: 'noop run',
+    });
     expect(delivery.deliverRuntimeCalls).toBe(0);
   });
 
@@ -471,7 +619,7 @@ describe('Workflow terminal delivery across stop races', () => {
       generateRunId: fixedRunIds('run-a'),
     });
     await service.start();
-    await service.run({ script: 'noop' });
+    await service.run({ script: SCRIPT });
 
     const runner = runnerFactory.runners[0]!;
     const stopEntered = gate();
@@ -519,7 +667,7 @@ describe('Workflow terminal delivery across stop races', () => {
       generateRunId: fixedRunIds('run-a'),
     });
     await service.start();
-    await service.run({ script: 'noop' });
+    await service.run({ script: SCRIPT });
 
     const runner = runnerFactory.runners[0]!;
     const stopEntered = gate();
@@ -573,7 +721,7 @@ describe('Workflow terminal delivery across stop races', () => {
       generateRunId: fixedRunIds('run-a'),
     });
     await service.start();
-    await service.run({ script: 'noop' });
+    await service.run({ script: SCRIPT });
 
     runnerFactory.runners[0]!.emit({
       type: 'run_result',
@@ -631,7 +779,7 @@ describe('team-scoped Workflow member creation: a narrow createLocked capability
       generateRunId: fixedRunIds('run-a'),
     });
     await service.start();
-    await service.run({ script: 'noop' });
+    await service.run({ script: SCRIPT });
 
     const runner = runnerFactory.runners[0]!;
     runner.emit({
@@ -678,7 +826,7 @@ describe('team-scoped Workflow member creation: a narrow createLocked capability
       generateRunId: fixedRunIds('run-a'),
     });
     await service.start();
-    await service.run({ script: 'noop', max_concurrency: 4 });
+    await service.run({ script: SCRIPT, max_concurrency: 4 });
     const runner = runnerFactory.runners[0]!;
 
     const schema = { type: 'object', properties: {} } as const;
@@ -749,8 +897,8 @@ describe('WorkflowService.stopAll() owns shutdown convergence', () => {
       generateRunId: fixedRunIds('run-a', 'run-b'),
     });
     await service.start();
-    await service.run({ script: 'noop' });
-    await service.run({ script: 'noop' });
+    await service.run({ script: SCRIPT });
+    await service.run({ script: SCRIPT });
     expect(runnerFactory.runners).toHaveLength(2);
 
     await service.stopAll();
@@ -791,7 +939,7 @@ describe('WorkflowService.stopAll() owns shutdown convergence', () => {
         await originalInitialize.call(this);
       });
     try {
-      const creating = service.run({ script: 'noop' });
+      const creating = service.run({ script: SCRIPT });
       await initializeEntered.promise;
 
       service.closeAdmission();
@@ -807,5 +955,28 @@ describe('WorkflowService.stopAll() owns shutdown convergence', () => {
       allowInitialize.release();
       initializeSpy.mockRestore();
     }
+  });
+});
+
+describe('the shape a run is advertised in', () => {
+  // A record field is projected verbatim by `workflowRunResult`, and the
+  // `workflow_status` / `workflow_list` output schema is closed
+  // (`additionalProperties: false`) around the keys it lists. So a field added
+  // to the record reaches the wire while the schema still forbids it, and the
+  // SDK rejects the result of every read — a total outage of both tools that
+  // build, lint, test, and typecheck:tests all stay green through, because
+  // nothing else compares the two. This is that comparison.
+  it('declares exactly the keys a run projects', () => {
+    const status = teammateToolDescriptors('dispatcher').find(
+      (tool) => tool.name === 'workflow_status',
+    );
+    const schema = status?.outputSchema as {
+      properties: Record<string, unknown>;
+      required: string[];
+    };
+    const projected = Object.keys(workflowRunResult(baseRecord())).sort();
+
+    expect(Object.keys(schema.properties).sort()).toEqual(projected);
+    expect([...schema.required].sort()).toEqual(projected);
   });
 });


### PR DESCRIPTION
## Why

A Workflow run returns a script's value, not prose written for a reader, and its
caller usually needs to know how the run went before deciding whether to read the
value at all. The old push inlined the whole JSON result into the caller's next
turn, so a large run flooded the context of a caller that never asked for it.

## What the push says now

```
This is an automated notification from Dreamux, not a message from the user.

<workflow-notification>
<task-id>run-9f2a</task-id>
<output-file>~/.dreamux/state/<dispatcher>/workflow/run-9f2a/output.json</output-file>
<status>completed — 4 agents: 4 succeeded, 0 failed</status>
<summary>Dynamic workflow "survey the tree" completed</summary>
<diagnostics>Per-agent results: .../journal.jsonl — one {"kind":"result",...} line per settled Agent. Read it before diagnosing an unexpected result.</diagnostics>
</workflow-notification>
```

No tag carries the result. A non-null run error is appended to `<status>`, so a
failed run needs no tag of its own. Agents are counted succeeded/failed against a
total; Dreamux cannot skip an Agent, and one a terminal settled as stopped is in
the total but in neither count, which the run's own status already explains.

TeamMate pushes are unchanged — they keep their prose-and-result shape, and the
producer notice each side publishes is untouched. Only the body a Workflow
renders is new.

## The result needs somewhere to live

Since it is no longer inlined, it needs a home with the run's own lifetime.
Every terminal writes `<run-dir>/output.json` beside `record.json` and
`journal.jsonl` — including a run converged to a terminal by startup recovery,
which notifies nobody, so the file exists for every finished run. The spill
directory would have been wrong: its own comment calls it a cache safe to
delete, and a sweep between the notification and the caller's read would hand
the caller a dangling path.

## The run reports itself in its own words

`<summary>` quotes the script's `meta.description`, so `record.json` now stores
the `meta.name` and `meta.description` the submitted script declared. They are
read at submission rather than in the runner child, because the record exists
before the child does. Consequence: **a script that declares no valid `meta` is
now rejected by `workflow_run` itself** instead of producing a durable failed
run. Records written before this build load with both as null.

`workflow_status` and `workflow_list` project both fields, and their closed
output schema declares them.

## One gate this added

The `workflow_status` / `workflow_list` output schema is
`additionalProperties: false`, and `workflowRunResult` projects the record
verbatim. A record field added without touching that schema makes the SDK reject
the result of every read — a total outage of both tools that build, lint, test,
and `typecheck:tests` all stay green through, because nothing compared the two.
A new test in `workflow-service.test.ts` does; it was verified to fail when a
field is dropped from the schema.

## Verification

`build`, `lint`, `test`, `typecheck:tests` all green on this rebase.
`.agents/scripts/check.sh` reports KB OK (227 files).

Rebased onto `af96c9f4`. The first rebase surfaced one semantic conflict: #401's
`admission-ledger.test.ts` asserts the workflow prose this change replaces; its
load-bearing assertion (the `workflow_completion` producer notice) is unchanged,
and only the body it looks for was updated.

## Open questions for the operator

1. A stopped run renders as e.g. `stopped — 3 agents: 1 succeeded, 0 failed — <reason>`,
   where 1+0≠3. Truthful, and the run status explains the gap, but no count names
   the stopped Agents. Deliberately not invented here.
2. The `workflow_status` tool description still reads "Read phase, agent
   progress, concrete TeamMate names, and terminal result" and does not mention
   the newly projected `name` / `description`. Neither text is false. Left alone
   because that string is a model-facing surface refined line by line in #380.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EeJaSKeU13M7GLZiHinwMZ
